### PR TITLE
NIFI-11995 Support multiple output formats for message headers in ConsumeAMQP

### DIFF
--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
@@ -47,6 +47,14 @@ language governing permissions and limitations under the License. -->
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
             <version>2.0.0-SNAPSHOT</version>

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.amqp.processors;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.Envelope;
@@ -26,6 +28,7 @@ import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
@@ -39,7 +42,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,13 +49,15 @@ import java.util.stream.Collectors;
 
 @Tags({"amqp", "rabbit", "get", "message", "receive", "consume"})
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
-@CapabilityDescription("Consumes AMQP Messages from an AMQP Broker using the AMQP 0.9.1 protocol. Each message that is received from the AMQP Broker will be "
-    + "emitted as its own FlowFile to the 'success' relationship.")
+@CapabilityDescription(
+    "Consumes AMQP Messages from an AMQP Broker using the AMQP 0.9.1 protocol. Each message that is received from the AMQP Broker will be "
+        + "emitted as its own FlowFile to the 'success' relationship.")
 @WritesAttributes({
     @WritesAttribute(attribute = "amqp$appId", description = "The App ID field from the AMQP Message"),
     @WritesAttribute(attribute = "amqp$contentEncoding", description = "The Content Encoding reported by the AMQP Message"),
     @WritesAttribute(attribute = "amqp$contentType", description = "The Content Type reported by the AMQP Message"),
-    @WritesAttribute(attribute = "amqp$headers", description = "The headers present on the AMQP Message"),
+    @WritesAttribute(attribute = "amqp$headers", description = "The headers present on the AMQP Message. Added only if processor is configured to output this attribute."),
+    @WritesAttribute(attribute = "<Header Key Prefix>.<attribute>", description = "Each message header will be inserted with this attribute name, if processor is configured to output headers as attribute"),
     @WritesAttribute(attribute = "amqp$deliveryMode", description = "The numeric indicator for the Message's Delivery Mode"),
     @WritesAttribute(attribute = "amqp$priority", description = "The Message priority"),
     @WritesAttribute(attribute = "amqp$correlationId", description = "The Message's Correlation ID"),
@@ -68,189 +72,274 @@ import java.util.stream.Collectors;
     @WritesAttribute(attribute = "amqp$exchange", description = "The exchange from which AMQP Message was received")
 })
 public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
-    private static final String ATTRIBUTES_PREFIX = "amqp$";
 
-    public static final PropertyDescriptor QUEUE = new PropertyDescriptor.Builder()
-        .name("Queue")
-        .description("The name of the existing AMQP Queue from which messages will be consumed. Usually pre-defined by AMQP administrator. ")
-        .required(true)
-        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-        .build();
-    static final PropertyDescriptor AUTO_ACKNOWLEDGE = new PropertyDescriptor.Builder()
-        .name("auto.acknowledge")
-        .displayName("Auto-Acknowledge Messages")
-        .description(" If false (Non-Auto-Acknowledge), the messages will be acknowledged by the processor after transferring the FlowFiles to success and committing "
-            + "the NiFi session. Non-Auto-Acknowledge mode provides 'at-least-once' delivery semantics. "
-            + "If true (Auto-Acknowledge), messages that are delivered to the AMQP Client will be auto-acknowledged by the AMQP Broker just after sending them out. "
-            + "This generally will provide better throughput but will also result in messages being lost upon restart/crash of the AMQP Broker, NiFi or the processor. "
-            + "Auto-Acknowledge mode provides 'at-most-once' delivery semantics and it is recommended only if loosing messages is acceptable.")
-        .allowableValues("true", "false")
-        .defaultValue("false")
-        .required(true)
-        .build();
-    static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
-        .name("batch.size")
-        .displayName("Batch Size")
-        .description("The maximum number of messages that should be processed in a single session. Once this many messages have been received (or once no more messages are readily available), "
-            + "the messages received will be transferred to the 'success' relationship and the messages will be acknowledged to the AMQP Broker. Setting this value to a larger number "
-            + "could result in better performance, particularly for very small messages, but can also result in more messages being duplicated upon sudden restart of NiFi.")
-        .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-        .expressionLanguageSupported(ExpressionLanguageScope.NONE)
-        .defaultValue("10")
-        .required(true)
-        .build();
-    public static final PropertyDescriptor HEADER_SEPARATOR = new PropertyDescriptor.Builder()
-       .name("header.separator")
-       .displayName("Header Separator")
-       .description("The character that is used to separate key-value for header in String. The value must only one character."
-               + "Otherwise you will get an error message")
-       .addValidator(StandardValidators.SINGLE_CHAR_VALIDATOR)
-       .defaultValue(",")
-       .required(false)
-       .build();
-    static final PropertyDescriptor REMOVE_CURLY_BRACES = new PropertyDescriptor.Builder()
-        .name("remove.curly.braces")
-        .displayName("Remove Curly Braces")
-        .description("If true Remove Curly Braces, Curly Braces in the header will be automatically remove.")
-        .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
-        .defaultValue("False")
-        .allowableValues("True", "False")
-        .required(false)
-        .build();
+  private static final String ATTRIBUTES_PREFIX = "amqp$";
+  public static final String DEFAULT_HEADERS_KEY_PREFIX = "consume.amqp";
 
-    public static final Relationship REL_SUCCESS = new Relationship.Builder()
-        .name("success")
-        .description("All FlowFiles that are received from the AMQP queue are routed to this relationship")
-        .build();
+  public static final AllowableValue HEADERS_FORMAT_COMMA_SEPARATED_STRING = new AllowableValue(
+      "Comma Separated String", "Comma Separated String",
+      "Put all headers as a string with the specified separator in the attribute 'amqp$headers'.");
+  public static final AllowableValue HEADERS_FORMAT_JSON_STRING = new AllowableValue("JSON String",
+      "JSON String",
+      "Format all headers as JSON string and output in the attribute 'amqp$headers'. It will include keys with null value as well.");
+  public static final AllowableValue HEADERS_FORMAT_ATTRIBUTES = new AllowableValue(
+      "Flow file attributes", "Flow file attributes",
+      "Put each header as attribute of the flow file with a prefix specified in the properties");
 
-    private static final List<PropertyDescriptor> propertyDescriptors;
-    private static final Set<Relationship> relationships;
+  public static final PropertyDescriptor QUEUE = new PropertyDescriptor.Builder()
+      .name("Queue")
+      .description(
+          "The name of the existing AMQP Queue from which messages will be consumed. Usually pre-defined by AMQP administrator. ")
+      .required(true)
+      .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+      .build();
+  public static final PropertyDescriptor AUTO_ACKNOWLEDGE = new PropertyDescriptor.Builder()
+      .name("auto.acknowledge")
+      .displayName("Auto-Acknowledge Messages")
+      .description(
+          " If false (Non-Auto-Acknowledge), the messages will be acknowledged by the processor after transferring the FlowFiles to success and committing "
+              + "the NiFi session. Non-Auto-Acknowledge mode provides 'at-least-once' delivery semantics. "
+              + "If true (Auto-Acknowledge), messages that are delivered to the AMQP Client will be auto-acknowledged by the AMQP Broker just after sending them out. "
+              + "This generally will provide better throughput but will also result in messages being lost upon restart/crash of the AMQP Broker, NiFi or the processor. "
+              + "Auto-Acknowledge mode provides 'at-most-once' delivery semantics and it is recommended only if loosing messages is acceptable.")
+      .allowableValues("true", "false")
+      .defaultValue("false")
+      .required(true)
+      .build();
+  static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
+      .name("batch.size")
+      .displayName("Batch Size")
+      .description(
+          "The maximum number of messages that should be processed in a single session. Once this many messages have been received (or once no more messages are readily available), "
+              + "the messages received will be transferred to the 'success' relationship and the messages will be acknowledged to the AMQP Broker. Setting this value to a larger number "
+              + "could result in better performance, particularly for very small messages, but can also result in more messages being duplicated upon sudden restart of NiFi.")
+      .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+      .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+      .defaultValue("10")
+      .required(true)
+      .build();
 
-    static {
-        List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(QUEUE);
-        properties.add(AUTO_ACKNOWLEDGE);
-        properties.add(BATCH_SIZE);
-        properties.add(REMOVE_CURLY_BRACES);
-        properties.add(HEADER_SEPARATOR);
-        properties.addAll(getCommonPropertyDescriptors());
-        propertyDescriptors = Collections.unmodifiableList(properties);
+  public static final PropertyDescriptor HEADER_FORMAT = new PropertyDescriptor.Builder()
+      .name("header.format")
+      .displayName("Header Output Format")
+      .description("Defines how to output headers from the received message")
+      .allowableValues(HEADERS_FORMAT_COMMA_SEPARATED_STRING, HEADERS_FORMAT_JSON_STRING,
+          HEADERS_FORMAT_ATTRIBUTES)
+      .defaultValue(HEADERS_FORMAT_COMMA_SEPARATED_STRING.getValue())
+      .required(true)
+      .build();
+  public static final PropertyDescriptor HEADER_KEY_PREFIX = new PropertyDescriptor.Builder()
+      .name("header.key.prefix")
+      .displayName("Header Key Prefix")
+      .description(
+          "Text to be prefixed to header keys as the are added to the flowfile attributes. Processor will append '.' to the value")
+      .defaultValue(DEFAULT_HEADERS_KEY_PREFIX)
+      .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+      .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_ATTRIBUTES)
+      .required(true)
+      .build();
 
