### PR TITLE
NIFI-12022 Extract verification logic from JMSConnectionFactoryProvider

### DIFF
--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/AbstractJMSConnectionFactoryProvider.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/AbstractJMSConnectionFactoryProvider.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jms.cf;
+
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.components.ConfigVerificationResult;
+import org.apache.nifi.components.ConfigVerificationResult.Outcome;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.controller.VerifiableControllerService;
+import org.apache.nifi.logging.ComponentLog;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.ExceptionListener;
+import javax.jms.JMSSecurityException;
+import javax.jms.Session;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Base JMS controller service implementation that provides verification logic.
+ */
+public abstract class AbstractJMSConnectionFactoryProvider extends AbstractControllerService implements JMSConnectionFactoryProviderDefinition, VerifiableControllerService {
+    private static final String ESTABLISH_CONNECTION = "Establish Connection";
+    private static final String VERIFY_JMS_INTERACTION = "Verify JMS Interaction";
+
+    protected volatile IJMSConnectionFactoryProvider delegate;
+
+    protected abstract IJMSConnectionFactoryProvider createConnectionFactory(ConfigurationContext context, ComponentLog logger);
+
+    @OnEnabled
+    public void onEnabled(ConfigurationContext context) {
+        delegate = createConnectionFactory(context, getLogger());
+    }
+
+    @OnDisabled
+    public void onDisabled() {
+        delegate = null;
+    }
+
+    @Override
+    public ConnectionFactory getConnectionFactory() {
+        return delegate.getConnectionFactory();
+    }
+
+    @Override
+    public void resetConnectionFactory(ConnectionFactory cachedFactory) {
+        delegate.resetConnectionFactory(cachedFactory);
+    }
+
+    @Override
+    public List<ConfigVerificationResult> verify(final ConfigurationContext context, final ComponentLog verificationLogger, final Map<String, String> variables) {
+        final List<ConfigVerificationResult> results = new ArrayList<>();
+        final IJMSConnectionFactoryProvider handler = createConnectionFactory(context, verificationLogger);
+
+        final AtomicReference<Exception> failureReason = new AtomicReference<>();
+        final ExceptionListener listener = failureReason::set;
+
+        final Connection connection = createConnection(handler.getConnectionFactory(), results, listener, verificationLogger);
+        if (connection != null) {
+            try {
+                createSession(connection, results, failureReason.get(), verificationLogger);
+            } finally {
+                try {
+                    connection.close();
+                } catch (final Exception ignored) {
+                }
+            }
+        }
+
+        return results;
+    }
+
+    private Connection createConnection(final ConnectionFactory connectionFactory, final List<ConfigVerificationResult> results, final ExceptionListener exceptionListener, final ComponentLog logger) {
+        try {
+            final Connection connection = connectionFactory.createConnection();
+            connection.setExceptionListener(exceptionListener);
+
+            results.add(new ConfigVerificationResult.Builder()
+                .verificationStepName(ESTABLISH_CONNECTION)
+                .outcome(Outcome.SUCCESSFUL)
+                .explanation("Successfully established a JMS Connection")
+                .build());
+
+            return connection;
+        } catch (final JMSSecurityException se) {
+            // If we encounter a JMS Security Exception, the documentation states that it is because of an invalid username or password.
+            // There is no username or password configured for the Controller Service itself, however. Those are configured in processors, etc.
+            // As a result, if this is encountered, we will skip verification.
+            logger.debug("Failed to establish a connection to the JMS Server in order to verify configuration because encountered JMS Security Exception", se);
+
+            results.add(new ConfigVerificationResult.Builder()
+                .verificationStepName(ESTABLISH_CONNECTION)
+                .outcome(Outcome.SKIPPED)
+                .explanation("Could not establish a Connection because doing so requires a valid username and password")
+                .build());
+        } catch (final Exception e) {
+            logger.warn("Failed to establish a connection to the JMS Server in order to verify configuration", e);
+
+            results.add(new ConfigVerificationResult.Builder()
+                .verificationStepName(ESTABLISH_CONNECTION)
+                .outcome(Outcome.FAILED)
+                .explanation("Was not able to establish a connection to the JMS Server: " + e)
+                .build());
+        }
+
+        return null;
+    }
+
+    private void createSession(final Connection connection, final List<ConfigVerificationResult> results, final Exception capturedException, final ComponentLog logger) {
+        try {
+            final Session session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+            session.close();
+
+            results.add(new ConfigVerificationResult.Builder()
+                .verificationStepName(VERIFY_JMS_INTERACTION)
+                .outcome(Outcome.SUCCESSFUL)
+                .explanation("Established a JMS Session with server and successfully terminated it")
+                .build());
+        } catch (final Exception e) {
+            final Exception failure;
+            if (capturedException == null) {
+                failure = e;
+            } else {
+                failure = capturedException;
+                failure.addSuppressed(e);
+            }
+
+            logger.warn("Failed to create a JMS Session in order to verify configuration", failure);
+
+            results.add(new ConfigVerificationResult.Builder()
+                .verificationStepName(VERIFY_JMS_INTERACTION)
+                .outcome(Outcome.FAILED)
+                .explanation("Was not able to create a JMS Session: " + failure)
+                .build());
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/AbstractJMSConnectionFactoryProvider.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/AbstractJMSConnectionFactoryProvider.java
@@ -44,11 +44,11 @@ public abstract class AbstractJMSConnectionFactoryProvider extends AbstractContr
 
     protected volatile IJMSConnectionFactoryProvider delegate;
 
-    protected abstract IJMSConnectionFactoryProvider createConnectionFactory(ConfigurationContext context, ComponentLog logger);
+    protected abstract IJMSConnectionFactoryProvider createConnectionFactoryProvider(ConfigurationContext context, ComponentLog logger);
 
     @OnEnabled
     public void onEnabled(ConfigurationContext context) {
-        delegate = createConnectionFactory(context, getLogger());
+        delegate = createConnectionFactoryProvider(context, getLogger());
     }
 
     @OnDisabled
@@ -69,7 +69,7 @@ public abstract class AbstractJMSConnectionFactoryProvider extends AbstractContr
     @Override
     public List<ConfigVerificationResult> verify(final ConfigurationContext context, final ComponentLog verificationLogger, final Map<String, String> variables) {
         final List<ConfigVerificationResult> results = new ArrayList<>();
-        final IJMSConnectionFactoryProvider handler = createConnectionFactory(context, verificationLogger);
+        final IJMSConnectionFactoryProvider handler = createConnectionFactoryProvider(context, verificationLogger);
 
         final AtomicReference<Exception> failureReason = new AtomicReference<>();
         final ExceptionListener listener = failureReason::set;

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/AbstractJMSConnectionFactoryProvider.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/AbstractJMSConnectionFactoryProvider.java
@@ -42,13 +42,13 @@ public abstract class AbstractJMSConnectionFactoryProvider extends AbstractContr
     private static final String ESTABLISH_CONNECTION = "Establish Connection";
     private static final String VERIFY_JMS_INTERACTION = "Verify JMS Interaction";
 
-    protected volatile IJMSConnectionFactoryProvider delegate;
+    protected volatile JMSConnectionFactoryHandlerDefinition delegate;
 
-    protected abstract IJMSConnectionFactoryProvider createConnectionFactoryProvider(ConfigurationContext context, ComponentLog logger);
+    protected abstract JMSConnectionFactoryHandlerDefinition createConnectionFactoryHandler(ConfigurationContext context, ComponentLog logger);
 
     @OnEnabled
     public void onEnabled(ConfigurationContext context) {
-        delegate = createConnectionFactoryProvider(context, getLogger());
+        delegate = createConnectionFactoryHandler(context, getLogger());
     }
 
     @OnDisabled
@@ -69,7 +69,7 @@ public abstract class AbstractJMSConnectionFactoryProvider extends AbstractContr
     @Override
     public List<ConfigVerificationResult> verify(final ConfigurationContext context, final ComponentLog verificationLogger, final Map<String, String> variables) {
         final List<ConfigVerificationResult> results = new ArrayList<>();
-        final IJMSConnectionFactoryProvider handler = createConnectionFactoryProvider(context, verificationLogger);
+        final IJMSConnectionFactoryProvider handler = createConnectionFactoryHandler(context, verificationLogger);
 
         final AtomicReference<Exception> failureReason = new AtomicReference<>();
         final ExceptionListener listener = failureReason::set;

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/CachedJMSConnectionFactoryHandler.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/CachedJMSConnectionFactoryHandler.java
@@ -20,13 +20,13 @@ import org.apache.nifi.logging.ComponentLog;
 
 import javax.jms.ConnectionFactory;
 
-public abstract class CachedJMSConnectionFactoryProvider implements IJMSConnectionFactoryProvider {
+public abstract class CachedJMSConnectionFactoryHandler implements JMSConnectionFactoryHandlerDefinition {
 
     private final ComponentLog logger;
 
     private volatile ConnectionFactory connectionFactory;
 
-    protected CachedJMSConnectionFactoryProvider(ComponentLog logger) {
+    protected CachedJMSConnectionFactoryHandler(ComponentLog logger) {
         this.logger = logger;
     }
 

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/CachedJMSConnectionFactoryProvider.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/CachedJMSConnectionFactoryProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jms.cf;
+
+import org.apache.nifi.logging.ComponentLog;
+
+import javax.jms.ConnectionFactory;
+
+public abstract class CachedJMSConnectionFactoryProvider implements IJMSConnectionFactoryProvider {
+
+    private final ComponentLog logger;
+
+    private volatile ConnectionFactory connectionFactory;
+
+    protected CachedJMSConnectionFactoryProvider(ComponentLog logger) {
+        this.logger = logger;
+    }
+
+    public abstract ConnectionFactory createConnectionFactory();
+
+    @Override
+    public synchronized ConnectionFactory getConnectionFactory() {
+        if (connectionFactory == null) {
+            connectionFactory = createConnectionFactory();
+        } else {
+            logger.debug("Connection Factory has already been initialized. Will return cached instance.");
+        }
+
+        return connectionFactory;
+    }
+
+    @Override
+    public synchronized void resetConnectionFactory(ConnectionFactory cachedFactory) {
+        if (cachedFactory == connectionFactory) {
+            logger.debug("Resetting connection factory");
+            connectionFactory = null;
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandlerDefinition.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-cf-service/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandlerDefinition.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.jms.cf;
+
+/**
+ * Base interface of handler implementations of IJMSConnectionFactoryProvider.
+ */
+public interface JMSConnectionFactoryHandlerDefinition extends IJMSConnectionFactoryProvider {
+}

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandler.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandler.java
@@ -38,46 +38,28 @@ import org.apache.nifi.ssl.SSLContextService;
  * implementation class and configuring the Connection Factory object directly.
  * The handler can be used from controller services and processors as well.
  */
-public class JMSConnectionFactoryHandler implements IJMSConnectionFactoryProvider {
+public class JMSConnectionFactoryHandler extends CachedJMSConnectionFactoryProvider {
 
     private final PropertyContext context;
     private final Set<PropertyDescriptor> propertyDescriptors;
     private final ComponentLog logger;
 
     public JMSConnectionFactoryHandler(ConfigurationContext context, ComponentLog logger) {
+        super(logger);
         this.context = context;
         this.propertyDescriptors = context.getProperties().keySet();
         this.logger = logger;
     }
 
     public JMSConnectionFactoryHandler(ProcessContext context, ComponentLog logger) {
+        super(logger);
         this.context = context;
         this.propertyDescriptors = context.getProperties().keySet();
         this.logger = logger;
     }
 
-    private volatile ConnectionFactory connectionFactory;
-
     @Override
-    public synchronized ConnectionFactory getConnectionFactory() {
-        if (connectionFactory == null) {
-            initConnectionFactory();
-        } else {
-            logger.debug("Connection Factory has already been initialized. Will return cached instance.");
-        }
-
-        return connectionFactory;
-    }
-
-    @Override
-    public synchronized void resetConnectionFactory(ConnectionFactory cachedFactory) {
-        if (cachedFactory == connectionFactory) {
-            logger.debug("Resetting connection factory");
-            connectionFactory = null;
-        }
-    }
-
-    private void initConnectionFactory() {
+    public ConnectionFactory createConnectionFactory() {
         try {
             if (logger.isInfoEnabled()) {
                 logger.info("Configuring " + getClass().getSimpleName() + " for '"
@@ -85,10 +67,11 @@ public class JMSConnectionFactoryHandler implements IJMSConnectionFactoryProvide
                         + context.getProperty(JMS_BROKER_URI).evaluateAttributeExpressions().getValue() + "'");
             }
 
-            createConnectionFactoryInstance();
-            setConnectionFactoryProperties();
+            final ConnectionFactory connectionFactory = createConnectionFactoryInstance();
+            setConnectionFactoryProperties(connectionFactory);
+
+            return connectionFactory;
         } catch (Exception e) {
-            connectionFactory = null;
             logger.error("Failed to configure " + getClass().getSimpleName(), e);
             throw new IllegalStateException(e);
         }
@@ -98,9 +81,9 @@ public class JMSConnectionFactoryHandler implements IJMSConnectionFactoryProvide
      * Creates an instance of the {@link ConnectionFactory} from the provided
      * 'CONNECTION_FACTORY_IMPL'.
      */
-    private void createConnectionFactoryInstance() {
-        String connectionFactoryImplName = context.getProperty(JMS_CONNECTION_FACTORY_IMPL).evaluateAttributeExpressions().getValue();
-        connectionFactory = Utils.newDefaultInstance(connectionFactoryImplName);
+    private ConnectionFactory createConnectionFactoryInstance() {
+        final String connectionFactoryImplName = context.getProperty(JMS_CONNECTION_FACTORY_IMPL).evaluateAttributeExpressions().getValue();
+        return Utils.newDefaultInstance(connectionFactoryImplName);
     }
 
     /**
@@ -135,18 +118,18 @@ public class JMSConnectionFactoryHandler implements IJMSConnectionFactoryProvide
      * @see <a href="https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_7.1.0/com.ibm.mq.javadoc.doc/WMQJMSClasses/com/ibm/mq/jms/MQConnectionFactory.html#setHostName_java.lang.String_">setHostName(String hostname)</a>
      * @see <a href="https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_7.1.0/com.ibm.mq.javadoc.doc/WMQJMSClasses/com/ibm/mq/jms/MQConnectionFactory.html#setPort_int_">setPort(int port)</a>
      * @see <a href="https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_7.1.0/com.ibm.mq.javadoc.doc/WMQJMSClasses/com/ibm/mq/jms/MQConnectionFactory.html#setConnectionNameList_java.lang.String_">setConnectionNameList(String hosts)</a>
-     * @see #setProperty(String propertyName, Object propertyValue)
+     * @see #setProperty(ConnectionFactory connectionFactory, String propertyName, Object propertyValue)
      */
-    void setConnectionFactoryProperties() {
+    void setConnectionFactoryProperties(ConnectionFactory connectionFactory) {
         String connectionFactoryValue = context.getProperty(JMS_CONNECTION_FACTORY_IMPL).evaluateAttributeExpressions().getValue();
         if (context.getProperty(JMS_BROKER_URI).isSet()) {
             String brokerValue = context.getProperty(JMS_BROKER_URI).evaluateAttributeExpressions().getValue();
             if (connectionFactoryValue.startsWith("org.apache.activemq")) {
-                setProperty("brokerURL", brokerValue);
+                setProperty(connectionFactory, "brokerURL", brokerValue);
             } else if (connectionFactoryValue.startsWith("com.tibco.tibjms")) {
-                setProperty("serverUrl", brokerValue);
+                setProperty(connectionFactory, "serverUrl", brokerValue);
             } else if (connectionFactoryValue.startsWith("org.apache.qpid.jms")) {
-                setProperty("remoteURI", brokerValue);
+                setProperty(connectionFactory, "remoteURI", brokerValue);
             } else {
                 String[] brokerList = brokerValue.split(",");
                 if (connectionFactoryValue.startsWith("com.ibm.mq.jms")) {
@@ -159,14 +142,14 @@ public class JMSConnectionFactoryHandler implements IJMSConnectionFactoryProvide
                             ibmConList.add(broker);
                         }
                     }
-                    setProperty("connectionNameList", String.join(",", ibmConList));
+                    setProperty(connectionFactory, "connectionNameList", String.join(",", ibmConList));
                 } else {
                     // Try to parse broker URI as colon separated host/port pair. Use first pair if multiple given.
                     String[] hostPort = brokerList[0].split(":");
                     if (hostPort.length == 2) {
                         // If broker URI indeed was colon separated host/port pair
-                        setProperty("hostName", hostPort[0]);
-                        setProperty("port", hostPort[1]);
+                        setProperty(connectionFactory, "hostName", hostPort[0]);
+                        setProperty(connectionFactory, "port", hostPort[1]);
                     }
                 }
             }
@@ -177,21 +160,21 @@ public class JMSConnectionFactoryHandler implements IJMSConnectionFactoryProvide
             SSLContext sslContext = sslContextService.createContext();
             if (connectionFactoryValue.startsWith("org.apache.activemq")) {
                 if (sslContextService.isTrustStoreConfigured()) {
-                    setProperty("trustStore", sslContextService.getTrustStoreFile());
-                    setProperty("trustStorePassword", sslContextService.getTrustStorePassword());
-                    setProperty("trustStoreType", sslContextService.getTrustStoreType());
+                    setProperty(connectionFactory, "trustStore", sslContextService.getTrustStoreFile());
+                    setProperty(connectionFactory, "trustStorePassword", sslContextService.getTrustStorePassword());
+                    setProperty(connectionFactory, "trustStoreType", sslContextService.getTrustStoreType());
                 }
                 if (sslContextService.isKeyStoreConfigured()) {
-                    setProperty("keyStore", sslContextService.getKeyStoreFile());
-                    setProperty("keyStorePassword", sslContextService.getKeyStorePassword());
-                    setProperty("keyStoreKeyPassword", sslContextService.getKeyPassword());
-                    setProperty("keyStoreType", sslContextService.getKeyStoreType());
+                    setProperty(connectionFactory, "keyStore", sslContextService.getKeyStoreFile());
+                    setProperty(connectionFactory, "keyStorePassword", sslContextService.getKeyStorePassword());
+                    setProperty(connectionFactory, "keyStoreKeyPassword", sslContextService.getKeyPassword());
+                    setProperty(connectionFactory, "keyStoreType", sslContextService.getKeyStoreType());
                 }
             } else if (connectionFactoryValue.startsWith("org.apache.qpid.jms")) {
-                setProperty("sslContext", sslContext);
+                setProperty(connectionFactory, "sslContext", sslContext);
             } else {
                 // IBM MQ (and others)
-                setProperty("sSLSocketFactory", sslContext.getSocketFactory());
+                setProperty(connectionFactory, "sSLSocketFactory", sslContext.getSocketFactory());
             }
         }
 
@@ -200,7 +183,7 @@ public class JMSConnectionFactoryHandler implements IJMSConnectionFactoryProvide
                 .forEach(descriptor -> {
                     String propertyName = descriptor.getName();
                     String propertyValue = context.getProperty(descriptor).evaluateAttributeExpressions().getValue();
-                    setProperty(propertyName, propertyValue);
+                    setProperty(connectionFactory, propertyName, propertyValue);
                 });
     }
 
@@ -222,7 +205,7 @@ public class JMSConnectionFactoryHandler implements IJMSConnectionFactoryProvide
      * follow bean convention and all their properties using Java primitives as
      * arguments.
      */
-    void setProperty(String propertyName, Object propertyValue) {
+    void setProperty(ConnectionFactory connectionFactory, String propertyName, Object propertyValue) {
         String methodName = toMethodName(propertyName);
         Method[] methods = Utils.findMethods(methodName, connectionFactory.getClass());
         if (methods != null && methods.length > 0) {
@@ -248,7 +231,7 @@ public class JMSConnectionFactoryHandler implements IJMSConnectionFactoryProvide
                 throw new IllegalStateException("Failed to set property " + propertyName, e);
             }
         } else if (propertyName.equals("hostName")) {
-            setProperty("host", propertyValue); // try 'host' as another common convention.
+            setProperty(connectionFactory, "host", propertyValue); // try 'host' as another common convention.
         }
     }
 
@@ -262,4 +245,5 @@ public class JMSConnectionFactoryHandler implements IJMSConnectionFactoryProvide
         c[0] = Character.toUpperCase(c[0]);
         return "set" + new String(c);
     }
+
 }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandler.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandler.java
@@ -38,7 +38,7 @@ import org.apache.nifi.ssl.SSLContextService;
  * implementation class and configuring the Connection Factory object directly.
  * The handler can be used from controller services and processors as well.
  */
-public class JMSConnectionFactoryHandler extends CachedJMSConnectionFactoryProvider {
+public class JMSConnectionFactoryHandler extends CachedJMSConnectionFactoryHandler {
 
     private final PropertyContext context;
     private final Set<PropertyDescriptor> propertyDescriptors;

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProvider.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProvider.java
@@ -71,9 +71,8 @@ public class JMSConnectionFactoryProvider extends AbstractJMSConnectionFactoryPr
         return JMSConnectionFactoryProperties.getDynamicPropertyDescriptor(propertyDescriptorName);
     }
 
-
     @Override
-    protected IJMSConnectionFactoryProvider createConnectionFactoryProvider(ConfigurationContext context, ComponentLog logger) {
+    protected JMSConnectionFactoryHandlerDefinition createConnectionFactoryHandler(ConfigurationContext context, ComponentLog logger) {
         return new JMSConnectionFactoryHandler(context, logger);
     }
 }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProvider.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProvider.java
@@ -73,7 +73,7 @@ public class JMSConnectionFactoryProvider extends AbstractJMSConnectionFactoryPr
 
 
     @Override
-    protected IJMSConnectionFactoryProvider createConnectionFactory(ConfigurationContext context, ComponentLog logger) {
-        return new JMSConnectionFactoryHandler(context, getLogger());
+    protected IJMSConnectionFactoryProvider createConnectionFactoryProvider(ConfigurationContext context, ComponentLog logger) {
+        return new JMSConnectionFactoryHandler(context, logger);
     }
 }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProvider.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProvider.java
@@ -22,27 +22,14 @@ import org.apache.nifi.annotation.behavior.Restriction;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
-import org.apache.nifi.annotation.lifecycle.OnDisabled;
-import org.apache.nifi.annotation.lifecycle.OnEnabled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.RequiredPermission;
-import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.logging.ComponentLog;
-import org.apache.nifi.components.ConfigVerificationResult;
-import org.apache.nifi.components.ConfigVerificationResult.Outcome;
-import org.apache.nifi.controller.VerifiableControllerService;
 
-import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
-import javax.jms.ExceptionListener;
-import javax.jms.JMSSecurityException;
-import javax.jms.Session;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Provides a factory service that creates and initializes
@@ -72,11 +59,7 @@ import java.util.concurrent.atomic.AtomicReference;
                 )
         }
 )
-public class JMSConnectionFactoryProvider extends AbstractControllerService implements JMSConnectionFactoryProviderDefinition, VerifiableControllerService {
-    private static final String ESTABLISH_CONNECTION = "Establish Connection";
-    private static final String VERIFY_JMS_INTERACTION = "Verify JMS Interaction";
-
-    protected volatile JMSConnectionFactoryHandler delegate;
+public class JMSConnectionFactoryProvider extends AbstractJMSConnectionFactoryProvider {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -88,111 +71,9 @@ public class JMSConnectionFactoryProvider extends AbstractControllerService impl
         return JMSConnectionFactoryProperties.getDynamicPropertyDescriptor(propertyDescriptorName);
     }
 
-    @OnEnabled
-    public void onEnabled(ConfigurationContext context) {
-        delegate = new JMSConnectionFactoryHandler(context, getLogger());
-    }
-
-    @OnDisabled
-    public void onDisabled() {
-        delegate = null;
-    }
 
     @Override
-    public ConnectionFactory getConnectionFactory() {
-        return delegate.getConnectionFactory();
-    }
-
-    @Override
-    public void resetConnectionFactory(ConnectionFactory cachedFactory) {
-        delegate.resetConnectionFactory(cachedFactory);
-    }
-
-    @Override
-    public List<ConfigVerificationResult> verify(final ConfigurationContext context, final ComponentLog verificationLogger, final Map<String, String> variables) {
-        final List<ConfigVerificationResult> results = new ArrayList<>();
-        final JMSConnectionFactoryHandler handler = new JMSConnectionFactoryHandler(context, verificationLogger);
-
-        final AtomicReference<Exception> failureReason = new AtomicReference<>();
-        final ExceptionListener listener = failureReason::set;
-
-        final Connection connection = createConnection(handler.getConnectionFactory(), results, listener, verificationLogger);
-        if (connection != null) {
-            try {
-                createSession(connection, results, failureReason.get(), verificationLogger);
-            } finally {
-                try {
-                    connection.close();
-                } catch (final Exception ignored) {
-                }
-            }
-        }
-
-        return results;
-    }
-
-    private Connection createConnection(final ConnectionFactory connectionFactory, final List<ConfigVerificationResult> results, final ExceptionListener exceptionListener, final ComponentLog logger) {
-        try {
-            final Connection connection = connectionFactory.createConnection();
-            connection.setExceptionListener(exceptionListener);
-
-            results.add(new ConfigVerificationResult.Builder()
-                .verificationStepName(ESTABLISH_CONNECTION)
-                .outcome(Outcome.SUCCESSFUL)
-                .explanation("Successfully established a JMS Connection")
-                .build());
-
-            return connection;
-        } catch (final JMSSecurityException se) {
-            // If we encounter a JMS Security Exception, the documentation states that it is because of an invalid username or password.
-            // There is no username or password configured for the Controller Service itself, however. Those are configured in processors, etc.
-            // As a result, if this is encountered, we will skip verification.
-            logger.debug("Failed to establish a connection to the JMS Server in order to verify configuration because encountered JMS Security Exception", se);
-
-            results.add(new ConfigVerificationResult.Builder()
-                .verificationStepName(ESTABLISH_CONNECTION)
-                .outcome(Outcome.SKIPPED)
-                .explanation("Could not establish a Connection because doing so requires that a username and password be provided")
-                .build());
-        } catch (final Exception e) {
-            logger.warn("Failed to establish a connection to the JMS Server in order to verify configuration", e);
-
-            results.add(new ConfigVerificationResult.Builder()
-                .verificationStepName(ESTABLISH_CONNECTION)
-                .outcome(Outcome.FAILED)
-                .explanation("Was not able to establish a connection to the JMS Server: " + e.toString())
-                .build());
-        }
-
-        return null;
-    }
-
-    private void createSession(final Connection connection, final List<ConfigVerificationResult> results, final Exception capturedException, final ComponentLog logger) {
-        try {
-            final Session session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
-            session.close();
-
-            results.add(new ConfigVerificationResult.Builder()
-                .verificationStepName(VERIFY_JMS_INTERACTION)
-                .outcome(Outcome.SUCCESSFUL)
-                .explanation("Established a JMS Session with server and successfully terminated it")
-                .build());
-        } catch (final Exception e) {
-            final Exception failure;
-            if (capturedException == null) {
-                failure = e;
-            } else {
-                failure = capturedException;
-                failure.addSuppressed(e);
-            }
-
-            logger.warn("Failed to create a JMS Session in order to verify configuration", failure);
-
-            results.add(new ConfigVerificationResult.Builder()
-                .verificationStepName(VERIFY_JMS_INTERACTION)
-                .outcome(Outcome.FAILED)
-                .explanation("Was not able to create a JMS Session: " + failure.toString())
-                .build());
-        }
+    protected IJMSConnectionFactoryProvider createConnectionFactory(ConfigurationContext context, ComponentLog logger) {
+        return new JMSConnectionFactoryHandler(context, getLogger());
     }
 }

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryHandler.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryHandler.java
@@ -43,43 +43,29 @@ import static org.apache.nifi.jms.cf.JndiJmsConnectionFactoryProperties.JNDI_PRO
  * Handler class to retrieve a JMS Connection Factory object via JNDI.
  * The handler can be used from controller services and processors as well.
  */
-public class JndiJmsConnectionFactoryHandler implements IJMSConnectionFactoryProvider {
+public class JndiJmsConnectionFactoryHandler extends CachedJMSConnectionFactoryProvider {
 
     private final PropertyContext context;
     private final Set<PropertyDescriptor> propertyDescriptors;
     private final ComponentLog logger;
 
-    private volatile ConnectionFactory connectionFactory;
-
     public JndiJmsConnectionFactoryHandler(ConfigurationContext context, ComponentLog logger) {
+        super(logger);
         this.context = context;
         this.propertyDescriptors = context.getProperties().keySet();
         this.logger = logger;
     }
 
     public JndiJmsConnectionFactoryHandler(ProcessContext context, ComponentLog logger) {
+        super(logger);
         this.context = context;
         this.propertyDescriptors = context.getProperties().keySet();
         this.logger = logger;
     }
 
     @Override
-    public synchronized ConnectionFactory getConnectionFactory() {
-        if (connectionFactory == null) {
-            connectionFactory = lookupConnectionFactory();
-        } else {
-            logger.debug("Connection Factory has already been obtained from JNDI. Will return cached instance.");
-        }
-
-        return connectionFactory;
-    }
-
-    @Override
-    public synchronized void resetConnectionFactory(ConnectionFactory cachedFactory) {
-        if (cachedFactory == connectionFactory) {
-            logger.debug("Resetting connection factory");
-            connectionFactory = null;
-        }
+    public ConnectionFactory createConnectionFactory() {
+        return lookupConnectionFactory();
     }
 
     private ConnectionFactory lookupConnectionFactory() {

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryHandler.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryHandler.java
@@ -43,7 +43,7 @@ import static org.apache.nifi.jms.cf.JndiJmsConnectionFactoryProperties.JNDI_PRO
  * Handler class to retrieve a JMS Connection Factory object via JNDI.
  * The handler can be used from controller services and processors as well.
  */
-public class JndiJmsConnectionFactoryHandler extends CachedJMSConnectionFactoryProvider {
+public class JndiJmsConnectionFactoryHandler extends CachedJMSConnectionFactoryHandler {
 
     private final PropertyContext context;
     private final Set<PropertyDescriptor> propertyDescriptors;

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandlerForTest.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandlerForTest.java
@@ -32,7 +32,7 @@ public class JMSConnectionFactoryHandlerForTest extends JMSConnectionFactoryHand
 
     public JMSConnectionFactoryHandlerForTest(ConfigurationContext context, ComponentLog logger) {
         super(context, logger);
-        setConnectionFactoryProperties(getConnectionFactory());
+        setConnectionFactoryProperties(null);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandlerForTest.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JMSConnectionFactoryHandlerForTest.java
@@ -19,6 +19,7 @@ package org.apache.nifi.jms.cf;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.logging.ComponentLog;
 
+import javax.jms.ConnectionFactory;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,14 +28,15 @@ import java.util.Map;
  */
 public class JMSConnectionFactoryHandlerForTest extends JMSConnectionFactoryHandler {
 
-    private Map<String, Object> configuredProperties = new HashMap<>();
+    private final Map<String, Object> configuredProperties = new HashMap<>();
 
     public JMSConnectionFactoryHandlerForTest(ConfigurationContext context, ComponentLog logger) {
         super(context, logger);
+        setConnectionFactoryProperties(getConnectionFactory());
     }
 
     @Override
-    void setProperty(String propertyName, Object propertyValue) {
+    void setProperty(ConnectionFactory connectionFactory, String propertyName, Object propertyValue) {
         configuredProperties.put(propertyName, propertyValue);
     }
 

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProviderForTest.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProviderForTest.java
@@ -29,8 +29,9 @@ public class JMSConnectionFactoryProviderForTest extends JMSConnectionFactoryPro
     @OnEnabled
     @Override
     public void onEnabled(ConfigurationContext context) {
-        delegate = new JMSConnectionFactoryHandlerForTest(context, getLogger());
-        delegate.setConnectionFactoryProperties();
+        final JMSConnectionFactoryHandlerForTest testHandler = new JMSConnectionFactoryHandlerForTest(context, getLogger());
+        testHandler.setConnectionFactoryProperties();
+        delegate = testHandler;
     }
 
     public Map<String, Object> getConfiguredProperties() {

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProviderForTest.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/cf/JMSConnectionFactoryProviderForTest.java
@@ -29,9 +29,7 @@ public class JMSConnectionFactoryProviderForTest extends JMSConnectionFactoryPro
     @OnEnabled
     @Override
     public void onEnabled(ConfigurationContext context) {
-        final JMSConnectionFactoryHandlerForTest testHandler = new JMSConnectionFactoryHandlerForTest(context, getLogger());
-        testHandler.setConnectionFactoryProperties();
-        delegate = testHandler;
+        delegate = new JMSConnectionFactoryHandlerForTest(context, getLogger());
     }
 
     public Map<String, Object> getConfiguredProperties() {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12022](https://issues.apache.org/jira/browse/NIFI-12022)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
