### PR TITLE
NIFI-8294 sink commits (#6)

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -108,7 +108,12 @@
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-data</artifactId>
-            <version>4.0.4</version>
+            <version>5.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure.kusto</groupId>
+            <artifactId>kusto-ingest</artifactId>
+            <version>5.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/IngestAzureDataExplorer.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/IngestAzureDataExplorer.java
@@ -1,0 +1,384 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.data.explorer;
+
+import com.microsoft.azure.kusto.data.KustoResultSetTable;
+import com.microsoft.azure.kusto.ingest.IngestionMapping;
+import com.microsoft.azure.kusto.ingest.IngestionProperties;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.behavior.ReadsAttribute;
+import org.apache.nifi.annotation.behavior.ReadsAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.services.azure.data.explorer.KustoIngestService;
+import org.apache.nifi.services.azure.data.explorer.KustoIngestionRequest;
+import org.apache.nifi.services.azure.data.explorer.KustoIngestionResult;
+import org.apache.nifi.services.azure.data.explorer.KustoQueryResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Tags({"azure", "adx", "microsoft", "data", "explorer"})
+@CapabilityDescription("The Azure ADX Ingest Processor acts as a ADX sink connector which sends flowFiles using the ADX-Service to the provided Azure Data" +
+        "Explorer Ingest Endpoint. The data can be sent through queued ingestion or streaming ingestion to the Azure Data Explorer cluster." +
+        "The data ingested to ADX can be in non-transactional mode or transactional mode. " +
+        "This processor supports transactionality of the ingested data ie. it ensures no duplicates are inserted while retries during ingestion failures. " +
+        "But a word of caution while selecting transactional mode is, it significantly reduces the ingestion time " +
+        "since the processor first tries to ingest the data into temporary table before ingesting to the main table. ")
+@ReadsAttributes({
+        @ReadsAttribute(attribute = "DB_NAME", description = "Specifies the name of the ADX database where the data needs to be stored."),
+        @ReadsAttribute(attribute = "TABLE_NAME", description = "Specifies the name of the ADX table where the data needs to be stored."),
+        @ReadsAttribute(attribute = "MAPPING_NAME", description = "Specifies the name of the mapping responsible for storing the data in appropriate columns."),
+        @ReadsAttribute(attribute = "FLUSH_IMMEDIATE", description = "In case of queued ingestion, this property determines whether the data should be flushed immediately to the ingest endpoint."),
+        @ReadsAttribute(attribute = "DATA_FORMAT", description = "Specifies the format of data that is send to Azure Data Explorer."),
+        @ReadsAttribute(attribute = "IGNORE_FIRST_RECORD", description = "Specifies whether we want to ignore ingestion of first record. " +
+                "This is primarily applicable for csv files. Default is set to NO"),
+})
+public class IngestAzureDataExplorer extends AbstractProcessor {
+
+    public static final String FETCH_TABLE_COMMAND = "%s | count";
+    public static final String STREAMING_POLICY_SHOW_COMMAND = ".show %s %s policy streamingingestion";
+    public static final String DATABASE = "database";
+
+    private List<PropertyDescriptor> descriptors;
+    private Set<Relationship> relationships;
+    private transient KustoIngestService service;
+    private boolean isStreamingEnabled;
+
+    public static final AllowableValue AVRO = new AllowableValue(
+            IngestionDataFormat.AVRO.name(), IngestionDataFormat.AVRO.getExtension(),
+            IngestionDataFormat.AVRO.getDescription());
+
+    public static final AllowableValue APACHEAVRO = new AllowableValue(
+            IngestionDataFormat.APACHEAVRO.name(), IngestionDataFormat.APACHEAVRO.getExtension(),
+            IngestionDataFormat.APACHEAVRO.getDescription());
+
+    public static final AllowableValue CSV = new AllowableValue(
+            IngestionDataFormat.CSV.name(), IngestionDataFormat.CSV.getExtension(),
+            IngestionDataFormat.CSV.getDescription());
+
+    public static final AllowableValue JSON = new AllowableValue(
+            IngestionDataFormat.JSON.name(), IngestionDataFormat.JSON.getExtension(),
+            IngestionDataFormat.JSON.getDescription());
+
+    public static final AllowableValue MULTIJSON = new AllowableValue(
+            IngestionDataFormat.MULTIJSON.name(), IngestionDataFormat.MULTIJSON.getExtension(),
+            IngestionDataFormat.MULTIJSON.getDescription());
+
+    public static final AllowableValue ORC = new AllowableValue(
+            IngestionDataFormat.ORC.name(), IngestionDataFormat.ORC.getExtension(), IngestionDataFormat.ORC.getDescription());
+
+    public static final AllowableValue PARQUET = new AllowableValue(
+            IngestionDataFormat.PARQUET.name(), IngestionDataFormat.PARQUET.getExtension(), IngestionDataFormat.PARQUET.getDescription());
+
+    public static final AllowableValue PSV = new AllowableValue(
+            IngestionDataFormat.PSV.name(), IngestionDataFormat.PSV.getExtension(), IngestionDataFormat.PSV.getDescription());
+
+    public static final AllowableValue SCSV = new AllowableValue(
+            IngestionDataFormat.SCSV.name(), IngestionDataFormat.SCSV.getExtension(), IngestionDataFormat.SCSV.getDescription());
+
+    public static final AllowableValue SOHSV = new AllowableValue(
+            IngestionDataFormat.SOHSV.name(), IngestionDataFormat.SOHSV.getExtension(),
+            IngestionDataFormat.SOHSV.getDescription());
+
+    public static final AllowableValue TSV = new AllowableValue(
+            IngestionDataFormat.TSV.name(), IngestionDataFormat.TSV.getExtension(), IngestionDataFormat.TSV.getDescription());
+
+    public static final AllowableValue TSVE = new AllowableValue(
+            IngestionDataFormat.TSVE.name(), IngestionDataFormat.TSVE.getExtension(),
+            IngestionDataFormat.TSVE.getDescription());
+
+    public static final AllowableValue TXT = new AllowableValue(
+            IngestionDataFormat.TXT.name(), IngestionDataFormat.TXT.getExtension(),
+            IngestionDataFormat.TXT.getDescription());
+
+    public static final AllowableValue IGNORE_FIRST_RECORD_YES = new AllowableValue(
+            "YES", "YES",
+            "Ignore first record during ingestion");
+
+    public static final AllowableValue IGNORE_FIRST_RECORD_NO = new AllowableValue(
+            "NO", "NO",
+            "Do not ignore first record during ingestion");
+
+    public static final PropertyDescriptor DATABASE_NAME = new PropertyDescriptor.Builder()
+            .name("Database Name")
+            .displayName("Database Name")
+            .description("Azure Data Explorer Database Name for querying")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor TABLE_NAME = new PropertyDescriptor.Builder()
+            .name("Table Name")
+            .displayName("Table Name")
+            .description("Azure Data Explorer Table Name for ingesting data")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor MAPPING_NAME = new PropertyDescriptor
+            .Builder().name("Mapping name")
+            .displayName("Mapping name")
+            .description("The name of the mapping responsible for storing the data in the appropriate columns.")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor IS_STREAMING_ENABLED = new PropertyDescriptor
+            .Builder().name("Is Streaming enabled")
+            .displayName("Is Streaming enabled")
+            .description("This property determines whether we want to stream data to ADX.")
+            .required(false)
+            .allowableValues("true", "false")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .defaultValue("false")
+            .build();
+    public static final PropertyDescriptor ADX_SERVICE = new PropertyDescriptor
+            .Builder().name("Kusto Ingest Service")
+            .displayName("Kusto Ingest Service")
+            .description("Azure Data Explorer Kusto Ingest Service")
+            .required(true)
+            .identifiesControllerService(KustoIngestService.class)
+            .build();
+
+    public static final Relationship SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("Relationship for success")
+            .build();
+    public static final Relationship FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("Relationship for failure")
+            .build();
+
+    static final PropertyDescriptor DATA_FORMAT = new PropertyDescriptor.Builder()
+            .name("Data Format")
+            .displayName("Data Format")
+            .description("The format of the data that is sent to ADX.")
+            .required(true)
+            .allowableValues(AVRO, APACHEAVRO, CSV, JSON, MULTIJSON, ORC, PARQUET, PSV, SCSV, SOHSV, TSV, TSVE, TXT)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    static final PropertyDescriptor IGNORE_FIRST_RECORD = new PropertyDescriptor.Builder()
+            .name("Ingestion Ignore First Record")
+            .displayName("Ingestion Ignore First Record")
+            .description("Defines whether ignore first record while ingestion.")
+            .required(false)
+            .allowableValues(IGNORE_FIRST_RECORD_YES, IGNORE_FIRST_RECORD_NO)
+            .defaultValue(IGNORE_FIRST_RECORD_NO.getValue())
+            .build();
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> descriptorList = new ArrayList<>();
+        descriptorList.add(ADX_SERVICE);
+        descriptorList.add(DATABASE_NAME);
+        descriptorList.add(TABLE_NAME);
+        descriptorList.add(MAPPING_NAME);
+        descriptorList.add(DATA_FORMAT);
+        descriptorList.add(IGNORE_FIRST_RECORD);
+        descriptorList.add(IS_STREAMING_ENABLED);
+        this.descriptors = Collections.unmodifiableList(descriptorList);
+
+        final Set<Relationship> relationshipSet = new HashSet<>();
+        relationshipSet.add(SUCCESS);
+        relationshipSet.add(FAILURE);
+        this.relationships = Collections.unmodifiableSet(relationshipSet);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return this.relationships;
+    }
+
+    @Override
+    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return descriptors;
+    }
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        service = context.getProperty(ADX_SERVICE).asControllerService(KustoIngestService.class);
+        if (checkIfIngestorRoleDoesntExist(context.getProperty(DATABASE_NAME).getValue(), context.getProperty(TABLE_NAME).getValue())) {
+            getLogger().error("User might not have ingestor privileges, table validation will be skipped for all table mappings.");
+            throw new ProcessException("User might not have ingestor privileges, table validation will be skipped for all table mappings. ");
+        }
+        isStreamingEnabled = context.getProperty(IS_STREAMING_ENABLED).evaluateAttributeExpressions().asBoolean();
+        if (isStreamingEnabled) {
+            checkIfStreamingPolicyIsEnabledInADX(context.getProperty(DATABASE_NAME).getValue(), context.getProperty(DATABASE_NAME).getValue());
+        }
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            context.yield();
+            return;
+        }
+
+        IngestionProperties ingestionProperties = new IngestionProperties(context.getProperty(DATABASE_NAME).getValue(),
+                context.getProperty(TABLE_NAME).getValue());
+
+        IngestionMapping.IngestionMappingKind ingestionMappingKind = null;
+
+        isStreamingEnabled = context.getProperty(IS_STREAMING_ENABLED).evaluateAttributeExpressions().asBoolean();
+
+        switch (IngestionDataFormat.valueOf(context.getProperty(DATA_FORMAT).getValue())) {
+            case AVRO:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.AVRO);
+                ingestionMappingKind = IngestionProperties.DataFormat.AVRO.getIngestionMappingKind();
+                break;
+            case APACHEAVRO:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.APACHEAVRO);
+                ingestionMappingKind = IngestionProperties.DataFormat.APACHEAVRO.getIngestionMappingKind();
+                break;
+            case CSV:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.CSV);
+                ingestionMappingKind = IngestionProperties.DataFormat.CSV.getIngestionMappingKind();
+                break;
+            case JSON:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.JSON);
+                ingestionMappingKind = IngestionProperties.DataFormat.JSON.getIngestionMappingKind();
+                break;
+            case MULTIJSON:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.MULTIJSON);
+                ingestionMappingKind = IngestionProperties.DataFormat.MULTIJSON.getIngestionMappingKind();
+                break;
+            case ORC:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.ORC);
+                ingestionMappingKind = IngestionProperties.DataFormat.ORC.getIngestionMappingKind();
+                break;
+            case PARQUET:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.PARQUET);
+                ingestionMappingKind = IngestionProperties.DataFormat.PARQUET.getIngestionMappingKind();
+                break;
+            case PSV:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.PSV);
+                ingestionMappingKind = IngestionProperties.DataFormat.PSV.getIngestionMappingKind();
+                break;
+            case SCSV:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.SCSV);
+                ingestionMappingKind = IngestionProperties.DataFormat.SCSV.getIngestionMappingKind();
+                break;
+            case SOHSV:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.SOHSV);
+                ingestionMappingKind = IngestionProperties.DataFormat.SOHSV.getIngestionMappingKind();
+                break;
+            case TSV:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.TSV);
+                ingestionMappingKind = IngestionProperties.DataFormat.TSV.getIngestionMappingKind();
+                break;
+            case TSVE:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.TSVE);
+                ingestionMappingKind = IngestionProperties.DataFormat.TSVE.getIngestionMappingKind();
+                break;
+            case TXT:
+                ingestionProperties.setDataFormat(IngestionProperties.DataFormat.TXT);
+                ingestionMappingKind = IngestionProperties.DataFormat.TXT.getIngestionMappingKind();
+                break;
+        }
+
+        if (StringUtils.isNotEmpty(context.getProperty(MAPPING_NAME).getValue()) && ingestionMappingKind != null) {
+            ingestionProperties.setIngestionMapping(context.getProperty(MAPPING_NAME).getValue(), ingestionMappingKind);
+        }
+
+        ingestionProperties.setReportLevel(IngestionProperties.IngestionReportLevel.FAILURES_AND_SUCCESSES);
+        ingestionProperties.setReportMethod(IngestionProperties.IngestionReportMethod.TABLE);
+        ingestionProperties.setFlushImmediately(false);
+        ingestionProperties.setIgnoreFirstRecord(StringUtils.equalsIgnoreCase(context.getProperty(IGNORE_FIRST_RECORD).getValue(), IGNORE_FIRST_RECORD_YES.getValue()));
+
+        boolean isError = false;
+
+        // ingestion into ADX
+        try (final InputStream inputStream = session.read(flowFile)) {
+            StringBuilder ingestLogString = new StringBuilder().append("Ingesting with: ")
+                    .append("dataFormat - ").append(ingestionProperties.getDataFormat()).append("|")
+                    .append("ingestionMapping - ").append(ingestionProperties.getIngestionMapping().getIngestionMappingReference()).append("|")
+                    .append("reportLevel - ").append(ingestionProperties.getReportLevel()).append("|")
+                    .append("reportMethod - ").append(ingestionProperties.getReportMethod()).append("|")
+                    .append("databaseName - ").append(ingestionProperties.getDatabaseName()).append("|")
+                    .append("tableName - ").append(ingestionProperties.getTableName()).append("|")
+                    .append("flushImmediately - ").append(ingestionProperties.getFlushImmediately());
+            getLogger().info(ingestLogString.toString());
+
+            KustoIngestionResult result = service.ingestData(new KustoIngestionRequest(isStreamingEnabled, inputStream, ingestionProperties));
+
+            getLogger().info("Operation status: {} ", result.toString());
+            if (result == KustoIngestionResult.SUCCEEDED) {
+                getLogger().info("Operation status Succeeded - {}", result.toString());
+            }
+
+            if (result == KustoIngestionResult.FAILED) {
+                getLogger().error("Operation status Error - {}", result.toString());
+                isError = true;
+            }
+
+            if (result == KustoIngestionResult.PARTIALLY_SUCCEEDED) {
+                getLogger().error("Operation status Partially succeeded - {}", result.toString());
+                isError = true;
+            }
+        } catch (IOException | URISyntaxException e) {
+            getLogger().error("Non Transactional/Streaming Ingestion mode : Exception occurred while ingesting data into ADX with exception {} ", e);
+            isError = true;
+        }
+
+        if (isError) {
+            getLogger().error("Process failed - {}");
+            session.transfer(flowFile, FAILURE);
+        } else {
+            getLogger().info("Process succeeded - {}");
+            session.transfer(flowFile, SUCCESS);
+        }
+    }
+
+    protected void checkIfStreamingPolicyIsEnabledInADX(String entityName, String database) {
+        KustoQueryResponse kustoQueryResponse = service.executeQuery(database, String.format(STREAMING_POLICY_SHOW_COMMAND, IngestAzureDataExplorer.DATABASE, entityName));
+        if (kustoQueryResponse.isError()) {
+            throw new ProcessException("Error occurred while checking if streaming policy is enabled for the table");
+        }
+        KustoResultSetTable ingestionResultSet = kustoQueryResponse.getIngestionResultSet();
+        ingestionResultSet.next();
+        ingestionResultSet.getString("Policy");
+    }
+
+    protected boolean checkIfIngestorRoleDoesntExist(String databaseName, String tableName) {
+        KustoQueryResponse kustoQueryResponse = service.executeQuery(databaseName, String.format(FETCH_TABLE_COMMAND, tableName));
+        return kustoQueryResponse.isError();
+    }
+
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/IngestionDataFormat.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/IngestionDataFormat.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.data.explorer;
+
+public enum IngestionDataFormat {
+    AVRO(".avro", "An Avro format with support for logical types and for the snappy compression codec."),
+    APACHEAVRO(".apacheavro", "An Avro format with support for logical types and for the snappy compression codec."),
+    CSV(".csv", "A text file with comma-separated values (,). For more information, see RFC 4180: Common Format " +
+            "and MIME Type for Comma-Separated Values (CSV) Files."),
+    JSON(".json", "A text file containing JSON objects separated by \\n or \\r\\n. For more information, " +
+            "see JSON Lines (JSONL)."),
+    MULTIJSON(".multijson", "A text file containing a JSON array of property containers (each representing a record) or any " +
+            "number of property containers separated by spaces, \\n or \\r\\n. Each property container may be " +
+            "spread across multiple lines. This format is preferable to JSON unless the data is not property " +
+            "containers."),
+    ORC(".orc", "An ORC file."),
+    PARQUET(".parquet", "A parquet file."),
+    PSV(".psv", "A text file with values separated by vertical bars (|)."),
+    SCSV(".scsv", "A text file with values separated by semicolons (;)."),
+    SOHSV(".sohsv", "A text file with SOH-separated values. (SOH is the ASCII code point 1. " +
+            "This format is used by Hive in HDInsight)."),
+    TSV(".tsv", "A text file with tab delimited values (\\t)."),
+    TSVE(".tsv", "A text file with tab-delimited values (\\t). A backslash (\\) is used as escape character."),
+    TXT(".txt", "A text file with lines separated by \\n. Empty lines are skipped.");
+
+    IngestionDataFormat(String extension, String description) {
+        this.extension = extension;
+        this.description = description;
+    }
+
+    private final String extension;
+
+    private final String description;
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public String getDescription(){
+        return description;
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoIngestService.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoIngestService.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.services.azure.data.explorer;
+
+import com.microsoft.azure.kusto.data.Client;
+import com.microsoft.azure.kusto.data.ClientFactory;
+import com.microsoft.azure.kusto.data.KustoResultSetTable;
+import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
+import com.microsoft.azure.kusto.data.exceptions.DataClientException;
+import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
+import com.microsoft.azure.kusto.ingest.IngestClientFactory;
+import com.microsoft.azure.kusto.ingest.ManagedStreamingIngestClient;
+import com.microsoft.azure.kusto.ingest.QueuedIngestClient;
+import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
+import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException;
+import com.microsoft.azure.kusto.ingest.result.IngestionResult;
+import com.microsoft.azure.kusto.ingest.result.IngestionStatus;
+import com.microsoft.azure.kusto.ingest.result.OperationStatus;
+import com.microsoft.azure.kusto.ingest.source.StreamSourceInfo;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.nifi.annotation.behavior.ReadsAttribute;
+import org.apache.nifi.annotation.behavior.ReadsAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.reporting.InitializationException;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.nifi.services.azure.data.explorer.StandardKustoQueryService.AUTHENTICATION_STRATEGY;
+
+@Tags({"Azure", "ADX", "Kusto", "ingest", "azure"})
+@CapabilityDescription("Sends batches of flowfile content or stream flowfile content to an Azure ADX cluster.")
+@ReadsAttributes({
+        @ReadsAttribute(attribute = "AUTH_STRATEGY", description = "The strategy/method to authenticate against Azure Active Directory, either 'application' or 'managed_identity'."),
+        @ReadsAttribute(attribute = "INGEST_URL", description = "Specifies the URL of ingestion endpoint of the Azure Data Explorer cluster."),
+        @ReadsAttribute(attribute = "APP_ID", description = "Specifies Azure application id for accessing the ADX-Cluster."),
+        @ReadsAttribute(attribute = "APP_KEY", description = "Specifies Azure application key for accessing the ADX-Cluster."),
+        @ReadsAttribute(attribute = "APP_TENANT", description = "Azure application tenant for accessing the ADX-Cluster."),
+        @ReadsAttribute(attribute = "CLUSTER_URL", description = "Endpoint of ADX cluster. This is required only when streaming data to ADX cluster is enabled."),
+})
+public class StandardKustoIngestService extends AbstractControllerService implements KustoIngestService {
+
+    public static final PropertyDescriptor INGEST_URL = new PropertyDescriptor
+            .Builder().name("Ingest URL")
+            .displayName("Ingest URL")
+            .description("Ingestion URL of the Azure Data Explorer cluster.")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(StandardValidators.URL_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor KUSTO_AUTH_STRATEGY = new PropertyDescriptor
+            .Builder().name("Authentication Strategy")
+            .displayName("Authentication Strategy")
+            .description("Authentication method for access to Azure Data Explorer")
+            .required(false)
+            .defaultValue(KustoAuthenticationStrategy.MANAGED_IDENTITY.getValue())
+            .allowableValues(KustoAuthenticationStrategy.class)
+            .build();
+
+    public static final PropertyDescriptor APPLICATION_CLIENT_ID = new PropertyDescriptor
+            .Builder().name("Application Client ID")
+            .displayName("Application Client ID")
+            .description("Azure Data Explorer Application Client Identifier for Authentication")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor APPLICATION_KEY = new PropertyDescriptor
+            .Builder().name("Application Key")
+            .displayName("Application Key")
+            .description("Azure Data Explorer Application Key for Authentication")
+            .required(true)
+            .sensitive(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .dependsOn(AUTHENTICATION_STRATEGY, KustoAuthenticationStrategy.APPLICATION_CREDENTIALS.getValue())
+            .build();
+
+    public static final PropertyDescriptor APPLICATION_TENANT_ID = new PropertyDescriptor.Builder()
+            .name("Application Tenant ID")
+            .displayName("Application Tenant ID")
+            .description("Azure Data Explorer Application Tenant Identifier for Authentication")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .dependsOn(AUTHENTICATION_STRATEGY, KustoAuthenticationStrategy.APPLICATION_CREDENTIALS.getValue())
+            .build();
+
+    public static final PropertyDescriptor CLUSTER_URI = new PropertyDescriptor
+            .Builder().name("Cluster URI")
+            .displayName("Cluster URI")
+            .description("Azure Data Explorer Cluster URI")
+            .required(true)
+            .addValidator(StandardValidators.URL_VALIDATOR)
+            .build();
+
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
+            KUSTO_AUTH_STRATEGY,
+                    INGEST_URL,
+                    APPLICATION_CLIENT_ID,
+                    APPLICATION_KEY,
+                    APPLICATION_TENANT_ID,
+                    CLUSTER_URI));
+
+    public static final Pair<String, String> NIFI_SINK = Pair.of("processor", "nifi-sink");
+
+    private volatile QueuedIngestClient queuedIngestClient;
+
+    private volatile ManagedStreamingIngestClient managedStreamingIngestClient;
+
+    private volatile Client executionClient;
+
+    @Override
+    public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
+    /**
+     * @param context the configuration context
+     * @throws InitializationException if unable to create a database connection
+     */
+    @OnEnabled
+    public void onEnabled(final ConfigurationContext context) throws ProcessException, URISyntaxException {
+
+        getLogger().info("Starting Azure ADX Connection Service...");
+        final String applicationClientId = context.getProperty(APPLICATION_CLIENT_ID).getValue();
+        final String applicationKey = context.getProperty(APPLICATION_KEY).getValue();
+        final String applicationTenantId = context.getProperty(APPLICATION_TENANT_ID).getValue();
+        final String clusterUri = context.getProperty(CLUSTER_URI).getValue();
+        final String ingestUrl = context.getProperty(INGEST_URL).getValue();
+        final KustoAuthenticationStrategy kustoAuthenticationStrategy = KustoAuthenticationStrategy.valueOf(context.getProperty(KUSTO_AUTH_STRATEGY).getValue());
+
+        if (this.queuedIngestClient == null) {
+            this.queuedIngestClient = createKustoQueuedIngestClient(ingestUrl, applicationClientId, applicationKey, applicationTenantId, kustoAuthenticationStrategy);
+        }
+
+        if (this.managedStreamingIngestClient == null) {
+            this.managedStreamingIngestClient = createKustoStreamingIngestClient(ingestUrl, applicationClientId, applicationKey, applicationTenantId, clusterUri, kustoAuthenticationStrategy);
+        }
+
+        if (this.executionClient == null) {
+            this.executionClient = createKustoExecutionClient(clusterUri, applicationClientId, applicationKey, applicationTenantId, kustoAuthenticationStrategy);
+        }
+
+    }
+
+    @OnStopped
+    public final void onStopped() {
+        if (this.queuedIngestClient != null) {
+            try {
+                this.queuedIngestClient.close();
+            } catch (IOException e) {
+                getLogger().error("Closing Azure ADX Queued Ingest Client failed with: " + e.getMessage(), e);
+            } finally {
+                this.queuedIngestClient = null;
+            }
+        }
+        if (this.managedStreamingIngestClient != null) {
+            try {
+                this.managedStreamingIngestClient.close();
+            } catch (IOException e) {
+                getLogger().error("Closing Azure ADX Managed Streaming Ingest Client failed with: " + e.getMessage(), e);
+            } finally {
+                this.managedStreamingIngestClient = null;
+            }
+        }
+        if (this.executionClient != null) {
+            try {
+                this.executionClient.close();
+            } catch (IOException e) {
+                getLogger().error("Closing Azure ADX Execution Client failed with: " + e.getMessage(), e);
+            } finally {
+                this.executionClient = null;
+            }
+        }
+    }
+
+
+    protected QueuedIngestClient createKustoQueuedIngestClient(final String ingestUrl,
+                                                               final String appId,
+                                                               final String appKey,
+                                                               final String appTenant,
+                                                   final KustoAuthenticationStrategy kustoAuthStrategy) throws URISyntaxException {
+        ConnectionStringBuilder ingestConnectionStringBuilder = createKustoEngineConnectionString(ingestUrl, appId, appKey, appTenant, kustoAuthStrategy);
+        return IngestClientFactory.createClient(ingestConnectionStringBuilder);
+    }
+
+    protected ManagedStreamingIngestClient createKustoStreamingIngestClient(final String ingestUrl,
+                                                         final String appId,
+                                                         final String appKey,
+                                                         final String appTenant,
+                                                         final String kustoEngineUrl,
+                                                         final KustoAuthenticationStrategy kustoAuthStrategy) throws URISyntaxException {
+        ConnectionStringBuilder ingestConnectionStringBuilder = createKustoEngineConnectionString(ingestUrl, appId, appKey, appTenant, kustoAuthStrategy);
+        ConnectionStringBuilder streamingConnectionStringBuilder = createKustoEngineConnectionString(kustoEngineUrl, appId, appKey, appTenant, kustoAuthStrategy);
+        return IngestClientFactory.createManagedStreamingIngestClient(ingestConnectionStringBuilder, streamingConnectionStringBuilder);
+    }
+
+    public KustoIngestionResult ingestData(KustoIngestionRequest kustoIngestionRequest) {
+        StreamSourceInfo info = new StreamSourceInfo(kustoIngestionRequest.getInputStream());
+        //ingest data
+        IngestionResult ingestionResult;
+        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+        try {
+            if(kustoIngestionRequest.isStreamingEnabled()){
+                ingestionResult = managedStreamingIngestClient.ingestFromStream(info, kustoIngestionRequest.getIngestionProperties());
+            }else {
+                ingestionResult = queuedIngestClient.ingestFromStream(info, kustoIngestionRequest.getIngestionProperties());
+            }
+            List<IngestionStatus> statuses;
+            CompletableFuture<List<IngestionStatus>> future = new CompletableFuture<>();
+            IngestionResult finalIngestionResult = ingestionResult;
+            Runnable task = () -> {
+                try {
+                    List<IngestionStatus> statuses1 = finalIngestionResult.getIngestionStatusCollection();
+                    if (statuses1.get(0).status == OperationStatus.Succeeded
+                            || statuses1.get(0).status == OperationStatus.Failed
+                            || statuses1.get(0).status == OperationStatus.PartiallySucceeded) {
+                        future.complete(statuses1);
+                    }
+                } catch (Exception e) {
+                    future.completeExceptionally(new ProcessException("Error occurred while checking ingestion status", e));
+                }
+            };
+            scheduler.scheduleWithFixedDelay(task, 1, 2, TimeUnit.SECONDS);
+            statuses = future.get(1800, TimeUnit.SECONDS);
+            return KustoIngestionResult.fromString(statuses.get(0).status.toString());
+        } catch (IngestionClientException | IngestionServiceException e) {
+            throw new ProcessException("Error occurred while ingesting data into ADX", e);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new ProcessException("Error occurred while checking ingestion status", e);
+        } finally {
+            shutDownScheduler(scheduler);
+        }
+    }
+
+    public void shutDownScheduler(ScheduledExecutorService executorService) {
+        executorService.shutdown();
+        try {
+            // Wait a while for existing tasks to terminate
+            if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+                // Cancel currently executing tasks forcefully
+                executorService.shutdownNow();
+                // Wait a while for tasks to respond to being cancelled
+                if (!executorService.awaitTermination(60, TimeUnit.SECONDS))
+                    getLogger().error("Scheduler did not terminate");
+            }
+        } catch (InterruptedException ex) {
+            // (Re-)Cancel if current thread also interrupted
+            executorService.shutdownNow();
+        }
+    }
+
+    private ConnectionStringBuilder createKustoEngineConnectionString(final String clusterUrl,
+                                                                      final String appId,
+                                                                      final String appKey,
+                                                                      final String appTenant,
+                                                                      final KustoAuthenticationStrategy kustoAuthStrategy) {
+        final ConnectionStringBuilder builder;
+        if(KustoAuthenticationStrategy.APPLICATION_CREDENTIALS == kustoAuthStrategy){
+            builder = ConnectionStringBuilder.createWithAadApplicationCredentials(clusterUrl, appId, appKey, appTenant);
+        }else{
+            builder = ConnectionStringBuilder.createWithAadManagedIdentity(clusterUrl, appId);
+        }
+
+        final String vendor = System.getProperty("java.vendor");
+        final String version = System.getProperty("java.version");
+
+        builder.setConnectorDetails("Kusto.Nifi", StandardKustoIngestService.class.getPackage().getImplementationVersion(), vendor, version, false, null, NIFI_SINK);
+        return builder;
+    }
+
+    protected Client createKustoExecutionClient(final String clusterUrl,
+                                                final String appId,
+                                                final String appKey,
+                                                final String appTenant,
+                                                final KustoAuthenticationStrategy kustoAuthStrategy) throws URISyntaxException {
+        return ClientFactory.createClient(createKustoEngineConnectionString(clusterUrl, appId, appKey, appTenant, kustoAuthStrategy));
+    }
+
+    @Override
+    public KustoQueryResponse executeQuery(String databaseName, String query) {
+        Objects.requireNonNull(databaseName, "Database Name required");
+        Objects.requireNonNull(query, "Query required");
+        KustoQueryResponse kustoQueryResponse;
+        try {
+            KustoResultSetTable kustoResultSetTable = this.executionClient.execute(databaseName, query).getPrimaryResults();
+            kustoQueryResponse = new KustoQueryResponse(kustoResultSetTable);
+        } catch (DataServiceException | DataClientException e) {
+            getLogger().error("ADX Ingestion : Kusto Query execution failed", e);
+            kustoQueryResponse = new KustoQueryResponse(true, e.getMessage());
+        }
+        return kustoQueryResponse;
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoQueryService.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoQueryService.java
@@ -20,6 +20,7 @@ import com.microsoft.azure.kusto.data.ClientFactory;
 import com.microsoft.azure.kusto.data.StreamingClient;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
@@ -99,6 +100,8 @@ public class StandardKustoQueryService extends AbstractControllerService impleme
         return PROPERTY_DESCRIPTORS;
     }
 
+    public static final Pair<String, String> NIFI_SOURCE = Pair.of("processor", "nifi-source");
+
     @OnEnabled
     public void onEnabled(final ConfigurationContext context) throws ProcessException, URISyntaxException {
         if (this.kustoClient == null) {
@@ -162,7 +165,7 @@ public class StandardKustoQueryService extends AbstractControllerService impleme
         final String vendor = System.getProperty("java.vendor");
         final String version = System.getProperty("java.version");
 
-        builder.setConnectorDetails(vendor, version, null, null, false, null);
+        builder.setConnectorDetails("Kusto.Nifi", StandardKustoQueryService.class.getPackage().getImplementationVersion(), vendor, version, false, null, NIFI_SOURCE);
         return builder;
     }
 }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -17,6 +17,7 @@ org.apache.nifi.services.azure.storage.ADLSCredentialsControllerService
 org.apache.nifi.services.azure.storage.ADLSCredentialsControllerServiceLookup
 org.apache.nifi.services.azure.cosmos.document.AzureCosmosDBClientService
 org.apache.nifi.services.azure.data.explorer.StandardKustoQueryService
+org.apache.nifi.services.azure.data.explorer.StandardKustoIngestService
 org.apache.nifi.services.azure.storage.AzureStorageCredentialsControllerService_v12
 org.apache.nifi.services.azure.storage.AzureStorageCredentialsControllerServiceLookup_v12
 org.apache.nifi.services.azure.StandardAzureCredentialsControllerService

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -21,6 +21,7 @@ org.apache.nifi.processors.azure.storage.FetchAzureDataLakeStorage
 org.apache.nifi.processors.azure.storage.ListAzureDataLakeStorage
 org.apache.nifi.processors.azure.cosmos.document.PutAzureCosmosDBRecord
 org.apache.nifi.processors.azure.data.explorer.QueryAzureDataExplorer
+org.apache.nifi.processors.azure.data.explorer.IngestAzureDataExplorer
 org.apache.nifi.processors.azure.storage.ListAzureBlobStorage_v12
 org.apache.nifi.processors.azure.storage.FetchAzureBlobStorage_v12
 org.apache.nifi.processors.azure.storage.PutAzureBlobStorage_v12

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/data/explorer/IngestAzureDataExplorerTest.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/data/explorer/IngestAzureDataExplorerTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.data.explorer;
+
+import com.microsoft.azure.kusto.data.KustoResultSetTable;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.services.azure.data.explorer.KustoIngestService;
+import org.apache.nifi.services.azure.data.explorer.KustoIngestionResult;
+import org.apache.nifi.services.azure.data.explorer.KustoQueryResponse;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.URISyntaxException;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class IngestAzureDataExplorerTest {
+
+    private static final String SERVICE_ID = KustoIngestService.class.getName();
+
+    private static final String DATABASE_NAME = "records";
+
+    private static final String TABLE_NAME = "records";
+
+    private static final String MAPPING_NAME = "records";
+
+    private static final String DATA_FORMAT = "CSV";
+
+    private static final byte[] EMPTY = new byte[]{};
+
+    @Mock
+    private KustoIngestService kustoIngestService;
+
+    @Mock
+    private KustoResultSetTable kustoResultSetTable;
+
+    private TestRunner runner;
+
+    @BeforeEach
+    void setRunner() throws InitializationException {
+        runner = TestRunners.newTestRunner(IngestAzureDataExplorer.class);
+        runner.setValidateExpressionUsage(false);
+        when(kustoIngestService.getIdentifier()).thenReturn(SERVICE_ID);
+        runner.addControllerService(SERVICE_ID, kustoIngestService);
+        runner.enableControllerService(kustoIngestService);
+    }
+
+    @Test
+    void testProperties() {
+        runner.assertNotValid();
+
+        runner.setProperty(IngestAzureDataExplorer.DATABASE_NAME, DATABASE_NAME);
+        runner.setProperty(IngestAzureDataExplorer.TABLE_NAME, TABLE_NAME);
+        runner.setProperty(IngestAzureDataExplorer.MAPPING_NAME, MAPPING_NAME);
+        runner.setProperty(IngestAzureDataExplorer.DATA_FORMAT, DATA_FORMAT);
+        runner.setProperty(IngestAzureDataExplorer.ADX_SERVICE, SERVICE_ID);
+
+        runner.assertValid();
+    }
+
+    @Test
+    void testRunSuccessNonTransactional() throws URISyntaxException {
+        runner.setProperty(IngestAzureDataExplorer.DATABASE_NAME, DATABASE_NAME);
+        runner.setProperty(IngestAzureDataExplorer.TABLE_NAME, TABLE_NAME);
+        runner.setProperty(IngestAzureDataExplorer.MAPPING_NAME, MAPPING_NAME);
+        runner.setProperty(IngestAzureDataExplorer.DATA_FORMAT, DATA_FORMAT);
+        runner.setProperty(IngestAzureDataExplorer.ADX_SERVICE, SERVICE_ID);
+
+        runner.enqueue(EMPTY);
+
+        KustoQueryResponse kustoQueryResponse = Mockito.mock(KustoQueryResponse.class);
+        when(kustoIngestService.executeQuery(Mockito.anyString(), Mockito.anyString())).thenReturn(kustoQueryResponse);
+        final KustoIngestionResult kustoIngestionResult = KustoIngestionResult.SUCCEEDED;
+        when(kustoIngestService.ingestData(Mockito.any())).thenReturn(kustoIngestionResult);
+
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(IngestAzureDataExplorer.SUCCESS);
+    }
+
+    @Test
+    void testRunFailureNonTransactional() throws URISyntaxException {
+        runner.setProperty(IngestAzureDataExplorer.DATABASE_NAME, DATABASE_NAME);
+        runner.setProperty(IngestAzureDataExplorer.TABLE_NAME, TABLE_NAME);
+        runner.setProperty(IngestAzureDataExplorer.MAPPING_NAME, MAPPING_NAME);
+        runner.setProperty(IngestAzureDataExplorer.DATA_FORMAT, DATA_FORMAT);
+        runner.setProperty(IngestAzureDataExplorer.ADX_SERVICE, SERVICE_ID);
+
+        runner.enqueue(EMPTY);
+
+        KustoQueryResponse kustoQueryResponse = Mockito.mock(KustoQueryResponse.class);
+        when(kustoIngestService.executeQuery(Mockito.anyString(), Mockito.anyString())).thenReturn(kustoQueryResponse);
+        final KustoIngestionResult kustoIngestionResult = KustoIngestionResult.SUCCEEDED;
+        when(kustoIngestService.ingestData(Mockito.any())).thenReturn(kustoIngestionResult);
+
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(IngestAzureDataExplorer.SUCCESS);
+    }
+
+    @Test
+    void testRunSuccessStreaming() throws URISyntaxException{
+        runner.setProperty(IngestAzureDataExplorer.DATABASE_NAME, DATABASE_NAME);
+        runner.setProperty(IngestAzureDataExplorer.TABLE_NAME, TABLE_NAME);
+        runner.setProperty(IngestAzureDataExplorer.MAPPING_NAME, MAPPING_NAME);
+        runner.setProperty(IngestAzureDataExplorer.DATA_FORMAT, DATA_FORMAT);
+        runner.setProperty(IngestAzureDataExplorer.ADX_SERVICE, SERVICE_ID);
+        runner.setProperty(IngestAzureDataExplorer.IS_STREAMING_ENABLED, "true");
+
+        runner.enqueue(EMPTY);
+
+        KustoQueryResponse kustoQueryResponse = new KustoQueryResponse(kustoResultSetTable);
+        when(kustoIngestService.executeQuery(Mockito.anyString(), Mockito.anyString())).thenReturn(kustoQueryResponse);
+        final KustoIngestionResult kustoIngestionResult = KustoIngestionResult.SUCCEEDED;
+        when(kustoIngestService.ingestData(Mockito.any())).thenReturn(kustoIngestionResult);
+
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(IngestAzureDataExplorer.SUCCESS);
+    }
+
+    @Test
+    void testRunSuccessStreamingFailure() throws URISyntaxException{
+        runner.setProperty(IngestAzureDataExplorer.DATABASE_NAME, DATABASE_NAME);
+        runner.setProperty(IngestAzureDataExplorer.TABLE_NAME, TABLE_NAME);
+        runner.setProperty(IngestAzureDataExplorer.MAPPING_NAME, MAPPING_NAME);
+        runner.setProperty(IngestAzureDataExplorer.DATA_FORMAT, DATA_FORMAT);
+        runner.setProperty(IngestAzureDataExplorer.ADX_SERVICE, SERVICE_ID);
+        runner.setProperty(IngestAzureDataExplorer.IS_STREAMING_ENABLED, "true");
+
+        runner.enqueue(EMPTY);
+
+        KustoQueryResponse kustoQueryResponse = Mockito.mock(KustoQueryResponse.class);
+        when(kustoIngestService.executeQuery(Mockito.anyString(), Mockito.anyString())).thenReturn(kustoQueryResponse);
+        when(kustoQueryResponse.getIngestionResultSet()).thenReturn(kustoResultSetTable);
+        final KustoIngestionResult kustoIngestionResult = KustoIngestionResult.FAILED;
+        when(kustoIngestService.ingestData(Mockito.any())).thenReturn(kustoIngestionResult);
+
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(IngestAzureDataExplorer.FAILURE);
+    }
+
+
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/pom.xml
@@ -36,6 +36,16 @@
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure.kusto</groupId>
+            <artifactId>kusto-data</artifactId>
+            <version>5.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure.kusto</groupId>
+            <artifactId>kusto-ingest</artifactId>
+            <version>5.0.1</version>
+        </dependency>
         <!-- azure-core does not bring jackson-dataformat-xml dependency from version 1.37.0 on -->
         <!-- but some libraries in the processor nar module depend on jackson-dataformat-xml -->
         <!-- and check its existence and version via JacksonVersion in azure-core -->

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/data/explorer/KustoIngestService.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/data/explorer/KustoIngestService.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.services.azure.data.explorer;
+
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+
+import java.net.URISyntaxException;
+
+@Tags({"azure", "adx", "explorer", "kusto", "ingest"})
+@CapabilityDescription("Connection-Service for Azure ADX (Kusto) ingestion cluster to ingest data.")
+public interface KustoIngestService extends KustoQueryService {
+    KustoIngestionResult ingestData(KustoIngestionRequest kustoIngestionRequest) throws URISyntaxException;
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/data/explorer/KustoIngestionRequest.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/data/explorer/KustoIngestionRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.services.azure.data.explorer;
+
+import com.microsoft.azure.kusto.ingest.IngestionProperties;
+
+import java.io.InputStream;
+
+public class KustoIngestionRequest {
+
+    private boolean isStreamingEnabled;
+    private InputStream inputStream;
+    private IngestionProperties ingestionProperties;
+
+    public KustoIngestionRequest(boolean isStreamingEnabled, InputStream inputStream, IngestionProperties ingestionProperties) {
+        this.isStreamingEnabled = isStreamingEnabled;
+        this.inputStream = inputStream;
+        this.ingestionProperties = ingestionProperties;
+    }
+
+    public boolean isStreamingEnabled() {
+        return isStreamingEnabled;
+    }
+
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+
+    public IngestionProperties getIngestionProperties() {
+        return ingestionProperties;
+    }
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/data/explorer/KustoIngestionResult.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/data/explorer/KustoIngestionResult.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.services.azure.data.explorer;
+
+public enum KustoIngestionResult {
+    SUCCEEDED("Succeeded"),PARTIALLY_SUCCEEDED("PartiallySucceeded"),FAILED("Failed"),DEFAULT("Default");
+    private String status;
+
+    KustoIngestionResult(String status) {
+        this.status = status;
+    }
+
+    public static KustoIngestionResult fromString(String status) {
+        for (KustoIngestionResult result : KustoIngestionResult.values()) {
+            if (result.status.equalsIgnoreCase(status)) {
+                return result;
+            }
+        }
+        return DEFAULT;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/data/explorer/KustoQueryResponse.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/data/explorer/KustoQueryResponse.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.services.azure.data.explorer;
 
+import com.microsoft.azure.kusto.data.KustoResultSetTable;
+
 import java.io.InputStream;
 import java.util.Objects;
 
@@ -26,6 +28,8 @@ public class KustoQueryResponse {
     private final boolean error;
 
     private final String errorMessage;
+
+    private KustoResultSetTable ingestionResultSet;
 
     public KustoQueryResponse(final boolean error, final String errorMessage) {
         this.responseStream = null;
@@ -39,6 +43,13 @@ public class KustoQueryResponse {
         this.errorMessage = null;
     }
 
+    public KustoQueryResponse(KustoResultSetTable ingestionResultSet) {
+        this.responseStream = null;
+        this.error = false;
+        this.errorMessage = null;
+        this.ingestionResultSet = ingestionResultSet;
+    }
+
     public InputStream getResponseStream() {
         return responseStream;
     }
@@ -49,5 +60,9 @@ public class KustoQueryResponse {
 
     public String getErrorMessage() {
         return errorMessage;
+    }
+
+    public KustoResultSetTable getIngestionResultSet() {
+        return ingestionResultSet;
     }
 }


### PR DESCRIPTION
NIFI-8294 sink commits

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-8294](https://issues.apache.org/jira/browse/NIFI-8294)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
