### PR TITLE
NIFI-12093 Deprecate EncryptContent Processor

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EncryptContent.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EncryptContent.java
@@ -43,6 +43,7 @@ import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -99,6 +100,17 @@ import org.bouncycastle.openpgp.PGPEncryptedData;
         @WritesAttribute(attribute = "encryptcontent.salt_length", description = "The raw salt length in bytes"),
         @WritesAttribute(attribute = "encryptcontent.timestamp", description = "The timestamp at which the cryptographic operation occurred in 'yyyy-MM-dd HH:mm:ss.SSS Z' format"),
                })
+@DeprecationNotice(
+        classNames = {
+                "org.apache.nifi.processors.pgp.EncryptContentPGP",
+                "org.apache.nifi.processors.pgp.DecryptContentPGP",
+                "org.apache.nifi.processors.cipher.DecryptContent",
+                "org.apache.nifi.processors.cipher.DecryptContentCompatibility",
+                "org.apache.nifi.processors.cipher.EncryptContentAge",
+                "org.apache.nifi.processors.cipher.DecryptContentAge",
+        },
+        reason = "EncryptContentAge or EncryptContentPGP should be used for encrypting new files using standard formatting. DecryptContent supports deciphering historical files."
+)
 public class EncryptContent extends AbstractProcessor {
 
     public static final String ENCRYPT_MODE = "Encrypt";


### PR DESCRIPTION
# Summary

[NIFI-12093](https://issues.apache.org/jira/browse/NIFI-12093) Deprecates the `EncryptContent` Processor for subsequent removal from the main branch. The deprecation notice lists available and maintained alternatives for encrypting new files and decrypting historical files.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
