### PR TITLE
NIFI-12081 Remove HackerOne from Security Reporting Methods

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,8 +41,6 @@ While researching, we'd like to ask you to refrain from:
 
 * NiFi Security Mailing List: [security@nifi.apache.org](mailto:security@nifi.apache.org)
   * Members of the [Project Management Committee](https://nifi.apache.org/people.html) monitor this private mailing list and respond to disclosures
-* NiFi [HackerOne](https://hackerone.com/apache_nifi) project page
-  * HackerOne provides a triaged process for researchers and organizations to collaboratively report and resolve security vulnerabilities
 
 ## Publishing
 


### PR DESCRIPTION
# Summary

[NIFI-12081](https://issues.apache.org/jira/browse/NIFI-12081) The project uses the security@nifi.apache.org private email list for vulnerability reporting, so the link to HackerOne should be removed.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
