### PR TITLE
NIFI-11788 Modified logback configuration to have better cle…

### DIFF
--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
@@ -30,11 +30,11 @@
             -->
             <fileNamePattern>${org.apache.nifi.minifi.bootstrap.config.log.dir}/${org.apache.nifi.minifi.bootstrap.config.log.app.file.name}_%d{yyyy-MM-dd_HH}.%i.${org.apache.nifi.minifi.bootstrap.config.log.app.file.extension}.gz</fileNamePattern>
             <!-- Control the maximum size of each log file before rolling over -->
-            <maxFileSize>1MB</maxFileSize>
+            <maxFileSize>10MB</maxFileSize>
             <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>10</maxHistory>
             <!-- Control the total size of all log archive files for this appender -->
-            <totalSizeCap>10MB</totalSizeCap>
+            <totalSizeCap>100MB</totalSizeCap>
             <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
@@ -55,11 +55,11 @@
             -->
             <fileNamePattern>${org.apache.nifi.minifi.bootstrap.config.log.dir}/${org.apache.nifi.minifi.bootstrap.config.log.bootstrap.file.name}_%d.${org.apache.nifi.minifi.bootstrap.config.log.bootstrap.file.extension}.gz</fileNamePattern>
             <!-- Control the maximum size of each log file before rolling over -->
-            <maxFileSize>1MB</maxFileSize>
+            <maxFileSize>10MB</maxFileSize>
             <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>10</maxHistory>
             <!-- Control the total size of all log archive files for this appender -->
-            <totalSizeCap>10MB</totalSizeCap>
+            <totalSizeCap>100MB</totalSizeCap>
             <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
@@ -35,6 +35,8 @@
             <maxFileSize>1MB</maxFileSize>
             <!-- Provide a cap of 10 MB across all archive files -->
             <totalSizeCap>10MB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <immediateFlush>true</immediateFlush>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -54,6 +56,9 @@
             <fileNamePattern>${org.apache.nifi.minifi.bootstrap.config.log.dir}/${org.apache.nifi.minifi.bootstrap.config.log.bootstrap.file.name}_%d.${org.apache.nifi.minifi.bootstrap.config.log.bootstrap.file.extension}.gz</fileNamePattern>
             <!-- Keep 5 rolling periods worth of logs-->
             <maxHistory>5</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
@@ -29,13 +29,13 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.minifi.bootstrap.config.log.dir}/${org.apache.nifi.minifi.bootstrap.config.log.app.file.name}_%d{yyyy-MM-dd_HH}.%i.${org.apache.nifi.minifi.bootstrap.config.log.app.file.extension}.gz</fileNamePattern>
-            <!-- Keep 10 rolling periods worth of log files-->
-            <maxHistory>10</maxHistory>
-            <!-- Max size each log file will be-->
+            <!-- Control the maximum size of each log file before rolling over -->
             <maxFileSize>1MB</maxFileSize>
-            <!-- Provide a cap of 10 MB across all archive files -->
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
+            <maxHistory>10</maxHistory>
+            <!-- Control the total size of all log archive files for this appender -->
             <totalSizeCap>10MB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <immediateFlush>true</immediateFlush>
