### PR TITLE
NIFI-12025: Fixed duplicated bulletin messages

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/logging/repository/StandardLogRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/logging/repository/StandardLogRepository.java
@@ -127,6 +127,7 @@ public class StandardLogRepository implements LogRepository {
         try {
             final Set<LogObserver> observersCopy = new HashSet<>(observers);
             observers.clear();
+            observersPerLogLevel.clear();
 
             for (final LogObserver observer : observersCopy) {
                 addObserver(level, observer);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/logging/TestStandardLogRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/logging/TestStandardLogRepository.java
@@ -66,9 +66,25 @@ public class TestStandardLogRepository {
         MockFlowFile mockFlowFile1 = new MockFlowFile(1L);
         MockFlowFile mockFlowFile2 = new MockFlowFile(2L);
 
-        repo.addLogMessage(LogLevel.INFO, "Testing {} {} flowfiles are not being shown in exception message", new Object[]{mockFlowFile1, mockFlowFile2});
+        repo.addLogMessage(LogLevel.INFO, "Testing {} {} FlowFiles are not being shown in exception message", new Object[]{mockFlowFile1, mockFlowFile2});
 
         assertNull(observer.getMessages().get(0).getFlowFileUuid());
+    }
+
+    @Test
+    public void testLogRepositoryAfterLogLevelChange() {
+        StandardLogRepository repo = new StandardLogRepository();
+        MockLogObserver observer = new MockLogObserver();
+        repo.addObserver(LogLevel.ERROR, observer);
+
+        repo.setObservationLevel(LogLevel.ERROR);
+
+        IOException exception = new IOException("exception");
+
+        repo.addLogMessage(LogLevel.ERROR, "Testing {} to get exception message <{}>", new Object[]{observer.getClass().getName(), exception});
+
+        assertEquals(1, observer.getMessages().size());
+        assertEquals("Testing org.apache.nifi.logging.TestStandardLogRepository$MockLogObserver to get exception message <exception>", observer.getMessages().get(0).getMessage());
     }
 
     private static class MockLogObserver implements LogObserver {


### PR DESCRIPTION
# Summary

[NIFI-12025](https://issues.apache.org/jira/browse/NIFI-12025)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
