### PR TITLE
NIFI-11828 - Confluent Schema Encoding Access Strategy - Schema ID versus Schema Version ID

### DIFF
--- a/nifi-nar-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
+++ b/nifi-nar-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
@@ -296,7 +296,7 @@ public class ConfluentSchemaRegistry extends AbstractControllerService implement
     }
 
     private RecordSchema retrieveSchemaById(final SchemaIdentifier schemaIdentifier) throws IOException, SchemaNotFoundException {
-        final OptionalLong schemaId = schemaIdentifier.getIdentifier();
+        final OptionalLong schemaId = schemaIdentifier.getSchemaVersionId();
         if (!schemaId.isPresent()) {
             throw new org.apache.nifi.schema.access.SchemaNotFoundException("Cannot retrieve schema because Schema Id is not present");
         }

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/access/ConfluentSchemaRegistryStrategy.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/schema/access/ConfluentSchemaRegistryStrategy.java
@@ -54,7 +54,7 @@ public class ConfluentSchemaRegistryStrategy implements SchemaAccessStrategy {
 
         // This encoding follows the pattern that is provided for serializing data by the Confluent Schema Registry serializer
         // as it is provided at:
-        // http://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
+        // https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
         // The format consists of the first byte always being 0, to indicate a 'magic byte' followed by 4 bytes
         // representing the schema id.
         final ByteBuffer bb = ByteBuffer.wrap(buffer);
@@ -67,7 +67,7 @@ public class ConfluentSchemaRegistryStrategy implements SchemaAccessStrategy {
         final int schemaId = bb.getInt();
 
         final SchemaIdentifier schemaIdentifier = SchemaIdentifier.builder()
-                .id(Long.valueOf(schemaId))
+                .schemaVersionId(Long.valueOf(schemaId))
                 .version(1)
                 .build();
 

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/test/java/org/apache/nifi/schema/access/TestConfluentSchemaRegistryStrategy.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/test/java/org/apache/nifi/schema/access/TestConfluentSchemaRegistryStrategy.java
@@ -49,7 +49,7 @@ public class TestConfluentSchemaRegistryStrategy extends AbstractSchemaAccessStr
 
                 // the confluent strategy will read the id from the input stream and use '1' as the version
                 final SchemaIdentifier expectedSchemaIdentifier = SchemaIdentifier.builder()
-                        .id((long)schemaId)
+                        .schemaVersionId((long)schemaId)
                         .version(1)
                         .build();
 


### PR DESCRIPTION
# Summary

[NIFI-11828](https://issues.apache.org/jira/browse/NIFI-11828)

When we're using the Confluent Schema Encoding access strategy, we're currently retrieving the schema ID from the bytes at the beginning of the message and we're creating a Schema Identifier that is set with the Schema ID when it should actually use the Schema Version ID.

This bug may cause issues when trying to interoperate the Confluent Schema Encoding with different Schema Registries.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
