### PR TITLE
NIFI-11860 fixed bug in ResultSetRecordSet affecting decimalScale whe…

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -325,7 +325,7 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
             decimalPrecision = resultSetPrecision;
             //For the float data type Oracle return decimalScale < 0 which cause is not expected to org.apache.avro.LogicalTypes
             //Hence falling back to default scale if decimalScale < 0
-            decimalScale = resultSetScale > 0 ? resultSetScale : defaultScale;
+            decimalScale = resultSetScale >= 0 ? resultSetScale : defaultScale;
         } else {
             // If not, use default precision.
             decimalPrecision = defaultPrecision;

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/ResultSetRecordSetTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/ResultSetRecordSetTest.java
@@ -131,6 +131,20 @@ public class ResultSetRecordSetTest {
     }
 
     @Test
+    public void testCreateSchemaWhenScaleIsNonDefault() throws SQLException {
+        // given
+        final RecordSchema recordSchema = givenRecordSchema(COLUMNS);
+        final RecordSchema expectedSchema = givenRecordSchema(COLUMNS);
+
+        // when
+        final ResultSetRecordSet testSubject = new ResultSetRecordSet(resultSet, recordSchema, 10, 2);
+        final RecordSchema actualSchema = testSubject.getSchema();
+
+        // then
+        thenAllColumnDataTypesAreCorrect(COLUMNS, expectedSchema, actualSchema);
+    }
+
+    @Test
     public void testCreateSchemaWhenNoRecordSchema() throws SQLException {
         // given
         final RecordSchema expectedSchema = givenRecordSchema(COLUMNS);


### PR DESCRIPTION
…n resultSetScale was zero.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11860](https://issues.apache.org/jira/browse/NIFI-11860)

# Tracking

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
- [x] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
