### PR TITLE
NIFI-11993 Update 3.0.X Groovy Version to 3.0.19

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-scripting-bundle/pom.xml
@@ -31,7 +31,7 @@
     </modules>
 
     <properties>
-        <scripting.groovy.version>3.0.17</scripting.groovy.version>
+        <scripting.groovy.version>3.0.19</scripting.groovy.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-toolkit/pom.xml
+++ b/nifi-toolkit/pom.xml
@@ -31,7 +31,7 @@
         <module>nifi-toolkit-api</module>
     </modules>
     <properties>
-        <toolkit.groovy.version>3.0.17</toolkit.groovy.version>
+        <toolkit.groovy.version>3.0.19</toolkit.groovy.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
         <json.smart.version>2.4.11</json.smart.version>
-        <nifi.groovy.version>3.0.18</nifi.groovy.version>
+        <nifi.groovy.version>3.0.19</nifi.groovy.version>
         <groovy.eclipse.compiler.version>3.9.0</groovy.eclipse.compiler.version>
         <groovy.eclipse.batch.version>3.0.9-03</groovy.eclipse.batch.version>
         <surefire.version>3.1.2</surefire.version>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11993](https://issues.apache.org/jira/browse/NIFI-11993)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-11993) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
