### PR TITLE
NIFI-11834 Move Riemann and HBase 1.1.2 to optional profiles

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -506,18 +506,6 @@ language governing permissions and limitations under the License. -->
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-riemann-nar</artifactId>
-            <version>1.23.0-SNAPSHOT</version>
-            <type>nar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-hbase_1_1_2-client-service-nar</artifactId>
-            <version>1.23.0-SNAPSHOT</version>
-            <type>nar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hbase_2-client-service-nar</artifactId>
             <version>1.23.0-SNAPSHOT</version>
             <type>nar</type>
@@ -1090,6 +1078,23 @@ language governing permissions and limitations under the License. -->
             </dependencies>
         </profile>
         <profile>
+            <id>include-hbase1_1_2</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>allProfiles</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-hbase_1_1_2-client-service-nar</artifactId>
+                    <version>1.23.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>include-hive</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -1563,6 +1568,23 @@ language governing permissions and limitations under the License. -->
                 <dependency>
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-asn1-nar</artifactId>
+                    <version>1.23.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>include-riemann</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>allProfiles</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-riemann-nar</artifactId>
                     <version>1.23.0-SNAPSHOT</version>
                     <type>nar</type>
                 </dependency>

--- a/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -2721,21 +2721,23 @@ deprecationLogger.warn(
 
 [options="header,footer"]
 |==================================================================================================================================================
-| Package                | Maven Profile         | Description
-| Apache Accumulo Bundle | include-accumulo      | Adds support for https://accumulo.apache.org[Apache Accumulo].
-| Apache Atlas Bundle    | include-atlas         | Adds support for the Apache Atlas data governance tool. The functionality from this bundle is based around reporting tasks that integrate with https://atlas.apache.org[Apache Atlas].
-| Apache Hive 1.1 Bundle | include-hive1_1       | Adds support for Apache Hive 1.1.X
-| Apache Hive 3 Bundle   | include-hive3         | Adds support for Apache Hive 3.X
-| Apache IoTDB Bundle    | include-iotdb         | Adds support for Apache IoTDB
-| Apache Ranger Bundle   | include-ranger        | Adds support for https://ranger.apache.org[Apache Ranger].
-| ASN.1 Support          | include-asn1          | Adds support for ASN.1
-| Contribution Check     | contrib-check         | Runs various quality checks that are required to be accepted before a contribution can be accepted into the core NiFi code base.
-| Graph Database Bundle  | include-graph         | Adds support for various common graph database scenarios. Support is currently for https://neo4j.com/developer/cypher[Cypher] and https://tinkerpop.apache.org/gremlin.html[Gremlin]-compatible databases such as Neo4J and JanusGraph. Includes controller services that provide driver functionality and a suite of processors for ingestion and querying.
-| GRPC Bundle            | include-grpc          | **This profile is active in official builds and should be active** Provides support for the GRPC protocol.
-| Media Bundle           | include-media         | The media bundle provides functionality based on https://tika.apache.org[Apache Tika] for extracting content and metadata from various types of binary formats supported by Apache Tika (ex. PDF, Microsoft Office).
-| Rules Engine Bundle    | include-rules         | Adds support for creating scripted rules engines that can be integrated into existing flows. These rules engines can provide flexibility to people who need more complex flow logic or are more comfortable with flow decision-making using custom code.
-| Snowflake Bundle       | include-snowflake     | Adds support for integration with the https://www.snowflake.com[Snowflake platform].
-| SQL Reporting Bundle   | include-sql-reporting | Adds reporting tasks that are designed to use SQL to update a RDBMS with metrics and other related data from Apache NiFi.
+| Package                   | Maven Profile         | Description
+| Apache Accumulo Bundle    | include-accumulo      | Adds support for https://accumulo.apache.org[Apache Accumulo].
+| Apache Atlas Bundle       | include-atlas         | Adds support for the Apache Atlas data governance tool. The functionality from this bundle is based around reporting tasks that integrate with https://atlas.apache.org[Apache Atlas].
+| Apache HBase 1.1.2 Bundle | include-hbase1_1_2    | Adds support for Apache HBase 1.1.2
+| Apache Hive 1.1 Bundle    | include-hive1_1       | Adds support for Apache Hive 1.1.X
+| Apache Hive 3 Bundle      | include-hive3         | Adds support for Apache Hive 3.X
+| Apache IoTDB Bundle       | include-iotdb         | Adds support for Apache IoTDB
+| Apache Ranger Bundle      | include-ranger        | Adds support for https://ranger.apache.org[Apache Ranger].
+| ASN.1 Support             | include-asn1          | Adds support for ASN.1
+| Contribution Check        | contrib-check         | Runs various quality checks that are required to be accepted before a contribution can be accepted into the core NiFi code base.
+| Graph Database Bundle     | include-graph         | Adds support for various common graph database scenarios. Support is currently for https://neo4j.com/developer/cypher[Cypher] and https://tinkerpop.apache.org/gremlin.html[Gremlin]-compatible databases such as Neo4J and JanusGraph. Includes controller services that provide driver functionality and a suite of processors for ingestion and querying.
+| GRPC Bundle               | include-grpc          | **This profile is active in official builds and should be active** Provides support for the GRPC protocol.
+| Media Bundle              | include-media         | The media bundle provides functionality based on https://tika.apache.org[Apache Tika] for extracting content and metadata from various types of binary formats supported by Apache Tika (ex. PDF, Microsoft Office).
+| Riemann Bundle            | include-riemann       | Adds support for Riemann database components
+| Rules Engine Bundle       | include-rules         | Adds support for creating scripted rules engines that can be integrated into existing flows. These rules engines can provide flexibility to people who need more complex flow logic or are more comfortable with flow decision-making using custom code.
+| Snowflake Bundle          | include-snowflake     | Adds support for integration with the https://www.snowflake.com[Snowflake platform].
+| SQL Reporting Bundle      | include-sql-reporting | Adds reporting tasks that are designed to use SQL to update a RDBMS with metrics and other related data from Apache NiFi.
 |==================================================================================================================================================
 
 === Standard Build Instructions


### PR DESCRIPTION
# Summary

[NIFI-11834](https://issues.apache.org/jira/browse/NIFI-11834) Moves Riemann and HBase 1.1.2 bundles to optional build profiles named `include-riemann` and `include-hbase1_1_2`. This change is necessary for the NiFi 1 support branch to avoid exceeding the maximum binary size of 1.5 GB for the nifi-assembly.

The HBase 1.1.2 bundle has been removed from the main branch, but the Riemann bundle is still available, so this change could be carried forward to the main branch with just the Riemann bundle changes.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
