### PR TITLE
NIFI-12034 Upgrade Apache Commons Compress from 1.23.0 to 1.24.0

### DIFF
--- a/c2/c2-client-bundle/c2-client-service/pom.xml
+++ b/c2/c2-client-bundle/c2-client-service/pom.xml
@@ -46,7 +46,6 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.23.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-commons/nifi-flowfile-packager/pom.xml
+++ b/nifi-commons/nifi-flowfile-packager/pom.xml
@@ -25,7 +25,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.23.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
@@ -81,12 +81,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
             <!-- Override nimbus-jose-jwt 9.8.1 from hadoop-auth -->
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-nar-bundles/nifi-avro-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-avro-bundle/pom.xml
@@ -29,15 +29,4 @@
         <module>nifi-avro-processors</module>
         <module>nifi-avro-nar</module>
     </modules>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-cassandra-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/pom.xml
@@ -47,12 +47,6 @@
                 <artifactId>nifi-cassandra-processors</artifactId>
                 <version>2.0.0-SNAPSHOT</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>

--- a/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/pom.xml
@@ -32,7 +32,6 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.23.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.jponge</groupId>

--- a/nifi-nar-bundles/nifi-confluent-platform-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-confluent-platform-bundle/pom.xml
@@ -24,15 +24,4 @@
 		<module>nifi-confluent-schema-registry-service</module>
 		<module>nifi-confluent-platform-nar</module>
 	</modules>
-
-	<dependencyManagement>
-		<dependencies>
-			<!-- Override commons-compress -->
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-compress</artifactId>
-				<version>1.23.0</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -54,13 +54,6 @@ language governing permissions and limitations under the License. -->
                 <artifactId>nifi-elasticsearch-restapi-processors</artifactId>
                 <version>2.0.0-SNAPSHOT</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>elasticsearch-rest-client</artifactId>

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/pom.xml
@@ -23,17 +23,6 @@
 
     <artifactId>nifi-database-utils</artifactId>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/pom.xml
@@ -131,16 +131,6 @@
             </exclusions>
         </dependency>
     </dependencies>
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override commons-compress:1.19 from hadoop -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <build>
         <plugins>
             <plugin>

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/pom.xml
@@ -22,16 +22,6 @@
     </parent>
     <artifactId>nifi-hadoop-record-utils</artifactId>
     <packaging>jar</packaging>
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override commons-compress:1.19 -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/pom.xml
@@ -39,12 +39,6 @@
                 <artifactId>netty</artifactId>
                 <version>${netty.3.version}</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -523,11 +523,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
                 <version>${netty.3.version}</version>

--- a/nifi-nar-bundles/nifi-graph-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-graph-bundle/pom.xml
@@ -44,12 +44,6 @@
                 <artifactId>nifi-graph-processors</artifactId>
                 <version>2.0.0-SNAPSHOT</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy</artifactId>

--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -32,12 +32,6 @@
                 <artifactId>netty</artifactId>
                 <version>${netty.3.version}</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
             <!-- Override nimbus-jose-jwt 9.8.1 from hadoop-auth -->
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-nar-bundles/nifi-hbase-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hbase-bundle/pom.xml
@@ -37,12 +37,6 @@
                 <artifactId>nifi-hbase-processors</artifactId>
                 <version>2.0.0-SNAPSHOT</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -64,12 +64,6 @@
                 <artifactId>avatica</artifactId>
                 <version>${avatica.version}</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
             <!-- Override commons-beanutils -->
             <dependency>
                 <groupId>commons-beanutils</groupId>

--- a/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
@@ -52,12 +52,6 @@
                 <artifactId>javax.el</artifactId>
                 <version>3.0.1-b12</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
             <!-- Override commons-beanutils -->
             <dependency>
                 <groupId>commons-beanutils</groupId>

--- a/nifi-nar-bundles/nifi-media-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/pom.xml
@@ -40,12 +40,6 @@
         <dependencies>
             <!-- Override version from tika-parsers -->
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-            <!-- Override version from tika-parsers -->
-            <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
             </dependency>

