### PR TITLE
NIFI-11912 Add Proxy Configuration Service property to StandardOauth2AccessTokenProvider

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-proxy-configuration-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
@@ -42,12 +42,15 @@ import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.proxy.ProxyConfiguration;
+import org.apache.nifi.proxy.ProxySpec;
 import org.apache.nifi.ssl.SSLContextService;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.Proxy;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -205,6 +208,8 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         .dependsOn(SSL_CONTEXT)
         .build();
 
+    private static final ProxySpec[] PROXY_SPECS = {ProxySpec.HTTP_AUTH, ProxySpec.SOCKS};
+
     private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
         AUTHORIZATION_SERVER_URL,
         CLIENT_AUTHENTICATION_STRATEGY,
@@ -219,7 +224,8 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         AUDIENCE,
         REFRESH_WINDOW,
         SSL_CONTEXT,
-        HTTP_PROTOCOL_STRATEGY
+        HTTP_PROTOCOL_STRATEGY,
+        ProxyConfiguration.createProxyConfigPropertyDescriptor(true, PROXY_SPECS)
     ));
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
@@ -302,6 +308,8 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
                 .build());
         }
 
+        ProxyConfiguration.validateProxySpec(validationContext, validationResults, PROXY_SPECS);
+
         return validationResults;
     }
 
@@ -313,6 +321,21 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
             final X509TrustManager trustManager = sslService.createTrustManager();
             SSLContext sslContext = sslService.createContext();
             clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustManager);
+        }
+
+        final ProxyConfiguration proxyConfig = ProxyConfiguration.getConfiguration(context);
+
+        final Proxy proxy = proxyConfig.createProxy();
+        if (!Proxy.Type.DIRECT.equals(proxy.type())) {
+            clientBuilder.proxy(proxy);
+            if (proxyConfig.hasCredential()) {
+                clientBuilder.proxyAuthenticator((route, response) -> {
+                    final String credential= Credentials.basic(proxyConfig.getProxyUserName(), proxyConfig.getProxyUserPassword());
+                    return response.request().newBuilder()
+                                   .header("Proxy-Authorization", credential)
+                                   .build();
+                });
+            }
         }
 
         final HttpProtocolStrategy httpProtocolStrategy = HttpProtocolStrategy.valueOf(context.getProperty(HTTP_PROTOCOL_STRATEGY).getValue());

--- a/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
@@ -208,7 +208,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         .dependsOn(SSL_CONTEXT)
         .build();
 
-    private static final ProxySpec[] PROXY_SPECS = {ProxySpec.HTTP_AUTH, ProxySpec.SOCKS};
+    private static final ProxySpec[] PROXY_SPECS = { ProxySpec.HTTP_AUTH };
 
     private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
         AUTHORIZATION_SERVER_URL,


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11912](https://issues.apache.org/jira/browse/NIFI-11912)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
