### PR TITLE
NIFI-11519: handle sensitive dynamic properties not prefixed with SEN…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
@@ -272,7 +272,12 @@ public class DBCPConnectionPool extends AbstractDBCPConnectionPool implements DB
                 .map(descriptor -> {
                     final PropertyValue propertyValue = context.getProperty(descriptor);
                     if (descriptor.isSensitive()) {
-                        final String propertyName = StringUtils.substringAfter(descriptor.getName(), SENSITIVE_PROPERTY_PREFIX);
+                        final String propertyName;
+                        if (StringUtils.startsWith(descriptor.getName(), SENSITIVE_PROPERTY_PREFIX)) {
+                            propertyName = StringUtils.substringAfter(descriptor.getName(), SENSITIVE_PROPERTY_PREFIX);
+                        } else {
+                            propertyName = descriptor.getName();
+                        }
                         return new AbstractMap.SimpleEntry<>(propertyName, propertyValue.getValue());
                     } else {
                         return new AbstractMap.SimpleEntry<>(descriptor.getName(), propertyValue.evaluateAttributeExpressions().getValue());

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/java/org/apache/nifi/dbcp/DBCPServiceTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/java/org/apache/nifi/dbcp/DBCPServiceTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.opentest4j.AssertionFailedError;
 
 import java.io.File;
 import java.io.IOException;
@@ -160,6 +161,16 @@ public class DBCPServiceTest {
     @Test
     public void testGetConnectionDynamicPropertySensitivePrefixSupported() throws SQLException {
         assertConnectionNotNullDynamicProperty("SENSITIVE.create", "true");
+    }
+
+    @Test
+    public void testGetConnectionSensitiveDynamicPropertyWithoutPrefixAndWithPrefixShouldThrowException() throws SQLException {
+        runner.setProperty(service, "SENSITIVE.create", "true");
+        runner.setProperty(service, "create", "true");
+
+        final AssertionFailedError e =
+                assertThrows(AssertionFailedError.class, () -> runner.enableControllerService(service));
+        assertTrue(e.getMessage().contains("IllegalStateException"));
     }
 
     @Test


### PR DESCRIPTION
…SITIVE. for DBCPConnectionPool.

Important behavior to note is that the expected behavior is that controller service cannot be enabled successfully too if there is two properties are equal to each other if the `SENSITIVE` prefix is removed such as `SENSITIVE.test` and `test`. This is caused by an IllegalStateException of trying to add two entries with the same key to the map containing all dynamic properties.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11519](https://issues.apache.org/jira/browse/NIFI-11519)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
