### PR TITLE
NIFI-6240 Proxy Support for AzureEventHub processor via Websockets

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.processors.azure.eventhub;
 
 import com.azure.core.amqp.AmqpTransportType;
+import com.azure.core.amqp.ProxyOptions;
 import com.azure.core.credential.AzureNamedKeyCredential;
 import com.azure.identity.ManagedIdentityCredential;
 import com.azure.identity.ManagedIdentityCredentialBuilder;
@@ -301,7 +302,8 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
                 STORAGE_ACCOUNT_NAME,
                 STORAGE_ACCOUNT_KEY,
                 STORAGE_SAS_TOKEN,
-                STORAGE_CONTAINER_NAME
+                STORAGE_CONTAINER_NAME,
+                PROXY_CONFIGURATION_SERVICE
         ));
 
         Set<Relationship> relationships = new HashSet<>();
@@ -467,6 +469,10 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             }
         } else {
             eventProcessorClientBuilder.initialPartitionEventPosition(legacyPartitionEventPosition);
+        }
+        final ProxyOptions proxyOptions = AzureEventHubUtils.getProxyOptions(context);
+        if (proxyOptions != null) {
+            eventProcessorClientBuilder.proxyOptions(proxyOptions);
         }
 
         return eventProcessorClientBuilder.buildEventProcessorClient();

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
@@ -17,7 +17,6 @@
 package org.apache.nifi.processors.azure.eventhub;
 
 import com.azure.core.amqp.AmqpTransportType;
-import com.azure.core.amqp.ProxyOptions;
 import com.azure.core.credential.AzureNamedKeyCredential;
 import com.azure.identity.ManagedIdentityCredential;
 import com.azure.identity.ManagedIdentityCredentialBuilder;
@@ -470,10 +469,8 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
         } else {
             eventProcessorClientBuilder.initialPartitionEventPosition(legacyPartitionEventPosition);
         }
-        final ProxyOptions proxyOptions = AzureEventHubUtils.getProxyOptions(context);
-        if (proxyOptions != null) {
-            eventProcessorClientBuilder.proxyOptions(proxyOptions);
-        }
+
+        AzureEventHubUtils.getProxyOptions(context).ifPresent(eventProcessorClientBuilder::proxyOptions);
 
         return eventProcessorClientBuilder.buildEventProcessorClient();
     }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
@@ -27,21 +27,6 @@ import com.azure.messaging.eventhubs.EventHubConsumerClient;
 import com.azure.messaging.eventhubs.models.EventPosition;
 import com.azure.messaging.eventhubs.models.PartitionContext;
 import com.azure.messaging.eventhubs.models.PartitionEvent;
-import com.azure.core.amqp.ProxyOptions;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
@@ -70,6 +55,21 @@ import org.apache.nifi.processors.azure.eventhub.utils.AzureEventHubUtils;
 import org.apache.nifi.scheduling.ExecutionNode;
 import org.apache.nifi.shared.azure.eventhubs.AzureEventHubComponent;
 import org.apache.nifi.util.StopWatch;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Tags({"azure", "microsoft", "cloud", "eventhub", "events", "streaming", "streams"})
 @CapabilityDescription("Receives messages from Microsoft Azure Event Hubs without reliable checkpoint tracking. "
@@ -390,10 +390,7 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
         clientOptions.setIdentifier(clientIdentifier);
         eventHubClientBuilder.clientOptions(clientOptions);
 
-        final ProxyOptions proxyOptions = AzureEventHubUtils.getProxyOptions(context);
-        if (proxyOptions != null) {
-            eventHubClientBuilder.proxyOptions(proxyOptions);
-        }
+        AzureEventHubUtils.getProxyOptions(context).ifPresent(eventHubClientBuilder::proxyOptions);
 
         return eventHubClientBuilder;
     }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
@@ -27,6 +27,7 @@ import com.azure.messaging.eventhubs.EventHubConsumerClient;
 import com.azure.messaging.eventhubs.models.EventPosition;
 import com.azure.messaging.eventhubs.models.PartitionContext;
 import com.azure.messaging.eventhubs.models.PartitionEvent;
+import com.azure.core.amqp.ProxyOptions;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -173,7 +174,8 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
                 CONSUMER_GROUP,
                 ENQUEUE_TIME,
                 RECEIVER_FETCH_SIZE,
-                RECEIVER_FETCH_TIMEOUT
+                RECEIVER_FETCH_TIMEOUT,
+                PROXY_CONFIGURATION_SERVICE
         );
         relationships = Collections.singleton(REL_SUCCESS);
     }
@@ -388,6 +390,11 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
         clientOptions.setIdentifier(clientIdentifier);
         eventHubClientBuilder.clientOptions(clientOptions);
 
+        final ProxyOptions proxyOptions = AzureEventHubUtils.getProxyOptions(context);
+        if (proxyOptions != null) {
+            eventHubClientBuilder.proxyOptions(proxyOptions);
+        }
+
         return eventHubClientBuilder;
     }
 
@@ -434,7 +441,7 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
         attributes.put("eventhub.name", partitionContext.getEventHubName());
         attributes.put("eventhub.partition", partitionContext.getPartitionId());
 
-        final Map<String,String> applicationProperties = AzureEventHubUtils.getApplicationProperties(eventData.getProperties());
+        final Map<String, String> applicationProperties = AzureEventHubUtils.getApplicationProperties(eventData.getProperties());
         attributes.putAll(applicationProperties);
 
         return attributes;

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.processors.azure.eventhub;
 
 import com.azure.core.amqp.AmqpTransportType;
