### PR TITLE
NIFI-11829 Upgrade Spring Framework from 5.3.28 to 5.3.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <netty.4.version>4.1.94.Final</netty.4.version>
-        <spring.version>5.3.28</spring.version>
-        <spring.security.version>5.8.4</spring.security.version>
+        <spring.version>5.3.29</spring.version>
+        <spring.security.version>5.8.5</spring.security.version>
         <swagger.annotations.version>1.6.11</swagger.annotations.version>
         <h2.version>2.2.220</h2.version>
         <zookeeper.version>3.8.1</zookeeper.version>


### PR DESCRIPTION
# Summary

[NIFI-11829](https://issues.apache.org/jira/browse/NIFI-11829) Upgrades Spring Framework dependencies from 5.3.28 to [5.3.29](https://github.com/spring-projects/spring-framework/releases/tag/v5.3.29) and Spring Security from 5.8.4 to [5.8.5](https://github.com/spring-projects/spring-security/releases/tag/5.8.5).

Spring Security 5.8.5 resolves CVE-2023-34034 and CVE-2023-34035 related to specialized request matching for WebFlux and application resources. Apache NiFi does not use Spring WebFlux or request matchers in the ways described in vulnerability announcements.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