-        Set<Relationship> rels = new HashSet<>();
-        rels.add(REL_SUCCESS);
-        relationships = Collections.unmodifiableSet(rels);
+  public static final PropertyDescriptor HEADER_SEPARATOR = new PropertyDescriptor.Builder()
+      .name("header.separator")
+      .displayName("Header Separator")
+      .description(
+          "The character that is used to separate key-value for header in String. The value must only one character."
+              + "Otherwise you will get an error message")
+      .addValidator(StandardValidators.SINGLE_CHAR_VALIDATOR)
+      .defaultValue(",")
+      .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_COMMA_SEPARATED_STRING)
+      .required(false)
+      .build();
+  static final PropertyDescriptor REMOVE_CURLY_BRACES = new PropertyDescriptor.Builder()
+      .name("remove.curly.braces")
+      .displayName("Remove Curly Braces")
+      .description(
+          "If true Remove Curly Braces, Curly Braces in the header will be automatically remove.")
+      .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+      .defaultValue("False")
+      .allowableValues("True", "False")
+      .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_COMMA_SEPARATED_STRING)
+      .required(false)
+      .build();
+
+  public static final Relationship REL_SUCCESS = new Relationship.Builder()
+      .name("success")
+      .description(
+          "All FlowFiles that are received from the AMQP queue are routed to this relationship")
+      .build();
+
+  private static final List<PropertyDescriptor> propertyDescriptors;
+  private static final Set<Relationship> relationships;
+
+  static {
+    List<PropertyDescriptor> properties = new ArrayList<>();
+    properties.add(QUEUE);
+    properties.add(AUTO_ACKNOWLEDGE);
+    properties.add(BATCH_SIZE);
+    properties.add(HEADER_FORMAT);
+    properties.add(HEADER_KEY_PREFIX);
+    properties.add(REMOVE_CURLY_BRACES);
+    properties.add(HEADER_SEPARATOR);
+    properties.addAll(getCommonPropertyDescriptors());
+    propertyDescriptors = Collections.unmodifiableList(properties);
+
+    relationships = Set.of(REL_SUCCESS);
+  }
+
+  /**
+   * Will construct a {@link FlowFile} containing the body of the consumed AMQP message (if
+   * {@link GetResponse} returned by {@link AMQPConsumer} is not null) and AMQP properties that came
+   * with message which are added to a {@link FlowFile} as attributes, transferring {@link FlowFile}
+   * to 'success' {@link Relationship}.
+   */
+  @Override
+  protected void processResource(final Connection connection, final AMQPConsumer consumer,
+      final ProcessContext context, final ProcessSession session) {
+    GetResponse lastReceived = null;
+
+    if (!connection.isOpen() || !consumer.getChannel().isOpen()) {
+      throw new AMQPException("AMQP client has lost connection.");
     }
 
-    /**
-     * Will construct a {@link FlowFile} containing the body of the consumed AMQP message (if {@link GetResponse} returned by {@link AMQPConsumer} is
-     * not null) and AMQP properties that came with message which are added to a {@link FlowFile} as attributes, transferring {@link FlowFile} to
-     * 'success' {@link Relationship}.
-     */
-    @Override
-    protected void processResource(final Connection connection, final AMQPConsumer consumer, final ProcessContext context, final ProcessSession session) {
-        GetResponse lastReceived = null;
-
-        if (!connection.isOpen() || !consumer.getChannel().isOpen()) {
-            throw new AMQPException("AMQP client has lost connection.");
+    for (int i = 0; i < context.getProperty(BATCH_SIZE).asInteger(); i++) {
+      final GetResponse response = consumer.consume();
+      if (response == null) {
+        if (lastReceived == null) {
+          // If no messages received, then yield.
+          context.yield();
         }
 
-        for (int i = 0; i < context.getProperty(BATCH_SIZE).asInteger(); i++) {
-            final GetResponse response = consumer.consume();
-            if (response == null) {
-                if (lastReceived == null) {
-                    // If no messages received, then yield.
-                    context.yield();
-                }
+        break;
+      }
 
-                break;
-            }
+      FlowFile flowFile = session.create();
+      flowFile = session.write(flowFile, out -> out.write(response.getBody()));
 
-            FlowFile flowFile = session.create();
-            flowFile = session.write(flowFile, out -> out.write(response.getBody()));
+      final BasicProperties amqpProperties = response.getProps();
+      final Envelope envelope = response.getEnvelope();
+      final Map<String, String> attributes = buildAttributes(amqpProperties, envelope,
+          context.getProperty(HEADER_FORMAT).toString(),
+          context.getProperty(HEADER_KEY_PREFIX).toString(),
+          context.getProperty(REMOVE_CURLY_BRACES).asBoolean(),
+          context.getProperty(HEADER_SEPARATOR).toString());
+      flowFile = session.putAllAttributes(flowFile, attributes);
 
-            final BasicProperties amqpProperties = response.getProps();
-            final Envelope envelope = response.getEnvelope();
-            final Map<String, String> attributes = buildAttributes(amqpProperties, envelope, context.getProperty(REMOVE_CURLY_BRACES).asBoolean(),
-                    context.getProperty(HEADER_SEPARATOR).toString());
-            flowFile = session.putAllAttributes(flowFile, attributes);
-
-            session.getProvenanceReporter().receive(flowFile, connection.toString() + "/" + context.getProperty(QUEUE).getValue());
-            session.transfer(flowFile, REL_SUCCESS);
-            lastReceived = response;
-        }
-
-        if (lastReceived != null) {
-            final GetResponse finalGetResponse = lastReceived;
-            session.commitAsync(() -> consumer.acknowledge(finalGetResponse), null);
-        }
+      session.getProvenanceReporter()
+          .receive(flowFile, connection.toString() + "/" + context.getProperty(QUEUE).getValue());
+      session.transfer(flowFile, REL_SUCCESS);
+      lastReceived = response;
     }
 
-    private Map<String, String> buildAttributes(final BasicProperties properties, final Envelope envelope, boolean removeCurlyBraces, String valueSeperatorForHeaders) {
-        final Map<String, String> attributes = new HashMap<>();
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "appId", properties.getAppId());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "contentEncoding", properties.getContentEncoding());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "contentType", properties.getContentType());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "headers", buildHeaders(properties.getHeaders(), removeCurlyBraces, valueSeperatorForHeaders));
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "deliveryMode", properties.getDeliveryMode());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "priority", properties.getPriority());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "correlationId", properties.getCorrelationId());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "replyTo", properties.getReplyTo());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "expiration", properties.getExpiration());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "messageId", properties.getMessageId());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "timestamp", properties.getTimestamp() == null ? null : properties.getTimestamp().getTime());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "type", properties.getType());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "userId", properties.getUserId());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "clusterId", properties.getClusterId());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "routingKey",  envelope.getRoutingKey());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "exchange",  envelope.getExchange());
-        return attributes;
+    if (lastReceived != null) {
+      final GetResponse finalGetResponse = lastReceived;
+      session.commitAsync(() -> consumer.acknowledge(finalGetResponse), null);
+    }
+  }
+
+  private Map<String, String> buildAttributes(final BasicProperties properties,
+      final Envelope envelope, String headersStringFormat, String headerAttributePrefix,
+      boolean removeCurlyBraces,
+      String valueSeperatorForHeaders) {
+    AllowableValue headerFormat = new AllowableValue(headersStringFormat);
+    final Map<String, String> attributes = new HashMap<>();
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "appId", properties.getAppId());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "contentEncoding",
+        properties.getContentEncoding());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "contentType", properties.getContentType());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "deliveryMode", properties.getDeliveryMode());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "priority", properties.getPriority());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "correlationId", properties.getCorrelationId());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "replyTo", properties.getReplyTo());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "expiration", properties.getExpiration());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "messageId", properties.getMessageId());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "timestamp",
+        properties.getTimestamp() == null ? null : properties.getTimestamp().getTime());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "type", properties.getType());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "userId", properties.getUserId());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "clusterId", properties.getClusterId());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "routingKey", envelope.getRoutingKey());
+    addAttribute(attributes, ATTRIBUTES_PREFIX + "exchange", envelope.getExchange());
+    Map<String, Object> headers = properties.getHeaders();
+    if (headers != null) {
+      if (HEADERS_FORMAT_ATTRIBUTES.equals(headerFormat)) {
+        headers.forEach((key, value) -> addAttribute(attributes,
+            String.format("%s.%s", headerAttributePrefix, key), value));
+      } else {
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "headers",
+            buildHeaders(properties.getHeaders(), headerFormat, removeCurlyBraces,
+                valueSeperatorForHeaders));
+      }
+    }
+    return attributes;
+  }
+
+  private void addAttribute(final Map<String, String> attributes, final String attributeName,
+      final Object value) {
+    if (value == null) {
+      return;
     }
 
-    private void addAttribute(final Map<String, String> attributes, final String attributeName, final Object value) {
-        if (value == null) {
-            return;
-        }
+    attributes.put(attributeName, value.toString());
+  }
 
-        attributes.put(attributeName, value.toString());
+  private String buildHeaders(Map<String, Object> headers, AllowableValue headerFormat,
+      boolean removeCurlyBraces,
+      String valueSeparatorForHeaders) {
+    if (headers == null) {
+      return null;
     }
+    String headerString = null;
+    if (headerFormat.equals(HEADERS_FORMAT_COMMA_SEPARATED_STRING)) {
+      headerString = convertMapToString(headers, valueSeparatorForHeaders);
 
-    private String buildHeaders(Map<String, Object> headers,  boolean removeCurlyBraces, String valueSeparatorForHeaders) {
-        if (headers == null) {
-            return null;
-        }
-        String headerString = convertMapToString(headers,valueSeparatorForHeaders);
-
-        if (!removeCurlyBraces) {
-            headerString = "{" + headerString + "}";
-        }
-        return headerString;
+      if (!removeCurlyBraces) {
+        headerString = "{" + headerString + "}";
+      }
+    } else if (headerFormat.equals(HEADERS_FORMAT_JSON_STRING)) {
+      try {
+        headerString = convertMapToJSONString(headers);
+      } catch (JsonProcessingException e) {
+        getLogger().debug("error creating json string", e);
+      }
     }
+    return headerString;
+  }
 
-    private static String convertMapToString(Map<String, Object> headers, String valueSeparatorForHeaders) {
-        return headers.entrySet().stream().map(e -> (e.getValue()!= null) ? e.getKey() + "=" + e.getValue(): e.getKey())
-                .collect(Collectors.joining(valueSeparatorForHeaders));
+  private static String convertMapToString(Map<String, Object> headers,
+      String valueSeparatorForHeaders) {
+    return headers.entrySet().stream()
+        .map(e -> (e.getValue() != null) ? e.getKey() + "=" + e.getValue() : e.getKey())
+        .collect(Collectors.joining(valueSeparatorForHeaders));
+  }
+
+  private static String convertMapToJSONString(Map<String, Object> headers)
+      throws JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.writeValueAsString(headers);
+  }
+
+  @Override
+  protected synchronized AMQPConsumer createAMQPWorker(final ProcessContext context,
+      final Connection connection) {
+    try {
+      final String queueName = context.getProperty(QUEUE).getValue();
+      final boolean autoAcknowledge = context.getProperty(AUTO_ACKNOWLEDGE).asBoolean();
+      final AMQPConsumer amqpConsumer = new AMQPConsumer(connection, queueName, autoAcknowledge,
+          getLogger());
+
+      return amqpConsumer;
+    } catch (final IOException ioe) {
+      throw new ProcessException("Failed to connect to AMQP Broker", ioe);
     }
+  }
 
-    @Override
-    protected synchronized AMQPConsumer createAMQPWorker(final ProcessContext context, final Connection connection) {
-        try {
-            final String queueName = context.getProperty(QUEUE).getValue();
-            final boolean autoAcknowledge = context.getProperty(AUTO_ACKNOWLEDGE).asBoolean();
-            final AMQPConsumer amqpConsumer = new AMQPConsumer(connection, queueName, autoAcknowledge, getLogger());
+  @Override
+  protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+    return propertyDescriptors;
+  }
 
-            return amqpConsumer;
-        } catch (final IOException ioe) {
-            throw new ProcessException("Failed to connect to AMQP Broker", ioe);
-        }
-    }
-
-    @Override
-    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
-    }
-
-    @Override
-    public Set<Relationship> getRelationships() {
-        return relationships;
-    }
+  @Override
+  public Set<Relationship> getRelationships() {
+    return relationships;
+  }
 }

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -279,7 +279,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
             try {
                 headerString = convertMapToJSONString(headers);
             } catch (JsonProcessingException e) {
-                getLogger().debug("error creating json string", e);
+                getLogger().warn("Header formatting as JSON failed", e);
             }
         }
         return headerString;

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -49,297 +49,297 @@ import java.util.stream.Collectors;
 
 @Tags({"amqp", "rabbit", "get", "message", "receive", "consume"})
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
-@CapabilityDescription(
-    "Consumes AMQP Messages from an AMQP Broker using the AMQP 0.9.1 protocol. Each message that is received from the AMQP Broker will be "
+@CapabilityDescription("Consumes AMQP Messages from an AMQP Broker using the AMQP 0.9.1 protocol. Each message that is received from the AMQP Broker will be "
         + "emitted as its own FlowFile to the 'success' relationship.")
 @WritesAttributes({
-    @WritesAttribute(attribute = "amqp$appId", description = "The App ID field from the AMQP Message"),
-    @WritesAttribute(attribute = "amqp$contentEncoding", description = "The Content Encoding reported by the AMQP Message"),
-    @WritesAttribute(attribute = "amqp$contentType", description = "The Content Type reported by the AMQP Message"),
-    @WritesAttribute(attribute = "amqp$headers", description = "The headers present on the AMQP Message. Added only if processor is configured to output this attribute."),
-    @WritesAttribute(attribute = "<Header Key Prefix>.<attribute>", description = "Each message header will be inserted with this attribute name, if processor is configured to output headers as attribute"),
-    @WritesAttribute(attribute = "amqp$deliveryMode", description = "The numeric indicator for the Message's Delivery Mode"),
-    @WritesAttribute(attribute = "amqp$priority", description = "The Message priority"),
-    @WritesAttribute(attribute = "amqp$correlationId", description = "The Message's Correlation ID"),
-    @WritesAttribute(attribute = "amqp$replyTo", description = "The value of the Message's Reply-To field"),
-    @WritesAttribute(attribute = "amqp$expiration", description = "The Message Expiration"),
-    @WritesAttribute(attribute = "amqp$messageId", description = "The unique ID of the Message"),
-    @WritesAttribute(attribute = "amqp$timestamp", description = "The timestamp of the Message, as the number of milliseconds since epoch"),
-    @WritesAttribute(attribute = "amqp$type", description = "The type of message"),
-    @WritesAttribute(attribute = "amqp$userId", description = "The ID of the user"),
-    @WritesAttribute(attribute = "amqp$clusterId", description = "The ID of the AMQP Cluster"),
-    @WritesAttribute(attribute = "amqp$routingKey", description = "The routingKey of the AMQP Message"),
-    @WritesAttribute(attribute = "amqp$exchange", description = "The exchange from which AMQP Message was received")
+        @WritesAttribute(attribute = "amqp$appId", description = "The App ID field from the AMQP Message"),
+        @WritesAttribute(attribute = "amqp$contentEncoding", description = "The Content Encoding reported by the AMQP Message"),
+        @WritesAttribute(attribute = "amqp$contentType", description = "The Content Type reported by the AMQP Message"),
+        @WritesAttribute(attribute = "amqp$headers", description = "The headers present on the AMQP Message. Added only if processor is configured to output this attribute."),
+        @WritesAttribute(attribute = "<Header Key Prefix>.<attribute>",
+                description = "Each message header will be inserted with this attribute name, if processor is configured to output headers as attribute"),
+        @WritesAttribute(attribute = "amqp$deliveryMode", description = "The numeric indicator for the Message's Delivery Mode"),
+        @WritesAttribute(attribute = "amqp$priority", description = "The Message priority"),
+        @WritesAttribute(attribute = "amqp$correlationId", description = "The Message's Correlation ID"),
+        @WritesAttribute(attribute = "amqp$replyTo", description = "The value of the Message's Reply-To field"),
+        @WritesAttribute(attribute = "amqp$expiration", description = "The Message Expiration"),
+        @WritesAttribute(attribute = "amqp$messageId", description = "The unique ID of the Message"),
+        @WritesAttribute(attribute = "amqp$timestamp", description = "The timestamp of the Message, as the number of milliseconds since epoch"),
+        @WritesAttribute(attribute = "amqp$type", description = "The type of message"),
+        @WritesAttribute(attribute = "amqp$userId", description = "The ID of the user"),
+        @WritesAttribute(attribute = "amqp$clusterId", description = "The ID of the AMQP Cluster"),
+        @WritesAttribute(attribute = "amqp$routingKey", description = "The routingKey of the AMQP Message"),
+        @WritesAttribute(attribute = "amqp$exchange", description = "The exchange from which AMQP Message was received")
 })
 public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
 
-  private static final String ATTRIBUTES_PREFIX = "amqp$";
-  public static final String DEFAULT_HEADERS_KEY_PREFIX = "consume.amqp";
+    private static final String ATTRIBUTES_PREFIX = "amqp$";
+    public static final String DEFAULT_HEADERS_KEY_PREFIX = "consume.amqp";
 
-  public static final AllowableValue HEADERS_FORMAT_COMMA_SEPARATED_STRING = new AllowableValue(
-      "Comma Separated String", "Comma Separated String",
-      "Put all headers as a string with the specified separator in the attribute 'amqp$headers'.");
-  public static final AllowableValue HEADERS_FORMAT_JSON_STRING = new AllowableValue("JSON String",
-      "JSON String",
-      "Format all headers as JSON string and output in the attribute 'amqp$headers'. It will include keys with null value as well.");
-  public static final AllowableValue HEADERS_FORMAT_ATTRIBUTES = new AllowableValue(
-      "Flow file attributes", "Flow file attributes",
-      "Put each header as attribute of the flow file with a prefix specified in the properties");
+    public static final AllowableValue HEADERS_FORMAT_COMMA_SEPARATED_STRING = new AllowableValue(
+            "Comma Separated String", "Comma Separated String",
+            "Put all headers as a string with the specified separator in the attribute 'amqp$headers'.");
+    public static final AllowableValue HEADERS_FORMAT_JSON_STRING = new AllowableValue("JSON String",
+            "JSON String",
+            "Format all headers as JSON string and output in the attribute 'amqp$headers'. It will include keys with null value as well.");
+    public static final AllowableValue HEADERS_FORMAT_ATTRIBUTES = new AllowableValue(
+            "Flow file attributes", "Flow file attributes",
+            "Put each header as attribute of the flow file with a prefix specified in the properties");
 
-  public static final PropertyDescriptor QUEUE = new PropertyDescriptor.Builder()
-      .name("Queue")
-      .description(
-          "The name of the existing AMQP Queue from which messages will be consumed. Usually pre-defined by AMQP administrator. ")
-      .required(true)
-      .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-      .build();
-  public static final PropertyDescriptor AUTO_ACKNOWLEDGE = new PropertyDescriptor.Builder()
-      .name("auto.acknowledge")
-      .displayName("Auto-Acknowledge Messages")
-      .description(
-          " If false (Non-Auto-Acknowledge), the messages will be acknowledged by the processor after transferring the FlowFiles to success and committing "
-              + "the NiFi session. Non-Auto-Acknowledge mode provides 'at-least-once' delivery semantics. "
-              + "If true (Auto-Acknowledge), messages that are delivered to the AMQP Client will be auto-acknowledged by the AMQP Broker just after sending them out. "
-              + "This generally will provide better throughput but will also result in messages being lost upon restart/crash of the AMQP Broker, NiFi or the processor. "
-              + "Auto-Acknowledge mode provides 'at-most-once' delivery semantics and it is recommended only if loosing messages is acceptable.")
-      .allowableValues("true", "false")
-      .defaultValue("false")
-      .required(true)
-      .build();
-  static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
-      .name("batch.size")
-      .displayName("Batch Size")
-      .description(
-          "The maximum number of messages that should be processed in a single session. Once this many messages have been received (or once no more messages are readily available), "
-              + "the messages received will be transferred to the 'success' relationship and the messages will be acknowledged to the AMQP Broker. Setting this value to a larger number "
-              + "could result in better performance, particularly for very small messages, but can also result in more messages being duplicated upon sudden restart of NiFi.")
-      .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-      .expressionLanguageSupported(ExpressionLanguageScope.NONE)
-      .defaultValue("10")
-      .required(true)
-      .build();
+    public static final PropertyDescriptor QUEUE = new PropertyDescriptor.Builder()
+            .name("Queue")
+            .description(
+                    "The name of the existing AMQP Queue from which messages will be consumed. Usually pre-defined by AMQP administrator. ")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+    public static final PropertyDescriptor AUTO_ACKNOWLEDGE = new PropertyDescriptor.Builder()
+            .name("auto.acknowledge")
+            .displayName("Auto-Acknowledge Messages")
+            .description(
+                    " If false (Non-Auto-Acknowledge), the messages will be acknowledged by the processor after transferring the FlowFiles to success and committing "
+                            + "the NiFi session. Non-Auto-Acknowledge mode provides 'at-least-once' delivery semantics. "
+                            + "If true (Auto-Acknowledge), messages that are delivered to the AMQP Client will be auto-acknowledged by the AMQP Broker just after sending them out. "
+                            + "This generally will provide better throughput but will also result in messages being lost upon restart/crash of the AMQP Broker, NiFi or the processor. "
+                            + "Auto-Acknowledge mode provides 'at-most-once' delivery semantics and it is recommended only if loosing messages is acceptable.")
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .required(true)
+            .build();
+    static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
+            .name("batch.size")
+            .displayName("Batch Size")
+            .description(
+                    "The maximum number of messages that should be processed in a single session. Once this many messages have been received (or once no more messages are readily available), "
+                            + "the messages received will be transferred to the 'success' relationship and the messages will be acknowledged to the AMQP Broker. Setting this value to a larger number "
+                            + "could result in better performance, particularly for very small messages, but can also result in more messages being duplicated upon sudden restart of NiFi.")
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .defaultValue("10")
+            .required(true)
+            .build();
 
-  public static final PropertyDescriptor HEADER_FORMAT = new PropertyDescriptor.Builder()
-      .name("header.format")
-      .displayName("Header Output Format")
-      .description("Defines how to output headers from the received message")
-      .allowableValues(HEADERS_FORMAT_COMMA_SEPARATED_STRING, HEADERS_FORMAT_JSON_STRING,
-          HEADERS_FORMAT_ATTRIBUTES)
-      .defaultValue(HEADERS_FORMAT_COMMA_SEPARATED_STRING.getValue())
-      .required(true)
-      .build();
-  public static final PropertyDescriptor HEADER_KEY_PREFIX = new PropertyDescriptor.Builder()
-      .name("header.key.prefix")
-      .displayName("Header Key Prefix")
-      .description(
-          "Text to be prefixed to header keys as the are added to the flowfile attributes. Processor will append '.' to the value")
-      .defaultValue(DEFAULT_HEADERS_KEY_PREFIX)
-      .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-      .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_ATTRIBUTES)
-      .required(true)
-      .build();
+    public static final PropertyDescriptor HEADER_FORMAT = new PropertyDescriptor.Builder()
+            .name("header.format")
+            .displayName("Header Output Format")
+            .description("Defines how to output headers from the received message")
+            .allowableValues(HEADERS_FORMAT_COMMA_SEPARATED_STRING, HEADERS_FORMAT_JSON_STRING,
+                    HEADERS_FORMAT_ATTRIBUTES)
+            .defaultValue(HEADERS_FORMAT_COMMA_SEPARATED_STRING.getValue())
+            .required(true)
+            .build();
+    public static final PropertyDescriptor HEADER_KEY_PREFIX = new PropertyDescriptor.Builder()
+            .name("header.key.prefix")
+            .displayName("Header Key Prefix")
+            .description(
+                    "Text to be prefixed to header keys as the are added to the flowfile attributes. Processor will append '.' to the value")
+            .defaultValue(DEFAULT_HEADERS_KEY_PREFIX)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_ATTRIBUTES)
+            .required(true)
+            .build();
 