@@ -54,10 +54,13 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.minifi.bootstrap.config.log.dir}/${org.apache.nifi.minifi.bootstrap.config.log.bootstrap.file.name}_%d.${org.apache.nifi.minifi.bootstrap.config.log.bootstrap.file.extension}.gz</fileNamePattern>
-            <!-- Keep 5 rolling periods worth of logs-->
-            <maxHistory>5</maxHistory>
-            <totalSizeCap>100MB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Control the maximum size of each log file before rolling over -->
+            <maxFileSize>1MB</maxFileSize>
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
+            <maxHistory>10</maxHistory>
+            <!-- Control the total size of all log archive files for this appender -->
+            <totalSizeCap>10MB</totalSizeCap>
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -30,12 +30,14 @@
               To GZIP rolled files, replace '.log' with '.log.gz'.
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
-            <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-app_%d{yyyy-MM-dd_HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-app_%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
+            <!-- Control the maximum size of each log file before rolling over -->
             <maxFileSize>100MB</maxFileSize>
-            <!-- keep 30 log files worth of history -->
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>30</maxHistory>
-            <totalSizeCap>100GB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Control the total size of all log archive files for this appender -->
+            <totalSizeCap>3GB</totalSizeCap>
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <immediateFlush>true</immediateFlush>
@@ -54,10 +56,13 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-user_%d.log</fileNamePattern>
-            <!-- keep 30 log files worth of history -->
+            <!-- Control the maximum size of each log file before rolling over -->
+            <maxFileSize>100MB</maxFileSize>
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>30</maxHistory>
-            <totalSizeCap>5GB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Control the total size of all log archive files for this appender -->
+            <totalSizeCap>3GB</totalSizeCap>
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -69,9 +74,13 @@
         <file>${org.apache.nifi.bootstrap.config.log.dir}/nifi-request.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-request_%d.log</fileNamePattern>
+            <!-- Control the maximum size of each log file before rolling over -->
+            <maxFileSize>100MB</maxFileSize>
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>30</maxHistory>
-            <totalSizeCap>5GB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Control the total size of all log archive files for this appender -->
+            <totalSizeCap>3GB</totalSizeCap>
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -89,10 +98,13 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-bootstrap_%d.log</fileNamePattern>
-            <!-- keep 5 log files worth of history -->
-            <maxHistory>5</maxHistory>
-            <totalSizeCap>100MB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Control the maximum size of each log file before rolling over -->
+            <maxFileSize>100MB</maxFileSize>
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
+            <maxHistory>30</maxHistory>
+            <!-- Control the total size of all log archive files for this appender -->
+            <totalSizeCap>3GB</totalSizeCap>
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -104,11 +116,13 @@
         <file>${org.apache.nifi.bootstrap.config.log.dir}/nifi-deprecation.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-deprecation_%d.%i.log</fileNamePattern>
+            <!-- Control the maximum size of each log file before rolling over is lower for deprecations -->
             <maxFileSize>10MB</maxFileSize>
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>10</maxHistory>
+            <!-- Control the total size of all log archive files for this appender is lower as deprecations are repetitive -->
             <totalSizeCap>100MB</totalSizeCap>
-            <totalSizeCap>5GB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -129,11 +143,13 @@
                     To ZIP rolled files, replace '.log' with '.log.zip'.
                     -->
                     <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-app-${logFileSuffix}_%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
+                    <!-- Control the maximum size of each log file before rolling over -->
                     <maxFileSize>100MB</maxFileSize>
-                    <!-- keep 30 log files worth of history -->
+                    <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
                     <maxHistory>30</maxHistory>
-                    <totalSizeCap>100GB</totalSizeCap>
-                    <!-- This is supposed to force log cleanup when the service starts/restarts -->
+                    <!-- Control the total size of all log archive files for this appender -->
+                    <totalSizeCap>3GB</totalSizeCap>
+                    <!-- Log files exceeding maximum settings will be rolled on startup -->
                     <cleanHistoryOnStart>true</cleanHistoryOnStart>
                 </rollingPolicy>
                 <immediateFlush>true</immediateFlush>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -30,10 +30,13 @@
               To GZIP rolled files, replace '.log' with '.log.gz'.
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
-            <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-app_%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
+            <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-app_%d{yyyy-MM-dd_HH}.%i.log.gz</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
             <!-- keep 30 log files worth of history -->
             <maxHistory>30</maxHistory>
+            <totalSizeCap>100GB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <immediateFlush>true</immediateFlush>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -53,6 +56,9 @@
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-user_%d.log</fileNamePattern>
             <!-- keep 30 log files worth of history -->
             <maxHistory>30</maxHistory>
+            <totalSizeCap>5GB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
@@ -64,6 +70,9 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-request_%d.log</fileNamePattern>
             <maxHistory>30</maxHistory>
+            <totalSizeCap>5GB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%msg%n</pattern>
@@ -82,6 +91,9 @@
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-bootstrap_%d.log</fileNamePattern>
             <!-- keep 5 log files worth of history -->
             <maxHistory>5</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
@@ -95,6 +107,9 @@
             <maxFileSize>10MB</maxFileSize>
             <maxHistory>10</maxHistory>
             <totalSizeCap>100MB</totalSizeCap>
+            <totalSizeCap>5GB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%date %level [%thread] %logger %msg%n</pattern>
@@ -117,6 +132,9 @@
                     <maxFileSize>100MB</maxFileSize>
                     <!-- keep 30 log files worth of history -->
                     <maxHistory>30</maxHistory>
+                    <totalSizeCap>100GB</totalSizeCap>
+                    <!-- This is supposed to force log cleanup when the service starts/restarts -->
+                    <cleanHistoryOnStart>true</cleanHistoryOnStart>
                 </rollingPolicy>
                 <immediateFlush>true</immediateFlush>
                 <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/stateless-logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/stateless-logback.xml
@@ -32,6 +32,9 @@
             <maxFileSize>100MB</maxFileSize>
             <!-- keep 30 log files worth of history -->
             <maxHistory>30</maxHistory>
+            <totalSizeCap>10GB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <immediateFlush>true</immediateFlush>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/stateless-logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/stateless-logback.xml
@@ -29,11 +29,13 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-stateless_%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
+            <!-- Control the maximum size of each log file before rolling over -->
             <maxFileSize>100MB</maxFileSize>
-            <!-- keep 30 log files worth of history -->
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>30</maxHistory>
-            <totalSizeCap>10GB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Control the total size of all log archive files for this appender -->
+            <totalSizeCap>3GB</totalSizeCap>
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <immediateFlush>true</immediateFlush>

--- a/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/logback.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/logback.xml
@@ -28,12 +28,13 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.registry.bootstrap.config.log.dir}/nifi-registry-app_%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
+            <!-- Control the maximum size of each log file before rolling over -->
             <maxFileSize>100MB</maxFileSize>
