### PR TITLE
NIFI-11780 Add Certificate SAN Attributes to HandleHttpRequest

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/CertificateAttribute.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/CertificateAttribute.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.http;
+
+/**
+ * X.509 Client Certificate FlowFile Attribute Names
+ */
+public enum CertificateAttribute {
+    /** Certificate Subject Distinguished Name */
+    HTTP_SUBJECT_DN("http.subject.dn"),
+
+    /** Certificate Issuer Distinguished Name */
+    HTTP_ISSUER_DN("http.issuer.dn"),
+
+    /** Certificate Subject Distinguished Name */
+    HTTP_CERTIFICATE_PARSING_EXCEPTION("http.certificate.parsing.exception"),
+
+    /** Certificate Subject Alternative Names */
+    HTTP_CERTIFICATE_SANS("http.certificate.sans");
+
+    private final String name;
+
+    CertificateAttribute(final String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/CertificateAttributesProvider.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/CertificateAttributesProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.http;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+/**
+ * Provider abstraction for reading X.509 Client Certificates from an HTTP Servlet Request and returning FlowFile attributes
+ */
+public interface CertificateAttributesProvider {
+    /**
+     * Get X.509 Client Certificate Attributes
+     *
+     * @param request HTTP Servlet Request
+     * @return Map of Client Certificate Attributes or empty when no client certificate found
+     */
+    Map<String, String> getCertificateAttributes(HttpServletRequest request);
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/HandleHttpRequestCertificateAttributesProvider.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/HandleHttpRequestCertificateAttributesProvider.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.http;
+
+import javax.servlet.http.HttpServletRequest;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Certificate Attributes Provider for HandleHttpRequest reads the first X.509 Certificate presented
+ */
+public class HandleHttpRequestCertificateAttributesProvider implements CertificateAttributesProvider {
+    protected static final String REQUEST_CERTIFICATES_ATTRIBUTE_NAME = "javax.servlet.request.X509Certificate";
+
+    private static final String SAN_NAME_TYPE_FORMAT = "%s.%d.nameType";
+
+    private static final String SAN_NAME_FORMAT = "%s.%d.name";
+
+    private static final Map<String, String> GENERAL_NAME_TYPES = new LinkedHashMap<>();
+
+    static {
+        // General Name types defined in RFC 3280 Section 4.2.1.7 */
+        GENERAL_NAME_TYPES.put("0", "otherName");
+        GENERAL_NAME_TYPES.put("1", "rfc822Name");
+        GENERAL_NAME_TYPES.put("2", "dNSName");
+        GENERAL_NAME_TYPES.put("3", "x400Address");
+        GENERAL_NAME_TYPES.put("4", "directoryName");
+        GENERAL_NAME_TYPES.put("5", "ediPartyName");
+        GENERAL_NAME_TYPES.put("6", "uniformResourceIdentifier");
+        GENERAL_NAME_TYPES.put("7", "iPAddress");
+        GENERAL_NAME_TYPES.put("8", "registeredID");
+    }
+
+    @Override
+    public Map<String, String> getCertificateAttributes(final HttpServletRequest request) {
+        Objects.requireNonNull(request, "HTTP Servlet Request required");
+
+        final Map<String, String> attributes;
+
+        final Object requestCertificates = request.getAttribute(REQUEST_CERTIFICATES_ATTRIBUTE_NAME);
+        if (requestCertificates instanceof X509Certificate[]) {
+            final X509Certificate[] certificates = (X509Certificate[]) requestCertificates;
+            if (certificates.length == 0) {
+                attributes = Collections.emptyMap();
+            } else {
+                final X509Certificate clientCertificate = certificates[0];
+                attributes = getCertificateAttributes(clientCertificate);
+            }
+        } else {
+            attributes = Collections.emptyMap();
+        }
+
+        return attributes;
+    }
+
+    private Map<String, String> getCertificateAttributes(final X509Certificate certificate) {
+        final Map<String, String> attributes = new LinkedHashMap<>();
+
+        final String subjectPrincipal = certificate.getSubjectX500Principal().getName();
+        final String issuerPrincipal = certificate.getIssuerX500Principal().getName();
+
+        attributes.put(CertificateAttribute.HTTP_SUBJECT_DN.getName(), subjectPrincipal);
+        attributes.put(CertificateAttribute.HTTP_ISSUER_DN.getName(), issuerPrincipal);
+
+        try {
+            final Collection<List<?>> subjectAlternativeNames = certificate.getSubjectAlternativeNames();
+
+            if (subjectAlternativeNames != null) {
+                final Map<String, String> subjectAlternativeNameAttributes = getSubjectAlternativeNameAttributes(subjectAlternativeNames);
+                attributes.putAll(subjectAlternativeNameAttributes);
+            }
+        } catch (final CertificateParsingException e) {
+            attributes.put(CertificateAttribute.HTTP_CERTIFICATE_PARSING_EXCEPTION.getName(), e.getMessage());
+        }
+
+        return attributes;
+    }
+
+    private Map<String, String> getSubjectAlternativeNameAttributes(final Collection<List<?>> subjectAlternativeNames) {
+        final Map<String, String> attributes = new LinkedHashMap<>();
+
+        int subjectAlternativeNameIndex = 0;
+        for (final List<?> subjectAlternativeTypeName : subjectAlternativeNames) {
+            final String nameTypeAttributeKey = String.format(SAN_NAME_TYPE_FORMAT, CertificateAttribute.HTTP_CERTIFICATE_SANS.getName(), subjectAlternativeNameIndex);
+            final String nameType = subjectAlternativeTypeName.get(0).toString();
+            final String generalNameType = GENERAL_NAME_TYPES.getOrDefault(nameType, nameType);
+            attributes.put(nameTypeAttributeKey, generalNameType);
+
+            final String nameAttributeKey = String.format(SAN_NAME_FORMAT, CertificateAttribute.HTTP_CERTIFICATE_SANS.getName(), subjectAlternativeNameIndex);
+            final Object name = subjectAlternativeTypeName.get(1);
+            final String serializedName = getSerializedName(name);
+            attributes.put(nameAttributeKey, serializedName);
+
+            subjectAlternativeNameIndex++;
+        }
+
+        return attributes;
+    }
+
+    private String getSerializedName(final Object name) {
+        final String serializedName;
+        if (name instanceof byte[]) {
+            final byte[] encodedName = (byte[]) name;
+            serializedName = Base64.getEncoder().encodeToString(encodedName);
+        } else {
+            serializedName = name.toString();
+        }
+        return serializedName;
+    }
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/http/HandleHttpRequestCertificateAttributesProviderTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/http/HandleHttpRequestCertificateAttributesProviderTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.http;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.security.auth.x500.X500Principal;
+import javax.servlet.http.HttpServletRequest;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HandleHttpRequestCertificateAttributesProviderTest {
+    private static final X500Principal SUBJECT_PRINCIPAL = new X500Principal("CN=subject, OU=users");
+
+    private static final X500Principal ISSUER_PRINCIPAL = new X500Principal("CN=issuer, OU=authorities");
+
+    private static final String RFC_822_NAME_GENERAL_NAME = "rfc822Name";
+
+    private static final String DNS_NAME_GENERAL_NAME = "dNSName";
+
+    private static final Integer RFC_822_NAME_TYPE = 1;
+
+    private static final String EMAIL_ADDRESS = "username@localhost.localdomain";
+
+    private static final Integer DNS_NAME_TYPE = 2;
+
+    private static final String DNS_NAME = "localhost.localdomain";
+
+    private static final String FIRST_SAN_NAME_ATTRIBUTE_KEY = "http.certificate.sans.0.name";
+
+    private static final String FIRST_SAN_NAME_TYPE_ATTRIBUTE_KEY = "http.certificate.sans.0.nameType";
+
+    private static final String SECOND_SAN_NAME_ATTRIBUTE_KEY = "http.certificate.sans.1.name";
+
+    private static final String SECOND_SAN_NAME_TYPE_ATTRIBUTE_KEY = "http.certificate.sans.1.nameType";
+
+    private static final String PARSING_EXCEPTION_MESSAGE = "SAN parsing failed";
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private X509Certificate certificate;
+
+    private HandleHttpRequestCertificateAttributesProvider provider;
+
+    @BeforeEach
+    void setProvider() {
+        provider = new HandleHttpRequestCertificateAttributesProvider();
+    }
+
+    @Test
+    void testCertificatesNotFound() {
+        final Map<String, String> attributes = provider.getCertificateAttributes(request);
+
+        assertTrue(attributes.isEmpty());
+    }
+
+    @Test
+    void testCertificatesFound() {
+        final X509Certificate[] certificates = new X509Certificate[]{certificate};
+        when(request.getAttribute(eq(HandleHttpRequestCertificateAttributesProvider.REQUEST_CERTIFICATES_ATTRIBUTE_NAME))).thenReturn(certificates);
+
+        when(certificate.getSubjectX500Principal()).thenReturn(SUBJECT_PRINCIPAL);
+        when(certificate.getIssuerX500Principal()).thenReturn(ISSUER_PRINCIPAL);
+
+        final Map<String, String> attributes = provider.getCertificateAttributes(request);
+
+        assertSubjectIssuerFound(attributes);
+    }
+
+    @Test
+    void testCertificatesFoundParsingException() throws CertificateParsingException {
+        final X509Certificate[] certificates = new X509Certificate[]{certificate};
+        when(request.getAttribute(eq(HandleHttpRequestCertificateAttributesProvider.REQUEST_CERTIFICATES_ATTRIBUTE_NAME))).thenReturn(certificates);
+
+        when(certificate.getSubjectX500Principal()).thenReturn(SUBJECT_PRINCIPAL);
+        when(certificate.getIssuerX500Principal()).thenReturn(ISSUER_PRINCIPAL);
+
+        when(certificate.getSubjectAlternativeNames()).thenThrow(new CertificateParsingException(PARSING_EXCEPTION_MESSAGE));
+
+        final Map<String, String> attributes = provider.getCertificateAttributes(request);
+
+        assertSubjectIssuerFound(attributes);
+
+        assertEquals(attributes.get(CertificateAttribute.HTTP_CERTIFICATE_PARSING_EXCEPTION.getName()), PARSING_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    void testCertificateSubjectAlternativeNamesFound() throws CertificateParsingException {
+        final X509Certificate[] certificates = new X509Certificate[]{certificate};
+        when(request.getAttribute(eq(HandleHttpRequestCertificateAttributesProvider.REQUEST_CERTIFICATES_ATTRIBUTE_NAME))).thenReturn(certificates);
+
+        when(certificate.getSubjectX500Principal()).thenReturn(SUBJECT_PRINCIPAL);
+        when(certificate.getIssuerX500Principal()).thenReturn(ISSUER_PRINCIPAL);
+
+        final Collection<List<?>> subjectAlternativeNames = new ArrayList<>();
+
+        final List<?> emailAddressName = Arrays.asList(RFC_822_NAME_TYPE, EMAIL_ADDRESS);
+        subjectAlternativeNames.add(emailAddressName);
+
+        final List<?> dnsName = Arrays.asList(DNS_NAME_TYPE, DNS_NAME);
+        subjectAlternativeNames.add(dnsName);
+
+        when(certificate.getSubjectAlternativeNames()).thenReturn(subjectAlternativeNames);
+
+        final Map<String, String> attributes = provider.getCertificateAttributes(request);
+
+        assertSubjectIssuerFound(attributes);
+
+        assertEquals(attributes.get(FIRST_SAN_NAME_ATTRIBUTE_KEY), EMAIL_ADDRESS);
+        assertEquals(attributes.get(FIRST_SAN_NAME_TYPE_ATTRIBUTE_KEY), RFC_822_NAME_GENERAL_NAME);
+
+        assertEquals(attributes.get(SECOND_SAN_NAME_ATTRIBUTE_KEY), DNS_NAME);
+        assertEquals(attributes.get(SECOND_SAN_NAME_TYPE_ATTRIBUTE_KEY), DNS_NAME_GENERAL_NAME);
+    }
+
+    private void assertSubjectIssuerFound(final Map<String, String> attributes) {
+        assertEquals(SUBJECT_PRINCIPAL.getName(), attributes.get(CertificateAttribute.HTTP_SUBJECT_DN.getName()));
+        assertEquals(ISSUER_PRINCIPAL.getName(), attributes.get(CertificateAttribute.HTTP_ISSUER_DN.getName()));
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-11780](https://issues.apache.org/jira/browse/NIFI-11780) Adds X.509 Client Certificate Subject Alternative Name attributes to `HandleHttpRequest` FlowFiles.

`HandleHttpRequest` provides the certificate subject and issuer values when a client sends a request using mutual TLS, and these changes enumerate and add FlowFile attributes for all Subject Alternative Names. X.509 certificates may have zero or more Subject Alternative Names, so the implementation uses an indexed naming convention to include the SAN value and name type. [RFC 3280 Section 4.1.2.7](https://www.rfc-editor.org/rfc/rfc3280#section-4.2.1.7) defines standard General Name types for SANs, and the FlowFile attributes follow that naming convention. For example, a client certificate containing a DNS Name and an Email Address will produce the following attributes:

```
http.certificate.sans.0.name = username@localhost.localdomain
http.certificate.sans.0.nameType = rfc822Name
http.certificate.sans.1.name = localhost.localdomain
http.certificate.sans.1.nameType = dNSName
```
Attribute index ordering is based on the order defined in the client certificate itself.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
