### PR TITLE
NIFI-11676 Added EL support to every text field in the StandardOauth2…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
@@ -125,6 +125,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         .required(true)
         .sensitive(true)
         .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .build();
 
     public static final PropertyDescriptor REFRESH_TOKEN = new PropertyDescriptor.Builder()
@@ -153,6 +154,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         .required(true)
         .sensitive(true)
         .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .build();
 
     public static final PropertyDescriptor SCOPE = new PropertyDescriptor.Builder()
@@ -161,6 +163,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         .description("Space-delimited, case-sensitive list of scopes of the access request (as per the OAuth 2.0 specification)")
         .required(false)
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .build();
 
     public static final PropertyDescriptor RESOURCE = new PropertyDescriptor.Builder()
@@ -169,6 +172,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         .description("Resource URI for the access token request defined in RFC 8707 Section 2")
         .required(false)
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .build();
 
     public static final PropertyDescriptor AUDIENCE = new PropertyDescriptor.Builder()
@@ -177,6 +181,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         .description("Audience for the access token request defined in RFC 8693 Section 2.1")
         .required(false)
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .build();
 
     public static final PropertyDescriptor REFRESH_WINDOW = new PropertyDescriptor.Builder()
@@ -184,6 +189,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         .displayName("Refresh Window")
         .description("The service will attempt to refresh tokens expiring within the refresh window, subtracting the configured duration from the token expiration.")
         .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
         .defaultValue("0 s")
         .required(true)
         .build();
@@ -258,12 +264,12 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         clientAuthenticationStrategy = ClientAuthenticationStrategy.valueOf(context.getProperty(CLIENT_AUTHENTICATION_STRATEGY).getValue());
         grantType = context.getProperty(GRANT_TYPE).getValue();
         username = context.getProperty(USERNAME).evaluateAttributeExpressions().getValue();
-        password = context.getProperty(PASSWORD).getValue();
+        password = context.getProperty(PASSWORD).evaluateAttributeExpressions().getValue();
         clientId = context.getProperty(CLIENT_ID).evaluateAttributeExpressions().getValue();
-        clientSecret = context.getProperty(CLIENT_SECRET).getValue();
-        scope = context.getProperty(SCOPE).getValue();
-        resource = context.getProperty(RESOURCE).getValue();
-        audience = context.getProperty(AUDIENCE).getValue();
+        clientSecret = context.getProperty(CLIENT_SECRET).evaluateAttributeExpressions().getValue();
+        scope = context.getProperty(SCOPE).evaluateAttributeExpressions().getValue();
+        resource = context.getProperty(RESOURCE).evaluateAttributeExpressions().getValue();
+        audience = context.getProperty(AUDIENCE).evaluateAttributeExpressions().getValue();
 
         if (context.getProperty(REFRESH_TOKEN).isSet()) {
             String refreshToken = context.getProperty(REFRESH_TOKEN).evaluateAttributeExpressions().getValue();
@@ -275,7 +281,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
             this.accessDetails = accessDetailsWithRefreshTokenOnly;
         }
 
-        refreshWindowSeconds = context.getProperty(REFRESH_WINDOW).asTimePeriod(TimeUnit.SECONDS);
+        refreshWindowSeconds = context.getProperty(REFRESH_WINDOW).evaluateAttributeExpressions().asTimePeriod(TimeUnit.SECONDS);
     }
 
     @OnDisabled

--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/test/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProviderTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/test/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProviderTest.java
@@ -46,6 +46,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -72,6 +74,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class StandardOauth2AccessTokenProviderTest {
     private static final String AUTHORIZATION_SERVER_URL = "http://authorizationServerUrl";
     private static final String USERNAME = "username";
@@ -120,13 +123,13 @@ public class StandardOauth2AccessTokenProviderTest {
         when(mockContext.getProperty(StandardOauth2AccessTokenProvider.GRANT_TYPE).getValue()).thenReturn(StandardOauth2AccessTokenProvider.RESOURCE_OWNER_PASSWORD_CREDENTIALS_GRANT_TYPE.getValue());
         when(mockContext.getProperty(StandardOauth2AccessTokenProvider.AUTHORIZATION_SERVER_URL).evaluateAttributeExpressions().getValue()).thenReturn(AUTHORIZATION_SERVER_URL);
         when(mockContext.getProperty(StandardOauth2AccessTokenProvider.USERNAME).evaluateAttributeExpressions().getValue()).thenReturn(USERNAME);
-        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.PASSWORD).getValue()).thenReturn(PASSWORD);
+        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.PASSWORD).evaluateAttributeExpressions().getValue()).thenReturn(PASSWORD);
         when(mockContext.getProperty(StandardOauth2AccessTokenProvider.CLIENT_ID).evaluateAttributeExpressions().getValue()).thenReturn(CLIENT_ID);
-        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.CLIENT_SECRET).getValue()).thenReturn(CLIENT_SECRET);
-        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.SCOPE).getValue()).thenReturn(SCOPE);
-        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.RESOURCE).getValue()).thenReturn(RESOURCE);
-        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.AUDIENCE).getValue()).thenReturn(AUDIENCE);
-        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.REFRESH_WINDOW).asTimePeriod(eq(TimeUnit.SECONDS))).thenReturn(FIVE_MINUTES);
+        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.CLIENT_SECRET).evaluateAttributeExpressions().getValue()).thenReturn(CLIENT_SECRET);
+        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.SCOPE).evaluateAttributeExpressions().getValue()).thenReturn(SCOPE);
+        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.RESOURCE).evaluateAttributeExpressions().getValue()).thenReturn(RESOURCE);
+        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.AUDIENCE).evaluateAttributeExpressions().getValue()).thenReturn(AUDIENCE);
+        when(mockContext.getProperty(StandardOauth2AccessTokenProvider.REFRESH_WINDOW).evaluateAttributeExpressions().asTimePeriod(eq(TimeUnit.SECONDS))).thenReturn(FIVE_MINUTES);
         when(mockContext.getProperty(StandardOauth2AccessTokenProvider.CLIENT_AUTHENTICATION_STRATEGY).getValue()).thenReturn(ClientAuthenticationStrategy.BASIC_AUTHENTICATION.getValue());
 
         testSubject.onEnabled(mockContext);


### PR DESCRIPTION
…AccessToken

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
