### PR TITLE
NIFI-12014 NullPointerException in PutSQL when adding error attributes

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processors.standard;
 
+import java.util.Optional;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.ReadsAttribute;
@@ -75,9 +76,9 @@ import java.util.function.BiFunction;
 
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
-import static org.apache.nifi.processor.util.pattern.ErrorTypes.Destination.Failure;
 import static org.apache.nifi.processor.util.pattern.ExceptionHandler.createOnError;
 
 @SupportsBatching
@@ -462,15 +463,16 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
     private ExceptionHandler.OnError<FunctionContext, FlowFile> onFlowFileError(final ProcessContext context, final ProcessSession session, final RoutingResult result) {
         ExceptionHandler.OnError<FunctionContext, FlowFile> onFlowFileError = createOnError(context, session, result, REL_FAILURE, REL_RETRY);
         onFlowFileError = onFlowFileError.andThen((ctx, flowFile, errorTypesResult, exception) -> {
-            flowFile = addErrorAttributesToFlowFile(session, flowFile, exception);
 
             switch (errorTypesResult.destination()) {
                 case Failure:
                     getLogger().error("Failed to update database for {} due to {}; routing to failure", flowFile, exception, exception);
+                    addErrorAttributesToFlowFile(session, flowFile, exception);
                     break;
                 case Retry:
                     getLogger().error("Failed to update database for {} due to {}; it is possible that retrying the operation will succeed, so routing to retry",
                            flowFile, exception, exception);
+                    addErrorAttributesToFlowFile(session, flowFile, exception);
                     break;
                 case Self:
                     getLogger().error("Failed to update database for {} due to {};",  flowFile, exception, exception);
@@ -485,12 +487,24 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
                 ExceptionHandler.createOnGroupError(context, session, result, REL_FAILURE, REL_RETRY);
 
         onGroupError = onGroupError.andThen((ctx, flowFileGroup, errorTypesResult, exception) -> {
-            Relationship relationship = errorTypesResult.destination() == Failure ? REL_FAILURE : REL_RETRY;
-            List<FlowFile> flowFilesToRelationship = result.getRoutedFlowFiles().get(relationship);
-            result.getRoutedFlowFiles().put(relationship, addErrorAttributesToFlowFilesInGroup(session, flowFilesToRelationship, flowFileGroup.getFlowFiles(), exception));
+            switch (errorTypesResult.destination()) {
+                case Failure:
+                    List<FlowFile> flowFilesToFailure = getFlowFilesOnRelationship(result, REL_FAILURE);
+                    result.getRoutedFlowFiles().put(REL_FAILURE, addErrorAttributesToFlowFilesInGroup(session, flowFilesToFailure, flowFileGroup.getFlowFiles(), exception));
+                    break;
+                case Retry:
+                    List<FlowFile> flowFilesToRetry = getFlowFilesOnRelationship(result, REL_RETRY);
+                    result.getRoutedFlowFiles().put(REL_RETRY, addErrorAttributesToFlowFilesInGroup(session, flowFilesToRetry, flowFileGroup.getFlowFiles(), exception));
+                    break;
+            }
         });
 
         return onGroupError;
+    }
+
+    private List<FlowFile> getFlowFilesOnRelationship(RoutingResult result, final Relationship relationship) {
+        return Optional.ofNullable(result.getRoutedFlowFiles().get(relationship))
+                .orElse(emptyList());
     }
 
     private List<FlowFile> addErrorAttributesToFlowFilesInGroup(ProcessSession session, List<FlowFile> flowFilesOnRelationship, List<FlowFile> flowFilesInGroup, Exception exception) {
@@ -861,8 +875,16 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
         attributes.put(ERROR_MESSAGE_ATTR, exception.getMessage());
 
         if (exception instanceof SQLException) {
-            attributes.put(ERROR_CODE_ATTR, valueOf(((SQLException) exception).getErrorCode()));
-            attributes.put(ERROR_SQL_STATE_ATTR, valueOf(((SQLException) exception).getSQLState()));
+            int errorCode = ((SQLException) exception).getErrorCode();
+            String sqlState = ((SQLException) exception).getSQLState();
+
+            if (errorCode > 0) {
+                attributes.put(ERROR_CODE_ATTR, valueOf(errorCode));
+            }
+
+            if (sqlState != null) {
+                attributes.put(ERROR_SQL_STATE_ATTR, sqlState);
+            }
         }
 
         return session.putAllAttributes(flowFile, attributes);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12014](https://issues.apache.org/jira/browse/NIFI-12014)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
