### PR TITLE
NIFI-11928 Update gremlin.version to 3.7.0

### DIFF
--- a/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>nifi-graph-test-clients</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <gremlin.version>3.6.4</gremlin.version>
+        <gremlin.version>3.7.0</gremlin.version>
         <janusgraph.version>0.6.3</janusgraph.version>
         <guava.version>32.0.1-jre</guava.version>
     </properties>

--- a/nifi-nar-bundles/nifi-graph-bundle/nifi-other-graph-services/pom.xml
+++ b/nifi-nar-bundles/nifi-graph-bundle/nifi-other-graph-services/pom.xml
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <gremlin.version>3.6.4</gremlin.version>
+        <gremlin.version>3.7.0</gremlin.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11928](https://issues.apache.org/jira/browse/NIFI-11928)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-11928) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
