### PR TITLE
NIFI-11922: Honor catalog/schema field in UpdateDatabaseTable

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UpdateDatabaseTable.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UpdateDatabaseTable.java
@@ -486,7 +486,7 @@ public class UpdateDatabaseTable extends AbstractProcessor {
                         getLogger().debug("Adding column " + recordFieldName + " to table " + tableName);
                     }
 
-                    tableSchema = new TableSchema(tableName, columns, translateFieldNames, primaryKeyColumnNames, databaseAdapter.getColumnQuoteString());
+                    tableSchema = new TableSchema(catalogName, schemaName, tableName, columns, translateFieldNames, primaryKeyColumnNames, databaseAdapter.getColumnQuoteString());
 
                     final String createTableSql = databaseAdapter.getCreateTableStatement(tableSchema, quoteTableName, quoteColumnNames);
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/DatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/DatabaseAdapter.java
@@ -178,9 +178,7 @@ public interface DatabaseAdapter {
         }
 
         createTableStatement.append("CREATE TABLE IF NOT EXISTS ")
-                .append(quoteTableName ? getTableQuoteString() : "")
-                .append(tableSchema.getTableName())
-                .append(quoteTableName ? getTableQuoteString() : "")
+                .append(generateTableName(quoteTableName, tableSchema.getCatalogName(), tableSchema.getSchemaName(), tableSchema.getTableName(),tableSchema))
                 .append(" (")
                 .append(String.join(", ", columnsAndDatatypes))
                 .append(") ");
@@ -215,5 +213,42 @@ public interface DatabaseAdapter {
 
     default String getSQLForDataType(int sqlType) {
         return JDBCType.valueOf(sqlType).getName();
+    }
+
+    default String generateTableName(final boolean quoteTableName, final String catalog, final String schemaName, final String tableName, final TableSchema tableSchema) {
+        final StringBuilder tableNameBuilder = new StringBuilder();
+        if (catalog != null) {
+            if (quoteTableName) {
+                tableNameBuilder.append(tableSchema.getQuotedIdentifierString())
+                        .append(catalog)
+                        .append(tableSchema.getQuotedIdentifierString());
+            } else {
+                tableNameBuilder.append(catalog);
+            }
+
+            tableNameBuilder.append(".");
+        }
+
+        if (schemaName != null) {
+            if (quoteTableName) {
+                tableNameBuilder.append(tableSchema.getQuotedIdentifierString())
+                        .append(schemaName)
+                        .append(tableSchema.getQuotedIdentifierString());
+            } else {
+                tableNameBuilder.append(schemaName);
+            }
+
+            tableNameBuilder.append(".");
+        }
+
+        if (quoteTableName) {
+            tableNameBuilder.append(tableSchema.getQuotedIdentifierString())
+                    .append(tableName)
+                    .append(tableSchema.getQuotedIdentifierString());
+        } else {
+            tableNameBuilder.append(tableName);
+        }
+
+        return tableNameBuilder.toString();
     }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/TableSchema.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/TableSchema.java
@@ -34,10 +34,14 @@ public class TableSchema {
     private final Set<String> primaryKeyColumnNames;
     private final Map<String, ColumnDescription> columns;
     private final String quotedIdentifierString;
+    private final String catalogName;
+    private final String schemaName;
     private final String tableName;
 
-    public TableSchema(final String tableName, final List<ColumnDescription> columnDescriptions, final boolean translateColumnNames,
+    public TableSchema(final String catalogName, final String schemaName, final String tableName, final List<ColumnDescription> columnDescriptions, final boolean translateColumnNames,
                         final Set<String> primaryKeyColumnNames, final String quotedIdentifierString) {
+        this.catalogName = catalogName;
+        this.schemaName = schemaName;
         this.tableName = tableName;
         this.columns = new LinkedHashMap<>();
         this.primaryKeyColumnNames = primaryKeyColumnNames;
@@ -50,6 +54,14 @@ public class TableSchema {
                 requiredColumnNames.add(desc.getColumnName());
             }
         }
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public String getSchemaName() {
+        return schemaName;
     }
 
     public String getTableName() {
@@ -128,7 +140,7 @@ public class TableSchema {
                 }
             }
 
-            return new TableSchema(tableName, cols, translateColumnNames, primaryKeyColumns, dmd.getIdentifierQuoteString());
+            return new TableSchema(catalog, schema, tableName, cols, translateColumnNames, primaryKeyColumns, dmd.getIdentifierQuoteString());
         }
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordTest.java
@@ -265,6 +265,8 @@ public class PutDatabaseRecordTest {
         final RecordSchema schema = new SimpleRecordSchema(fields);
 
         final TableSchema tableSchema = new TableSchema(
+                null,
+                null,
                 "PERSONS",
                 Arrays.asList(
                         new ColumnDescription("id", 4, true, 2, false),
@@ -301,6 +303,8 @@ public class PutDatabaseRecordTest {
         final RecordSchema schema = new SimpleRecordSchema(fields);
 
         final TableSchema tableSchema = new TableSchema(
+                null,
+                null,
                 "PERSONS",
                 Arrays.asList(
                         new ColumnDescription("id", 4, true, 2, false),
@@ -1416,6 +1420,8 @@ public class PutDatabaseRecordTest {
         final RecordSchema schema = new SimpleRecordSchema(fields);
 
         final TableSchema tableSchema = new TableSchema(
+                null,
+                null,
                 "PERSONS",
                 Arrays.asList(
                         new ColumnDescription("id", 4, true, 2, false),

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/DerbyDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/DerbyDatabaseAdapter.java
@@ -137,9 +137,7 @@ public class DerbyDatabaseAdapter implements DatabaseAdapter {
 
         // This will throw an exception if the table already exists, but it should only be used for tests
         createTableStatement.append("CREATE TABLE ")
-                .append(quoteTableName ? getTableQuoteString() : "")
-                .append(tableSchema.getTableName())
-                .append(quoteTableName ? getTableQuoteString() : "")
+                .append(generateTableName(quoteTableName, tableSchema.getCatalogName(), tableSchema.getSchemaName(), tableSchema.getTableName(),tableSchema))
                 .append(" (")
                 .append(String.join(", ", columnsAndDatatypes))
                 .append(") ");


### PR DESCRIPTION
# Summary

[NIFI-11922](https://issues.apache.org/jira/browse/NIFI-11922) This PR fixes UpdateDatabaseRecord so it honors the Catalog Name and Schema Name properties, they used to be ignored and now they are used when generating a CREATE TABLE statement.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
