### PR TITLE
NIFI-8134 allow unescapeJson Record Path function to recursively convert Maps to Records

### DIFF
--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
@@ -352,13 +352,11 @@ public class RecordPathCompiler {
                     case "unescapeJson": {
                         final int numArgs = argumentListTree.getChildCount();
 
-                        if (numArgs == 1) {
-                            final RecordPathSegment[] args = getArgPaths(argumentListTree, 1, functionName, absolute);
-                            return new UnescapeJson(args[0], null, absolute);
-                        } else {
-                            final RecordPathSegment[] args = getArgPaths(argumentListTree, 2, functionName, absolute);
-                            return new UnescapeJson(args[0], args[1], absolute);
-                        }
+                        final RecordPathSegment[] args = getArgPaths(argumentListTree, numArgs, functionName, absolute);
+                        final RecordPathSegment convertToRecord = numArgs > 1 ? args[1] : null;
+                        final RecordPathSegment recursiveConversion = numArgs > 2 ? args[2] : null;
+
+                        return new UnescapeJson(args[0], convertToRecord, recursiveConversion, absolute);
                     }
                     case "hash":{
                         final RecordPathSegment[] args = getArgPaths(argumentListTree, 2, functionName, absolute);

--- a/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
+++ b/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
@@ -17,25 +17,6 @@
 
 package org.apache.nifi.record.path;
 
-import java.nio.charset.IllegalCharsetNameException;
-import java.nio.charset.StandardCharsets;
-import java.sql.Date;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.nifi.record.path.exception.RecordPathException;
 import org.apache.nifi.serialization.SimpleRecordSchema;
 import org.apache.nifi.serialization.record.DataType;
@@ -50,6 +31,27 @@ import org.apache.nifi.uuid5.Uuid5Util;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1853,24 +1855,25 @@ public class TestRecordPath {
                 new RecordField("person", RecordFieldType.RECORD.getRecordDataType(person))
         ));
 
-        final Map<String, Object> values = new HashMap<String, Object>(){{
-            put("person", new MapRecord(person, new HashMap<String, Object>(){{
-                put("firstName", "John");
-                put("age", 30);
-                put("nicknames", new String[] {"J", "Johnny"});
-                put("addresses", new MapRecord[]{
-                        new MapRecord(address, Collections.singletonMap("address_1", "123 Somewhere Street")),
-                        new MapRecord(address, Collections.singletonMap("address_1", "456 Anywhere Road"))
-                });
-            }}));
-        }};
+        final Map<String, Object> values = Map.of(
+                "person", new MapRecord(person, Map.of(
+                        "firstName", "John",
+                        "age", 30,
+                        "nicknames", new String[] {"J", "Johnny"},
+                        "addresses", new MapRecord[]{
+                                new MapRecord(address, Collections.singletonMap("address_1", "123 Somewhere Street")),
+                                new MapRecord(address, Collections.singletonMap("address_1", "456 Anywhere Road"))
+                        }
+                ) )
+        );
 
         final Record record = new MapRecord(schema, values);
 
         assertEquals("\"John\"", RecordPath.compile("escapeJson(/person/firstName)").evaluate(record).getSelectedFields().findFirst().orElseThrow(AssertionError::new).getValue());
         assertEquals("30", RecordPath.compile("escapeJson(/person/age)").evaluate(record).getSelectedFields().findFirst().orElseThrow(AssertionError::new).getValue());
         assertEquals(
-                "{\"firstName\":\"John\",\"age\":30,\"nicknames\":[\"J\",\"Johnny\"],\"addresses\":[{\"address_1\":\"123 Somewhere Street\"},{\"address_1\":\"456 Anywhere Road\"}]}",
+                """
+                {"firstName":"John","age":30,"nicknames":["J","Johnny"],"addresses":[{"address_1":"123 Somewhere Street"},{"address_1":"456 Anywhere Road"}]}""",
                 RecordPath.compile("escapeJson(/person)").evaluate(record).getSelectedFields().findFirst().orElseThrow(AssertionError::new).getValue()
         );
     }
