### PR TITLE
NIFI-11908 Update GitHub Build HTTP Settings

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,18 +25,12 @@ env:
     -XX:ReservedCodeCacheSize=1g
     -XX:+UseG1GC
     -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
-    -Dmaven.wagon.http.retryHandler.class=standard
-    -Dmaven.wagon.http.retryHandler.count=5
-    -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
-    -Dmaven.wagon.httpconnectionManager.maxPerRoute=5
-    -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
+    -Daether.connector.http.retryHandler.count=5
+    -Daether.connector.http.connectionMaxTtl=30
   COMPILE_MAVEN_OPTS: >-
     -Xmx3g
-    -Dmaven.wagon.http.retryHandler.class=standard
-    -Dmaven.wagon.http.retryHandler.count=5
-    -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
-    -Dmaven.wagon.httpconnectionManager.maxPerRoute=5
-    -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
+    -Daether.connector.http.retryHandler.count=5
+    -Daether.connector.http.connectionMaxTtl=30
   MAVEN_COMPILE_COMMAND: >-
     test-compile
     --show-version
@@ -69,7 +63,6 @@ env:
     --no-transfer-progress
     --fail-fast
     -D dir-only
-    -D disableXmlReport
   MAVEN_BUILD_PROFILES: >-
     -P include-grpc
     -P skip-nifi-bin-assembly


### PR DESCRIPTION
# Summary

[NIFI-11908](https://issues.apache.org/jira/browse/NIFI-11908) Updates the GitHub workflow Maven HTTP settings to use the native client settings instead of the Maven Wagon properties.

With the introduction of Maven Wrapper using Maven 3.9, the native HTTP transport is now the default, as described in the [Maven 3.9 Release Notes](https://maven.apache.org/docs/3.9.0/release-notes.html#potentially-breaking-core-changes-if-migrating-from-3-8-x).

These changes replace the Maven Wagon properties with a subset of the analogous properties for the Maven [Artifact Resolver](https://maven.apache.org/resolver/configuration.html).

Additional changes include removing the `disableXmlReport` argument, which is deprecated in recent versions of the Maven Surefire Plugin.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
