### PR TITLE
NIFI-11789: Support setting fragment.count on last FlowFile when Output Batch Size is set in ExecuteSQL processors

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteSQLRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteSQLRecord.java
@@ -63,6 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -607,6 +608,7 @@ public class TestExecuteSQLRecord {
         when(dbcp.getConnection(any(Map.class))).thenReturn(conn);
         when(dbcp.getIdentifier()).thenReturn("mockdbcp");
         PreparedStatement statement = mock(PreparedStatement.class);
+        when(conn.prepareStatement(anyString(), anyInt(), anyInt())).thenReturn(statement);
         when(conn.prepareStatement(anyString())).thenReturn(statement);
         when(statement.execute()).thenReturn(true);
         ResultSet rs = mock(ResultSet.class);


### PR DESCRIPTION
# Summary

[NIFI-11789](https://issues.apache.org/jira/browse/NIFI-11789) This PR changes AbstractExecuteSQL in order to attempt to try to set the `fragment.count` attribute on the "last" FlowFile to be committed to the session in `onTrigger`.  It introduces some extra concepts that aren't consistent with the intended design of ProcessSession, and currently doesn't work when the query returns multiple result sets. That would require the DB driver to support a handful of methods and configurations that not all of them do (notably Derby). 

Perhaps it is too much outside the Process Session design principles to try and make this work. I a user NEEDS Output Batch Size it's because they have too much data to send downstream at once, which makes a downstream Merge seem like a moot point as the bottleneck would presumably show up there. Perhaps someone will do some performance metrics on how the two types of flows perform, one with Output Batch Size set and one without.

Until more discussion and pathfinding is done, this PR is in draft status.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
