### PR TITLE
NIFI-12083 Upgrade Jetty from 9.4.51 to 9.4.52

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <testcontainers.version>1.19.0</testcontainers.version>
         <org.slf4j.version>2.0.9</org.slf4j.version>
         <ranger.version>2.4.0</ranger.version>
-        <jetty.version>9.4.51.v20230217</jetty.version>
+        <jetty.version>9.4.52.v20230823</jetty.version>
         <jackson.bom.version>2.15.2</jackson.bom.version>
         <avro.version>1.11.2</avro.version>
         <jaxb.runtime.version>2.3.8</jaxb.runtime.version>


### PR DESCRIPTION
# Summary

[NIFI-12083](https://issues.apache.org/jira/browse/NIFI-12083) Upgrades Jetty from 9.4.51 to 9.4.52 on the support branch to mitigate CVE-2023-40167 and several other minor bugs that do not apply directly to project usage of Jetty libraries.

The main branch is already using Jetty version 10.0.16 containing similar updates.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