-  public static final PropertyDescriptor HEADER_SEPARATOR = new PropertyDescriptor.Builder()
-      .name("header.separator")
-      .displayName("Header Separator")
-      .description(
-          "The character that is used to separate key-value for header in String. The value must only one character."
-              + "Otherwise you will get an error message")
-      .addValidator(StandardValidators.SINGLE_CHAR_VALIDATOR)
-      .defaultValue(",")
-      .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_COMMA_SEPARATED_STRING)
-      .required(false)
-      .build();
-  static final PropertyDescriptor REMOVE_CURLY_BRACES = new PropertyDescriptor.Builder()
-      .name("remove.curly.braces")
-      .displayName("Remove Curly Braces")
-      .description(
-          "If true Remove Curly Braces, Curly Braces in the header will be automatically remove.")
-      .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
-      .defaultValue("False")
-      .allowableValues("True", "False")
-      .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_COMMA_SEPARATED_STRING)
-      .required(false)
-      .build();
+    public static final PropertyDescriptor HEADER_SEPARATOR = new PropertyDescriptor.Builder()
+            .name("header.separator")
+            .displayName("Header Separator")
+            .description(
+                    "The character that is used to separate key-value for header in String. The value must only one character."
+                            + "Otherwise you will get an error message")
+            .addValidator(StandardValidators.SINGLE_CHAR_VALIDATOR)
+            .defaultValue(",")
+            .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_COMMA_SEPARATED_STRING)
+            .required(false)
+            .build();
+    static final PropertyDescriptor REMOVE_CURLY_BRACES = new PropertyDescriptor.Builder()
+            .name("remove.curly.braces")
+            .displayName("Remove Curly Braces")
+            .description(
+                    "If true Remove Curly Braces, Curly Braces in the header will be automatically remove.")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .defaultValue("False")
+            .allowableValues("True", "False")
+            .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_COMMA_SEPARATED_STRING)
+            .required(false)
+            .build();
 
