### PR TITLE
NIFI-11924 Closing FileSystem after using in HDFSExternalResourceProvider

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
@@ -16,6 +16,21 @@
  */
 package org.apache.nifi.processors.hadoop;
 
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+import javax.net.SocketFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -47,22 +62,6 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.security.krb.KerberosKeytabUser;
 import org.apache.nifi.security.krb.KerberosPasswordUser;
 import org.apache.nifi.security.krb.KerberosUser;
-
-import javax.net.SocketFactory;
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.net.URI;
-import java.security.PrivilegedExceptionAction;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Pattern;
 
 /**
  * This is a base class that is helpful when building processors interacting with HDFS.
@@ -376,20 +375,7 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
         if (resources != null) {
             // Attempt to close the FileSystem
             final FileSystem fileSystem = resources.getFileSystem();
-            try {
-                interruptStatisticsThread(fileSystem);
-            } catch (Exception e) {
-                getLogger().warn("Error stopping FileSystem statistics thread: " + e.getMessage());
-                getLogger().debug("", e);
-            } finally {
-                if (fileSystem != null) {
-                    try {
-                        fileSystem.close();
-                    } catch (IOException e) {
-                        getLogger().warn("Error close FileSystem: " + e.getMessage(), e);
-                    }
-                }
-            }
+            HDFSResourceHelper.closeFileSystem(fileSystem);
         }
 
         // Clear out the reference to the resources

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/HDFSResourceHelper.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/HDFSResourceHelper.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.hadoop;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import org.apache.hadoop.fs.FileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class HDFSResourceHelper {
+    private final static Logger LOGGER = LoggerFactory.getLogger(HDFSResourceHelper.class);
+
+    private HDFSResourceHelper() {
+        // Not to be instantiated
+    }
+
+    public static void closeFileSystem(final FileSystem fileSystem) {
+        try {
+            interruptStatisticsThread(fileSystem);
+        } catch (Exception e) {
+            LOGGER.warn("Error stopping FileSystem statistics thread: " + e.getMessage());
+            LOGGER.debug("", e);
+        } finally {
+            if (fileSystem != null) {
+                try {
+                    fileSystem.close();
+                } catch (IOException e) {
+                    LOGGER.warn("Error close FileSystem: " + e.getMessage(), e);
+                }
+            }
+        }
+    }
+
+    private static void interruptStatisticsThread(final FileSystem fileSystem) throws NoSuchFieldException, IllegalAccessException {
+        final Field statsField = FileSystem.class.getDeclaredField("statistics");
+        statsField.setAccessible(true);
+
+        final Object statsObj = statsField.get(fileSystem);
+        if (statsObj instanceof FileSystem.Statistics) {
+            final FileSystem.Statistics statistics = (FileSystem.Statistics) statsObj;
+
+            final Field statsThreadField = statistics.getClass().getDeclaredField("STATS_DATA_CLEANER");
+            statsThreadField.setAccessible(true);
+
+            final Object statsThreadObj = statsThreadField.get(statistics);
+            if (statsThreadObj instanceof Thread) {
+                final Thread statsThread = (Thread) statsThreadObj;
+                try {
+                    statsThread.interrupt();
+                } catch (Exception e) {
+                    LOGGER.warn("Error interrupting thread: " + e.getMessage(), e);
+                }
+            }
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/flow/resource/hadoop/HDFSResourceInputStream.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/flow/resource/hadoop/HDFSResourceInputStream.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.flow.resource.hadoop;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.nifi.processors.hadoop.HDFSResourceHelper;
+
+final class HDFSResourceInputStream extends InputStream {
+    private final FileSystem fileSystem;
+    private final FSDataInputStream payload;
+
+    HDFSResourceInputStream(final FileSystem fileSystem, final FSDataInputStream payload) {
+        this.fileSystem = fileSystem;
+        this.payload = payload;
+    }
+
+    @Override
+    public int read() throws IOException {
+        return payload.read();
+    }
+
+    @Override
+    public int read(final byte[] b) throws IOException {
+        return payload.read(b);
+    }
+
+    @Override
+    public int read(final byte[] b, final int off, final int len) throws IOException {
+        return payload.read(b, off, len);
+    }
+
+    @Override
+    public byte[] readAllBytes() throws IOException {
+        return payload.readAllBytes();
+    }
+
+    @Override
+    public byte[] readNBytes(final int len) throws IOException {
+        return payload.readNBytes(len);
+    }
+
+    @Override
+    public int readNBytes(final byte[] b, final int off, final int len) throws IOException {
+        return payload.readNBytes(b, off, len);
+    }
+
+    @Override
+    public long skip(final long n) throws IOException {
+        return payload.skip(n);
+    }
+
+    @Override
+    public void skipNBytes(final long n) throws IOException {
+        payload.skipNBytes(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return payload.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        payload.close();
+        HDFSResourceHelper.closeFileSystem(fileSystem);
+    }
+
+    @Override
+    public synchronized void mark(final int readlimit) {
+        payload.mark(readlimit);
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        payload.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return payload.markSupported();
+    }
+
+    @Override
+    public long transferTo(final OutputStream out) throws IOException {
+        return payload.transferTo(out);
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-11924](https://issues.apache.org/jira/browse/NIFI-11924)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