--- a/nifi-nar-bundles/nifi-mongodb-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/pom.xml
@@ -50,12 +50,6 @@
                 <artifactId>nifi-mongodb-processors</artifactId>
                 <version>2.0.0-SNAPSHOT</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-parquet-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-parquet-bundle/pom.xml
@@ -36,12 +36,6 @@
                 <artifactId>netty</artifactId>
                 <version>${netty.3.version}</version>
             </dependency>
-            <!-- Override commons-compress:1.20 from avro -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
             <!-- Override commons-beanutils -->
             <dependency>
                 <groupId>commons-beanutils</groupId>

--- a/nifi-nar-bundles/nifi-poi-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-poi-bundle/pom.xml
@@ -35,11 +35,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi</artifactId>
                 <version>${poi.version}</version>

--- a/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
@@ -43,12 +43,6 @@
                 <artifactId>zookeeper</artifactId>
                 <version>${zookeeper.version}</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
             <!-- Override commons-beanutils -->
             <dependency>
                 <groupId>commons-beanutils</groupId>

--- a/nifi-nar-bundles/nifi-registry-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-registry-bundle/pom.xml
@@ -24,15 +24,4 @@
 		<module>nifi-registry-service</module>
 		<module>nifi-registry-nar</module>
 	</modules>
-
-	<dependencyManagement>
-		<dependencies>
-			<!-- Override commons-compress -->
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-compress</artifactId>
-				<version>1.23.0</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/pom.xml
@@ -36,12 +36,6 @@
                 <artifactId>nifi-site-to-site-reporting-task</artifactId>
                 <version>2.0.0-SNAPSHOT</version>
        	    </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
@@ -35,12 +35,6 @@
                 <artifactId>nifi-sql-reporting-tasks</artifactId>
                 <version>2.0.0-SNAPSHOT</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
             <!-- Override Guava 31.1. from calcite-core -->
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -109,15 +109,6 @@
                 <version>${yammer.metrics.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-            </dependency>
-            <dependency>
                 <groupId>com.hierynomus</groupId>
                 <artifactId>sshj</artifactId>
                 <version>0.35.0</version>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hadoop-dbcp-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hadoop-dbcp-service-bundle/pom.xml
@@ -26,14 +26,4 @@
         <module>nifi-hadoop-dbcp-service</module>
         <module>nifi-hadoop-dbcp-service-nar</module>
     </modules>
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override commons-compress:1.19 -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
@@ -55,12 +55,6 @@
                 <artifactId>netty</artifactId>
                 <version>${netty.3.version}</version>
             </dependency>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
             <!-- Override commons-beanutils -->
             <dependency>
                 <groupId>commons-beanutils</groupId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/pom.xml
@@ -25,14 +25,4 @@
         <module>nifi-lookup-services</module>
         <module>nifi-lookup-services-nar</module>
     </modules>
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/pom.xml
@@ -28,15 +28,4 @@
         <module>nifi-record-serialization-services-nar</module>
         <module>nifi-record-serialization-services-shared</module>
     </modules>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override commons-compress -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -20,17 +20,6 @@
     <artifactId>nifi-registry-test</artifactId>
     <packaging>jar</packaging>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override version from testcontainers -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
@@ -32,12 +32,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Override commons-compress:1.19 from ranger -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
-            </dependency>
             <!-- Override jetty-server:9.4.20 -->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
         <okio.version>3.5.0</okio.version>
         <org.apache.commons.cli.version>1.5.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.16.0</org.apache.commons.codec.version>
+        <org.apache.commons.compress.version>1.24.0</org.apache.commons.compress.version>
         <org.apache.commons.lang3.version>3.13.0</org.apache.commons.lang3.version>
         <org.apache.commons.net.version>3.9.0</org.apache.commons.net.version>
         <org.apache.commons.io.version>2.13.0</org.apache.commons.io.version>
@@ -264,6 +265,11 @@
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>${org.apache.commons.codec.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${org.apache.commons.compress.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
# Summary

[NIFI-12034](https://issues.apache.org/jira/browse/NIFI-12034) Upgrades Apache Commons Compress from 1.23.0 to 1.24.0, resolving CVE-2023-42503 related to potential Denial-of-Service from crafted Tar archives.

Changes include moving the managed dependency version to the root Maven configuration, and removing lower-level version configuration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
