### PR TITLE
NIFI-11915 Upgrade gRPC from 1.57.0 to 1.57.1

### DIFF
--- a/nifi-nar-bundles/nifi-grpc-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-grpc-bundle/pom.xml
@@ -33,7 +33,7 @@
     </modules>
 
     <properties>
-        <grpc.version>1.57.0</grpc.version>
+        <grpc.version>1.57.1</grpc.version>
         <protoc.version>3.22.5</protoc.version>
     </properties>
 


### PR DESCRIPTION
# Summary

[NIFI-11915](https://issues.apache.org/jira/browse/NIFI-11915) Upgrades gRPC dependencies from 1.57.0 to [1.57.1](https://github.com/grpc/grpc-java/releases/tag/v1.57.1) correcting a method reference error for Java 8.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
