### PR TITLE
NIFI-11822 Upgrade Okio to 3.4.0 for OkHttp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
         <io.fabric8.kubernetes.client.version>6.5.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>1.8.20</kotlin.version>
         <okhttp.version>4.11.0</okhttp.version>
+        <okio.version>3.4.0</okio.version>
         <org.apache.commons.cli.version>1.5.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.16.0</org.apache.commons.codec.version>
         <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>
@@ -683,6 +684,11 @@
                 <version>${okhttp.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>${okio.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
# Summary

[NIFI-11822](https://issues.apache.org/jira/browse/NIFI-11822) Upgrades Okio to [3.4.0](https://github.com/square/okio/blob/master/CHANGELOG.md#version-340) to resolve CVE-2023-3635 related to Gzip buffer handling. Okio supports OkHttp client HTTP requests and responses for framework and extension components. The change adds a managed dependency version in the parent Maven configuration to set the version for all project modules.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