-  public static final Relationship REL_SUCCESS = new Relationship.Builder()
-      .name("success")
-      .description(
-          "All FlowFiles that are received from the AMQP queue are routed to this relationship")
-      .build();
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description(
+                    "All FlowFiles that are received from the AMQP queue are routed to this relationship")
+            .build();
 
-  private static final List<PropertyDescriptor> propertyDescriptors;
-  private static final Set<Relationship> relationships;
+    private static final List<PropertyDescriptor> propertyDescriptors;
+    private static final Set<Relationship> relationships;
 
-  static {
-    List<PropertyDescriptor> properties = new ArrayList<>();
-    properties.add(QUEUE);
-    properties.add(AUTO_ACKNOWLEDGE);
-    properties.add(BATCH_SIZE);
-    properties.add(HEADER_FORMAT);
-    properties.add(HEADER_KEY_PREFIX);
-    properties.add(REMOVE_CURLY_BRACES);
-    properties.add(HEADER_SEPARATOR);
-    properties.addAll(getCommonPropertyDescriptors());
-    propertyDescriptors = Collections.unmodifiableList(properties);
+    static {
+        List<PropertyDescriptor> properties = new ArrayList<>();
+        properties.add(QUEUE);
+        properties.add(AUTO_ACKNOWLEDGE);
+        properties.add(BATCH_SIZE);
+        properties.add(HEADER_FORMAT);
+        properties.add(HEADER_KEY_PREFIX);
+        properties.add(REMOVE_CURLY_BRACES);
+        properties.add(HEADER_SEPARATOR);
+        properties.addAll(getCommonPropertyDescriptors());
+        propertyDescriptors = Collections.unmodifiableList(properties);
 
-    relationships = Set.of(REL_SUCCESS);
-  }
-
-  /**
-   * Will construct a {@link FlowFile} containing the body of the consumed AMQP message (if
-   * {@link GetResponse} returned by {@link AMQPConsumer} is not null) and AMQP properties that came
-   * with message which are added to a {@link FlowFile} as attributes, transferring {@link FlowFile}
-   * to 'success' {@link Relationship}.
-   */
-  @Override
-  protected void processResource(final Connection connection, final AMQPConsumer consumer,
-      final ProcessContext context, final ProcessSession session) {
-    GetResponse lastReceived = null;
-
-    if (!connection.isOpen() || !consumer.getChannel().isOpen()) {
-      throw new AMQPException("AMQP client has lost connection.");
+        relationships = Set.of(REL_SUCCESS);
     }
 
-    for (int i = 0; i < context.getProperty(BATCH_SIZE).asInteger(); i++) {
-      final GetResponse response = consumer.consume();
-      if (response == null) {
-        if (lastReceived == null) {
-          // If no messages received, then yield.
-          context.yield();
+    /**
+     * Will construct a {@link FlowFile} containing the body of the consumed AMQP message (if
+     * {@link GetResponse} returned by {@link AMQPConsumer} is not null) and AMQP properties that came
+     * with message which are added to a {@link FlowFile} as attributes, transferring {@link FlowFile}
+     * to 'success' {@link Relationship}.
+     */
+    @Override
+    protected void processResource(final Connection connection, final AMQPConsumer consumer,
+                                   final ProcessContext context, final ProcessSession session) {
+        GetResponse lastReceived = null;
+
+        if (!connection.isOpen() || !consumer.getChannel().isOpen()) {
+            throw new AMQPException("AMQP client has lost connection.");
         }
 
-        break;
-      }
+        for (int i = 0; i < context.getProperty(BATCH_SIZE).asInteger(); i++) {
+            final GetResponse response = consumer.consume();
+            if (response == null) {
+                if (lastReceived == null) {
+                    // If no messages received, then yield.
+                    context.yield();
+                }
 
-      FlowFile flowFile = session.create();
-      flowFile = session.write(flowFile, out -> out.write(response.getBody()));
+                break;
+            }
 
-      final BasicProperties amqpProperties = response.getProps();
-      final Envelope envelope = response.getEnvelope();
-      final Map<String, String> attributes = buildAttributes(amqpProperties, envelope,
-          context.getProperty(HEADER_FORMAT).toString(),
-          context.getProperty(HEADER_KEY_PREFIX).toString(),
-          context.getProperty(REMOVE_CURLY_BRACES).asBoolean(),
-          context.getProperty(HEADER_SEPARATOR).toString());
-      flowFile = session.putAllAttributes(flowFile, attributes);
+            FlowFile flowFile = session.create();
+            flowFile = session.write(flowFile, out -> out.write(response.getBody()));
 
-      session.getProvenanceReporter()
-          .receive(flowFile, connection.toString() + "/" + context.getProperty(QUEUE).getValue());
-      session.transfer(flowFile, REL_SUCCESS);
-      lastReceived = response;
+            final BasicProperties amqpProperties = response.getProps();
+            final Envelope envelope = response.getEnvelope();
+            final Map<String, String> attributes = buildAttributes(amqpProperties, envelope,
+                    context.getProperty(HEADER_FORMAT).toString(),
+                    context.getProperty(HEADER_KEY_PREFIX).toString(),
+                    context.getProperty(REMOVE_CURLY_BRACES).asBoolean(),
+                    context.getProperty(HEADER_SEPARATOR).toString());
+            flowFile = session.putAllAttributes(flowFile, attributes);
+
+            session.getProvenanceReporter()
+                    .receive(flowFile, connection.toString() + "/" + context.getProperty(QUEUE).getValue());
+            session.transfer(flowFile, REL_SUCCESS);
+            lastReceived = response;
+        }
+
+        if (lastReceived != null) {
+            final GetResponse finalGetResponse = lastReceived;
+            session.commitAsync(() -> consumer.acknowledge(finalGetResponse), null);
+        }
     }
 
-    if (lastReceived != null) {
-      final GetResponse finalGetResponse = lastReceived;
-      session.commitAsync(() -> consumer.acknowledge(finalGetResponse), null);
-    }
-  }
-
-  private Map<String, String> buildAttributes(final BasicProperties properties,
-      final Envelope envelope, String headersStringFormat, String headerAttributePrefix,
-      boolean removeCurlyBraces,
-      String valueSeperatorForHeaders) {
-    AllowableValue headerFormat = new AllowableValue(headersStringFormat);
-    final Map<String, String> attributes = new HashMap<>();
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "appId", properties.getAppId());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "contentEncoding",
-        properties.getContentEncoding());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "contentType", properties.getContentType());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "deliveryMode", properties.getDeliveryMode());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "priority", properties.getPriority());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "correlationId", properties.getCorrelationId());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "replyTo", properties.getReplyTo());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "expiration", properties.getExpiration());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "messageId", properties.getMessageId());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "timestamp",
-        properties.getTimestamp() == null ? null : properties.getTimestamp().getTime());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "type", properties.getType());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "userId", properties.getUserId());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "clusterId", properties.getClusterId());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "routingKey", envelope.getRoutingKey());
-    addAttribute(attributes, ATTRIBUTES_PREFIX + "exchange", envelope.getExchange());
-    Map<String, Object> headers = properties.getHeaders();
-    if (headers != null) {
-      if (HEADERS_FORMAT_ATTRIBUTES.equals(headerFormat)) {
-        headers.forEach((key, value) -> addAttribute(attributes,
-            String.format("%s.%s", headerAttributePrefix, key), value));
-      } else {
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "headers",
-            buildHeaders(properties.getHeaders(), headerFormat, removeCurlyBraces,
-                valueSeperatorForHeaders));
-      }
-    }
-    return attributes;
-  }
-
-  private void addAttribute(final Map<String, String> attributes, final String attributeName,
-      final Object value) {
-    if (value == null) {
-      return;
+    private Map<String, String> buildAttributes(final BasicProperties properties,
+                                                final Envelope envelope, String headersStringFormat, String headerAttributePrefix,
+                                                boolean removeCurlyBraces,
+                                                String valueSeperatorForHeaders) {
+        AllowableValue headerFormat = new AllowableValue(headersStringFormat);
+        final Map<String, String> attributes = new HashMap<>();
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "appId", properties.getAppId());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "contentEncoding",
+                properties.getContentEncoding());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "contentType", properties.getContentType());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "deliveryMode", properties.getDeliveryMode());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "priority", properties.getPriority());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "correlationId", properties.getCorrelationId());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "replyTo", properties.getReplyTo());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "expiration", properties.getExpiration());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "messageId", properties.getMessageId());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "timestamp",
+                properties.getTimestamp() == null ? null : properties.getTimestamp().getTime());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "type", properties.getType());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "userId", properties.getUserId());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "clusterId", properties.getClusterId());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "routingKey", envelope.getRoutingKey());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "exchange", envelope.getExchange());
+        Map<String, Object> headers = properties.getHeaders();
+        if (headers != null) {
+            if (HEADERS_FORMAT_ATTRIBUTES.equals(headerFormat)) {
+                headers.forEach((key, value) -> addAttribute(attributes,
+                        String.format("%s.%s", headerAttributePrefix, key), value));
+            } else {
+                addAttribute(attributes, ATTRIBUTES_PREFIX + "headers",
+                        buildHeaders(properties.getHeaders(), headerFormat, removeCurlyBraces,
+                                valueSeperatorForHeaders));
+            }
+        }
+        return attributes;
     }
 