+import com.azure.core.amqp.ProxyOptions;
 import com.azure.core.credential.AzureNamedKeyCredential;
 import com.azure.identity.ManagedIdentityCredential;
 import com.azure.identity.ManagedIdentityCredentialBuilder;
@@ -135,6 +136,7 @@ public class PutAzureEventHub extends AbstractProcessor implements AzureEventHub
         configuredDescriptors.add(USE_MANAGED_IDENTITY);
         configuredDescriptors.add(PARTITIONING_KEY_ATTRIBUTE_NAME);
         configuredDescriptors.add(MAX_BATCH_SIZE);
+        configuredDescriptors.add(PROXY_CONFIGURATION_SERVICE);
         propertyDescriptors = Collections.unmodifiableList(configuredDescriptors);
 
         final Set<Relationship> configuredRelationships = new HashSet<>();
@@ -214,7 +216,10 @@ public class PutAzureEventHub extends AbstractProcessor implements AzureEventHub
                 final AzureNamedKeyCredential azureNamedKeyCredential = new AzureNamedKeyCredential(policyName, policyKey);
                 eventHubClientBuilder.credential(fullyQualifiedNamespace, eventHubName, azureNamedKeyCredential);
             }
-
+            final ProxyOptions proxyOptions = AzureEventHubUtils.getProxyOptions(context);
+            if (proxyOptions != null) {
+                eventHubClientBuilder.proxyOptions(proxyOptions);
+            }
             return eventHubClientBuilder.buildProducerClient();
         } catch (final Exception e) {
             throw new ProcessException("EventHubClient creation failed", e);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
@@ -17,7 +17,6 @@
 package org.apache.nifi.processors.azure.eventhub;
 
 import com.azure.core.amqp.AmqpTransportType;
-import com.azure.core.amqp.ProxyOptions;
 import com.azure.core.credential.AzureNamedKeyCredential;
 import com.azure.identity.ManagedIdentityCredential;
 import com.azure.identity.ManagedIdentityCredentialBuilder;
@@ -25,17 +24,6 @@ import com.azure.messaging.eventhubs.EventData;
 import com.azure.messaging.eventhubs.EventHubClientBuilder;
 import com.azure.messaging.eventhubs.EventHubProducerClient;
 import com.azure.messaging.eventhubs.models.SendOptions;
-import org.apache.nifi.processors.azure.eventhub.utils.AzureEventHubUtils;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -57,10 +45,20 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.azure.eventhub.utils.AzureEventHubUtils;
 import org.apache.nifi.processors.azure.storage.utils.FlowFileResultCarrier;
 import org.apache.nifi.shared.azure.eventhubs.AzureEventHubComponent;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.apache.nifi.util.StopWatch;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @SupportsBatching
 @Tags({"microsoft", "azure", "cloud", "eventhub", "events", "streams", "streaming"})
@@ -216,10 +214,7 @@ public class PutAzureEventHub extends AbstractProcessor implements AzureEventHub
                 final AzureNamedKeyCredential azureNamedKeyCredential = new AzureNamedKeyCredential(policyName, policyKey);
                 eventHubClientBuilder.credential(fullyQualifiedNamespace, eventHubName, azureNamedKeyCredential);
             }
-            final ProxyOptions proxyOptions = AzureEventHubUtils.getProxyOptions(context);
-            if (proxyOptions != null) {
-                eventHubClientBuilder.proxyOptions(proxyOptions);
-            }
+            AzureEventHubUtils.getProxyOptions(context).ifPresent(eventHubClientBuilder::proxyOptions);
             return eventHubClientBuilder.buildProducerClient();
         } catch (final Exception e) {
             throw new ProcessException("EventHubClient creation failed", e);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/AzureEventHubUtils.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/utils/AzureEventHubUtils.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public final class AzureEventHubUtils {
 
@@ -118,7 +119,7 @@ public final class AzureEventHubUtils {
      * @param propertyContext to supply Proxy configurations
      * @return {@link ProxyOptions proxy options}, null if Proxy is not set
      */
-    public static ProxyOptions getProxyOptions(final PropertyContext propertyContext) {
+    public static Optional<ProxyOptions> getProxyOptions(final PropertyContext propertyContext) {
         final ProxyConfiguration proxyConfiguration = ProxyConfiguration.getConfiguration(propertyContext);
         final ProxyOptions proxyOptions;
         if (proxyConfiguration != ProxyConfiguration.DIRECT_CONFIGURATION) {
@@ -137,7 +138,7 @@ public final class AzureEventHubUtils {
             proxyOptions = null;
         }
 
-        return proxyOptions;
+        return Optional.ofNullable(proxyOptions);
     }
 
     private static Proxy getProxy(ProxyConfiguration proxyConfiguration) {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/shared/azure/eventhubs/AzureEventHubComponent.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/shared/azure/eventhubs/AzureEventHubComponent.java
@@ -19,6 +19,8 @@ package org.apache.nifi.shared.azure.eventhubs;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.proxy.ProxyConfiguration;
+import org.apache.nifi.proxy.ProxySpec;
 
 /**
  * Azure Event Hub Component interface with shared properties
@@ -33,5 +35,11 @@ public interface AzureEventHubComponent {
             .required(true)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .build();
+    ProxySpec[] PROXY_SPECS = {ProxySpec.HTTP, ProxySpec.HTTP_AUTH};
+    PropertyDescriptor PROXY_CONFIGURATION_SERVICE
+            = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(ProxyConfiguration.createProxyConfigPropertyDescriptor(false, PROXY_SPECS))
+            .dependsOn(TRANSPORT_TYPE, AzureEventHubTransportType.AMQP_WEB_SOCKETS.getValue())
             .build();
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-6240](https://issues.apache.org/jira/browse/NIFI-6240)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
