### PR TITLE
NIFI-11990 Disable Kubernetes Auto Config in Test Class

### DIFF
--- a/nifi-commons/nifi-kubernetes-client/src/test/java/org/apache/nifi/kubernetes/client/StandardKubernetesClientProviderTest.java
+++ b/nifi-commons/nifi-kubernetes-client/src/test/java/org/apache/nifi/kubernetes/client/StandardKubernetesClientProviderTest.java
@@ -17,6 +17,8 @@
 package org.apache.nifi.kubernetes.client;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -24,7 +26,19 @@ import org.junit.jupiter.api.Timeout;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class StandardKubernetesClientProviderTest {
+    private static final String DISABLE_AUTO_CONFIG_PROPERTY = "kubernetes.disable.autoConfig";
+
     StandardKubernetesClientProvider provider;
+
+    @BeforeAll
+    static void setDisableAutoConfig() {
+        System.setProperty(DISABLE_AUTO_CONFIG_PROPERTY, Boolean.TRUE.toString());
+    }
+
+    @AfterAll
+    static void clearDisableAutoConfig() {
+        System.clearProperty(DISABLE_AUTO_CONFIG_PROPERTY);
+    }
 
     @BeforeEach
     void setProvider() {


### PR DESCRIPTION
# Summary

[NIFI-11990](https://issues.apache.org/jira/browse/NIFI-11990) Disables Kubernetes Client automatic configuration in the `StandardKubernetesClientProviderTest` class to avoid unexpected failures on systems that have a default Kubernetes configuration. The change sets and clears the `kubernetes.disable.autoConfig` System property as described in the [Fabric8 Client](https://github.com/fabric8io/kubernetes-client#configuring-the-client) configuration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
