### PR TITLE
NIFI-11864 Upgrade Calcite Core from 1.34.0 to 1.35.0

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -118,7 +118,7 @@
         <hive3.version>3.1.3</hive3.version>
         <hive.version>${hive3.version}</hive.version>
         <avatica.version>1.23.0</avatica.version>
-        <calcite.version>1.34.0</calcite.version>
+        <calcite.version>1.35.0</calcite.version>
         <calcite.avatica.version>1.6.0</calcite.avatica.version>
     </properties>
 

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/pom.xml
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.34.0</version>
+            <version>1.35.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -264,7 +264,7 @@
             <dependency>
                 <groupId>org.apache.calcite</groupId>
                 <artifactId>calcite-core</artifactId>
-                <version>1.34.0</version>
+                <version>1.35.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>log4j</groupId>


### PR DESCRIPTION
# Summary

[NIFI-11864](https://issues.apache.org/jira/browse/NIFI-11864) Upgrades Apache Calcite Core dependencies from 1.34.0 to [1.35.0](https://calcite.apache.org/news/2023/07/26/release-1.35.0/), applying bug fixes and improvements to standard extension components such as QueryRecord.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
