### PR TITLE
NIFI-11927 Downgrade SSHD from 2.10.0 to 2.9.2 for Registry

### DIFF
--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -43,7 +43,8 @@
         <groovy.eclipse.compiler.version>3.7.0</groovy.eclipse.compiler.version>
         <jaxb.version>2.3.2</jaxb.version>
         <jgit.version>5.13.1.202206130422-r</jgit.version>
-        <org.apache.sshd.version>2.10.0</org.apache.sshd.version>
+        <!-- JGit 5.13 requires SSHD 2.9.2 or earlier -->
+        <org.apache.sshd.version>2.9.2</org.apache.sshd.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-11927](https://issues.apache.org/jira/browse/NIFI-11927) Downgrades SSHD from 2.10.0 to 2.9.2 for Registry on the version 1 support branch to correct [compatibility issues](https://github.com/apache/mina-sshd/blob/master/docs/changes/2.10.0.md#potential-compatibility-issues) with SSHD 2.10.0 and JGit 5.13.

The current main branch includes JGit 6, but requires Java 11 or higher, so this change is specific to the support branch for version 1.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