-    attributes.put(attributeName, value.toString());
-  }
+    private void addAttribute(final Map<String, String> attributes, final String attributeName,
+                              final Object value) {
+        if (value == null) {
+            return;
+        }
 
-  private String buildHeaders(Map<String, Object> headers, AllowableValue headerFormat,
-      boolean removeCurlyBraces,
-      String valueSeparatorForHeaders) {
-    if (headers == null) {
-      return null;
+        attributes.put(attributeName, value.toString());
     }
-    String headerString = null;
-    if (headerFormat.equals(HEADERS_FORMAT_COMMA_SEPARATED_STRING)) {
-      headerString = convertMapToString(headers, valueSeparatorForHeaders);
 
-      if (!removeCurlyBraces) {
-        headerString = "{" + headerString + "}";
-      }
-    } else if (headerFormat.equals(HEADERS_FORMAT_JSON_STRING)) {
-      try {
-        headerString = convertMapToJSONString(headers);
-      } catch (JsonProcessingException e) {
-        getLogger().debug("error creating json string", e);
-      }
+    private String buildHeaders(Map<String, Object> headers, AllowableValue headerFormat,
+                                boolean removeCurlyBraces,
+                                String valueSeparatorForHeaders) {
+        if (headers == null) {
+            return null;
+        }
+        String headerString = null;
+        if (headerFormat.equals(HEADERS_FORMAT_COMMA_SEPARATED_STRING)) {
+            headerString = convertMapToString(headers, valueSeparatorForHeaders);
+
+            if (!removeCurlyBraces) {
+                headerString = "{" + headerString + "}";
+            }
+        } else if (headerFormat.equals(HEADERS_FORMAT_JSON_STRING)) {
+            try {
+                headerString = convertMapToJSONString(headers);
+            } catch (JsonProcessingException e) {
+                getLogger().debug("error creating json string", e);
+            }
+        }
+        return headerString;
     }
-    return headerString;
-  }
 
-  private static String convertMapToString(Map<String, Object> headers,
-      String valueSeparatorForHeaders) {
-    return headers.entrySet().stream()
-        .map(e -> (e.getValue() != null) ? e.getKey() + "=" + e.getValue() : e.getKey())
-        .collect(Collectors.joining(valueSeparatorForHeaders));
-  }
-
-  private static String convertMapToJSONString(Map<String, Object> headers)
-      throws JsonProcessingException {
-    ObjectMapper objectMapper = new ObjectMapper();
-    return objectMapper.writeValueAsString(headers);
-  }
-
-  @Override
-  protected synchronized AMQPConsumer createAMQPWorker(final ProcessContext context,
-      final Connection connection) {
-    try {
-      final String queueName = context.getProperty(QUEUE).getValue();
-      final boolean autoAcknowledge = context.getProperty(AUTO_ACKNOWLEDGE).asBoolean();
-      final AMQPConsumer amqpConsumer = new AMQPConsumer(connection, queueName, autoAcknowledge,
-          getLogger());
-
-      return amqpConsumer;
-    } catch (final IOException ioe) {
-      throw new ProcessException("Failed to connect to AMQP Broker", ioe);
+    private static String convertMapToString(Map<String, Object> headers,
+                                             String valueSeparatorForHeaders) {
+        return headers.entrySet().stream()
+                .map(e -> (e.getValue() != null) ? e.getKey() + "=" + e.getValue() : e.getKey())
+                .collect(Collectors.joining(valueSeparatorForHeaders));
     }
-  }
 
-  @Override
-  protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-    return propertyDescriptors;
-  }
+    private static String convertMapToJSONString(Map<String, Object> headers)
+            throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(headers);
+    }
 
-  @Override
-  public Set<Relationship> getRelationships() {
-    return relationships;
-  }
+    @Override
+    protected synchronized AMQPConsumer createAMQPWorker(final ProcessContext context,
+                                                         final Connection connection) {
+        try {
+            final String queueName = context.getProperty(QUEUE).getValue();
+            final boolean autoAcknowledge = context.getProperty(AUTO_ACKNOWLEDGE).asBoolean();
+            final AMQPConsumer amqpConsumer = new AMQPConsumer(connection, queueName, autoAcknowledge,
+                    getLogger());
+
+            return amqpConsumer;
+        } catch (final IOException ioe) {
+            throw new ProcessException("Failed to connect to AMQP Broker", ioe);
+        }
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return propertyDescriptors;
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
 }

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -50,126 +50,117 @@ import java.util.stream.Collectors;
 @Tags({"amqp", "rabbit", "get", "message", "receive", "consume"})
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
 @CapabilityDescription("Consumes AMQP Messages from an AMQP Broker using the AMQP 0.9.1 protocol. Each message that is received from the AMQP Broker will be "
-        + "emitted as its own FlowFile to the 'success' relationship.")
+    + "emitted as its own FlowFile to the 'success' relationship.")
 @WritesAttributes({
-        @WritesAttribute(attribute = "amqp$appId", description = "The App ID field from the AMQP Message"),
-        @WritesAttribute(attribute = "amqp$contentEncoding", description = "The Content Encoding reported by the AMQP Message"),
-        @WritesAttribute(attribute = "amqp$contentType", description = "The Content Type reported by the AMQP Message"),
-        @WritesAttribute(attribute = "amqp$headers", description = "The headers present on the AMQP Message. Added only if processor is configured to output this attribute."),
-        @WritesAttribute(attribute = "<Header Key Prefix>.<attribute>",
-                description = "Each message header will be inserted with this attribute name, if processor is configured to output headers as attribute"),
-        @WritesAttribute(attribute = "amqp$deliveryMode", description = "The numeric indicator for the Message's Delivery Mode"),
-        @WritesAttribute(attribute = "amqp$priority", description = "The Message priority"),
-        @WritesAttribute(attribute = "amqp$correlationId", description = "The Message's Correlation ID"),
-        @WritesAttribute(attribute = "amqp$replyTo", description = "The value of the Message's Reply-To field"),
-        @WritesAttribute(attribute = "amqp$expiration", description = "The Message Expiration"),
-        @WritesAttribute(attribute = "amqp$messageId", description = "The unique ID of the Message"),
-        @WritesAttribute(attribute = "amqp$timestamp", description = "The timestamp of the Message, as the number of milliseconds since epoch"),
-        @WritesAttribute(attribute = "amqp$type", description = "The type of message"),
-        @WritesAttribute(attribute = "amqp$userId", description = "The ID of the user"),
-        @WritesAttribute(attribute = "amqp$clusterId", description = "The ID of the AMQP Cluster"),
-        @WritesAttribute(attribute = "amqp$routingKey", description = "The routingKey of the AMQP Message"),
-        @WritesAttribute(attribute = "amqp$exchange", description = "The exchange from which AMQP Message was received")
+    @WritesAttribute(attribute = "amqp$appId", description = "The App ID field from the AMQP Message"),
+    @WritesAttribute(attribute = "amqp$contentEncoding", description = "The Content Encoding reported by the AMQP Message"),
+    @WritesAttribute(attribute = "amqp$contentType", description = "The Content Type reported by the AMQP Message"),
+    @WritesAttribute(attribute = "amqp$headers", description = "The headers present on the AMQP Message. Added only if processor is configured to output this attribute."),
+    @WritesAttribute(attribute = "<Header Key Prefix>.<attribute>",
+        description = "Each message header will be inserted with this attribute name, if processor is configured to output headers as attribute"),
+    @WritesAttribute(attribute = "amqp$deliveryMode", description = "The numeric indicator for the Message's Delivery Mode"),
+    @WritesAttribute(attribute = "amqp$priority", description = "The Message priority"),
+    @WritesAttribute(attribute = "amqp$correlationId", description = "The Message's Correlation ID"),
+    @WritesAttribute(attribute = "amqp$replyTo", description = "The value of the Message's Reply-To field"),
+    @WritesAttribute(attribute = "amqp$expiration", description = "The Message Expiration"),
+    @WritesAttribute(attribute = "amqp$messageId", description = "The unique ID of the Message"),
+    @WritesAttribute(attribute = "amqp$timestamp", description = "The timestamp of the Message, as the number of milliseconds since epoch"),
+    @WritesAttribute(attribute = "amqp$type", description = "The type of message"),
+    @WritesAttribute(attribute = "amqp$userId", description = "The ID of the user"),
+    @WritesAttribute(attribute = "amqp$clusterId", description = "The ID of the AMQP Cluster"),
+    @WritesAttribute(attribute = "amqp$routingKey", description = "The routingKey of the AMQP Message"),
+    @WritesAttribute(attribute = "amqp$exchange", description = "The exchange from which AMQP Message was received")
 })
 public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
 
     private static final String ATTRIBUTES_PREFIX = "amqp$";
     public static final String DEFAULT_HEADERS_KEY_PREFIX = "consume.amqp";
 
