### PR TITLE
NIFI-11874: apply new layout of Process Group configuration into two columns

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/process-group-configuration.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/process-group-configuration.jsp
@@ -26,91 +26,102 @@
             <button id="add-process-group-configuration-controller-service" class="add-button fa fa-plus" title="Create a new controller service"></button>
             <div id="general-process-group-configuration-tab-content" class="configuration-tab">
                 <div id="general-process-group-configuration">
-                    <div class="setting">
-                        <div class="setting-name">Process group name</div>
-                        <span id="process-group-id" class="hidden"></span>
-                        <div class="editable setting-field">
-                            <input type="text" id="process-group-name" class="setting-input"/>
+                    <div class="settings-columns">
+                        <div class="settings-column">
+                            <div class="setting">
+                                <div class="setting-name">Process group name</div>
+                                <span id="process-group-id" class="hidden"></span>
+                                <div class="editable setting-field">
+                                    <input type="text" id="process-group-name" class="setting-input"/>
+                                </div>
+                                <div class="read-only setting-field">
+                                    <span id="read-only-process-group-name" class="unset"></span>
+                                </div>
+                            </div>
+                            <div class="setting">
+                                <div class="setting-name">Process group parameter context</div>
+                                <div class="editable setting-field">
+                                    <div id="process-group-parameter-context-combo"></div>
+                                </div>
+                                <div class="read-only setting-field">
+                                    <span id="read-only-process-group-parameter-context" class="unset">Unauthorized</span>
+                                </div>
+                            </div>
+                            <div class="setting">
+                                <div class="setting-name">Process group comments</div>
+                                <div class="editable setting-field">
+                                    <textarea id="process-group-comments" class="setting-input"></textarea>
+                                </div>
+                                <div class="read-only setting-field">
+                                    <span id="read-only-process-group-comments" class="unset"></span>
+                                </div>
+                            </div>
+                            <div class="setting">
+                                <div class="setting-name">Process group FlowFile concurrency</div>
+                                <div class="editable setting-field">
+                                    <div id="process-group-flowfile-concurrency-combo"></div>
+                                </div>
+                                <div class="read-only setting-field">
+                                    <span id="read-only-process-group-flowfile-concurrency" class="unset"></span>
+                                </div>
+                            </div>
+                            <div class="setting">
+                                <div class="setting-name">Process group outbound policy</div>
+                                <div class="editable setting-field">
+                                    <div id="process-group-outbound-policy-combo"></div>
+                                </div>
+                                <div class="read-only setting-field">
+                                    <span id="read-only-process-group-outbound-policy" class="unset"></span>
+                                </div>
+                            </div>
                         </div>
