### PR TITLE
NIFI-12058 Upgrade Apache Kudu from 1.16.0 to 1.17.0

### DIFF
--- a/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-kudu-bundle/nifi-kudu-processors/pom.xml
@@ -94,6 +94,12 @@
             <artifactId>kudu-test-utils</artifactId>
             <version>${kudu.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-kudu-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-kudu-bundle/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <exclude.tests>None</exclude.tests>
-        <kudu.version>1.16.0</kudu.version>
+        <kudu.version>1.17.0</kudu.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
# Summary

[NIFI-12058](https://issues.apache.org/jira/browse/NIFI-12058) Upgrades Apache Kudu dependencies from 1.16.0 to [1.17.0](https://kudu.apache.org/releases/1.17.0/docs/release_notes.html) incorporating bug fixes and improvements while maintaining backward compatibility with earlier Kudu server versions.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
