### PR TITLE
NIFI-11921: populate system load average in HB

### DIFF
--- a/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/c2/client/service/C2HeartbeatFactory.java
+++ b/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/c2/client/service/C2HeartbeatFactory.java
@@ -228,7 +228,7 @@ public class C2HeartbeatFactory {
 
         // getSystemLoadAverage is not available in Windows, so we need to prevent to send invalid data
         if (systemLoadAverage >= 0) {
-            systemInfo.setCpuUtilization(systemLoadAverage / (double) osMXBean.getAvailableProcessors());
+            systemInfo.setCpuLoadAverage(systemLoadAverage);
         }
 
         return systemInfo;

--- a/c2/c2-protocol/c2-protocol-api/src/main/java/org/apache/nifi/c2/protocol/api/SystemInfo.java
+++ b/c2/c2-protocol/c2-protocol-api/src/main/java/org/apache/nifi/c2/protocol/api/SystemInfo.java
@@ -45,6 +45,7 @@ public class SystemInfo implements Serializable {
 
     @ApiModelProperty
     private Double cpuUtilization;
+    private Double cpuLoadAverage;
 
     public String getMachineArch() {
         return machineArch;
@@ -92,5 +93,13 @@ public class SystemInfo implements Serializable {
 
     public void setvCores(Integer vCores) {
         this.vCores = vCores;
+    }
+
+    public Double getCpuLoadAverage() {
+        return cpuLoadAverage;
+    }
+
+    public void setCpuLoadAverage(Double cpuLoadAverage) {
+        this.cpuLoadAverage = cpuLoadAverage;
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11921](https://issues.apache.org/jira/browse/NIFI-11921)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