-    public static final AllowableValue HEADERS_FORMAT_COMMA_SEPARATED_STRING = new AllowableValue(
-            "Comma Separated String", "Comma Separated String",
+    public static final AllowableValue HEADERS_FORMAT_COMMA_SEPARATED_STRING = new AllowableValue("Comma Separated String", "Comma Separated String",
             "Put all headers as a string with the specified separator in the attribute 'amqp$headers'.");
-    public static final AllowableValue HEADERS_FORMAT_JSON_STRING = new AllowableValue("JSON String",
-            "JSON String",
+    public static final AllowableValue HEADERS_FORMAT_JSON_STRING = new AllowableValue("JSON String", "JSON String",
             "Format all headers as JSON string and output in the attribute 'amqp$headers'. It will include keys with null value as well.");
-    public static final AllowableValue HEADERS_FORMAT_ATTRIBUTES = new AllowableValue(
-            "Flow file attributes", "Flow file attributes",
+    public static final AllowableValue HEADERS_FORMAT_ATTRIBUTES = new AllowableValue("Flow file attributes", "Flow file attributes",
             "Put each header as attribute of the flow file with a prefix specified in the properties");
 
     public static final PropertyDescriptor QUEUE = new PropertyDescriptor.Builder()
-            .name("Queue")
-            .description(
-                    "The name of the existing AMQP Queue from which messages will be consumed. Usually pre-defined by AMQP administrator. ")
-            .required(true)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .build();
+        .name("Queue")
+        .description("The name of the existing AMQP Queue from which messages will be consumed. Usually pre-defined by AMQP administrator. ")
+        .required(true)
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .build();
     public static final PropertyDescriptor AUTO_ACKNOWLEDGE = new PropertyDescriptor.Builder()
-            .name("auto.acknowledge")
-            .displayName("Auto-Acknowledge Messages")
-            .description(
-                    " If false (Non-Auto-Acknowledge), the messages will be acknowledged by the processor after transferring the FlowFiles to success and committing "
-                            + "the NiFi session. Non-Auto-Acknowledge mode provides 'at-least-once' delivery semantics. "
-                            + "If true (Auto-Acknowledge), messages that are delivered to the AMQP Client will be auto-acknowledged by the AMQP Broker just after sending them out. "
-                            + "This generally will provide better throughput but will also result in messages being lost upon restart/crash of the AMQP Broker, NiFi or the processor. "
-                            + "Auto-Acknowledge mode provides 'at-most-once' delivery semantics and it is recommended only if loosing messages is acceptable.")
-            .allowableValues("true", "false")
-            .defaultValue("false")
-            .required(true)
-            .build();
+        .name("auto.acknowledge")
+        .displayName("Auto-Acknowledge Messages")
+        .description(" If false (Non-Auto-Acknowledge), the messages will be acknowledged by the processor after transferring the FlowFiles to success and committing "
+            + "the NiFi session. Non-Auto-Acknowledge mode provides 'at-least-once' delivery semantics. "
+            + "If true (Auto-Acknowledge), messages that are delivered to the AMQP Client will be auto-acknowledged by the AMQP Broker just after sending them out. "
+            + "This generally will provide better throughput but will also result in messages being lost upon restart/crash of the AMQP Broker, NiFi or the processor. "
+            + "Auto-Acknowledge mode provides 'at-most-once' delivery semantics and it is recommended only if loosing messages is acceptable.")
+        .allowableValues("true", "false")
+        .defaultValue("false")
+        .required(true)
+        .build();
     static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
-            .name("batch.size")
-            .displayName("Batch Size")
-            .description(
-                    "The maximum number of messages that should be processed in a single session. Once this many messages have been received (or once no more messages are readily available), "
-                            + "the messages received will be transferred to the 'success' relationship and the messages will be acknowledged to the AMQP Broker. Setting this value to a larger number "
-                            + "could result in better performance, particularly for very small messages, but can also result in more messages being duplicated upon sudden restart of NiFi.")
-            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
-            .defaultValue("10")
-            .required(true)
-            .build();
+        .name("batch.size")
+        .displayName("Batch Size")
+        .description("The maximum number of messages that should be processed in a single session. Once this many messages have been received (or once no more messages are readily available), "
+            + "the messages received will be transferred to the 'success' relationship and the messages will be acknowledged to the AMQP Broker. Setting this value to a larger number "
+            + "could result in better performance, particularly for very small messages, but can also result in more messages being duplicated upon sudden restart of NiFi.")
+        .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+        .defaultValue("10")
+        .required(true)
+        .build();
 
     public static final PropertyDescriptor HEADER_FORMAT = new PropertyDescriptor.Builder()
-            .name("header.format")
-            .displayName("Header Output Format")
-            .description("Defines how to output headers from the received message")
-            .allowableValues(HEADERS_FORMAT_COMMA_SEPARATED_STRING, HEADERS_FORMAT_JSON_STRING,
-                    HEADERS_FORMAT_ATTRIBUTES)
-            .defaultValue(HEADERS_FORMAT_COMMA_SEPARATED_STRING.getValue())
-            .required(true)
-            .build();
+        .name("header.format")
+        .displayName("Header Output Format")
+        .description("Defines how to output headers from the received message")
+        .allowableValues(HEADERS_FORMAT_COMMA_SEPARATED_STRING, HEADERS_FORMAT_JSON_STRING, HEADERS_FORMAT_ATTRIBUTES)
+        .defaultValue(HEADERS_FORMAT_COMMA_SEPARATED_STRING.getValue())
+        .required(true)
+        .build();
     public static final PropertyDescriptor HEADER_KEY_PREFIX = new PropertyDescriptor.Builder()
-            .name("header.key.prefix")
-            .displayName("Header Key Prefix")
-            .description(
-                    "Text to be prefixed to header keys as the are added to the flowfile attributes. Processor will append '.' to the value")
-            .defaultValue(DEFAULT_HEADERS_KEY_PREFIX)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_ATTRIBUTES)
-            .required(true)
-            .build();
+        .name("header.key.prefix")
+        .displayName("Header Key Prefix")
+        .description("Text to be prefixed to header keys as the are added to the flowfile attributes. Processor will append '.' to the value")
+        .defaultValue(DEFAULT_HEADERS_KEY_PREFIX)
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_ATTRIBUTES)
+        .required(true)
+        .build();
 
     public static final PropertyDescriptor HEADER_SEPARATOR = new PropertyDescriptor.Builder()
-            .name("header.separator")
-            .displayName("Header Separator")
-            .description(
-                    "The character that is used to separate key-value for header in String. The value must only one character."
-                            + "Otherwise you will get an error message")
-            .addValidator(StandardValidators.SINGLE_CHAR_VALIDATOR)
-            .defaultValue(",")
-            .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_COMMA_SEPARATED_STRING)
-            .required(false)
-            .build();
+        .name("header.separator")
+        .displayName("Header Separator")
+        .description("The character that is used to separate key-value for header in String. The value must only one character."
+                + "Otherwise you will get an error message")
+        .addValidator(StandardValidators.SINGLE_CHAR_VALIDATOR)
+        .defaultValue(",")
+        .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_COMMA_SEPARATED_STRING)
+        .required(false)
+        .build();
     static final PropertyDescriptor REMOVE_CURLY_BRACES = new PropertyDescriptor.Builder()
