### PR TITLE
NIFI-11896 Correct QuestDB Status Repository Shutdown handling

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/EmbeddedQuestDbRolloverHandler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/EmbeddedQuestDbRolloverHandler.java
@@ -71,9 +71,9 @@ public class EmbeddedQuestDbRolloverHandler implements Runnable {
 
     @Override
     public void run() {
-        LOGGER.debug("Starting rollover");
+        LOGGER.debug("Rollover started for Tables {}", tables);
         tables.forEach(tableName -> rolloverTable(tableName));
-        LOGGER.debug("Finishing rollover");
+        LOGGER.debug("Rollover completed for Tables {}", tables);
     }
 
     private void rolloverTable(final CharSequence tableName) {
@@ -89,7 +89,7 @@ public class EmbeddedQuestDbRolloverHandler implements Runnable {
                 }
             }
         } catch (final Exception e) {
-            LOGGER.error("Could not rollover table " + tableName, e);
+            LOGGER.error("Rollover failed for table [{}]", tableName, e);
         }
     }
 
@@ -98,7 +98,7 @@ public class EmbeddedQuestDbRolloverHandler implements Runnable {
             final CompiledQuery compile = compiler.compile(String.format(DELETION_QUERY, tableName, partition), dbContext.getSqlExecutionContext());
             compile.execute(new SCSequence(new TimeoutBlockingWaitStrategy(5, TimeUnit.SECONDS)));
         } catch (final Exception e) {
-            LOGGER.error("Dropping partition " + partition + " of table " + tableName + " failed", e);
+            LOGGER.error("Dropping partition [{}] of table [{}] failed", partition, tableName, e);
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/questdb/QuestDbDatabaseManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/questdb/QuestDbDatabaseManager.java
@@ -62,7 +62,7 @@ public final class QuestDbDatabaseManager {
 
     public static void checkDatabaseStatus(final Path persistLocation) {
         final QuestDbDatabaseManager.DatabaseStatus databaseStatus = getDatabaseStatus(persistLocation);
-        LOGGER.debug("Starting status repository. It's estimated status is {}", databaseStatus);
+        LOGGER.debug("Starting Status Repository: Database Status [{}]", databaseStatus);
 
         if (databaseStatus == QuestDbDatabaseManager.DatabaseStatus.NON_EXISTING) {
             createDatabase(persistLocation);
@@ -118,27 +118,28 @@ public final class QuestDbDatabaseManager {
     }
 
     private static boolean checkConnection(final Path persistLocation) {
-        final CairoConfiguration configuration = new DefaultCairoConfiguration(persistLocation.toFile().getAbsolutePath());
+        final String absolutePath = persistLocation.toFile().getAbsolutePath();
+        final CairoConfiguration configuration = new DefaultCairoConfiguration(absolutePath);
 
         try (
             final CairoEngine engine = new CairoEngine(configuration)
         ) {
-            LOGGER.info("Connection to database was successful");
+            LOGGER.info("Database connection successful [{}]", absolutePath);
             return true;
         } catch (Exception e) {
-            LOGGER.error("Error during connection to database", e);
+            LOGGER.error("Database connection failed [{}]", absolutePath, e);
             return false;
         }
     }
 
     private static void createDatabase(final Path persistLocation) {
-        LOGGER.info("Creating database");
+        LOGGER.debug("Database creation started [{}]", persistLocation);
         final CairoConfiguration configuration;
 
         try {
             FileUtils.ensureDirectoryExistAndCanReadAndWrite(persistLocation.toFile());
         } catch (final Exception e) {
-            throw new RuntimeException("Could not create database folder " + persistLocation.toAbsolutePath().toString(), e);
+            throw new RuntimeException(String.format("Database directory creation failed [%s]", persistLocation), e);
         }
 
         configuration = new DefaultCairoConfiguration(persistLocation.toFile().getAbsolutePath());
@@ -161,9 +162,9 @@ public final class QuestDbDatabaseManager {
             compiler.compile(QuestDbQueries.CREATE_PROCESSOR_STATUS, context);
             compiler.compile(QuestDbQueries.CREATE_COMPONENT_COUNTER, context);
 
-            LOGGER.info("Database is created");
+            LOGGER.info("Database creation completed [{}]", persistLocation);
         } catch (final Exception e) {
-            throw new RuntimeException("Could not create database!", e);
+            throw new RuntimeException(String.format("Database creation failed [%s]", persistLocation), e);
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/storage/BufferedWriterFlushWorker.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/storage/BufferedWriterFlushWorker.java
@@ -34,9 +34,9 @@ public class BufferedWriterFlushWorker implements Runnable {
     @Override
     public void run() {
         try {
-            bufferedWriterList.forEach(bufferedWriter -> bufferedWriter.flush());
+            bufferedWriterList.forEach(BufferedEntryWriter::flush);
         } catch (final Exception e) {
-            LOGGER.error("Error happened during calling flush.", e);
+            LOGGER.error("Flush Buffered Writer failed", e);
         }
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/AbstractEmbeddedQuestDbStatusHistoryRepositoryTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/AbstractEmbeddedQuestDbStatusHistoryRepositoryTest.java
@@ -18,10 +18,12 @@ package org.apache.nifi.controller.status.history;
 
 import org.apache.nifi.util.NiFiProperties;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +43,15 @@ public abstract class AbstractEmbeddedQuestDbStatusHistoryRepositoryTest extends
 
     @TempDir
     private Path temporaryDirectory;
+
+    @BeforeAll
+    public static void setLogging() {
+        final URL logConfUrl = AbstractEmbeddedQuestDbStatusHistoryRepositoryTest.class.getResource("/log-stdout.conf");
+        if (logConfUrl == null) {
+            throw new IllegalStateException("QuestDB log configuration not found");
+        }
+        System.setProperty("out", logConfUrl.getPath());
+    }
 
     @BeforeEach
     public void setUp() throws Exception {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/EmbeddedQuestDbStatusHistoryRepositoryForNodeTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/status/history/EmbeddedQuestDbStatusHistoryRepositoryForNodeTest.java
@@ -22,6 +22,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EmbeddedQuestDbStatusHistoryRepositoryForNodeTest extends AbstractEmbeddedQuestDbStatusHistoryRepositoryTest {
+    private static final long ZERO_BYTES = 0L;
+
+    private static final int ZERO_COUNT = 0;
 
     @Test
     public void testReadingEmptyRepository() {
@@ -35,7 +38,9 @@ public class EmbeddedQuestDbStatusHistoryRepositoryForNodeTest extends AbstractE
 
     @Test
     public void testWritingThenReadingComponents() throws Exception {
-        repository.capture(givenNodeStatus(), new ProcessGroupStatus(), givenGarbageCollectionStatuses(INSERTED_AT), INSERTED_AT);
+        final ProcessGroupStatus processGroupStatus = getProcessGroupStatus();
+
+        repository.capture(givenNodeStatus(), processGroupStatus, givenGarbageCollectionStatuses(INSERTED_AT), INSERTED_AT);
         waitUntilPersisted();
 
         final StatusHistory nodeStatusHistory = repository.getNodeStatusHistory(START, END);
@@ -44,5 +49,18 @@ public class EmbeddedQuestDbStatusHistoryRepositoryForNodeTest extends AbstractE
         final GarbageCollectionHistory garbageCollectionHistory = repository.getGarbageCollectionHistory(START, END);
         assertGc1Status(garbageCollectionHistory.getGarbageCollectionStatuses("gc1"));
         assertGc2Status(garbageCollectionHistory.getGarbageCollectionStatuses("gc2"));
+    }
+
+    private static ProcessGroupStatus getProcessGroupStatus() {
+        final ProcessGroupStatus processGroupStatus = new ProcessGroupStatus();
+        processGroupStatus.setBytesRead(ZERO_BYTES);
+        processGroupStatus.setBytesWritten(ZERO_BYTES);
+        processGroupStatus.setInputCount(ZERO_COUNT);
+        processGroupStatus.setOutputCount(ZERO_COUNT);
+        processGroupStatus.setQueuedCount(ZERO_COUNT);
+        processGroupStatus.setInputContentSize(ZERO_BYTES);
+        processGroupStatus.setOutputContentSize(ZERO_BYTES);
+        processGroupStatus.setQueuedContentSize(ZERO_BYTES);
+        return processGroupStatus;
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-11896](https://issues.apache.org/jira/browse/NIFI-11896) Corrects QuestDB Status Repository shutdown handling at runtime and during unit tests.

Changes include updating the repository start and shutdown methods to track scheduled future tasks and attempt cancellation before shutting down the executor service. This approach provides a stronger guarantee of stopping scheduled tasks than shutting down the executor service itself.

Additional changes include setting the initial delay for scheduled tasks from 0 to the configured interval, avoiding initial execution when starting the repository. This approach avoids unnecessary task execution in unit tests.

Test changes include setting the `out` System property pointing to the QuestDB logging configuration, avoiding unnecessary debug logs during unit testing, which can corrupt the console output stream, described in [NIFI-11897](https://issues.apache.org/jira/browse/NIFI-11897).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
