### PR TITLE
NIFI-12009 Upgrade ZooKeeper from 3.8.2 to 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <spring.security.version>5.8.6</spring.security.version>
         <swagger.annotations.version>1.6.11</swagger.annotations.version>
         <h2.version>2.2.220</h2.version>
-        <zookeeper.version>3.8.2</zookeeper.version>
+        <zookeeper.version>3.9.0</zookeeper.version>
         <caffeine.version>3.1.6</caffeine.version>
     </properties>
     <pluginRepositories>


### PR DESCRIPTION
# Summary

[NIFI-12009](https://issues.apache.org/jira/browse/NIFI-12009) Upgrades ZooKeeper dependencies from 3.8.2 to [3.9.0](https://zookeeper.apache.org/doc/r3.9.0/releasenotes.html). [ZooKeeper 3.9.0](https://zookeeper.apache.org/releases.html) clients maintain compatibility with ZooKeeper Server 3.5 and following.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