-            .name("remove.curly.braces")
-            .displayName("Remove Curly Braces")
-            .description(
-                    "If true Remove Curly Braces, Curly Braces in the header will be automatically remove.")
-            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
-            .defaultValue("False")
-            .allowableValues("True", "False")
-            .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_COMMA_SEPARATED_STRING)
-            .required(false)
-            .build();
+        .name("remove.curly.braces")
+        .displayName("Remove Curly Braces")
+        .description("If true Remove Curly Braces, Curly Braces in the header will be automatically remove.")
+        .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+        .defaultValue("False")
+        .allowableValues("True", "False")
+        .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_COMMA_SEPARATED_STRING)
+        .required(false)
+        .build();
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
-            .name("success")
-            .description(
-                    "All FlowFiles that are received from the AMQP queue are routed to this relationship")
-            .build();
+        .name("success")
+        .description("All FlowFiles that are received from the AMQP queue are routed to this relationship")
+        .build();
 
     private static final List<PropertyDescriptor> propertyDescriptors;
     private static final Set<Relationship> relationships;
+
+    private static final ObjectMapper objectMapper;
 
     static {
         List<PropertyDescriptor> properties = new ArrayList<>();
@@ -184,17 +175,17 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         propertyDescriptors = Collections.unmodifiableList(properties);
 
         relationships = Set.of(REL_SUCCESS);
+
+        objectMapper = new ObjectMapper();
     }
 
     /**
-     * Will construct a {@link FlowFile} containing the body of the consumed AMQP message (if
-     * {@link GetResponse} returned by {@link AMQPConsumer} is not null) and AMQP properties that came
-     * with message which are added to a {@link FlowFile} as attributes, transferring {@link FlowFile}
-     * to 'success' {@link Relationship}.
+     * Will construct a {@link FlowFile} containing the body of the consumed AMQP message (if {@link GetResponse} returned by {@link AMQPConsumer} is
+     * not null) and AMQP properties that came with message which are added to a {@link FlowFile} as attributes, transferring {@link FlowFile} to
+     * 'success' {@link Relationship}.
      */
     @Override
-    protected void processResource(final Connection connection, final AMQPConsumer consumer,
-                                   final ProcessContext context, final ProcessSession session) {
+    protected void processResource(final Connection connection, final AMQPConsumer consumer, final ProcessContext context, final ProcessSession session) {
         GetResponse lastReceived = null;
 
         if (!connection.isOpen() || !consumer.getChannel().isOpen()) {
@@ -217,15 +208,11 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
 
             final BasicProperties amqpProperties = response.getProps();
             final Envelope envelope = response.getEnvelope();
-            final Map<String, String> attributes = buildAttributes(amqpProperties, envelope,
-                    context.getProperty(HEADER_FORMAT).toString(),
-                    context.getProperty(HEADER_KEY_PREFIX).toString(),
-                    context.getProperty(REMOVE_CURLY_BRACES).asBoolean(),
-                    context.getProperty(HEADER_SEPARATOR).toString());
+            final Map<String, String> attributes = buildAttributes(amqpProperties, envelope, context.getProperty(HEADER_FORMAT).toString(), context.getProperty(HEADER_KEY_PREFIX).toString(),
+                    context.getProperty(REMOVE_CURLY_BRACES).asBoolean(), context.getProperty(HEADER_SEPARATOR).toString());
             flowFile = session.putAllAttributes(flowFile, attributes);
 
-            session.getProvenanceReporter()
-                    .receive(flowFile, connection.toString() + "/" + context.getProperty(QUEUE).getValue());
+            session.getProvenanceReporter().receive(flowFile, connection.toString() + "/" + context.getProperty(QUEUE).getValue());
             session.transfer(flowFile, REL_SUCCESS);
             lastReceived = response;
         }
@@ -236,15 +223,12 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         }
     }
 
-    private Map<String, String> buildAttributes(final BasicProperties properties,
-                                                final Envelope envelope, String headersStringFormat, String headerAttributePrefix,
-                                                boolean removeCurlyBraces,
-                                                String valueSeperatorForHeaders) {
+    private Map<String, String> buildAttributes(final BasicProperties properties, final Envelope envelope, String headersStringFormat, String headerAttributePrefix, boolean removeCurlyBraces,
+                                                String valueSeparatorForHeaders) {
         AllowableValue headerFormat = new AllowableValue(headersStringFormat);
         final Map<String, String> attributes = new HashMap<>();
         addAttribute(attributes, ATTRIBUTES_PREFIX + "appId", properties.getAppId());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "contentEncoding",
-                properties.getContentEncoding());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "contentEncoding", properties.getContentEncoding());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "contentType", properties.getContentType());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "deliveryMode", properties.getDeliveryMode());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "priority", properties.getPriority());
@@ -252,8 +236,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         addAttribute(attributes, ATTRIBUTES_PREFIX + "replyTo", properties.getReplyTo());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "expiration", properties.getExpiration());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "messageId", properties.getMessageId());
-        addAttribute(attributes, ATTRIBUTES_PREFIX + "timestamp",
-                properties.getTimestamp() == null ? null : properties.getTimestamp().getTime());
+        addAttribute(attributes, ATTRIBUTES_PREFIX + "timestamp", properties.getTimestamp() == null ? null : properties.getTimestamp().getTime());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "type", properties.getType());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "userId", properties.getUserId());
         addAttribute(attributes, ATTRIBUTES_PREFIX + "clusterId", properties.getClusterId());
