### PR TITLE
NIFI-11825 - QueryRecord processor; fix for failure to close resources

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/calcite/RecordResultSetOutputStreamCallback.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/calcite/RecordResultSetOutputStreamCallback.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.calcite;
+
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.io.OutputStreamCallback;
+import org.apache.nifi.schema.access.SchemaNotFoundException;
+import org.apache.nifi.serialization.RecordSetWriter;
+import org.apache.nifi.serialization.RecordSetWriterFactory;
+import org.apache.nifi.serialization.WriteResult;
+import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.serialization.record.ResultSetRecordSet;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class RecordResultSetOutputStreamCallback implements OutputStreamCallback {
+    private final ComponentLog logger;
+    private final ResultSet rs;
+    private final RecordSchema writerSchema;
+    private final Integer defaultPrecision;
+    private final Integer defaultScale;
+    private final RecordSetWriterFactory recordSetWriterFactory;
+    private final Map<String, String> originalAttributes;
+    private final AtomicReference<WriteResult> writeResultRef;
+    private final AtomicReference<String> mimeTypeRef;
+
+    public RecordResultSetOutputStreamCallback(
+            final ComponentLog logger, final ResultSet rs, final RecordSchema writerSchema,
+            final Integer defaultPrecision, final Integer defaultScale,
+            final RecordSetWriterFactory recordSetWriterFactory, final Map<String, String> originalAttributes,
+            final AtomicReference<WriteResult> writeResultRef, final AtomicReference<String> mimeTypeRef) {
+        this.logger = logger;
+        this.rs = rs;
+        this.writerSchema = writerSchema;
+        this.defaultPrecision = defaultPrecision;
+        this.defaultScale = defaultScale;
+        this.recordSetWriterFactory = recordSetWriterFactory;
+        this.originalAttributes = originalAttributes;
+        this.writeResultRef = writeResultRef;
+        this.mimeTypeRef = mimeTypeRef;
+    }
+
+    @Override
+    public void process(OutputStream out) throws IOException {
+        final RecordSchema writeSchema;
+
+        try (final ResultSetRecordSet recordSet = new ResultSetRecordSet(rs, writerSchema, defaultPrecision, defaultScale)) {
+            final RecordSchema resultSetSchema = recordSet.getSchema();
+            writeSchema = recordSetWriterFactory.getSchema(originalAttributes, resultSetSchema);
+
+            try (final RecordSetWriter resultSetWriter = recordSetWriterFactory.createWriter(logger, writeSchema, out, originalAttributes)) {
+                writeResultRef.set(resultSetWriter.write(recordSet));
+                mimeTypeRef.set(resultSetWriter.getMimeType());
+            } catch (final Exception e) {
+                throw new IOException(e);
+            }
+        } catch (final SQLException | SchemaNotFoundException e) {
+            throw new ProcessException(e);
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/calcite/TestRecordResultSetOutputStreamCallback.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/calcite/TestRecordResultSetOutputStreamCallback.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.calcite;
+
+import org.apache.calcite.adapter.java.ReflectiveSchema;
+import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.nifi.csv.CSVRecordSetWriter;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processors.standard.QueryRecord;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.RecordSetWriterFactory;
+import org.apache.nifi.serialization.SimpleRecordSchema;
+import org.apache.nifi.serialization.WriteResult;
+import org.apache.nifi.serialization.record.RecordField;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestRecordResultSetOutputStreamCallback {
+
+    @Test
+    void testResultSetClosed() throws IOException, SQLException, ClassNotFoundException, InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(QueryRecord.class);
+
+        final String writerId = "record-writer";
+        runner.setProperty(writerId, writerId);
+
+        final RecordSetWriterFactory writerService = new CSVRecordSetWriter();
+        runner.addControllerService(writerId, writerService);
+        runner.setProperty(writerService, "schema-access-strategy", "inherit-record-schema");
+        runner.enableControllerService(writerService);
+
+        final ResultSet resultSet = getResultSet();
+
+        final RecordField fieldFirst = new RecordField("first", RecordFieldType.STRING.getDataType());
+        final RecordField fieldLast = new RecordField("last", RecordFieldType.STRING.getDataType());
+        final RecordSchema writerSchema = new SimpleRecordSchema(Arrays.asList(fieldFirst, fieldLast));
+
+        final FlowFile flowFile = mock(FlowFile.class);
+        when(flowFile.getAttributes()).thenReturn(new LinkedHashMap<>());
+
+        final AtomicReference<WriteResult> writeResultRef = new AtomicReference<>();
+        final AtomicReference<String> mimeTypeRef = new AtomicReference<>();
+
+        final RecordResultSetOutputStreamCallback writer = new RecordResultSetOutputStreamCallback(runner.getLogger(),
+                resultSet, writerSchema, 0, 0, writerService, flowFile.getAttributes(), writeResultRef, mimeTypeRef);
+
+        final OutputStream os = new ByteArrayOutputStream();
+        writer.process(os);
+
+        Assertions.assertTrue(resultSet.isClosed());
+    }
+
+    private ResultSet getResultSet() throws ClassNotFoundException, SQLException {
+        Class.forName("org.apache.calcite.jdbc.Driver");
+        final Connection connection = DriverManager.getConnection("jdbc:calcite:");
+        final CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class);
+        calciteConnection.getRootSchema().add("TEST", new ReflectiveSchema(new CalciteTestSchema()));
+        final Statement statement = calciteConnection.createStatement();
+        return statement.executeQuery("SELECT * FROM TEST.PERSONS");
+    }
+
+    @SuppressWarnings("ClassCanBeRecord")
+    public static class Person {
+        public final String first;
+        public final String last;
+
+        public Person(final String first, final String last) {
+            this.first = first;
+            this.last = last;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class CalciteTestSchema extends AbstractSchema {
+        public Person[] PERSONS = { new Person("Joe", "Smith"), new Person("Bob", "Jones") };
+    }
+}


### PR DESCRIPTION
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
