### PR TITLE
NIFI-11848 Allocate unused port in TlsCertificateAuthorityTest

### DIFF
--- a/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/service/TlsCertificateAuthorityTest.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/service/TlsCertificateAuthorityTest.java
@@ -23,7 +23,6 @@ import org.apache.nifi.security.util.KeystoreType;
 import org.apache.nifi.toolkit.tls.configuration.TlsClientConfig;
 import org.apache.nifi.toolkit.tls.configuration.TlsConfig;
 import org.apache.nifi.toolkit.tls.service.client.TlsCertificateAuthorityClient;
-import org.apache.nifi.toolkit.tls.service.client.TlsCertificateAuthorityClientCommandLine;
 import org.apache.nifi.toolkit.tls.service.server.TlsCertificateAuthorityService;
 import org.apache.nifi.toolkit.tls.standalone.TlsToolkitStandalone;
 import org.apache.nifi.toolkit.tls.util.InputStreamFactory;
@@ -100,10 +99,12 @@ public class TlsCertificateAuthorityTest {
         serverConfig.setCaHostname("localhost");
         serverConfig.setToken(myTestTokenUseSomethingStronger);
         serverConfig.setKeyStore(serverKeyStore);
-        serverConfig.setPort(0);
         serverConfig.setDays(5);
         serverConfig.setKeySize(2048);
         serverConfig.initDefaults();
+
+        // set port back to 0, so Jetty will allocate a free port
+        serverConfig.setPort(0);
 
         clientConfig = new TlsClientConfig();
         clientConfig.setCaHostname("localhost");
@@ -112,7 +113,6 @@ public class TlsCertificateAuthorityTest {
         clientConfig.setTrustStore(clientTrustStore);
         clientConfig.setToken(myTestTokenUseSomethingStronger);
         clientConfig.setDomainAlternativeNames(Collections.singletonList(subjectAlternativeName));
-        clientConfig.setPort(0);
         clientConfig.setKeySize(2048);
         clientConfig.initDefaults();
 
@@ -146,6 +146,7 @@ public class TlsCertificateAuthorityTest {
         try {
             tlsCertificateAuthorityService = new TlsCertificateAuthorityService(outputStreamFactory);
             tlsCertificateAuthorityService.start(serverConfig, serverConfigFile.getAbsolutePath(), true);
+            clientConfig.setPort(tlsCertificateAuthorityService.getPort());
             TlsCertificateAuthorityClient tlsCertificateAuthorityClient = new TlsCertificateAuthorityClient(outputStreamFactory);
             tlsCertificateAuthorityClient.generateCertificateAndGetItSigned(clientConfig, null, clientConfigFile.getAbsolutePath(), true);
             validate();
@@ -162,6 +163,7 @@ public class TlsCertificateAuthorityTest {
         try {
             tlsCertificateAuthorityService = new TlsCertificateAuthorityService(outputStreamFactory);
             tlsCertificateAuthorityService.start(serverConfig, serverConfigFile.getAbsolutePath(), false);
+            clientConfig.setPort(tlsCertificateAuthorityService.getPort());
             TlsCertificateAuthorityClient tlsCertificateAuthorityClient = new TlsCertificateAuthorityClient(outputStreamFactory);
             tlsCertificateAuthorityClient.generateCertificateAndGetItSigned(clientConfig, null, clientConfigFile.getAbsolutePath(), false);
             validate();
@@ -180,8 +182,8 @@ public class TlsCertificateAuthorityTest {
         try {
             tlsCertificateAuthorityService = new TlsCertificateAuthorityService(outputStreamFactory);
             tlsCertificateAuthorityService.start(serverConfig, serverConfigFile.getAbsolutePath(), false);
+            clientConfig.setPort(tlsCertificateAuthorityService.getPort());
             TlsCertificateAuthorityClient tlsCertificateAuthorityClient = new TlsCertificateAuthorityClient(outputStreamFactory);
-            new TlsCertificateAuthorityClientCommandLine(inputStreamFactory);
             tlsCertificateAuthorityClient.generateCertificateAndGetItSigned(clientConfig, null, clientConfigFile.getAbsolutePath(), true);
             validate();
         } finally {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11848](https://issues.apache.org/jira/browse/NIFI-11848)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
