### PR TITLE
NIFI-11853 Change Embedded QuestDB Tests to use JUnit5 TempDir

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/EmbeddedQuestDbStatusHistoryRepositoryForComponentsTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/EmbeddedQuestDbStatusHistoryRepositoryForComponentsTest.java
@@ -29,72 +29,67 @@ public class EmbeddedQuestDbStatusHistoryRepositoryForComponentsTest extends Abs
 
     @Test
     public void testReadingEmptyRepository() {
-        // when
-        final StatusHistory result = testSubject.getProcessGroupStatusHistory(ROOT_GROUP_ID, START, END, PREFERRED_DATA_POINTS);
+        final StatusHistory result = repository.getProcessGroupStatusHistory(ROOT_GROUP_ID, START, END, PREFERRED_DATA_POINTS);
 
-        // then
         assertStatusHistoryIsEmpty(result);
     }
 
     @Test
     public void testWritingThenReadingComponents() throws Exception {
-        // given
-        testSubject.capture(new NodeStatus(), givenRootProcessGroupStatus(), new ArrayList<>(), INSERTED_AT);
-        givenWaitUntilPersisted();
+        repository.capture(new NodeStatus(), givenRootProcessGroupStatus(), new ArrayList<>(), INSERTED_AT);
+        waitUntilPersisted();
 
-        // when & then - reading root processor group
-        final StatusHistory rootGroupStatus = testSubject.getProcessGroupStatusHistory(ROOT_GROUP_ID, START, END, PREFERRED_DATA_POINTS);
+        // reading root processor group
+        final StatusHistory rootGroupStatus = repository.getProcessGroupStatusHistory(ROOT_GROUP_ID, START, END, PREFERRED_DATA_POINTS);
         assertCorrectStatusHistory(rootGroupStatus, ROOT_GROUP_ID, "Root");
         assertRootProcessGroupStatusSnapshot(rootGroupStatus.getStatusSnapshots().get(0));
 
-        // when & then - reading child processor group
-        final StatusHistory childGroupStatus = testSubject.getProcessGroupStatusHistory(CHILD_GROUP_ID, START, END, PREFERRED_DATA_POINTS);
+        // reading child processor group
+        final StatusHistory childGroupStatus = repository.getProcessGroupStatusHistory(CHILD_GROUP_ID, START, END, PREFERRED_DATA_POINTS);
         assertCorrectStatusHistory(childGroupStatus, CHILD_GROUP_ID, "Child");
         assertChildProcessGroupStatusSnapshot(childGroupStatus.getStatusSnapshots().get(0));
 
-        //  when & then - reading processor (no-counter processor)
-        final StatusHistory processorStatus = testSubject.getProcessorStatusHistory(PROCESSOR_ID, START, END, PREFERRED_DATA_POINTS, false);
+        // reading processor (no-counter processor)
+        final StatusHistory processorStatus = repository.getProcessorStatusHistory(PROCESSOR_ID, START, END, PREFERRED_DATA_POINTS, false);
         assertCorrectStatusHistory(processorStatus, PROCESSOR_ID, "Processor");
         assertProcessorStatusSnapshot(processorStatus.getStatusSnapshots().get(0));
 
-        //  when & then - reading processor (with-counter processor)
-        final StatusHistory processorWithCounterStatus1 = testSubject.getProcessorStatusHistory(PROCESSOR_WITH_COUNTER_ID, START, END, PREFERRED_DATA_POINTS, false);
+        // reading processor (with-counter processor)
+        final StatusHistory processorWithCounterStatus1 = repository.getProcessorStatusHistory(PROCESSOR_WITH_COUNTER_ID, START, END, PREFERRED_DATA_POINTS, false);
         assertCorrectStatusHistory(processorWithCounterStatus1, PROCESSOR_WITH_COUNTER_ID, "ProcessorWithCounter");
         assertProcessorWithCounterStatusSnapshot(processorWithCounterStatus1.getStatusSnapshots().get(0), false);
 
-        //  when & then - reading processor (with-counter processor)
-        final StatusHistory processorWithCounterStatus2 = testSubject.getProcessorStatusHistory(PROCESSOR_WITH_COUNTER_ID, START, END, PREFERRED_DATA_POINTS, true);
+        // reading processor (with-counter processor)
+        final StatusHistory processorWithCounterStatus2 = repository.getProcessorStatusHistory(PROCESSOR_WITH_COUNTER_ID, START, END, PREFERRED_DATA_POINTS, true);
         assertCorrectStatusHistory(processorWithCounterStatus2, PROCESSOR_WITH_COUNTER_ID, "ProcessorWithCounter");
         assertProcessorWithCounterStatusSnapshot(processorWithCounterStatus2.getStatusSnapshots().get(0), true);
 
-        // when & then - reading connection
-        final StatusHistory connectionStatus = testSubject.getConnectionStatusHistory(CONNECTION_ID, START, END, PREFERRED_DATA_POINTS);
+        // reading connection
+        final StatusHistory connectionStatus = repository.getConnectionStatusHistory(CONNECTION_ID, START, END, PREFERRED_DATA_POINTS);
         assertCorrectStatusHistory(connectionStatus, CONNECTION_ID, "Connection");
         assertConnectionStatusSnapshot(connectionStatus.getStatusSnapshots().get(0));
 
-        // when & then - reading remote process group
-        final StatusHistory remoteProcessGroupStatus = testSubject.getRemoteProcessGroupStatusHistory(REMOTE_PROCESS_GROUP_ID, START, END, PREFERRED_DATA_POINTS);
+        // reading remote process group
+        final StatusHistory remoteProcessGroupStatus = repository.getRemoteProcessGroupStatusHistory(REMOTE_PROCESS_GROUP_ID, START, END, PREFERRED_DATA_POINTS);
         assertCorrectStatusHistory(remoteProcessGroupStatus, REMOTE_PROCESS_GROUP_ID, "RemoteProcessGroup");
         assertRemoteProcessGroupSnapshot(remoteProcessGroupStatus.getStatusSnapshots().get(0));
 
-        // when & then - requesting data from out of recorded range
-        final StatusHistory rootGroupStatus2 = testSubject.getProcessGroupStatusHistory(ROOT_GROUP_ID, START, END_EARLY, PREFERRED_DATA_POINTS);
+        // requesting data from out of recorded range
+        final StatusHistory rootGroupStatus2 = repository.getProcessGroupStatusHistory(ROOT_GROUP_ID, START, END_EARLY, PREFERRED_DATA_POINTS);
         assertStatusHistoryIsEmpty(rootGroupStatus2);
     }
 
     @Test
     public void testReadingLimitedByPreferredDataPoints() throws Exception {
-        // given
-        testSubject.capture(new NodeStatus(), givenSimpleRootProcessGroupStatus(), new ArrayList<>(), new Date(INSERTED_AT.getTime() - TimeUnit.MINUTES.toMillis(8)));
-        testSubject.capture(new NodeStatus(), givenSimpleRootProcessGroupStatus(), new ArrayList<>(), new Date(INSERTED_AT.getTime() - TimeUnit.MINUTES.toMillis(7)));
-        testSubject.capture(new NodeStatus(), givenSimpleRootProcessGroupStatus(), new ArrayList<>(), new Date(INSERTED_AT.getTime() - TimeUnit.MINUTES.toMillis(6)));
-        testSubject.capture(new NodeStatus(), givenSimpleRootProcessGroupStatus(), new ArrayList<>(), new Date(INSERTED_AT.getTime() - TimeUnit.MINUTES.toMillis(5)));
-        givenWaitUntilPersisted();
+        repository.capture(new NodeStatus(), givenSimpleRootProcessGroupStatus(), new ArrayList<>(), new Date(INSERTED_AT.getTime() - TimeUnit.MINUTES.toMillis(8)));
+        repository.capture(new NodeStatus(), givenSimpleRootProcessGroupStatus(), new ArrayList<>(), new Date(INSERTED_AT.getTime() - TimeUnit.MINUTES.toMillis(7)));
+        repository.capture(new NodeStatus(), givenSimpleRootProcessGroupStatus(), new ArrayList<>(), new Date(INSERTED_AT.getTime() - TimeUnit.MINUTES.toMillis(6)));
+        repository.capture(new NodeStatus(), givenSimpleRootProcessGroupStatus(), new ArrayList<>(), new Date(INSERTED_AT.getTime() - TimeUnit.MINUTES.toMillis(5)));
+        waitUntilPersisted();
 
-        // when
-        final StatusHistory result = testSubject.getProcessGroupStatusHistory(ROOT_GROUP_ID, START, END, 3);
+        final StatusHistory result = repository.getProcessGroupStatusHistory(ROOT_GROUP_ID, START, END, 3);
 
-        // then - in case the value of preferred data points are lower than the number of snapshots available, the latest will added to the result
+        // in case the value of preferred data points are lower than the number of snapshots available, the latest will added to the result
         assertEquals(3, result.getStatusSnapshots().size());
         assertEquals(new Date(INSERTED_AT.getTime() - TimeUnit.MINUTES.toMillis(7)), result.getStatusSnapshots().get(0).getTimestamp());
         assertEquals(new Date(INSERTED_AT.getTime() - TimeUnit.MINUTES.toMillis(6)), result.getStatusSnapshots().get(1).getTimestamp());

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/EmbeddedQuestDbStatusHistoryRepositoryForNodeTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/EmbeddedQuestDbStatusHistoryRepositoryForNodeTest.java
@@ -25,11 +25,9 @@ public class EmbeddedQuestDbStatusHistoryRepositoryForNodeTest extends AbstractE
 
     @Test
     public void testReadingEmptyRepository() {
-        // when
-        final StatusHistory nodeStatusHistory = testSubject.getNodeStatusHistory(START, END);
-        final GarbageCollectionHistory garbageCollectionHistory = testSubject.getGarbageCollectionHistory(START, END);
+        final StatusHistory nodeStatusHistory = repository.getNodeStatusHistory(START, END);
+        final GarbageCollectionHistory garbageCollectionHistory = repository.getGarbageCollectionHistory(START, END);
 
-        // then
         assertTrue(nodeStatusHistory.getStatusSnapshots().isEmpty());
         assertTrue(garbageCollectionHistory.getGarbageCollectionStatuses("gc1").isEmpty());
         assertTrue(garbageCollectionHistory.getGarbageCollectionStatuses("gc2").isEmpty());
@@ -37,16 +35,13 @@ public class EmbeddedQuestDbStatusHistoryRepositoryForNodeTest extends AbstractE
 
     @Test
     public void testWritingThenReadingComponents() throws Exception {
-        // given
-        testSubject.capture(givenNodeStatus(), new ProcessGroupStatus(), givenGarbageCollectionStatuses(INSERTED_AT), INSERTED_AT);
-        givenWaitUntilPersisted();
+        repository.capture(givenNodeStatus(), new ProcessGroupStatus(), givenGarbageCollectionStatuses(INSERTED_AT), INSERTED_AT);
+        waitUntilPersisted();
 
-        // when & then - reading node status
-        final StatusHistory nodeStatusHistory = testSubject.getNodeStatusHistory(START, END);
+        final StatusHistory nodeStatusHistory = repository.getNodeStatusHistory(START, END);
         assertNodeStatusHistory(nodeStatusHistory.getStatusSnapshots().get(0));
 
-        // when & then - garbage collection status
-        final GarbageCollectionHistory garbageCollectionHistory = testSubject.getGarbageCollectionHistory(START, END);
+        final GarbageCollectionHistory garbageCollectionHistory = repository.getGarbageCollectionHistory(START, END);
         assertGc1Status(garbageCollectionHistory.getGarbageCollectionStatuses("gc1"));
         assertGc2Status(garbageCollectionHistory.getGarbageCollectionStatuses("gc2"));
     }


### PR DESCRIPTION
# Summary

[NIFI-11853](https://issues.apache.org/jira/browse/NIFI-11853) Changes the Embedded QuestDB test classes to use the JUnit 5 `TempDir` annotation instead of a path inside the target directory.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
