### PR TITLE
NIFI-12040 Upgrade Apache IoTDB from 1.1.2 to 1.2.0

### DIFF
--- a/nifi-nar-bundles/nifi-iotdb-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-iotdb-bundle/pom.xml
@@ -31,7 +31,7 @@
     </modules>
 
     <properties>
-        <iotdb.sdk.version>1.1.2</iotdb.sdk.version>
+        <iotdb.sdk.version>1.2.0</iotdb.sdk.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-12040](https://issues.apache.org/jira/browse/NIFI-12040) Upgrades Apache IoTDB dependencies from 1.1.2 to [1.2.0](https://dlcdn.apache.org/iotdb/1.2.0/RELEASE_NOTES.md), incorporating several improvements and bug fixes, retaining compatibility with Java 8 and higher.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
