### PR TITLE
NIFI-11899 - Clear bulletin metrics registry to ensure it is reset with latest bulletins

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -438,28 +438,9 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     private AuthorizableLookup authorizableLookup;
 
     // Prometheus Metrics objects
-    private final NiFiMetricsRegistry nifiMetricsRegistry = new NiFiMetricsRegistry();
     private final JvmMetricsRegistry jvmMetricsRegistry = new JvmMetricsRegistry();
     private final ConnectionAnalyticsMetricsRegistry connectionAnalyticsMetricsRegistry = new ConnectionAnalyticsMetricsRegistry();
-    private final BulletinMetricsRegistry bulletinMetricsRegistry = new BulletinMetricsRegistry();
     private final ClusterMetricsRegistry clusterMetricsRegistry = new ClusterMetricsRegistry();
-
-    private final Collection<AbstractMetricsRegistry> configuredRegistries = Arrays.asList(
-            nifiMetricsRegistry,
-            jvmMetricsRegistry,
-            connectionAnalyticsMetricsRegistry,
-            bulletinMetricsRegistry,
-            clusterMetricsRegistry
-    );
-
-    private final Collection<CollectorRegistry> metricsRegistries = Arrays.asList(
-            nifiMetricsRegistry.getRegistry(),
-            jvmMetricsRegistry.getRegistry(),
-            connectionAnalyticsMetricsRegistry.getRegistry(),
-            bulletinMetricsRegistry.getRegistry(),
-            clusterMetricsRegistry.getRegistry()
-    );
-
 
     // -----------------------------------------
     // Synchronization methods
@@ -6038,12 +6019,14 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         return entityFactory.createProcessorDiagnosticsEntity(dto, revisionDto, permissionsDto, processorStatusDto, bulletins);
     }
 
-    @Override
-    public Collection<CollectorRegistry> generateFlowMetrics() {
+    protected Collection<AbstractMetricsRegistry> populateFlowMetrics() {
+        // Include registries which are fully refreshed upon each invocation
+        NiFiMetricsRegistry nifiMetricsRegistry = new NiFiMetricsRegistry();
+        BulletinMetricsRegistry bulletinMetricsRegistry = new BulletinMetricsRegistry();
+
         final String instanceId = StringUtils.isEmpty(controllerFacade.getInstanceId()) ? "" : controllerFacade.getInstanceId();
         ProcessGroupStatus rootPGStatus = controllerFacade.getProcessGroupStatus("root");
 
-        nifiMetricsRegistry.clear();
         PrometheusMetricsUtil.createNifiMetrics(nifiMetricsRegistry, rootPGStatus, instanceId, "", ROOT_PROCESS_GROUP,
                 PrometheusMetricsUtil.METRICS_STRATEGY_COMPONENTS.getValue());
 
@@ -6109,7 +6092,6 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         // Create a query to get all bulletins
         final BulletinQueryDTO query = new BulletinQueryDTO();
         BulletinBoardDTO bulletinBoardDTO = getBulletinBoard(query);
-        bulletinMetricsRegistry.clear();
         for(BulletinEntity bulletinEntity : bulletinBoardDTO.getBulletins()) {
             BulletinDTO bulletin = bulletinEntity.getBulletin();
             if(bulletin != null) {
@@ -6143,8 +6125,22 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         final boolean isClustered = clusterCoordinator != null;
         final boolean isConnectedToCluster = isClustered() && clusterCoordinator.isConnected();
         PrometheusMetricsUtil.createClusterMetrics(clusterMetricsRegistry, instanceId, isClustered, isConnectedToCluster, connectedNodesLabel, connectedNodeCount, totalNodeCount);
+        Collection<AbstractMetricsRegistry> metricsRegistries = Arrays.asList(
+                nifiMetricsRegistry,
+                jvmMetricsRegistry,
+                connectionAnalyticsMetricsRegistry,
+                bulletinMetricsRegistry,
+                clusterMetricsRegistry
+        );
 
         return metricsRegistries;
+    }
+
+    @Override
+    public Collection<CollectorRegistry> generateFlowMetrics() {
+
+        return populateFlowMetrics().stream().map(AbstractMetricsRegistry::getRegistry)
+                                             .collect(Collectors.toList());
     }
 
     @Override
@@ -6155,7 +6151,8 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
                 .map(FlowMetricsRegistry::getRegistryClass)
                 .collect(Collectors.toSet());
 
-        generateFlowMetrics();
+        Collection<AbstractMetricsRegistry> configuredRegistries = populateFlowMetrics();
+
         return configuredRegistries.stream()
                 .filter(configuredRegistry -> registryClasses.contains(configuredRegistry.getClass()))
                 .map(AbstractMetricsRegistry::getRegistry)

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -6109,6 +6109,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         // Create a query to get all bulletins
         final BulletinQueryDTO query = new BulletinQueryDTO();
         BulletinBoardDTO bulletinBoardDTO = getBulletinBoard(query);
+        bulletinMetricsRegistry.clear();
         for(BulletinEntity bulletinEntity : bulletinBoardDTO.getBulletins()) {
             BulletinDTO bulletin = bulletinEntity.getBulletin();
             if(bulletin != null) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11899](https://issues.apache.org/jira/browse/NIFI-11899)

The JIRA resolves an issue where the nifi_bulletin metric value was not reset to reflect bulletins that are currently firing. Previously any bulletin that fired was added to the metric registry however the registry was never updated, giving a false sense that the bulletin is still firing. 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

1. Create a flow which would generate an error.  For example the flow below uses ConsumeTwitter and LogAttribute with ConsumeTwitter bearer token misconfigured purposefully. Do not start the flow.

<img width="1773" alt="image" src="https://github.com/apache/nifi/assets/1371858/b0e00c73-b529-4825-abdd-7d47d1c7ae5d">

2. Capture current metrics available using the Prometheus metrics api endpoint (e.g. https://127.0.0.1:8443/nifi-api/flow/metrics/prometheus) and search output to confirm that the nifi_bulletin metric does not appear, indicating there are no bulletins present

4. Start flow and confirm that bulletins showing an error/warning is present

<img width="1773" alt="image" src="https://github.com/apache/nifi/assets/1371858/3cd295ea-e92b-4f15-b51d-7c7b0702deb5">

5. On the metrics endpoint confirm that the nifi_bulletin metrics appear with values corresponding to each component demonstrating an error. With the example flow metrics show a single metric entry with a value of 1

<img width="1773" alt="image" src="https://github.com/apache/nifi/assets/1371858/210a8d8d-25a9-4505-be1e-ba028331c039">

6. Stop the flow and await for bulletins to clear from the UI

7. Confirm on metrics endpoint that nifi_bulletin metric no longer appears or no longer contains the specific bulletin that was created

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
- [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
