### PR TITLE
NIFI-8128: add support for specifying a password for Sentinel

### DIFF
--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/pom.xml
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>nifi-record-path</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-ssl-context-service-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -96,15 +101,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.kstyrc</groupId>
-            <artifactId>embedded-redis</artifactId>
-            <version>0.6</version>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-ssl-context-service-api</artifactId>
-            <scope>compile</scope>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/pom.xml
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-ssl-context-service-api</artifactId>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <!-- Test dependencies -->
         <dependency>

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/util/RedisUtils.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/util/RedisUtils.java
@@ -35,6 +35,7 @@ import org.springframework.data.redis.connection.RedisSentinelConfiguration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisClientConfiguration;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.lang.Nullable;
 import redis.clients.jedis.JedisPoolConfig;
 
 import javax.net.ssl.SSLContext;
@@ -134,7 +135,16 @@ public class RedisUtils {
     public static final PropertyDescriptor PASSWORD = new PropertyDescriptor.Builder()
             .name("Password")
             .displayName("Password")
-            .description("The password used to authenticate to the Redis server. See the requirepass property in redis.conf.")
+            .description("The password used to authenticate to the Redis server. See the 'requirepass' property in redis.conf.")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+            .sensitive(true)
+            .build();
+
+    public static final PropertyDescriptor SENTINEL_PASSWORD = new PropertyDescriptor.Builder()
+            .name("Sentinel Password")
+            .displayName("Sentinel Password")
+            .description("The password used to authenticate to the Redis Sentinel server. See the 'requirepass' and 'sentinel sentinel-pass' properties in sentinel.conf.")
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .sensitive(true)
@@ -275,6 +285,7 @@ public class RedisUtils {
         props.add(RedisUtils.CLUSTER_MAX_REDIRECTS);
         props.add(RedisUtils.SENTINEL_MASTER);
         props.add(RedisUtils.PASSWORD);
+        props.add(RedisUtils.SENTINEL_PASSWORD);
         props.add(RedisUtils.SSL_CONTEXT_SERVICE);
         props.add(RedisUtils.POOL_MAX_TOTAL);
         props.add(RedisUtils.POOL_MAX_IDLE);
@@ -297,6 +308,7 @@ public class RedisUtils {
         final String connectionString = context.getProperty(RedisUtils.CONNECTION_STRING).evaluateAttributeExpressions().getValue();
         final Integer dbIndex = context.getProperty(RedisUtils.DATABASE).evaluateAttributeExpressions().asInteger();
         final String password = context.getProperty(RedisUtils.PASSWORD).evaluateAttributeExpressions().getValue();
+        final String sentinelPassword = context.getProperty(RedisUtils.SENTINEL_PASSWORD).evaluateAttributeExpressions().getValue();
         final Integer timeout = context.getProperty(RedisUtils.COMMUNICATION_TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue();
         final JedisPoolConfig poolConfig = createJedisPoolConfig(context);
 
@@ -323,7 +335,7 @@ public class RedisUtils {
             final String host = hostAndPortSplit[0].trim();
             final Integer port = Integer.parseInt(hostAndPortSplit[1].trim());
             final RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
-            enrichRedisConfiguration(redisStandaloneConfiguration, dbIndex, password);
+            enrichRedisConfiguration(redisStandaloneConfiguration, dbIndex, password, sentinelPassword);
 
             connectionFactory = new JedisConnectionFactory(redisStandaloneConfiguration, jedisClientConfiguration);
 
@@ -331,7 +343,7 @@ public class RedisUtils {
             final String[] sentinels = connectionString.split("[,]");
             final String sentinelMaster = context.getProperty(RedisUtils.SENTINEL_MASTER).evaluateAttributeExpressions().getValue();
             final RedisSentinelConfiguration sentinelConfiguration = new RedisSentinelConfiguration(sentinelMaster, new HashSet<>(getTrimmedValues(sentinels)));
-            enrichRedisConfiguration(sentinelConfiguration, dbIndex, password);
+            enrichRedisConfiguration(sentinelConfiguration, dbIndex, password, sentinelPassword);
 
             logger.info("Connecting to Redis in sentinel mode...");
             logger.info("Redis master = " + sentinelMaster);
@@ -347,7 +359,7 @@ public class RedisUtils {
             final Integer maxRedirects = context.getProperty(RedisUtils.CLUSTER_MAX_REDIRECTS).asInteger();
 
             final RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration(getTrimmedValues(clusterNodes));
-            enrichRedisConfiguration(clusterConfiguration, dbIndex, password);
+            enrichRedisConfiguration(clusterConfiguration, dbIndex, password, sentinelPassword);
             clusterConfiguration.setMaxRedirects(maxRedirects);
 
             logger.info("Connecting to Redis in clustered mode...");
@@ -373,12 +385,16 @@ public class RedisUtils {
 
     private static void enrichRedisConfiguration(final RedisConfiguration redisConfiguration,
                                                  final Integer dbIndex,
-                                                 final String password) {
+                                                 @Nullable final String password,
+                                                 @Nullable final String sentinelPassword) {
         if (redisConfiguration instanceof RedisConfiguration.WithDatabaseIndex) {
             ((RedisConfiguration.WithDatabaseIndex) redisConfiguration).setDatabase(dbIndex);
         }
         if (redisConfiguration instanceof RedisConfiguration.WithPassword) {
             ((RedisConfiguration.WithPassword) redisConfiguration).setPassword(RedisPassword.of(password));
+        }
+        if (redisConfiguration instanceof RedisConfiguration.SentinelConfiguration) {
+            ((RedisConfiguration.SentinelConfiguration) redisConfiguration).setSentinelPassword(RedisPassword.of(sentinelPassword));
         }
     }
 

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/service/ITRedisDistributedMapCacheClientService.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/service/ITRedisDistributedMapCacheClientService.java
@@ -169,7 +169,7 @@ public class ITRedisDistributedMapCacheClientService {
     private RedisContainer setupStandaloneRedis(final @Nullable String redisPassword) throws IOException {
         int redisPort = getAvailablePort();
 
-        RedisContainer redisContainer = new RedisContainer("redis:7.0.12-alpine");
+        RedisContainer redisContainer = new RedisContainer(CONTAINER_IMAGE_TAG);
         redisContainer.mountConfigurationFrom(testDirectory);
         redisContainer.setPort(redisPort);
         redisContainer.addPortBinding(redisPort, redisPort);

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/service/ITRedisDistributedMapCacheClientService.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/service/ITRedisDistributedMapCacheClientService.java
@@ -73,10 +73,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class ITRedisDistributedMapCacheClientService {
 
-    @TempDir
-    private Path testDirectory;
+    public static final String CONTAINER_IMAGE_TAG = "redis:7.0.12-alpine";
 
     private static final String masterName = "redisLeader";
+    @TempDir
+
+    private Path testDirectory;
 
     private final TestRedisProcessor proc = new TestRedisProcessor();
     private final TestRunner testRunner = TestRunners.newTestRunner(proc);
@@ -186,7 +188,7 @@ public class ITRedisDistributedMapCacheClientService {
                                                     final @Nullable String redisPassword) throws IOException {
         int replicaPort = getAvailablePort();
 
-        RedisReplicaContainer redisReplicaContainer = new RedisReplicaContainer("redis:7.0.12-alpine");
+        RedisReplicaContainer redisReplicaContainer = new RedisReplicaContainer(CONTAINER_IMAGE_TAG);
         redisReplicaContainer.mountConfigurationFrom(testDirectory);
         redisReplicaContainer.setPort(replicaPort);
         redisReplicaContainer.addPortBinding(replicaPort, replicaPort);
@@ -206,7 +208,7 @@ public class ITRedisDistributedMapCacheClientService {
                                                  final @Nullable String sentinelPassword) throws IOException {
         int sentinelPort = getAvailablePort();
 
-        RedisSentinelContainer redisSentinelContainer = new RedisSentinelContainer("redis:7.0.12-alpine");
+        RedisSentinelContainer redisSentinelContainer = new RedisSentinelContainer(CONTAINER_IMAGE_TAG);
         redisSentinelContainer.mountConfigurationFrom(testDirectory);
         redisSentinelContainer.setPort(sentinelPort);
         redisSentinelContainer.addPortBinding(sentinelPort, sentinelPort);

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/state/ITRedisStateProvider.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/state/ITRedisStateProvider.java
@@ -23,18 +23,17 @@ import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.components.state.StateProvider;
 import org.apache.nifi.components.state.StateProviderInitializationContext;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.redis.testcontainers.RedisContainer;
 import org.apache.nifi.redis.util.RedisUtils;
 import org.apache.nifi.util.MockComponentLog;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import redis.embedded.RedisServer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.StandardSocketOptions;
-import java.nio.channels.SocketChannel;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,22 +50,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * NOTE: These test cases should be kept in-sync with AbstractTestStateProvider which is in the framework
  * and couldn't be extended here.
  */
+@Testcontainers
 public class ITRedisStateProvider {
 
     protected final String componentId = "111111111-1111-1111-1111-111111111111";
 
-    private RedisServer redisServer;
+    @Container
+    public RedisContainer redisContainer = new RedisContainer("redis:7.0.12-alpine")
+            .withExposedPorts(6379);
+
     private RedisStateProvider provider;
 
     @BeforeEach
-    public void setup() throws Exception {
-        final int redisPort = getAvailablePort();
-
-        this.redisServer = new RedisServer(redisPort);
-        redisServer.start();
-
+    public void setup() {
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
-        properties.put(RedisUtils.CONNECTION_STRING, "localhost:" + redisPort);
+        properties.put(RedisUtils.CONNECTION_STRING, redisContainer.getHost() + ":" + redisContainer.getFirstMappedPort());
         this.provider = createProvider(properties);
     }
 
@@ -79,10 +77,6 @@ public class ITRedisStateProvider {
             }
             provider.disable();
             provider.shutdown();
-        }
-
-        if (redisServer != null) {
-            redisServer.stop();
         }
     }
 
@@ -173,7 +167,7 @@ public class ITRedisStateProvider {
         assertEquals(1, map.size());
         assertEquals("value", map.get(key));
 
-        provider.setState(Collections.<String, String> emptyMap(), componentId);
+        provider.setState(Collections.<String, String>emptyMap(), componentId);
 
         final StateMap stateMap = provider.getState(componentId);
         map = stateMap.toMap();
@@ -284,8 +278,8 @@ public class ITRedisStateProvider {
             }
 
             @Override
-            public Map<String,String> getAllProperties() {
-                final Map<String,String> propValueMap = new LinkedHashMap<>();
+            public Map<String, String> getAllProperties() {
+                final Map<String, String> propValueMap = new LinkedHashMap<>();
                 for (final Map.Entry<PropertyDescriptor, String> entry : properties.entrySet()) {
                     propValueMap.put(entry.getKey().getName(), entry.getValue());
                 }
@@ -321,13 +315,4 @@ public class ITRedisStateProvider {
         provider.enable();
         return provider;
     }
-
-    private int getAvailablePort() throws IOException {
-        try (SocketChannel socket = SocketChannel.open()) {
-            socket.setOption(StandardSocketOptions.SO_REUSEADDR, true);
-            socket.bind(new InetSocketAddress("localhost", 0));
-            return socket.socket().getLocalPort();
-        }
-    }
-
 }

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/state/ITRedisStateProvider.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/state/ITRedisStateProvider.java
@@ -23,6 +23,7 @@ import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.components.state.StateProvider;
 import org.apache.nifi.components.state.StateProviderInitializationContext;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.redis.service.ITRedisDistributedMapCacheClientService;
 import org.apache.nifi.redis.testcontainers.RedisContainer;
 import org.apache.nifi.redis.util.RedisUtils;
 import org.apache.nifi.util.MockComponentLog;
@@ -56,7 +57,7 @@ public class ITRedisStateProvider {
     protected final String componentId = "111111111-1111-1111-1111-111111111111";
 
     @Container
-    public RedisContainer redisContainer = new RedisContainer("redis:7.0.12-alpine")
+    public RedisContainer redisContainer = new RedisContainer(ITRedisDistributedMapCacheClientService.CONTAINER_IMAGE_TAG)
             .withExposedPorts(6379);
 
     private RedisStateProvider provider;

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisContainer.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisContainer.java
@@ -107,7 +107,7 @@ public class RedisContainer extends GenericContainer<RedisContainer> {
 
             return configFile;
         } catch (IOException ioException) {
-            throw new IllegalStateException("Cannot start container because configuration could not be written!", ioException);
+            throw new IllegalStateException("Cannot start container because configuration could not be written", ioException);
         }
     }
 }

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisContainer.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisContainer.java
@@ -1,0 +1,97 @@
+package org.apache.nifi.redis.testcontainers;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class RedisContainer extends GenericContainer<RedisContainer> {
+
+    public static final int REDIS_PORT = 6379;
+
+    public RedisContainer(@NonNull DockerImageName dockerImageName) {
+        super(dockerImageName);
+    }
+
+    public RedisContainer(@NonNull String fullImageName) {
+        this(DockerImageName.parse(fullImageName));
+    }
+
+    public int port = REDIS_PORT;
+
+    @Nullable
+    protected String password = null;
+    @Nullable
+    protected Path configurationMountDirectory = null;
+
+    protected final List<String> configurationOptions = new ArrayList<>();
+
+    public void setPassword(final @Nullable String password) {
+        this.password = password;
+    }
+
+    public void setPort(final int port) {
+        this.port = port;
+    }
+
+    public void mountConfigurationFrom(final Path mountDirectory) {
+        this.configurationMountDirectory = mountDirectory;
+    }
+
+    public void addConfigurationOption(final String configurationOption) {
+        this.configurationOptions.add(configurationOption);
+    }
+
+    protected void adjustConfiguration() {
+        addConfigurationOption("port " + port);
+
+        if (password != null) {
+            addConfigurationOption("requirepass " + password);
+        }
+    }
+
+    /**
+     * Sets up a static binding between a port on the host and one in the container.
+     * In order for auto-discovery mechanisms of Redis to work, 1-to-1 mapped ports are useful.
+     */
+    public void addPortBinding(int hostPort, int containerPort) {
+        addFixedExposedPort(hostPort, containerPort);
+    }
+
+    @Override
+    protected void configure() {
+        adjustConfiguration();
+
+        Path configurationFilePath = writeConfigurationFile().toAbsolutePath();
+        String hostPath = configurationFilePath.toString();
+        String containerPath = "/usr/local/etc/redis/redis.conf";
+        addFileSystemBind(hostPath, containerPath, BindMode.READ_WRITE);
+
+        setCommand(containerPath);
+    }
+
+    protected Path writeConfigurationFile() {
+        try {
+            Path mountDirectory = this.configurationMountDirectory;
+            if (mountDirectory == null) {
+                mountDirectory = Files.createTempDirectory("redis-container-configuration");
+            }
+
+            Path configFile = mountDirectory.resolve("redis-" + UUID.randomUUID() + ".conf");
+            Files.write(configFile, configurationOptions, StandardCharsets.UTF_8);
+
+            return configFile;
+        } catch (IOException ioException) {
+            throw new IllegalStateException("Cannot start container because configuration could not be written!", ioException);
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisContainer.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisContainer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.nifi.redis.testcontainers;
 
 import org.springframework.lang.NonNull;

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisReplicaContainer.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisReplicaContainer.java
@@ -1,0 +1,44 @@
+package org.apache.nifi.redis.testcontainers;
+
+import org.springframework.lang.NonNull;
+import org.testcontainers.utility.DockerImageName;
+
+public class RedisReplicaContainer extends RedisContainer {
+
+    public RedisReplicaContainer(@NonNull DockerImageName dockerImageName) {
+        super(dockerImageName);
+    }
+
+    public RedisReplicaContainer(@NonNull String fullImageName) {
+        this(DockerImageName.parse(fullImageName));
+    }
+
+    @NonNull
+    protected String masterHost = "localhost";
+    protected int masterPort = REDIS_PORT;
+
+    public void setMasterHost(@NonNull String masterHost) {
+        this.masterHost = masterHost;
+    }
+
+    public void setMasterPort(int masterPort) {
+        this.masterPort = masterPort;
+    }
+
+    public void setReplicaOf(@NonNull String masterHost, int masterPort) {
+        setMasterHost(masterHost);
+        setMasterPort(masterPort);
+    }
+
+    @Override
+    protected void adjustConfiguration() {
+        addConfigurationOption("port " + port);
+        
+        if (password != null) {
+            addConfigurationOption("requirepass " + password);
+            addConfigurationOption("masterauth " + password);
+        }
+
+        addConfigurationOption("replicaof " + masterHost + " " + masterPort);
+    }
+}

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisReplicaContainer.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisReplicaContainer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.nifi.redis.testcontainers;
 
 import org.springframework.lang.NonNull;
@@ -33,7 +49,7 @@ public class RedisReplicaContainer extends RedisContainer {
     @Override
     protected void adjustConfiguration() {
         addConfigurationOption("port " + port);
-        
+
         if (password != null) {
             addConfigurationOption("requirepass " + password);
             addConfigurationOption("masterauth " + password);

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisSentinelContainer.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisSentinelContainer.java
@@ -1,0 +1,99 @@
+package org.apache.nifi.redis.testcontainers;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RedisSentinelContainer extends RedisContainer {
+
+    public static final int REDIS_SENTINEL_PORT = 26379;
+
+    public RedisSentinelContainer(final @NonNull DockerImageName dockerImageName) {
+        super(dockerImageName);
+
+        setPort(REDIS_SENTINEL_PORT);
+    }
+
+    public RedisSentinelContainer(final @NonNull String fullImageName) {
+        this(DockerImageName.parse(fullImageName));
+    }
+
+    @NonNull
+    protected String masterHost = "localhost";
+    protected int masterPort = REDIS_PORT;
+    @NonNull
+    protected String masterName = "mymaster";
+    @Nullable
+    protected String sentinelPassword = null;
+    private long downAfterMilliseconds = 60000L;
+    private long failoverTimeout = 180000L;
+    private int parallelSyncs = 1;
+    private int quorumSize = 1;
+
+    public void setMasterHost(final @NonNull String masterHost) {
+        this.masterHost = masterHost;
+    }
+
+    public void setMasterPort(final int masterPort) {
+        this.masterPort = masterPort;
+    }
+
+    public void setMasterName(final @NonNull String masterName) {
+        this.masterName = masterName;
+    }
+
+    public void setSentinelPassword(final @Nullable String sentinelPassword) {
+        this.sentinelPassword = sentinelPassword;
+    }
+
+    public void setQuorumSize(final int quorumSize) {
+        this.quorumSize = quorumSize;
+    }
+
+    public void setDownAfterMilliseconds(final long downAfterMilliseconds) {
+        this.downAfterMilliseconds = downAfterMilliseconds;
+    }
+
+    public void setFailoverTimeout(final long failoverTimeout) {
+        this.failoverTimeout = failoverTimeout;
+    }
+
+    public void setParallelSyncs(final int parallelSyncs) {
+        this.parallelSyncs = parallelSyncs;
+    }
+
+
+    @Override
+    protected void adjustConfiguration() {
+        addConfigurationOption("port " + port);
+
+        addConfigurationOption(String.format("sentinel monitor %s %s %d %d", masterName, masterHost, masterPort, quorumSize));
+        addConfigurationOption(String.format("sentinel down-after-milliseconds %s %d", masterName, downAfterMilliseconds));
+        addConfigurationOption(String.format("sentinel failover-timeout %s %d", masterName, failoverTimeout));
+        addConfigurationOption(String.format("sentinel parallel-syncs %s %d", masterName, parallelSyncs));
+
+        if (password != null) {
+            addConfigurationOption("sentinel auth-pass " + masterName + " " + password);
+        }
+        if (sentinelPassword != null) {
+            addConfigurationOption("requirepass " + sentinelPassword);
+            addConfigurationOption("sentinel sentinel-pass " + sentinelPassword);
+        }
+    }
+
+    @Override
+    protected void configure() {
+        super.configure();
+
+        System.err.println("SENTINEL AT PORT " + port);
+        System.err.println(configurationOptions);
+
+        List<String> commandParts = new ArrayList<>(Arrays.asList(getCommandParts()));
+        commandParts.add("--sentinel");
+        setCommandParts(commandParts.toArray(new String[0]));
+    }
+}

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisSentinelContainer.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisSentinelContainer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.nifi.redis.testcontainers;
 
 import org.springframework.lang.NonNull;

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisSentinelContainer.java
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/testcontainers/RedisSentinelContainer.java
@@ -105,8 +105,6 @@ public class RedisSentinelContainer extends RedisContainer {
     protected void configure() {
         super.configure();
 
-        System.err.println("SENTINEL AT PORT " + port);
-        System.err.println(configurationOptions);
 
         List<String> commandParts = new ArrayList<>(Arrays.asList(getCommandParts()));
         commandParts.add("--sentinel");


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-8128](https://issues.apache.org/jira/browse/NIFI-8128)

In order to reproduce the issue in a test case the Redis Sentinel setting `sentinel auth-pass` is required, which is only available in a newer Redis server binary as the one bundled into the `com.github.kstyrc:embedded-redis` dependency.
Thus I bundled a more recent binary (for Linux only).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
