### PR TITLE
NIFI-11918: Used java.security.cert in ListenGRPC

### DIFF
--- a/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-common/pom.xml
+++ b/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-common/pom.xml
@@ -45,6 +45,11 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-security-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
@@ -70,13 +75,6 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-security-utils</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-common/pom.xml
+++ b/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-common/pom.xml
@@ -45,11 +45,6 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-security-utils</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
@@ -75,6 +70,13 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-security-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-common/src/main/java/org/apache/nifi/processors/grpc/FlowFileIngestServiceInterceptor.java
+++ b/nifi-nar-bundles/nifi-grpc-bundle/nifi-grpc-common/src/main/java/org/apache/nifi/processors/grpc/FlowFileIngestServiceInterceptor.java
@@ -26,12 +26,16 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.security.util.CertificateUtils;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.regex.Pattern;
 
 import static java.util.Objects.requireNonNull;
@@ -100,10 +104,11 @@ public class FlowFileIngestServiceInterceptor implements ServerInterceptor {
         final SSLSession sslSession = attributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION);
         if (this.authorizedDNPattern != null && sslSession != null) {
             try {
-                final X509Certificate[] certs = sslSession.getPeerCertificateChain();
+                final Certificate[] certs = sslSession.getPeerCertificates();
                 if (certs != null && certs.length > 0) {
-                    for (final X509Certificate cert : certs) {
-                        foundSubject = cert.getSubjectDN().getName();
+                    for (final Certificate cert : certs) {
+                        final X509Certificate x509Cert = CertificateUtils.convertAbstractX509Certificate(cert);
+                        foundSubject = x509Cert.getSubjectX500Principal().getName();
                         if (authorizedDNPattern.matcher(foundSubject).matches()) {
                             break;
                         } else {
@@ -115,6 +120,8 @@ public class FlowFileIngestServiceInterceptor implements ServerInterceptor {
                 }
             } catch (final SSLPeerUnverifiedException e) {
                 logger.debug("Skipping DN authorization for request from {}", clientIp, e);
+            } catch (CertificateException e) {
+                throw new ProcessException("Certificate is not an X.509 certificate", e);
             }
         }
         // contextualize the DN and IP for use in the RPC implementation


### PR DESCRIPTION
# Summary

[NIFI-11918](https://issues.apache.org/jira/browse/NIFI-11918)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