-                        <div class="read-only setting-field">
-                            <span id="read-only-process-group-name" class="unset"></span>
+                        <div class="settings-column">
+                            <div class="setting">
+                                <div class="setting-name">Default FlowFile Expiration
+                                    <div class="fa fa-question-circle" alt="Info" title="This setting applies as the default for any new connections. Configuration of existing connections are unaffected."></div>
+                                </div>
+                                <div class="editable setting-field">
+                                    <input type="text" id="process-group-default-flowfile-expiration" class="setting-input"/>
+                                </div>
+                                <div class="read-only setting-field">
+                                    <span id="read-only-process-group-default-flowfile-expiration" class="unset"></span>
+                                </div>
+                            </div>
+                            <div class="setting">
+                                <div class="setting-name">Default Back Pressure Object Threshold
+                                    <div class="fa fa-question-circle" alt="Info" title="This setting applies as the default for any new connections. Configuration of existing connections are unaffected."></div>
+                                </div>
+                                <div class="editable setting-field">
+                                    <input type="text" id="process-group-default-back-pressure-object-threshold" class="setting-input"/>
+                                </div>
+                                <div class="read-only setting-field">
+                                    <span id="read-only-process-group-default-back-pressure-object-threshold" class="unset"></span>
+                                </div>
+                            </div>
+                            <div class="setting">
+                                <div class="setting-name">Default Back Pressure Data Size Threshold
+                                    <div class="fa fa-question-circle" alt="Info" title="This setting applies as the default for any new connections. Configuration of existing connections are unaffected."></div>
+                                </div>
+                                <div class="editable setting-field">
+                                    <input type="text" id="process-group-default-back-pressure-data-size-threshold" class="setting-input"/>
+                                </div>
+                                <div class="read-only setting-field">
+                                    <span id="read-only-process-group-default-back-pressure-data-size-threshold" class="unset"></span>
+                                </div>
+                            </div>
+                            <div class="setting">
+                                <div class="setting-name">Log File Suffix
+                                    <div class="fa fa-question-circle" alt="Info" title="Turns on dedicated logging. When left empty log messages will be logged only to the primary app log. When set messages logged by components in this group will be sent to the standard app log, as well as a separate log file, with the provided name, specific to this group."></div>
+                                </div>
+                                <div class="editable setting-field">
+                                    <input type="text" id="process-group-log-file-suffix" class="setting-input"/>
+                                </div>
+                                <div class="read-only setting-field">
+                                    <span id="read-only-process-group-log-file-suffix" class="unset"></span>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                    <div class="setting">
-                        <div class="setting-name">Process group parameter context</div>
-                        <div class="editable setting-field">
-                            <div id="process-group-parameter-context-combo"></div>
-                        </div>
-                        <div class="read-only setting-field">
-                            <span id="read-only-process-group-parameter-context" class="unset">Unauthorized</span>
-                        </div>
-                    </div>
-                    <div class="setting">
-                        <div class="setting-name">Process group comments</div>
-                        <div class="editable setting-field">
-                            <textarea id="process-group-comments" class="setting-input"></textarea>
-                        </div>
-                        <div class="read-only setting-field">
-                            <span id="read-only-process-group-comments" class="unset"></span>
-                        </div>
-                    </div>
-                    <div class="setting">
-                        <div class="setting-name">Process group FlowFile concurrency</div>
-                        <div class="editable setting-field">
-                            <div id="process-group-flowfile-concurrency-combo"></div>
-                        </div>
-                        <div class="read-only setting-field">
-                            <span id="read-only-process-group-flowfile-concurrency" class="unset"></span>
-                        </div>
-                    </div>
-                    <div class="setting">
-                        <div class="setting-name">Process group outbound policy</div>
-                        <div class="editable setting-field">
-                            <div id="process-group-outbound-policy-combo"></div>
-                        </div>
-                        <div class="read-only setting-field">
-                            <span id="read-only-process-group-outbound-policy" class="unset"></span>
-                        </div>
-                    </div>
-                    <div class="setting">
-                        <div class="setting-name">Default FlowFile Expiration</div>
-                        <div class="editable setting-field">
-                            <input type="text" id="process-group-default-flowfile-expiration" class="setting-input"/>
-                        </div>
-                        <div class="read-only setting-field">
-                            <span id="read-only-process-group-default-flowfile-expiration" class="unset"></span>
-                        </div>
-                    </div>
-                    <div class="setting">
-                        <div class="setting-name">Default Back Pressure Object Threshold</div>
-                        <div class="editable setting-field">
-                            <input type="text" id="process-group-default-back-pressure-object-threshold" class="setting-input"/>
-                        </div>
-                        <div class="read-only setting-field">
-                            <span id="read-only-process-group-default-back-pressure-object-threshold" class="unset"></span>
-                        </div>
-                    </div>
-                    <div class="setting">
-                        <div class="setting-name">Default Back Pressure Data Size Threshold</div>
-                        <div class="editable setting-field">
-                            <input type="text" id="process-group-default-back-pressure-data-size-threshold" class="setting-input"/>
-                        </div>
-                        <div class="read-only setting-field">
-                            <span id="read-only-process-group-default-back-pressure-data-size-threshold" class="unset"></span>
-                        </div>
-                    </div>
-                    <div class="setting">
-                        <div class="setting-name">Log File Suffix
-                        <div class="fa fa-question-circle" alt="Info" title="Turns on dedicated logging. When left empty log messages will be logged only to the primary app log. When set messages logged by components in this group will be sent to the standard app log, as well as a separate log file, with the provided name, specific to this group."></div>
-                        </div>
-                        <div class="editable setting-field">
-                            <input type="text" id="process-group-log-file-suffix" class="setting-input"/>
-                        </div>
-                        <div class="read-only setting-field">
-                            <span id="read-only-process-group-log-file-suffix" class="unset"></span>
-                        </div>
-                    </div>
-
                     <div class="editable settings-buttons">
                         <div id="process-group-configuration-save" class="button">Apply</div>
                         <div class="clear"></div>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/process-group-configuration.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/process-group-configuration.css
@@ -75,6 +75,13 @@
 }
 
 /* general */
+#general-process-group-configuration div.settings-columns {
+    display: flex;
+}
+
+#general-process-group-configuration div.settings-columns .settings-column {
+    margin-right: 20px;
+}
 
 #general-process-group-configuration input, #general-process-group-configuration textarea {
     width: 350px;


### PR DESCRIPTION
# Summary

[NIFI-11874](https://issues.apache.org/jira/browse/NIFI-11874)
UI modification for the layout of Process Group configuration. It separates the increasing number of configuration options into two columns. This presents better in the UI and keeps the Apply button easily accessible without the need to scroll (for most display resolutions.)

Includes additional details for several of the Process Group properties to explicitly clarify that the default connections settings apply only to new connections - not existing connections.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
