### PR TITLE
NIFI-12019 improve reliability of TestSynchronousFileWatcher

### DIFF
--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/monitor/TestSynchronousFileWatcher.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/monitor/TestSynchronousFileWatcher.java
@@ -37,9 +37,8 @@ public class TestSynchronousFileWatcher {
         Files.copy(new ByteArrayInputStream("Hello, World!".getBytes("UTF-8")), path, StandardCopyOption.REPLACE_EXISTING);
         final UpdateMonitor monitor = new DigestUpdateMonitor();
 
-        final SynchronousFileWatcher watcher = new SynchronousFileWatcher(path, monitor, 40L);
+        final SynchronousFileWatcher watcher = new SynchronousFileWatcher(path, monitor, 0L);
         assertFalse(watcher.checkAndReset());
-        Thread.sleep(41L);
         assertFalse(watcher.checkAndReset());
 
         try (FileOutputStream fos = new FileOutputStream(path.toFile())) {
@@ -47,11 +46,7 @@ public class TestSynchronousFileWatcher {
             fos.getFD().sync();
         }
 
-        // immediately after file changes, but before the next check time is reached, answer should be false
-        assertFalse(watcher.checkAndReset());
-
-        // after check time has passed, answer should be true
-        Thread.sleep(41L);
+        // file has changed, answer should be true once
         assertTrue(watcher.checkAndReset());
         assertFalse(watcher.checkAndReset());
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12019](https://issues.apache.org/jira/browse/NIFI-12019)
TestSynchronousFileWatcher unit test was not reliable which caused some builds to fail randomly.  Removed the reliance on specific timing from the unit test, to make it reliable.  Sorry about that!

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [n/a] Documentation formatting appears as expected in rendered files