-            <!-- keep 30 log files worth of history -->
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>30</maxHistory>
-            <!-- keep 10GB total of log files -->
-            <totalSizeCap>10GB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Control the total size of all log archive files for this appender -->
+            <totalSizeCap>3GB</totalSizeCap>
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <immediateFlush>true</immediateFlush>
@@ -52,11 +53,13 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.registry.bootstrap.config.log.dir}/nifi-registry-bootstrap_%d.log</fileNamePattern>
-            <!-- keep 5 log files worth of history -->
-            <maxHistory>5</maxHistory>
-
-            <totalSizeCap>10MB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Control the maximum size of each log file before rolling over -->
+            <maxFileSize>100MB</maxFileSize>
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
+            <maxHistory>30</maxHistory>
+            <!-- Control the total size of all log archive files for this appender -->
+            <totalSizeCap>3GB</totalSizeCap>
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -74,10 +77,13 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.registry.bootstrap.config.log.dir}/nifi-registry-event_%d.log</fileNamePattern>
-            <!-- keep 5 log files worth of history -->
-            <maxHistory>5</maxHistory>
-            <totalSizeCap>100MB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Control the maximum size of each log file before rolling over -->
+            <maxFileSize>100MB</maxFileSize>
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
+            <maxHistory>30</maxHistory>
+            <!-- Control the total size of all log archive files for this appender -->
+            <totalSizeCap>3GB</totalSizeCap>
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">

--- a/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/logback.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/logback.xml
@@ -33,6 +33,8 @@
             <maxHistory>30</maxHistory>
             <!-- keep 10GB total of log files -->
             <totalSizeCap>10GB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <immediateFlush>true</immediateFlush>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -52,6 +54,10 @@
             <fileNamePattern>${org.apache.nifi.registry.bootstrap.config.log.dir}/nifi-registry-bootstrap_%d.log</fileNamePattern>
             <!-- keep 5 log files worth of history -->
             <maxHistory>5</maxHistory>
+
+            <totalSizeCap>10MB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
@@ -70,6 +76,9 @@
             <fileNamePattern>${org.apache.nifi.registry.bootstrap.config.log.dir}/nifi-registry-event_%d.log</fileNamePattern>
             <!-- keep 5 log files worth of history -->
             <maxHistory>5</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%date ## %msg%n</pattern>

--- a/nifi-stateless/nifi-stateless-resources/src/main/resources/conf/stateless-logback.xml
+++ b/nifi-stateless/nifi-stateless-resources/src/main/resources/conf/stateless-logback.xml
@@ -32,6 +32,9 @@
             <maxFileSize>100MB</maxFileSize>
             <!-- keep 30 log files worth of history -->
             <maxHistory>30</maxHistory>
+            <totalSizeCap>10GB</totalSizeCap>
+            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <immediateFlush>true</immediateFlush>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">

--- a/nifi-stateless/nifi-stateless-resources/src/main/resources/conf/stateless-logback.xml
+++ b/nifi-stateless/nifi-stateless-resources/src/main/resources/conf/stateless-logback.xml
@@ -29,11 +29,13 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-stateless_%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
+            <!-- Control the maximum size of each log file before rolling over -->
             <maxFileSize>100MB</maxFileSize>
-            <!-- keep 30 log files worth of history -->
+            <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>30</maxHistory>
-            <totalSizeCap>10GB</totalSizeCap>
-            <!-- This is supposed to force log cleanup when the service starts/restarts -->
+            <!-- Control the total size of all log archive files for this appender -->
+            <totalSizeCap>3GB</totalSizeCap>
+            <!-- Log files exceeding maximum settings will be rolled on startup -->
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <immediateFlush>true</immediateFlush>


### PR DESCRIPTION
…anup

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
