### PR TITLE
NIFI-11944 Remove validation warning from ExecuteStreamCommand

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteStreamCommand.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteStreamCommand.java
@@ -36,7 +36,6 @@ import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.components.RequiredPermission;
-import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.expression.AttributeExpression.ResultType;
@@ -64,7 +63,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ProcessBuilder.Redirect;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -190,13 +188,11 @@ public class ExecuteStreamCommand extends AbstractProcessor {
     private final static Set<Relationship> ATTRIBUTE_RELATIONSHIP_SET;
 
     private static final Pattern COMMAND_ARGUMENT_PATTERN = Pattern.compile("command\\.argument\\.(?<commandIndex>[0-9]+)$");
-    public static final String executionArguments = "Command Arguments Property";
-    public static final String dynamicArguements = "Dynamic Property Arguments";
 
-    static final AllowableValue EXECUTION_ARGUMENTS_PROPERTY_STRATEGY = new AllowableValue(executionArguments, executionArguments,
+    static final AllowableValue COMMAND_ARGUMENTS_PROPERTY_STRATEGY = new AllowableValue("Command Arguments Property", "Command Arguments Property",
             "Arguments to be supplied to the executable are taken from the Command Arguments property");
 
-    static final AllowableValue DYNAMIC_PROPERTY_ARGUMENTS_STRATEGY = new AllowableValue(dynamicArguements, dynamicArguements,
+    static final AllowableValue DYNAMIC_PROPERTY_ARGUMENTS_STRATEGY = new AllowableValue("Dynamic Property Arguments", "Dynamic Property Arguments",
             "Arguments to be supplied to the executable are taken from dynamic properties with pattern of 'command.argument.<commandIndex>'");
 
    static final PropertyDescriptor WORKING_DIR = new PropertyDescriptor.Builder()
@@ -222,14 +218,14 @@ public class ExecuteStreamCommand extends AbstractProcessor {
             .description("Strategy for configuring arguments to be supplied to the command.")
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .required(false)
-            .allowableValues(EXECUTION_ARGUMENTS_PROPERTY_STRATEGY, DYNAMIC_PROPERTY_ARGUMENTS_STRATEGY)
-            .defaultValue(EXECUTION_ARGUMENTS_PROPERTY_STRATEGY.getValue())
+            .allowableValues(COMMAND_ARGUMENTS_PROPERTY_STRATEGY, DYNAMIC_PROPERTY_ARGUMENTS_STRATEGY)
+            .defaultValue(COMMAND_ARGUMENTS_PROPERTY_STRATEGY.getValue())
             .build();
 
     static final PropertyDescriptor EXECUTION_ARGUMENTS = new PropertyDescriptor.Builder()
             .name("Command Arguments")
             .description("The arguments to supply to the executable delimited by the ';' character.")
-            .dependsOn(ARGUMENTS_STRATEGY, EXECUTION_ARGUMENTS_PROPERTY_STRATEGY)
+            .dependsOn(ARGUMENTS_STRATEGY, COMMAND_ARGUMENTS_PROPERTY_STRATEGY)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .addValidator((subject, input, context) -> {
                 ValidationResult result = new ValidationResult.Builder()
@@ -248,7 +244,7 @@ public class ExecuteStreamCommand extends AbstractProcessor {
    static final PropertyDescriptor ARG_DELIMITER = new PropertyDescriptor.Builder()
             .name("Argument Delimiter")
             .description("Delimiter to use to separate arguments for a command [default: ;]. Must be a single character")
-            .dependsOn(ARGUMENTS_STRATEGY, EXECUTION_ARGUMENTS_PROPERTY_STRATEGY)
+            .dependsOn(ARGUMENTS_STRATEGY, COMMAND_ARGUMENTS_PROPERTY_STRATEGY)
             .addValidator(StandardValidators.SINGLE_CHAR_VALIDATOR)
             .required(true)
             .defaultValue(";")
@@ -354,29 +350,6 @@ public class ExecuteStreamCommand extends AbstractProcessor {
                     .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
                     .build();
         }
-    }
-
-    @Override
-    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
-        final List<ValidationResult> validationResults = new ArrayList<>(super.customValidate(validationContext));
-
-        final String argumentStrategy = validationContext.getProperty(ARGUMENTS_STRATEGY).getValue();
-        if (DYNAMIC_PROPERTY_ARGUMENTS_STRATEGY.getValue() != argumentStrategy) {
-            for (final PropertyDescriptor propertyDescriptor : validationContext.getProperties().keySet()) {
-                if (!propertyDescriptor.isDynamic()) {
-                    continue;
-                }
-
-                final String propertyName = propertyDescriptor.getName();
-                final Matcher matcher = COMMAND_ARGUMENT_PATTERN.matcher(propertyName);
-                if (matcher.matches()) {
-                    logger.warn("[{}] should be set to [{}] when command arguments are supplied as Dynamic Properties. The property [{}] will be ignored.",
-                                ARGUMENTS_STRATEGY.getDisplayName(), DYNAMIC_PROPERTY_ARGUMENTS_STRATEGY.getDisplayName(), propertyName);
-                }
-            }
-        }
-
-        return validationResults;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteStreamCommand.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteStreamCommand.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processors.standard.util.ArgumentUtils;
+import org.apache.nifi.util.LogMessage;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -48,6 +49,34 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Test only runs on *nix")
 public class TestExecuteStreamCommand {
+
+    @Test
+    public void testDynamicPropertyArgumentsStrategyValid() {
+        final TestRunner runner = TestRunners.newTestRunner(ExecuteStreamCommand.class);
+
+        runner.setProperty(ExecuteStreamCommand.ARGUMENTS_STRATEGY, ExecuteStreamCommand.DYNAMIC_PROPERTY_ARGUMENTS_STRATEGY.getValue());
+        runner.setProperty(ExecuteStreamCommand.EXECUTION_COMMAND, "java");
+        runner.setProperty("command.argument.1", "-version");
+
+        runner.assertValid();
+
+        final List<LogMessage> warnMessages = runner.getLogger().getWarnMessages();
+        assertTrue(warnMessages.isEmpty(), "Warning Log Messages found");
+    }
+
+    @Test
+    public void testCommandArgumentsPropertyStrategyValid() {
+        final TestRunner runner = TestRunners.newTestRunner(ExecuteStreamCommand.class);
+
+        runner.setProperty(ExecuteStreamCommand.ARGUMENTS_STRATEGY, ExecuteStreamCommand.COMMAND_ARGUMENTS_PROPERTY_STRATEGY.getValue());
+        runner.setProperty(ExecuteStreamCommand.EXECUTION_COMMAND, "java");
+        runner.setProperty("RUNTIME_VERSION", "version-1");
+
+        runner.assertValid();
+
+        final List<LogMessage> warnMessages = runner.getLogger().getWarnMessages();
+        assertTrue(warnMessages.isEmpty(), "Warning Log Messages found");
+    }
 
     @Test
     public void testExecuteJar() throws Exception {


### PR DESCRIPTION
# Summary

[NIFI-11944](https://issues.apache.org/jira/browse/NIFI-11944) Removes the `customValidate()` method from `ExecuteStreamCommand` which would log a warning every five seconds based on the presence of dynamic properties.

The validate method used instance equality comparison instead of string content comparison, causing inaccurate log warnings when configuring the `Dynamic Property Arguments` strategy. Although this comparison could be corrected, the warning could still repeat every five seconds during component validation. As this warning does not make the component invalid, the best approach for now seems to be removing the validation warning approach.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