@@ -1900,18 +1903,19 @@ public class TestRecordPath {
         final Record mapAddressesArray = new MapRecord(schema,
                 Collections.singletonMap(
                         "json_str",
-                        "{\"firstName\":\"John\",\"age\":30,\"nicknames\":[\"J\",\"Johnny\"],\"addresses\":[{\"address_1\":\"123 Somewhere Street\"},{\"address_1\":\"456 Anywhere Road\"}]}")
+                        """
+                        {"firstName":"John","age":30,"nicknames":["J","Johnny"],"addresses":[{"address_1":"123 Somewhere Street"},{"address_1":"456 Anywhere Road"}]}""")
         );
         assertEquals(
-                new HashMap<String, Object>(){{
-                    put("firstName", "John");
-                    put("age", 30);
-                    put("nicknames", Arrays.asList("J", "Johnny"));
-                    put("addresses", Arrays.asList(
+                Map.of(
+                    "firstName", "John",
+                    "age", 30,
+                    "nicknames", Arrays.asList("J", "Johnny"),
+                    "addresses", Arrays.asList(
                             Collections.singletonMap("address_1", "123 Somewhere Street"),
                             Collections.singletonMap("address_1", "456 Anywhere Road")
-                    ));
-                }},
+                    )
+                ),
                 RecordPath.compile("unescapeJson(/json_str)").evaluate(mapAddressesArray).getSelectedFields().findFirst().orElseThrow(AssertionError::new).getValue()
         );
 
@@ -1919,15 +1923,16 @@ public class TestRecordPath {
         final Record mapAddressesSingle = new MapRecord(schema,
                 Collections.singletonMap(
                         "json_str",
-                        "{\"firstName\":\"John\",\"age\":30,\"nicknames\":[\"J\",\"Johnny\"],\"addresses\":{\"address_1\":\"123 Somewhere Street\"}}")
+                        """
+                        {"firstName":"John","age":30,"nicknames":["J","Johnny"],"addresses":{"address_1":"123 Somewhere Street"}}""")
         );
         assertEquals(
-                new HashMap<String, Object>(){{
-                    put("firstName", "John");
-                    put("age", 30);
-                    put("nicknames", Arrays.asList("J", "Johnny"));
-                    put("addresses", Collections.singletonMap("address_1", "123 Somewhere Street"));
-                }},
+                Map.of(
+                    "firstName", "John",
+                    "age", 30,
+                    "nicknames", Arrays.asList("J", "Johnny"),
+                    "addresses", Collections.singletonMap("address_1", "123 Somewhere Street")
+                ),
                 RecordPath.compile("unescapeJson(/json_str, 'false')").evaluate(mapAddressesSingle).getSelectedFields().findFirst().orElseThrow(AssertionError::new).getValue()
         );
 
@@ -1935,13 +1940,14 @@ public class TestRecordPath {
         final Record recordFromMap = new MapRecord(schema,
                 Collections.singletonMap(
                         "json_str",
-                        "{\"firstName\":\"John\",\"age\":30}")
+                        """
+                        {"firstName":"John","age":30}""")
         );
+        Map<String, Object> expectedMap = new LinkedHashMap<>();
+        expectedMap.put("firstName", "John");
+        expectedMap.put("age", 30);
         assertEquals(
-                DataTypeUtils.toRecord(new HashMap<String, Object>(){{
-                    put("firstName", "John");
-                    put("age", 30);
-                }}, "json_str"),
+                DataTypeUtils.toRecord(expectedMap, "json_str"),
                 RecordPath.compile("unescapeJson(/json_str, 'true')").evaluate(recordFromMap).getSelectedFields().findFirst().orElseThrow(AssertionError::new).getValue()
         );
 
@@ -1949,41 +1955,34 @@ public class TestRecordPath {
         final Record nestedRecordFromMap = new MapRecord(schema,
                 Collections.singletonMap(
                         "json_str",
-                        "{\"firstName\":\"John\",\"age\":30,\"addresses\":[{\"address_1\":\"123 Fake Street\"}]}")
+                        """
+                        {"firstName":"John","age":30,"addresses":[{"address_1":"123 Fake Street"}]}""")
         );
         // recursively convert Maps to Records (addresses becomes and ARRAY or RECORDs)
