### PR TITLE
NIFI-11934 allow FlowFile filename to be transmitted in HTTP header f…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -131,7 +131,7 @@ import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 @InputRequirement(Requirement.INPUT_ALLOWED)
 @CapabilityDescription("An HTTP client processor which can interact with a configurable HTTP Endpoint. The destination URL and HTTP Method are configurable."
         + " When the HTTP Method is PUT, POST or PATCH, the FlowFile contents are included as the body of the request and FlowFile attributes are converted"
-        + " to HTTP headers (optionally, if configured to be sent via the 'Attributes to Send' property)")
+        + " to HTTP headers, optionally, based on configuration properties.")
 @WritesAttributes({
         @WritesAttribute(attribute = InvokeHTTP.STATUS_CODE, description = "The status code that is returned"),
         @WritesAttribute(attribute = InvokeHTTP.STATUS_MESSAGE, description = "The status message that is returned"),
@@ -391,7 +391,7 @@ public class InvokeHTTP extends AbstractProcessor {
     public static final PropertyDescriptor REQUEST_HEADER_ATTRIBUTES_PATTERN = new PropertyDescriptor.Builder()
             .name("Attributes to Send")
             .displayName("Request Header Attributes Pattern")
-            .description("Regular expression that defines which FlowFile attribute(s) to send as HTTP headers in the request. "
+            .description("Regular expression that defines which FlowFile attributes to send as HTTP headers in the request. "
                     + "If not defined, no attributes are sent as headers. Dynamic properties will be always be sent as headers. "
                     + "The dynamic property name will be the header key and the dynamic property value, interpreted as Expression "
                     + "Language, will be the header value. Attributes and their values are limited to ASCII characters due to "

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -130,7 +130,8 @@ import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 @Tags({"http", "https", "rest", "client"})
 @InputRequirement(Requirement.INPUT_ALLOWED)
 @CapabilityDescription("An HTTP client processor which can interact with a configurable HTTP Endpoint. The destination URL and HTTP Method are configurable."
-        + " FlowFile attributes are converted to HTTP headers and the FlowFile contents are included as the body of the request (if the HTTP Method is PUT, POST or PATCH).")
+        + " When the HTTP Method is PUT, POST or PATCH, the FlowFile contents are included as the body of the request and FlowFile attributes are converted"
+        + " to HTTP headers (optionally, if configured to be sent via the 'Attributes to Send' property)")
 @WritesAttributes({
         @WritesAttribute(attribute = InvokeHTTP.STATUS_CODE, description = "The status code that is returned"),
         @WritesAttribute(attribute = InvokeHTTP.STATUS_MESSAGE, description = "The status message that is returned"),
@@ -185,7 +186,6 @@ public class InvokeHTTP extends AbstractProcessor {
             EXCEPTION_CLASS,
             EXCEPTION_MESSAGE,
             CoreAttributes.UUID.key(),
-            CoreAttributes.FILENAME.key(),
             CoreAttributes.PATH.key()
     )));
 
@@ -391,10 +391,11 @@ public class InvokeHTTP extends AbstractProcessor {
     public static final PropertyDescriptor REQUEST_HEADER_ATTRIBUTES_PATTERN = new PropertyDescriptor.Builder()
             .name("Attributes to Send")
             .displayName("Request Header Attributes Pattern")
-            .description("Regular expression that defines which attributes to send as HTTP headers in the request. "
-                    + "If not defined, no attributes are sent as headers. Dynamic properties will be sent as headers. "
-                    + "The dynamic property name will be the header key and the dynamic property value will be interpreted as expression "
-                    + "language will be the header value.")
+            .description("Regular expression that defines which FlowFile attribute(s) to send as HTTP headers in the request. "
+                    + "If not defined, no attributes are sent as headers. Dynamic properties will be always be sent as headers. "
+                    + "The dynamic property name will be the header key and the dynamic property value, interpreted as Expression "
+                    + "Language, will be the header value. Attributes and their values are limited to ASCII characters due to "
+                    + "the requirement of the HTTP protocol.")
             .required(false)
             .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
             .build();


### PR DESCRIPTION
…or InvokeHTTP

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary
Removed 'filename' from the list of attributes to exclude when sending FlowFIle attributes using InvokeHTTP. Updated some of the documentation as well.
[NIFI-11934](https://issues.apache.org/jira/browse/NIFI-11934)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Instantiate InvokeHTTP and set 'Request Header Attributes Pattern' to ".*" (or any other value which will include the "filename" attribute.) Receive FlowFile with a corresponding ListenHTTP. Verify 'filename' is as expected (same as FlowFile that was transferred.)

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