@@ -267,14 +250,13 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
             } else {
                 addAttribute(attributes, ATTRIBUTES_PREFIX + "headers",
                         buildHeaders(properties.getHeaders(), headerFormat, removeCurlyBraces,
-                                valueSeperatorForHeaders));
+                                valueSeparatorForHeaders));
             }
         }
         return attributes;
     }
 
-    private void addAttribute(final Map<String, String> attributes, final String attributeName,
-                              final Object value) {
+    private void addAttribute(final Map<String, String> attributes, final String attributeName, final Object value) {
         if (value == null) {
             return;
         }
@@ -282,9 +264,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         attributes.put(attributeName, value.toString());
     }
 
-    private String buildHeaders(Map<String, Object> headers, AllowableValue headerFormat,
-                                boolean removeCurlyBraces,
-                                String valueSeparatorForHeaders) {
+    private String buildHeaders(Map<String, Object> headers, AllowableValue headerFormat, boolean removeCurlyBraces, String valueSeparatorForHeaders) {
         if (headers == null) {
             return null;
         }
@@ -305,27 +285,21 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         return headerString;
     }
 
-    private static String convertMapToString(Map<String, Object> headers,
-                                             String valueSeparatorForHeaders) {
-        return headers.entrySet().stream()
-                .map(e -> (e.getValue() != null) ? e.getKey() + "=" + e.getValue() : e.getKey())
+    private static String convertMapToString(Map<String, Object> headers, String valueSeparatorForHeaders) {
+        return headers.entrySet().stream().map(e -> (e.getValue()!= null) ? e.getKey() + "=" + e.getValue(): e.getKey())
                 .collect(Collectors.joining(valueSeparatorForHeaders));
     }
 
-    private static String convertMapToJSONString(Map<String, Object> headers)
-            throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+    private static String convertMapToJSONString(Map<String, Object> headers) throws JsonProcessingException {
         return objectMapper.writeValueAsString(headers);
     }
 
     @Override
-    protected synchronized AMQPConsumer createAMQPWorker(final ProcessContext context,
-                                                         final Connection connection) {
+    protected synchronized AMQPConsumer createAMQPWorker(final ProcessContext context, final Connection connection) {
         try {
             final String queueName = context.getProperty(QUEUE).getValue();
             final boolean autoAcknowledge = context.getProperty(AUTO_ACKNOWLEDGE).asBoolean();
-            final AMQPConsumer amqpConsumer = new AMQPConsumer(connection, queueName, autoAcknowledge,
-                    getLogger());
+            final AMQPConsumer amqpConsumer = new AMQPConsumer(connection, queueName, autoAcknowledge, getLogger());
 
             return amqpConsumer;
         } catch (final IOException ioe) {

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -76,11 +76,11 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
     private static final String ATTRIBUTES_PREFIX = "amqp$";
     public static final String DEFAULT_HEADERS_KEY_PREFIX = "consume.amqp";
 
-    public static final AllowableValue HEADERS_FORMAT_COMMA_SEPARATED_STRING = new AllowableValue("Comma Separated String", "Comma Separated String",
+    public static final AllowableValue HEADERS_FORMAT_COMMA_SEPARATED_STRING = new AllowableValue("Comma-Separated String", "Comma-Separated String",
             "Put all headers as a string with the specified separator in the attribute 'amqp$headers'.");
     public static final AllowableValue HEADERS_FORMAT_JSON_STRING = new AllowableValue("JSON String", "JSON String",
             "Format all headers as JSON string and output in the attribute 'amqp$headers'. It will include keys with null value as well.");
-    public static final AllowableValue HEADERS_FORMAT_ATTRIBUTES = new AllowableValue("Flow file attributes", "Flow file attributes",
+    public static final AllowableValue HEADERS_FORMAT_ATTRIBUTES = new AllowableValue("FlowFile Attributes", "FlowFile Attributes",
             "Put each header as attribute of the flow file with a prefix specified in the properties");
 
     public static final PropertyDescriptor QUEUE = new PropertyDescriptor.Builder()
@@ -124,7 +124,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
     public static final PropertyDescriptor HEADER_KEY_PREFIX = new PropertyDescriptor.Builder()
         .name("header.key.prefix")
         .displayName("Header Key Prefix")
-        .description("Text to be prefixed to header keys as the are added to the flowfile attributes. Processor will append '.' to the value")
+        .description("Text to be prefixed to header keys as the are added to the FlowFile attributes. Processor will append '.' to the value of this property")
         .defaultValue(DEFAULT_HEADERS_KEY_PREFIX)
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_ATTRIBUTES)
@@ -134,8 +134,8 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
     public static final PropertyDescriptor HEADER_SEPARATOR = new PropertyDescriptor.Builder()
         .name("header.separator")
         .displayName("Header Separator")
-        .description("The character that is used to separate key-value for header in String. The value must only one character."
-                + "Otherwise you will get an error message")
+        .description("The character that is used to separate key-value for header in String. The value must be only one character."
+                )
         .addValidator(StandardValidators.SINGLE_CHAR_VALIDATOR)
         .defaultValue(",")
         .dependsOn(HEADER_FORMAT, HEADERS_FORMAT_COMMA_SEPARATED_STRING)
@@ -208,7 +208,9 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
 
             final BasicProperties amqpProperties = response.getProps();
             final Envelope envelope = response.getEnvelope();
-            final Map<String, String> attributes = buildAttributes(amqpProperties, envelope, context.getProperty(HEADER_FORMAT).toString(), context.getProperty(HEADER_KEY_PREFIX).toString(),
+            final String headerFormat = context.getProperty(HEADER_FORMAT).getValue();
+            final String headerKeyPrefix = context.getProperty(HEADER_KEY_PREFIX).getValue();
+            final Map<String, String> attributes = buildAttributes(amqpProperties, envelope, headerFormat, headerKeyPrefix,
                     context.getProperty(REMOVE_CURLY_BRACES).asBoolean(), context.getProperty(HEADER_SEPARATOR).toString());
             flowFile = session.putAllAttributes(flowFile, attributes);
 

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
@@ -175,7 +175,7 @@ public class ConsumeAMQPTest {
         headersMap.put("foo3", "null");
         headersMap.put("foo4", null);
         ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode EXPECTED_JSON = objectMapper.valueToTree(headersMap);
+        JsonNode expectedJson = objectMapper.valueToTree(headersMap);
 
         AMQP.BasicProperties.Builder builderBasicProperties = new AMQP.BasicProperties.Builder();
         builderBasicProperties.headers(headersMap);
@@ -195,7 +195,7 @@ public class ConsumeAMQPTest {
             successFF.assertAttributeEquals("amqp$exchange", "myExchange");
             String headers = successFF.getAttribute("amqp$headers");
             JsonNode jsonNode = objectMapper.readTree(headers);
-            assertEquals(EXPECTED_JSON, jsonNode);
+            assertEquals(expectedJson, jsonNode);
         }
     }
 
@@ -210,7 +210,7 @@ public class ConsumeAMQPTest {
         final Map<String, Object> headersMap = new HashMap<>(expectedHeadersMap);
         headersMap.put("foo4", null);
 
-        final String HEADER_PREFIX = "test.header";
+        final String headerPrefix = "test.header";
 
         AMQP.BasicProperties.Builder builderBasicProperties = new AMQP.BasicProperties.Builder();
         builderBasicProperties.headers(headersMap);
@@ -223,7 +223,7 @@ public class ConsumeAMQPTest {
             ConsumeAMQP proc = new LocalConsumeAMQP(connection);
             TestRunner runner = initTestRunner(proc);
             runner.setProperty(ConsumeAMQP.HEADER_FORMAT, ConsumeAMQP.HEADERS_FORMAT_ATTRIBUTES);
-            runner.setProperty(ConsumeAMQP.HEADER_KEY_PREFIX,HEADER_PREFIX);
+            runner.setProperty(ConsumeAMQP.HEADER_KEY_PREFIX,headerPrefix);
             runner.run();
             final MockFlowFile successFF = runner.getFlowFilesForRelationship(ConsumeAMQP.REL_SUCCESS).get(0);
             assertNotNull(successFF);
@@ -231,7 +231,7 @@ public class ConsumeAMQPTest {
             successFF.assertAttributeEquals("amqp$exchange", "myExchange");
             successFF.assertAttributeNotExists("amqp$headers");
             expectedHeadersMap.forEach((key, value) ->{
-                successFF.assertAttributeEquals(HEADER_PREFIX+"."+key,value.toString());
+                successFF.assertAttributeEquals(headerPrefix + "." + key, value.toString());
             } );
         }
     }


### PR DESCRIPTION


<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11995](https://issues.apache.org/jira/browse/NIFI-11995) extends ConsumeAMQP processor and allows the user to configure how to output headers from a received message. It provides three options:
* Output headers to `amqp$headers` attribute as string joined by the provided separator (Default) -> backward compatible
* Output headers to `amqp$headers` attribute as a valid JSON string. Headers with null value will be present as well in json with null value
* Output each header key as `<Header Key Prefix>.<header key>` attribute. It will not put headers which are null in message
  * Property `<Header Key Prefix>` specifies the prefix value, defaults to `consume.amqp`

Test cases updated for new changes to the processor

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