-        assertEquals(
-                DataTypeUtils.toRecord(new LinkedHashMap<String, Object>(){{
-                    put("firstName", "John");
-                    put("age", 30);
-                    put("addresses", new Object[] {DataTypeUtils.toRecord(Collections.singletonMap("address_1", "123 Fake Street"), "addresses")});
-                }}, "json_str"),
+        expectedMap.put("addresses", new Object[] {DataTypeUtils.toRecord(Collections.singletonMap("address_1", "123 Fake Street"), "addresses")});
+        assertRecordsMatch(
+                DataTypeUtils.toRecord(expectedMap, "json_str"),
                 RecordPath.compile("unescapeJson(/json_str, 'true', 'true')").evaluate(nestedRecordFromMap).getSelectedFields().findFirst().orElseThrow(AssertionError::new).getValue()
         );
         // convert Map to Record, without recursion (addresses becomes an ARRAY, but contents are still Maps)
-        assertEquals(
-                DataTypeUtils.toRecord(new LinkedHashMap<String, Object>(){{
-                    put("firstName", "John");
-                    put("age", 30);
-                    put("addresses", new Object[] {Collections.singletonMap("address_1", "123 Fake Street")});
-                }}, "json_str"),
+        expectedMap.put("addresses", new Object[] {Collections.singletonMap("address_1", "123 Fake Street")});
+        assertRecordsMatch(
+                DataTypeUtils.toRecord(expectedMap, "json_str"),
                 RecordPath.compile("unescapeJson(/json_str, 'true', 'false')").evaluate(nestedRecordFromMap).getSelectedFields().findFirst().orElseThrow(AssertionError::new).getValue()
         );
         // without Map conversion to Record (addresses remains a Collection, Maps are unchanged)
-        assertEquals(
-                new LinkedHashMap<String, Object>(){{
-                    put("firstName", "John");
-                    put("age", 30);
-                    put("addresses", Collections.singletonList(Collections.singletonMap("address_1", "123 Fake Street")));
-                }},
-                RecordPath.compile("unescapeJson(/json_str, 'false')").evaluate(nestedRecordFromMap).getSelectedFields().findFirst().orElseThrow(AssertionError::new).getValue()
+        assertMapsMatch(
+                expectedMap,
+                RecordPath.compile("unescapeJson(/json_str, 'false')").evaluate(nestedRecordFromMap).getSelectedFields().findFirst().orElseThrow(AssertionError::new).getValue(),
+                false
         );
 
         // test collection of Record converted from Map collection
         final Record recordCollectionFromMaps = new MapRecord(schema,
                 Collections.singletonMap(
                         "json_str",
-                        "[{\"address_1\":\"123 Somewhere Street\"},{\"address_1\":\"456 Anywhere Road\"}]")
+                        """
+                        [{"address_1":"123 Somewhere Street"},{"address_1":"456 Anywhere Road"}]""")
         );
         assertEquals(
                 Arrays.asList(
@@ -1994,9 +1993,11 @@ public class TestRecordPath {
         );
 
         // test simple String field
-        final Record recordJustName = new MapRecord(schema, Collections.singletonMap("json_str", "{\"firstName\":\"John\"}"));
+        final Record recordJustName = new MapRecord(schema, Collections.singletonMap("json_str",
+                """
+                {"firstName":"John"}"""));
         assertEquals(
-                new HashMap<String, Object>(){{put("firstName", "John");}},
+                Map.of("firstName", "John"),
                 RecordPath.compile("unescapeJson(/json_str)").evaluate(recordJustName).getSelectedFields().findFirst().orElseThrow(AssertionError::new).getValue()
         );
 
@@ -2024,6 +2025,31 @@ public class TestRecordPath {
                         .evaluate(recordNotString).getSelectedFields()
                         .findFirst().orElseThrow(AssertionError::new).getValue());
         assertEquals("Argument supplied to unescapeJson must be a String", iae.getMessage());
+    }
+
+    private void assertRecordsMatch(final Record expectedRecord, final Object result) {
+        assertInstanceOf(Record.class, result);
+        final Record resultRecord = (Record) result;
+        assertMapsMatch(expectedRecord.toMap(), resultRecord.toMap(), true);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertMapsMatch(final Map<String, Object> expectedMap, final Object result, final boolean convertMapToRecord) {
+        assertInstanceOf(Map.class, result);
+        final Map<String, Object> resultMap = (Map<String, Object>) result;
+        assertEquals(expectedMap.size(), resultMap.size());
+
+        for (final Map.Entry<String, Object> e : expectedMap.entrySet()) {
+            // can't directly assertEquals two Object[] as the #equals method checks whether they're the same Object, rather than comparing the array content
+            if (e.getValue() instanceof Object[] expectedArray) {
+                final Object resultObj = resultMap.get(e.getKey());
+                // Record conversion changes Collections to Arrays, otherwise they remain Collections
+                final Object[] resultArray = convertMapToRecord ? (Object[]) resultObj : ((Collection<?>) resultObj).toArray();
+                assertArrayEquals(expectedArray, resultArray);
+            } else {
+                assertEquals(e.getValue(), resultMap.get(e.getKey()));
+            }
+        }
     }
 
     @Test

--- a/nifi-docs/src/main/asciidoc/record-path-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/record-path-guide.adoc
@@ -936,7 +936,11 @@ The following record path expression would convert the record into an escaped JS
 === unescapeJson
 
 Converts a stringified JSON element to a Record, Array or simple field (e.g. String), using the UTF-8 character set.
-Optionally convert JSON Objects parsed as Maps into Records (defaults to false).
+Optionally convert JSON Objects parsed as Maps into Records (defaults to false), recursively (defaults to false).
+
+*Note*: RecordSetWriters will not be able to serialise Maps, so fields may be omitted if not converted to Records.
+For example, using `unescapeJson` to replace the root ("/") of a Record in `UpdateRecord` without using the Record conversion,
+would result in an empty output because the RecordSetWriter is unable to match the resultant Map content to a RecordSchema.
 
 For example, given a schema such as:
 
@@ -987,6 +991,27 @@ The following record path expression would return:
 | `unescapeJson(/json_str)` | {"name"="John", "age"=30} (as a Map)
 |==========================================================
 
+*Note* that Maps cannot be serialised with a RecordSetWriter.
+
+Given a record such as:
+
+----
+{
+  "json_str": "{\"name\":\"John\",\"age\":30,\"addresses\"[{\"address_1\": \"123 Fake Street\"}]}"
+}
+----
+
+The following record path expression would return:
+
+|==========================================================
+| RecordPath | Return value
+| `unescapeJson(/json_str, 'false')` | {"name"="John", "age"=30, "addresses"=[{address_1"="123 Fake Street"}]} (as a Map, with each entry in "addresses" as a Map)
+| `unescapeJson(/json_str, 'true', 'false')` | {"name": "John", "age": 30, "addresses"=[{address_1"="123 Fake Street"}]} (as a Record, with each entry in "addresses" as a Map)
+| `unescapeJson(/json_str, 'true', 'true')` | {"name": "John", "age": 30, "addresses": [{"address_1": "123 Fake Street"}]} (as a Record, with each entry in "addresses" as a Record)
+|==========================================================
+
+*Note* that Maps cannot be serialised with a RecordSetWriter.
+
 Given a record such as:
 
 ----
@@ -1002,7 +1027,7 @@ The following record path expression would return:
 | `unescapeJson(/json_str)` | "John"
 |==========================================================
 
-Note that the target schema must be pre-defined if the unescaped JSON is to be set in a Record's fields - Infer Schema will not currently do this automatically.
+*Note* that the target schema must be pre-defined if the `unescaped` JSON is to be set in a Record's fields - Infer Schema will not currently do this automatically.
 
 === hash
 

--- a/nifi-docs/src/main/asciidoc/record-path-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/record-path-guide.adoc
@@ -936,7 +936,12 @@ The following record path expression would convert the record into an escaped JS
 === unescapeJson
 
 Converts a stringified JSON element to a Record, Array or simple field (e.g. String), using the UTF-8 character set.
-Optionally convert JSON Objects parsed as Maps into Records (defaults to false), recursively (defaults to false).
+
+This function takes up to three arguments:
+
+1. The Record Path of the stringified JSON element to be parsed
+2. (optional) whether to convert parsed JSON Objects from Maps to Records, default = `false`
+3. (optional) whether to recursively convert nested JSON Objects from Maps to Records, default = `false`
 
 *Note*: RecordSetWriters will not be able to serialise Maps, so fields may be omitted if not converted to Records.
 For example, using `unescapeJson` to replace the root ("/") of a Record in `UpdateRecord` without using the Record conversion,
@@ -991,8 +996,6 @@ The following record path expression would return:
 | `unescapeJson(/json_str)` | {"name"="John", "age"=30} (as a Map)
 |==========================================================
 
-*Note* that Maps cannot be serialised with a RecordSetWriter.
-
 Given a record such as:
 
 ----
@@ -1005,12 +1008,10 @@ The following record path expression would return:
 
 |==========================================================
 | RecordPath | Return value
-| `unescapeJson(/json_str, 'false')` | {"name"="John", "age"=30, "addresses"=[{address_1"="123 Fake Street"}]} (as a Map, with each entry in "addresses" as a Map)
-| `unescapeJson(/json_str, 'true', 'false')` | {"name": "John", "age": 30, "addresses"=[{address_1"="123 Fake Street"}]} (as a Record, with each entry in "addresses" as a Map)
+| `unescapeJson(/json_str, 'false')` | {"name"="John", "age"=30, "addresses"=[{"address_1"="123 Fake Street"}]} (as a Map, with each entry in "addresses" as a Map)
+| `unescapeJson(/json_str, 'true', 'false')` | {"name": "John", "age": 30, "addresses"=[{"address_1"="123 Fake Street"}]} (as a Record, with each entry in "addresses" as a Map)
 | `unescapeJson(/json_str, 'true', 'true')` | {"name": "John", "age": 30, "addresses": [{"address_1": "123 Fake Street"}]} (as a Record, with each entry in "addresses" as a Record)
 |==========================================================
-
-*Note* that Maps cannot be serialised with a RecordSetWriter.
 
 Given a record such as:
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -791,6 +791,7 @@
                         <exclude>src/test/resources/TestUpdateRecord/input/addresses.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/input/embedded-string.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/input/multi-arrays.json</exclude>
+                        <exclude>src/test/resources/TestUpdateRecord/input/organisation.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/input/person-address.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/input/person-stringified-name.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/input/person-with-null-array.json</exclude>
@@ -799,6 +800,7 @@
                         <exclude>src/test/resources/TestUpdateRecord/output/full-addresses.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/name-and-mother-same.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/name-fields-only.json</exclude>
+                        <exclude>src/test/resources/TestUpdateRecord/output/organisation.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/person-with-capital-lastname.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/person-with-firstname-lastname.json</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/output/person-with-firstname.json</exclude>
@@ -811,6 +813,8 @@
                         <exclude>src/test/resources/TestUpdateRecord/schema/embedded-record.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc</exclude>
+                        <exclude>src/test/resources/TestUpdateRecord/schema/organisation-with-departments.avsc</exclude>
+                        <exclude>src/test/resources/TestUpdateRecord/schema/organisation-with-departments-string.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/person-with-address.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/person-with-name-and-mother.avsc</exclude>
                         <exclude>src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc</exclude>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUpdateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUpdateRecord.java
@@ -69,7 +69,6 @@ public class TestUpdateRecord {
         readerService.addSchemaField("age", RecordFieldType.INT);
     }
 
-
     @Test
     public void testLiteralReplacementValue() {
         runner.setProperty("/name", "Jane Doe");
@@ -214,7 +213,8 @@ public class TestUpdateRecord {
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.INHERIT_RECORD_SCHEMA);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.INHERIT_RECORD_SCHEMA);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
         runner.enableControllerService(jsonWriter);
@@ -225,7 +225,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/full-addresses.json")));
+        final String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/full-addresses.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -234,16 +235,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-string.avsc")));
+        final String inputSchemaText = new String(Files
+                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(Files
+                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-string.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -255,7 +260,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-firstname.json")));
+        final String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-firstname.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -264,16 +270,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
+        final String inputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
+        final String outputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -285,7 +295,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-new-city.json")));
+        final String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-new-city.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -294,16 +305,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
+        final String inputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
+        final String outputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -315,7 +330,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-null-array.json")));
+        final String expectedOutput = new String(Files
+                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-null-array.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -324,16 +340,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-string-fields.avsc")));
+        final String inputSchemaText = new String(Files
+                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-string-fields.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -346,7 +366,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-firstname-lastname.json")));
+        final String expectedOutput = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/output/person-with-firstname-lastname.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -355,16 +376,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String inputSchemaText = new String(Files
+                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(Files
+                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -376,7 +401,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-capital-lastname.json")));
+        final String expectedOutput = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/output/person-with-capital-lastname.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -385,16 +411,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
+        final String inputSchemaText = new String(Files
+                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -406,7 +436,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
+        final String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -415,16 +446,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
+        final String inputSchemaText = new String(Files
+                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -436,7 +471,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
+        final String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -445,16 +481,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-stringified-name.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-stringified-name.avsc")));
+        final String outputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -466,7 +506,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
+        final String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -475,16 +516,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/organisation-with-departments-string.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/organisation-with-departments.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/schema/organisation-with-departments-string.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/schema/organisation-with-departments.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -499,7 +544,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/organisation.json")));
+        String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/organisation.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         assertTrue(runner.getLogger().getErrorMessages().isEmpty());
 
@@ -510,11 +556,12 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = "[ {\n" +
-                "  \"name\" : null,\n" +
-                "  \"departments\" : null,\n" +
-                "  \"address\" : null\n" +
-                "} ]";
+        expectedOutput = """
+                [ {
+                  "name" : null,
+                  "departments" : null,
+                  "address" : null
+                } ]""";
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         assertTrue(runner.getLogger().getErrorMessages().isEmpty());
 
@@ -527,8 +574,8 @@ public class TestUpdateRecord {
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_FAILURE, 1);
         final LogMessage errorMessage = runner.getLogger().getErrorMessages().get(0);
-        assertTrue(errorMessage.getMsg().contains("java.lang.ClassCastException: " +
-                "class java.util.LinkedHashMap cannot be cast to class org.apache.nifi.serialization.record.Record"));
+        assertTrue(errorMessage.getMsg().contains("ClassCastException"));
+        assertTrue(errorMessage.getMsg().contains("Record"));
     }
 
     @Test
@@ -536,16 +583,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-stringified-name.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-stringified-name.avsc")));
+        final String outputSchemaText = new String(Files
+                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -557,7 +608,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-name.json")));
+        final String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-name.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -566,15 +618,18 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String schemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/embedded-record.avsc")));
+        final String schemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/embedded-record.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, schemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, schemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -586,7 +641,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/embedded-record.json")));
+        final String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/embedded-record.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -595,16 +651,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
+        final String inputSchemaText = new String(Files
+                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -616,7 +676,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
+        final String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -625,16 +686,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
+        final String inputSchemaText = new String(Files
+                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -646,7 +711,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
+        final String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -655,16 +721,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-and-mother.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-and-mother.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-and-mother.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-and-mother.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -676,7 +746,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-and-mother-same.json")));
+        final String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-and-mother-same.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -685,16 +756,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
+        final String inputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
+        final String outputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -705,7 +780,8 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[*]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        String expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "8, 8, 8");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[*]");
@@ -724,7 +800,8 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[1]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "1, 8, 4");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[1]");
@@ -734,7 +811,8 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[0..1]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "8, 8, 4");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[0..1]");
@@ -744,7 +822,8 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[0,2]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "8, null, 8");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[0,2]");
@@ -754,7 +833,8 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[0,1..2]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "8, 8, 8");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[0,1..2]");
@@ -764,7 +844,8 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[0..-1][. = 4]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        expectedOutput = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "1, null, 8");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[0..-1][. = 4]");
@@ -775,16 +856,20 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
+        final String inputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
+        final String outputSchemaText = new String(
+                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
+                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -815,7 +900,8 @@ public class TestUpdateRecord {
         runner.setProperty("/peoples[0..1]", "/peoples[3]");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-0and1.json")));
+        String expectedOutput = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-0and1.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/peoples[0..1]");
 
@@ -824,7 +910,8 @@ public class TestUpdateRecord {
         runner.setProperty("/peoples[0,2]", "/peoples[3]");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-0and2.json")));
+        expectedOutput = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-0and2.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/peoples[0,2]");
 
@@ -863,7 +950,8 @@ public class TestUpdateRecord {
         runner.setProperty("/peoples[0..-1][./name != 'Mary Doe']/addresses[0,1..2]", "/peoples[3]/addresses[0]");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-streets.json")));
+        expectedOutput = new String(Files.readAllBytes(
+                Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-streets.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/peoples[0..-1][./name != 'Mary Doe']/addresses[0,1..2]");
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUpdateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUpdateRecord.java
@@ -69,6 +69,7 @@ public class TestUpdateRecord {
         readerService.addSchemaField("age", RecordFieldType.INT);
     }
 
+
     @Test
     public void testLiteralReplacementValue() {
         runner.setProperty("/name", "Jane Doe");
@@ -213,8 +214,7 @@ public class TestUpdateRecord {
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.INHERIT_RECORD_SCHEMA);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.INHERIT_RECORD_SCHEMA);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
         runner.enableControllerService(jsonWriter);
@@ -225,8 +225,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/full-addresses.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/full-addresses.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -235,20 +234,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files
-                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(Files
-                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-string.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-string.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -260,8 +255,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-firstname.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-firstname.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -270,20 +264,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
-        final String outputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -295,8 +285,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-new-city.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-new-city.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -305,20 +294,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
-        final String outputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-address.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -330,8 +315,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files
-                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-null-array.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-null-array.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -340,20 +324,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files
-                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-string-fields.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-string-fields.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -366,8 +346,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/output/person-with-firstname-lastname.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-firstname-lastname.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -376,20 +355,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files
-                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(Files
-                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -401,8 +376,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/output/person-with-capital-lastname.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-capital-lastname.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -411,20 +385,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files
-                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -436,8 +406,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -446,20 +415,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files
-                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -471,8 +436,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -481,20 +445,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-stringified-name.avsc")));
-        final String outputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-stringified-name.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -506,8 +466,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -516,20 +475,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/schema/organisation-with-departments-string.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/schema/organisation-with-departments.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/organisation-with-departments-string.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/organisation-with-departments.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -544,9 +499,8 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/organisation.json")));
-        runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
+        String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/organisation.json")));
+        runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).getFirst().assertContentEquals(expectedOutput);
         assertTrue(runner.getLogger().getErrorMessages().isEmpty());
 
         // no conversion
@@ -562,7 +516,7 @@ public class TestUpdateRecord {
                   "departments" : null,
                   "address" : null
                 } ]""";
-        runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
+        runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).getFirst().assertContentEquals(expectedOutput);
         assertTrue(runner.getLogger().getErrorMessages().isEmpty());
 
         // non-recursive conversion
@@ -573,7 +527,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_FAILURE, 1);
-        final LogMessage errorMessage = runner.getLogger().getErrorMessages().get(0);
+        final LogMessage errorMessage = runner.getLogger().getErrorMessages().getFirst();
         assertTrue(errorMessage.getMsg().contains("ClassCastException"));
         assertTrue(errorMessage.getMsg().contains("Record"));
     }
@@ -583,20 +537,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-stringified-name.avsc")));
-        final String outputSchemaText = new String(Files
-                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-stringified-name.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -608,8 +558,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-name.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/person-with-name.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -618,18 +567,15 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String schemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/embedded-record.avsc")));
+        final String schemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/embedded-record.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, schemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, schemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -641,8 +587,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/embedded-record.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/embedded-record.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -651,20 +596,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files
-                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -676,8 +617,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -686,20 +626,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files
-                .readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
-        final String outputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-record.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/name-fields-only.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -711,8 +647,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-fields-only.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -721,20 +656,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-and-mother.avsc")));
-        final String outputSchemaText = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-and-mother.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-and-mother.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/person-with-name-and-mother.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -746,8 +677,7 @@ public class TestUpdateRecord {
 
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        final String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-and-mother-same.json")));
+        final String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/name-and-mother-same.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
     }
 
@@ -756,20 +686,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
-        final String outputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -780,8 +706,7 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[*]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        String expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "8, 8, 8");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[*]");
@@ -800,8 +725,7 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[1]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "1, 8, 4");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[1]");
@@ -811,8 +735,7 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[0..1]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "8, 8, 4");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[0..1]");
@@ -822,8 +745,7 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[0,2]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "8, null, 8");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[0,2]");
@@ -833,8 +755,7 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[0,1..2]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "8, 8, 8");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[0,1..2]");
@@ -844,8 +765,7 @@ public class TestUpdateRecord {
         runner.setProperty("/numbers[0..-1][. = 4]", "8");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
+        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/input/multi-arrays.json")));
         expectedOutput = expectedOutput.replaceFirst("1, null, 4", "1, null, 8");
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/numbers[0..-1][. = 4]");
@@ -856,20 +776,16 @@ public class TestUpdateRecord {
         final JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("reader", jsonReader);
 
-        final String inputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
-        final String outputSchemaText = new String(
-                Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
+        final String inputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
+        final String outputSchemaText = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/schema/multi-arrays.avsc")));
 
-        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, inputSchemaText);
         runner.enableControllerService(jsonReader);
 
         final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
         runner.addControllerService("writer", jsonWriter);
-        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY,
-                SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
         runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, outputSchemaText);
         runner.setProperty(jsonWriter, "Pretty Print JSON", "true");
         runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
@@ -900,8 +816,7 @@ public class TestUpdateRecord {
         runner.setProperty("/peoples[0..1]", "/peoples[3]");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        String expectedOutput = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-0and1.json")));
+        String expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-0and1.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/peoples[0..1]");
 
@@ -910,8 +825,7 @@ public class TestUpdateRecord {
         runner.setProperty("/peoples[0,2]", "/peoples[3]");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-0and2.json")));
+        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-0and2.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/peoples[0,2]");
 
@@ -950,8 +864,7 @@ public class TestUpdateRecord {
         runner.setProperty("/peoples[0..-1][./name != 'Mary Doe']/addresses[0,1..2]", "/peoples[3]/addresses[0]");
         runner.run();
         runner.assertAllFlowFilesTransferred(UpdateRecord.REL_SUCCESS, 1);
-        expectedOutput = new String(Files.readAllBytes(
-                Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-streets.json")));
+        expectedOutput = new String(Files.readAllBytes(Paths.get("src/test/resources/TestUpdateRecord/output/updateArrays/multi-arrays-streets.json")));
         runner.getFlowFilesForRelationship(UpdateRecord.REL_SUCCESS).get(0).assertContentEquals(expectedOutput);
         runner.removeProperty("/peoples[0..-1][./name != 'Mary Doe']/addresses[0,1..2]");
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/input/organisation.json
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/input/organisation.json
@@ -1,0 +1,3 @@
+{
+  "record_json": "{\"name\":\"An Organisation\",\"departments\":[{\"name\":\"Department 1\",\"manager\":\"Joe Bloggs\"},{\"name\":\"Coders\",\"manager\":\"Jane Biggs\"}],\"address\":{\"address_1\":\"123 Fake Street\",\"address_2\":\"Somewhere There\",\"postcode\":\"AB1 6HT\"}}"
+}

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/output/organisation.json
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/output/organisation.json
@@ -1,0 +1,15 @@
+[ {
+  "name" : "An Organisation",
+  "departments" : [ {
+    "name" : "Department 1",
+    "manager" : "Joe Bloggs"
+  }, {
+    "name" : "Coders",
+    "manager" : "Jane Biggs"
+  } ],
+  "address" : {
+    "address_1" : "123 Fake Street",
+    "address_2" : "Somewhere There",
+    "postcode" : "AB1 6HT"
+  }
+} ]

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/schema/organisation-with-departments-string.avsc
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/schema/organisation-with-departments-string.avsc
@@ -1,0 +1,8 @@
+{
+	"name": "record_json",
+	"namespace": "nifi",
+	"type": "record",
+	"fields": [
+		{ "name": "record_json", "type": "string" }
+	]
+}

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/schema/organisation-with-departments.avsc
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestUpdateRecord/schema/organisation-with-departments.avsc
@@ -1,0 +1,78 @@
+{
+  "fields": [
+    {
+      "name": "name",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "departments",
+      "type": [
+        {
+          "items": {
+            "fields": [
+              {
+                "name": "name",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              {
+                "name": "manager",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            ],
+            "name": "department",
+            "namespace": "test.nifi",
+            "type": "record"
+          },
+          "type": "array"
+        },
+        "null"
+      ]
+    },
+    {
+      "name": "address",
+      "type": [
+        {
+          "fields": [
+            {
+              "name": "address_1",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            {
+              "name": "address_2",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            {
+              "name": "postcode",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          ],
+          "name": "address",
+          "namespace": "test.nifi",
+          "type": "record"
+        },
+        "null"
+      ]
+    }
+  ],
+  "name": "organisation",
+  "namespace": "test.nifi",
+  "type": "record"
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-8134](https://issues.apache.org/jira/browse/NIFI-8134) allow unescapeJson Record Path function to recursively convert Maps to Records

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 17

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- [x] Documentation formatting appears as expected in rendered files
