### PR TITLE
NIFI-12103 - URL(String) in URL has been deprecated

### DIFF
--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/AbstractTestSecure.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/AbstractTestSecure.java
@@ -28,7 +28,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -195,7 +195,7 @@ public abstract class AbstractTestSecure extends AbstractTestUnsecure {
 
     protected HttpsURLConnection openUrlConnection(String url, SSLContext sslContext) throws IOException {
         DockerPort dockerPort = docker.containers().container("squid").port(3128);
-        HttpsURLConnection httpURLConnection = (HttpsURLConnection) new URL(url).openConnection(
+        HttpsURLConnection httpURLConnection = (HttpsURLConnection) URI.create(url).toURL().openConnection(
             new Proxy(Proxy.Type.HTTP, new InetSocketAddress(dockerPort.getIp(), dockerPort.getExternalPort())));
         httpURLConnection.setSSLSocketFactory(sslContext.getSocketFactory());
         return httpURLConnection;

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/AbstractTestUnsecure.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/AbstractTestUnsecure.java
@@ -28,7 +28,7 @@ import com.palantir.docker.compose.connection.DockerPort;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import org.apache.commons.io.IOUtils;
 import org.apache.nifi.controller.flow.VersionedDataflow;
 import org.junit.jupiter.api.Test;
@@ -99,7 +99,7 @@ public abstract class AbstractTestUnsecure {
     }
 
     protected HttpURLConnection openSuperUserUrlConnection(String url) throws IOException {
-        return (HttpURLConnection) new URL(url).openConnection();
+        return (HttpURLConnection) URI.create(url).toURL().openConnection();
     }
 
     protected VersionedDataflow toVersionedDataFlow(InputStream inputStream) throws IOException {

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/health/HttpStatusCodeHealthCheck.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/health/HttpStatusCodeHealthCheck.java
@@ -23,7 +23,7 @@ import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.util.function.Function;
 
 public class HttpStatusCodeHealthCheck implements HealthCheck<Container> {
@@ -50,6 +50,6 @@ public class HttpStatusCodeHealthCheck implements HealthCheck<Container> {
     }
 
     protected HttpURLConnection openConnection(String url) throws IOException {
-        return ((HttpURLConnection) new URL(url).openConnection());
+        return ((HttpURLConnection) URI.create(url).toURL().openConnection());
     }
 }

--- a/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/health/HttpsStatusCodeHealthCheck.java
+++ b/minifi/minifi-c2/minifi-c2-integration-tests/src/test/java/org/apache/nifi/minifi/c2/integration/test/health/HttpsStatusCodeHealthCheck.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -62,7 +62,7 @@ public class HttpsStatusCodeHealthCheck implements HealthCheck<List<Container>> 
     }
 
     public static HttpURLConnection getHttpURLConnection(String url, SSLSocketFactory sslSocketFactory, String proxyHostname, int proxyPort) throws IOException {
-        HttpsURLConnection httpURLConnection = (HttpsURLConnection) new URL(url).openConnection(
+        HttpsURLConnection httpURLConnection = (HttpsURLConnection) URI.create(url).toURL().openConnection(
                 new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHostname, proxyPort)));
         httpURLConnection.setSSLSocketFactory(sslSocketFactory);
         return httpURLConnection;

--- a/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-util/src/main/java/org/apache/nifi/minifi/c2/provider/util/HttpConnector.java
+++ b/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-util/src/main/java/org/apache/nifi/minifi/c2/provider/util/HttpConnector.java
@@ -33,6 +33,7 @@ import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -150,7 +151,7 @@ public class HttpConnector {
         }
         URL url;
         try {
-            url = new URL(endpointUrl);
+            url = URI.create(endpointUrl).toURL();
         } catch (MalformedURLException e) {
             throw new ConfigurationProviderException("Malformed url " + endpointUrl, e);
         }

--- a/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-util/src/main/java/org/apache/nifi/minifi/c2/provider/util/HttpConnector.java
+++ b/minifi/minifi-c2/minifi-c2-provider/minifi-c2-provider-util/src/main/java/org/apache/nifi/minifi/c2/provider/util/HttpConnector.java
@@ -152,7 +152,7 @@ public class HttpConnector {
         URL url;
         try {
             url = URI.create(endpointUrl).toURL();
-        } catch (MalformedURLException e) {
+        } catch (IllegalArgumentException | MalformedURLException e) {
             throw new ConfigurationProviderException("Malformed url " + endpointUrl, e);
         }
 

--- a/minifi/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/util/LogUtil.java
+++ b/minifi/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/util/LogUtil.java
@@ -27,6 +27,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class LogUtil {
         }
         DockerPort dockerPort = container.port(8000);
         logger.info("Connecting to external port {} for docker internal port of {}", new Object[]{dockerPort.getExternalPort(), dockerPort.getInternalPort()});
-        URL url = new URL("http://" + dockerPort.getIp() + ":" + dockerPort.getExternalPort());
+        URL url = URI.create("http://" + dockerPort.getIp() + ":" + dockerPort.getExternalPort()).toURL();
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
         try (InputStream inputStream = urlConnection.getInputStream();
              InputStreamReader inputStreamReader = new InputStreamReader(inputStream);

--- a/nifi-api/src/main/java/org/apache/nifi/components/resource/StandardResourceReferenceFactory.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/resource/StandardResourceReferenceFactory.java
@@ -19,6 +19,7 @@ package org.apache.nifi.components.resource;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -69,11 +70,11 @@ public class StandardResourceReferenceFactory implements ResourceReferenceFactor
         if (allowedResourceTypes.contains(ResourceType.URL)) {
             try {
                 if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
-                    return new URLResourceReference(new URL(trimmed));
+                    return new URLResourceReference(URI.create(trimmed).toURL());
                 }
 
                 if (trimmed.startsWith("file:")) {
-                    final URL url = new URL(trimmed);
+                    final URL url = URI.create(trimmed).toURL();
                     final String filename = url.getFile();
                     final File file = new File(filename);
                     return new FileResourceReference(file);

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/util/SiteToSiteRestApiClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/util/SiteToSiteRestApiClient.java
@@ -38,10 +38,8 @@ import java.io.InputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.net.InetAddress;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
@@ -93,6 +91,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.client.utils.URIUtils;
 import org.apache.http.conn.ManagedHttpClientConnection;
 import org.apache.http.entity.BasicHttpEntity;
@@ -1356,8 +1355,14 @@ public class SiteToSiteRestApiClient implements Closeable {
         }
 
         try {
-            return new URL(clusterUrl.getScheme(), clusterUrl.getHost(), clusterUrl.getPort(), uriPath).toURI().toString();
-        } catch (MalformedURLException|URISyntaxException e) {
+            return new URIBuilder()
+                    .setScheme(clusterUrl.getScheme())
+                    .setHost(clusterUrl.getHost())
+                    .setPort(clusterUrl.getPort())
+                    .setPath(uriPath)
+                    .build()
+                    .toString();
+        } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
     }
@@ -1369,8 +1374,14 @@ public class SiteToSiteRestApiClient implements Closeable {
     private void setBaseUrl(final String scheme, final String host, final int port, final String path) {
         final String baseUri;
         try {
-            baseUri = new URL(scheme, host, port, path).toURI().toString();
-        } catch (MalformedURLException|URISyntaxException e) {
+            baseUri = new URIBuilder()
+                    .setScheme(scheme)
+                    .setHost(host)
+                    .setPort(port)
+                    .setPath(path)
+                    .build()
+                    .toString();
+        } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
         this.setBaseUrl(baseUri);

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
@@ -30,7 +30,6 @@ import org.apache.nifi.util.FormatUtils;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.text.NumberFormat;
@@ -548,7 +547,7 @@ public class StandardValidators {
 
                 try {
                     final String evaluatedInput = context.newPropertyValue(input).evaluateAttributeExpressions().getValue();
-                    new URL(evaluatedInput);
+                    URI.create(evaluatedInput).toURL();
                     return new ValidationResult.Builder().subject(subject).input(input).explanation("Valid URL").valid(true).build();
                 } catch (final Exception e) {
                     return new ValidationResult.Builder().subject(subject).input(input).explanation("Not a valid URL").valid(false).build();
@@ -577,7 +576,7 @@ public class StandardValidators {
 
                 // First check to see if it is a valid URL
                 try {
-                    new URL(evaluatedInput);
+                    URI.create(evaluatedInput).toURL();
                 } catch (MalformedURLException mue) {
                     validUrl = false;
                 }

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/StandardValidators.java
@@ -577,7 +577,7 @@ public class StandardValidators {
                 // First check to see if it is a valid URL
                 try {
                     URI.create(evaluatedInput).toURL();
-                } catch (MalformedURLException mue) {
+                } catch (IllegalArgumentException | MalformedURLException mue) {
                     validUrl = false;
                 }
 

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/classloader/ClassLoaderUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/classloader/ClassLoaderUtils.java
@@ -98,7 +98,7 @@ public class ClassLoaderUtils {
                 // If the path is already a URL, just add it (but don't check if it exists, too expensive and subject to network availability)
                 boolean isUrl = true;
                 try {
-                    additionalClasspath.add(new URL(modulePathString));
+                    additionalClasspath.add(URI.create(modulePathString).toURL());
                 } catch (MalformedURLException mue) {
                     isUrl = false;
                 }

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/classloader/ClassLoaderUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/file/classloader/ClassLoaderUtils.java
@@ -99,7 +99,7 @@ public class ClassLoaderUtils {
                 boolean isUrl = true;
                 try {
                     additionalClasspath.add(URI.create(modulePathString).toURL());
-                } catch (MalformedURLException mue) {
+                } catch (IllegalArgumentException | MalformedURLException e) {
                     isUrl = false;
                 }
                 if (!isUrl) {

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/classloader/TestClassLoaderUtils.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/classloader/TestClassLoaderUtils.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.FilenameFilter;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.HashSet;
@@ -124,7 +125,7 @@ public class TestClassLoaderUtils {
     @Test
     public void testGenerateAdditionalUrlsFingerprintForHttpUrl() throws MalformedURLException {
         final Set<URL> urls = new HashSet<>();
-        URL testUrl = new URL("http://myhost/TestSuccess.jar");
+        URL testUrl = URI.create("http://myhost/TestSuccess.jar").toURL();
         urls.add(testUrl);
         String testFingerprint = ClassLoaderUtils.generateAdditionalUrlsFingerprint(urls, null);
         assertNotNull(testFingerprint);

--- a/nifi-external/nifi-kafka-connect/nifi-kafka-connector/src/main/java/org/apache/nifi/kafka/connect/validators/ConnectHttpUrlValidator.java
+++ b/nifi-external/nifi-kafka-connect/nifi-kafka-connector/src/main/java/org/apache/nifi/kafka/connect/validators/ConnectHttpUrlValidator.java
@@ -20,7 +20,7 @@ package org.apache.nifi.kafka.connect.validators;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
-import java.net.URL;
+import java.net.URI;
 
 public class ConnectHttpUrlValidator implements ConfigDef.Validator {
     @Override
@@ -34,8 +34,7 @@ public class ConnectHttpUrlValidator implements ConfigDef.Validator {
         }
 
         try {
-            final URL url = new URL((String) value);
-            final String protocol = url.getProtocol();
+            final String protocol = URI.create((String) value).toURL().getProtocol();
             if (!protocol.equals("http") && !protocol.equals("https")) {
                 throw new ConfigException("Invalid value for property " + name + ": The value must be an http or https URL");
             }

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/java/org/apache/nifi/atlas/provenance/AbstractNiFiProvenanceEventAnalyzer.java
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/java/org/apache/nifi/atlas/provenance/AbstractNiFiProvenanceEventAnalyzer.java
@@ -49,7 +49,7 @@ public abstract class AbstractNiFiProvenanceEventAnalyzer implements NiFiProvena
     protected URL parseUrl(String url) {
         try {
             return URI.create(url).toURL();
-        } catch (MalformedURLException e) {
+        } catch (IllegalArgumentException | MalformedURLException e) {
             final String msg = String.format("Failed to parse url %s due to %s", url, e);
             throw new IllegalArgumentException(msg, e);
         }

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/java/org/apache/nifi/atlas/provenance/AbstractNiFiProvenanceEventAnalyzer.java
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/java/org/apache/nifi/atlas/provenance/AbstractNiFiProvenanceEventAnalyzer.java
@@ -48,7 +48,7 @@ public abstract class AbstractNiFiProvenanceEventAnalyzer implements NiFiProvena
      */
     protected URL parseUrl(String url) {
         try {
-            return new URL(url);
+            return URI.create(url).toURL();
         } catch (MalformedURLException e) {
             final String msg = String.format("Failed to parse url %s due to %s", url, e);
             throw new IllegalArgumentException(msg, e);

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/java/org/apache/nifi/atlas/reporting/ReportLineageToAtlas.java
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/java/org/apache/nifi/atlas/reporting/ReportLineageToAtlas.java
@@ -94,6 +94,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -446,7 +447,7 @@ public class ReportLineageToAtlas extends AbstractReportingTask {
                 .map(String::trim)
                 .forEach(input -> {
                     try {
-                        schemes.add(URI.create(input).getScheme());
+                        schemes.add(Objects.requireNonNull(URI.create(input).getScheme()));
                     } catch (Exception e) {
                         results.add(new ValidationResult.Builder().subject(ATLAS_URLS.getDisplayName()).input(input)
                                 .explanation("contains invalid URI: " + e).valid(false).build());

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/java/org/apache/nifi/atlas/reporting/ReportLineageToAtlas.java
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/main/java/org/apache/nifi/atlas/reporting/ReportLineageToAtlas.java
@@ -80,8 +80,7 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -447,8 +446,7 @@ public class ReportLineageToAtlas extends AbstractReportingTask {
                 .map(String::trim)
                 .forEach(input -> {
                     try {
-                        final URL url = new URL(input);
-                        schemes.add(url.toURI().getScheme());
+                        schemes.add(URI.create(input).getScheme());
                     } catch (Exception e) {
                         results.add(new ValidationResult.Builder().subject(ATLAS_URLS.getDisplayName()).input(input)
                                 .explanation("contains invalid URI: " + e).valid(false).build());
@@ -667,7 +665,7 @@ public class ReportLineageToAtlas extends AbstractReportingTask {
                 .map(String::trim)
                 .forEach(urlString -> {
                         try {
-                            new URL(urlString);
+                            URI.create(urlString).toURL();
                         } catch (Exception e) {
                             throw new ProcessException(e);
                         }
@@ -860,15 +858,8 @@ public class ReportLineageToAtlas extends AbstractReportingTask {
         final ProcessGroupStatus rootProcessGroup = context.getEventAccess().getGroupStatus("root");
         final String flowName = rootProcessGroup.getName();
         final String nifiUrl = context.getProperty(ATLAS_NIFI_URL).evaluateAttributeExpressions().getValue();
-
-
-        final String namespace;
-        try {
-            final String nifiHostName = new URL(nifiUrl).getHost();
-            namespace = namespaceResolvers.fromHostNames(nifiHostName);
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Failed to parse NiFi URL, " + e.getMessage(), e);
-        }
+        final String nifiHostName = URI.create(nifiUrl).getHost();
+        final String namespace = namespaceResolvers.fromHostNames(nifiHostName);
 
         NiFiFlow existingNiFiFlow = null;
         try {

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/test/java/org/apache/nifi/atlas/reporting/TestReportLineageToAtlas.java
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-reporting-task/src/test/java/org/apache/nifi/atlas/reporting/TestReportLineageToAtlas.java
@@ -53,7 +53,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -195,8 +194,8 @@ public class TestReportLineageToAtlas {
         atlasConf.setProperty("atlas.rest.address", atlasUrls);
 
         Consumer<Exception> assertion = e -> assertTrue(
-            e.getCause() instanceof MalformedURLException,
-            "Expected " + MalformedURLException.class.getSimpleName() + " for " + atlasUrls + ", got " + e
+            e.getCause() instanceof IllegalArgumentException,
+            "Expected " + IllegalArgumentException.class.getSimpleName() + " for " + atlasUrls + ", got " + e
         );
 
         // WHEN

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/wag/AbstractAWSGatewayApiProcessor.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/wag/AbstractAWSGatewayApiProcessor.java
@@ -31,7 +31,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/wag/AbstractAWSGatewayApiProcessor.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/wag/AbstractAWSGatewayApiProcessor.java
@@ -336,7 +336,7 @@ public abstract class AbstractAWSGatewayApiProcessor extends
                     // but we may need to when validating
                     final String encodedInput = URLEncoder.encode(evaluatedInput, "UTF-8");
                     final String url = String.format("http://www.foo.com?%s", encodedInput);
-                    new URL(url);
+                    URI.create(url).toURL();
                     results.add(new ValidationResult.Builder().subject(PROP_QUERY_PARAMS.getName())
                                                               .input(input)
                                                               .explanation("Valid URL params")

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AzureLogAnalyticsProvenanceReportingTask.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AzureLogAnalyticsProvenanceReportingTask.java
@@ -299,7 +299,7 @@ public class AzureLogAnalyticsProvenanceReportingTask extends AbstractAzureLogAn
                 URL url;
                 try {
                         url = URI.create(nifiUrl).toURL();
-                } catch (final MalformedURLException e1) {
+                } catch (IllegalArgumentException | MalformedURLException e) {
                         throw new AssertionError();
                 }
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AzureLogAnalyticsProvenanceReportingTask.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AzureLogAnalyticsProvenanceReportingTask.java
@@ -18,6 +18,7 @@ package org.apache.nifi.reporting.azure.loganalytics;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.text.DateFormat;
 import java.text.MessageFormat;
@@ -45,7 +46,6 @@ import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.controller.status.ProcessGroupStatus;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -168,8 +168,6 @@ public class AzureLogAnalyticsProvenanceReportingTask extends AbstractAzureLogAn
                         .displayName("Batch Size")
                         .description("Specifies how many records to send in a single batch, at most.").required(true)
                         .defaultValue("1000").addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR).build();
-
-        private ConfigurationContext context;
 
         private volatile ProvenanceEventConsumer consumer;
 
@@ -300,7 +298,7 @@ public class AzureLogAnalyticsProvenanceReportingTask extends AbstractAzureLogAn
                 final String nifiUrl = context.getProperty(INSTANCE_URL).evaluateAttributeExpressions().getValue();
                 URL url;
                 try {
-                        url = new URL(nifiUrl);
+                        url = URI.create(nifiUrl).toURL();
                 } catch (final MalformedURLException e1) {
                         throw new AssertionError();
                 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -70,6 +70,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.Proxy;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -397,7 +398,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
         this.url = hostsSplit.get(0);
         final List<HttpHost> hh = new ArrayList<>(hostsSplit.size());
         for (final String host : hostsSplit) {
-            final URL u = new URL(host);
+            final URL u = URI.create(host).toURL();
             hh.add(new HttpHost(u.getHost(), u.getPort(), u.getProtocol()));
         }
 
@@ -538,8 +539,8 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
         }
         sb.append("/").append(endpoint);
 
-        final HttpEntity queryEntity = new NStringEntity(query, ContentType.APPLICATION_JSON);
         try {
+            final HttpEntity queryEntity = new NStringEntity(query, ContentType.APPLICATION_JSON);
             return performRequest("POST", sb.toString(), requestParameters, queryEntity);
         } catch (final Exception e) {
             throw new ElasticsearchException(e);

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
@@ -40,6 +40,7 @@ import org.testcontainers.utility.DockerImageName;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -134,7 +135,7 @@ public abstract class AbstractElasticsearchITBase {
 
     protected static void setupTestData() throws IOException {
         final int majorVersion = getElasticMajorVersion();
-        final URL url = new URL(elasticsearchHost);
+        final URL url = URI.create(elasticsearchHost).toURL();
         testDataManagementClient = RestClient
                 .builder(new HttpHost(url.getHost(), url.getPort(), url.getProtocol()))
                 .setHttpClientConfigCallback(httpClientBuilder -> {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/oidc/web/authentication/OidcAuthenticationSuccessHandlerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/oidc/web/authentication/OidcAuthenticationSuccessHandlerTest.java
@@ -41,6 +41,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import javax.servlet.ServletContext;
 import javax.servlet.http.Cookie;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
 import java.time.Instant;
@@ -204,7 +205,7 @@ class OidcAuthenticationSuccessHandlerTest {
 
     URL getIssuer() {
         try {
-            return new URL(ISSUER);
+            return URI.create(ISSUER).toURL();
         } catch (final MalformedURLException e) {
             throw new RuntimeException(e);
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/oidc/web/authentication/OidcAuthenticationSuccessHandlerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/oidc/web/authentication/OidcAuthenticationSuccessHandlerTest.java
@@ -206,7 +206,7 @@ class OidcAuthenticationSuccessHandlerTest {
     URL getIssuer() {
         try {
             return URI.create(ISSUER).toURL();
-        } catch (final MalformedURLException e) {
+        } catch (IllegalArgumentException | MalformedURLException e) {
             throw new RuntimeException(e);
         }
     }

--- a/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/PrometheusReportingTaskIT.java
+++ b/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/PrometheusReportingTaskIT.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -158,8 +158,7 @@ public class PrometheusReportingTaskIT {
     }
 
     private String getMetrics() throws IOException {
-        URL url = new URL("http://localhost:9092/metrics");
-        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        HttpURLConnection con = (HttpURLConnection) URI.create("http://localhost:9092/metrics").toURL().openConnection();
         con.setRequestMethod("GET");
         int status = con.getResponseCode();
         assertEquals(HttpURLConnection.HTTP_OK, status);

--- a/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
+++ b/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
@@ -51,7 +51,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -124,8 +124,7 @@ public class TestPrometheusRecordSink {
     }
 
     private String getMetrics() throws IOException {
-        URL url = new URL("http://localhost:" + portString + "/metrics");
-        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        HttpURLConnection con = (HttpURLConnection) URI.create("http://localhost:" + portString + "/metrics").toURL().openConnection();
         con.setRequestMethod("GET");
         int status = con.getResponseCode();
         assertEquals(HttpURLConnection.HTTP_OK, status);

--- a/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteProvenanceReportingTask.java
+++ b/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteProvenanceReportingTask.java
@@ -276,7 +276,7 @@ public class SiteToSiteProvenanceReportingTask extends AbstractSiteToSiteReporti
         URL url;
         try {
             url = URI.create(nifiUrl).toURL();
-        } catch (final MalformedURLException e1) {
+        } catch (IllegalArgumentException | MalformedURLException e) {
             // already validated
             throw new AssertionError();
         }

--- a/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteProvenanceReportingTask.java
+++ b/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteProvenanceReportingTask.java
@@ -20,6 +20,7 @@ package org.apache.nifi.reporting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -274,7 +275,7 @@ public class SiteToSiteProvenanceReportingTask extends AbstractSiteToSiteReporti
         final String nifiUrl = context.getProperty(SiteToSiteUtils.INSTANCE_URL).evaluateAttributeExpressions().getValue();
         URL url;
         try {
-            url = new URL(nifiUrl);
+            url = URI.create(nifiUrl).toURL();
         } catch (final MalformedURLException e1) {
             // already validated
             throw new AssertionError();

--- a/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
+++ b/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
@@ -134,7 +134,7 @@ public class SiteToSiteStatusReportingTask extends AbstractSiteToSiteReportingTa
         URL url;
         try {
             url = URI.create(nifiUrl).toURL();
-        } catch (final MalformedURLException e1) {
+        } catch (IllegalArgumentException | MalformedURLException e) {
             // already validated
             throw new AssertionError();
         }

--- a/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
+++ b/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteStatusReportingTask.java
@@ -20,6 +20,7 @@ package org.apache.nifi.reporting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -132,7 +133,7 @@ public class SiteToSiteStatusReportingTask extends AbstractSiteToSiteReportingTa
         final String nifiUrl = context.getProperty(SiteToSiteUtils.INSTANCE_URL).evaluateAttributeExpressions().getValue();
         URL url;
         try {
-            url = new URL(nifiUrl);
+            url = URI.create(nifiUrl).toURL();
         } catch (final MalformedURLException e1) {
             // already validated
             throw new AssertionError();

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PutSlack.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PutSlack.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Arrays;
@@ -255,7 +256,7 @@ public class PutSlack extends AbstractProcessor {
             jsonWriter.writeObject(jsonObject);
             jsonWriter.close();
 
-            URL url = new URL(context.getProperty(WEBHOOK_URL).evaluateAttributeExpressions(flowFile).getValue());
+            URL url = URI.create(context.getProperty(WEBHOOK_URL).evaluateAttributeExpressions(flowFile).getValue()).toURL();
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("POST");
             conn.setDoOutput(true);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -27,6 +27,7 @@ import java.net.CookieManager;
 import java.net.CookiePolicy;
 import java.net.Proxy;
 import java.net.Proxy.Type;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -836,7 +837,7 @@ public class InvokeHTTP extends AbstractProcessor {
         FlowFile responseFlowFile = null;
         try {
             final String urlProperty = trimToEmpty(context.getProperty(HTTP_URL).evaluateAttributeExpressions(requestFlowFile).getValue());
-            final URL url = new URL(urlProperty);
+            final URL url = URI.create(urlProperty).toURL();
 
             Request httpRequest = configureRequest(context, session, requestFlowFile, url);
             logRequest(logger, httpRequest);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/ITestHandleHttpRequest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/ITestHandleHttpRequest.java
@@ -56,7 +56,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -125,8 +125,8 @@ public class ITestHandleHttpRequest {
                 try {
                     serverReady.await();
                     final int port = ((HandleHttpRequest) runner.getProcessor()).getPort();
-                    final HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:"
-                            + port + "/my/path?query=true&value1=value1&value2=&value3&value4=apple=orange").openConnection();
+                    final HttpURLConnection connection = (HttpURLConnection) URI.create("http://localhost:"
+                            + port + "/my/path?query=true&value1=value1&value2=&value3&value4=apple=orange").toURL().openConnection();
 
                     connection.setDoOutput(false);
                     connection.setRequestMethod("GET");
@@ -470,8 +470,8 @@ public class ITestHandleHttpRequest {
                     serverReady.await();
 
                     final int port = ((HandleHttpRequest) runner.getProcessor()).getPort();
-                    connection = (HttpURLConnection) new URL("http://localhost:"
-                            + port + "/my/path?query=true&value1=value1&value2=&value3&value4=apple=orange").openConnection();
+                    connection = (HttpURLConnection) URI.create("http://localhost:"
+                            + port + "/my/path?query=true&value1=value1&value2=&value3&value4=apple=orange").toURL().openConnection();
                     connection.setDoOutput(false);
                     connection.setRequestMethod("GET");
                     connection.setRequestProperty("header1", "value1");
@@ -598,8 +598,8 @@ public class ITestHandleHttpRequest {
                     serverReady.await();
 
                     final int port = ((HandleHttpRequest) runner.getProcessor()).getPort();
-                    final HttpsURLConnection connection = (HttpsURLConnection) new URL("https://localhost:"
-                            + port + "/my/path?query=true&value1=value1&value2=&value3&value4=apple=orange").openConnection();
+                    final HttpsURLConnection connection = (HttpsURLConnection) URI.create("https://localhost:"
+                            + port + "/my/path?query=true&value1=value1&value2=&value3&value4=apple=orange").toURL().openConnection();
 
                     SSLContext clientSslContext;
                     if (twoWaySsl) {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/InvokeHTTPTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/InvokeHTTPTest.java
@@ -22,7 +22,6 @@ import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.oauth2.OAuth2AccessTokenProvider;
 import org.apache.nifi.processor.Relationship;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/InvokeHTTPTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/InvokeHTTPTest.java
@@ -22,6 +22,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import okio.Buffer;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.oauth2.OAuth2AccessTokenProvider;
 import org.apache.nifi.processor.Relationship;
@@ -764,8 +765,7 @@ public class InvokeHTTPTest {
     @ParameterizedTest(name = "{index} => When {0} http://baseUrl/{1}, filename of the response FlowFile should be {2}")
     @MethodSource
     public void testResponseFlowFileFilenameExtractedFromRemoteUrl(String httpMethod, String inputUrl, String expectedFileName) throws MalformedURLException {
-        URL baseUrl = new URL(getMockWebServerUrl());
-        URL targetUrl = new URL(baseUrl, inputUrl);
+        URL targetUrl = URI.create(getMockWebServerUrl() + "/" + inputUrl).toURL();
 
         runner.setProperty(InvokeHTTP.HTTP_METHOD, httpMethod);
         runner.setProperty(InvokeHTTP.HTTP_URL, targetUrl.toString());

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/util/ClassLoaderUtils.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/util/ClassLoaderUtils.java
@@ -94,7 +94,7 @@ public class ClassLoaderUtils {
                 boolean isUrl = true;
                 try {
                     additionalClasspath.add(URI.create(modulePathString).toURL());
-                } catch (MalformedURLException mue) {
+                } catch (IllegalArgumentException | MalformedURLException mue) {
                     isUrl = false;
                 }
                 if (!isUrl) {

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/util/ClassLoaderUtils.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/util/ClassLoaderUtils.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
@@ -92,7 +93,7 @@ public class ClassLoaderUtils {
                 // If the path is already a URL, just add it (but don't check if it exists, too expensive and subject to network availability)
                 boolean isUrl = true;
                 try {
-                    additionalClasspath.add(new URL(modulePathString));
+                    additionalClasspath.add(URI.create(modulePathString).toURL());
                 } catch (MalformedURLException mue) {
                     isUrl = false;
                 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProvider.java
@@ -244,7 +244,7 @@ public class StandardOidcIdentityProvider implements OidcIdentityProvider {
      * @throws ParseException if there is a problem parsing the response
      */
     private OIDCProviderMetadata retrieveOidcProviderMetadata(final String discoveryUri) throws IOException, ParseException {
-        final URL url = new URL(discoveryUri);
+        final URL url = URI.create(discoveryUri).toURL();
         final HTTPRequest httpRequest = new HTTPRequest(HTTPRequest.Method.GET, url);
         httpRequest.setConnectTimeout(oidcConnectTimeout);
         httpRequest.setReadTimeout(oidcReadTimeout);

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/flow/registry/FileSystemFlowRegistryClient.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/flow/registry/FileSystemFlowRegistryClient.java
@@ -38,7 +38,7 @@ import org.apache.nifi.util.file.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -77,8 +77,7 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
     @Override
     public boolean isStorageLocationApplicable(final FlowRegistryClientConfigurationContext context, final String storageLocation) {
         try {
-            final URL url = new URL(storageLocation);
-            final File file = new java.io.File(url.toURI());
+            final File file = new java.io.File(URI.create(storageLocation));
             final Path path = file.toPath();
 
             final String configuredDirectory = context.getProperty(DIRECTORY).getValue();

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/AbstractCommand.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/AbstractCommand.java
@@ -32,7 +32,6 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Objects;
@@ -242,8 +241,7 @@ public abstract class AbstractCommand<R extends Result> implements Command<R> {
         String contents;
         try {
             // try a public resource URL
-            URL url = new URL(inputFile);
-            contents = IOUtils.toString(url, StandardCharsets.UTF_8);
+            contents = IOUtils.toString(URI.create(inputFile).toURL(), StandardCharsets.UTF_8);
         } catch (MalformedURLException e) {
             // assume a local file then
             URI uri = Paths.get(inputFile).toAbsolutePath().toUri();

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/AbstractCommand.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/AbstractCommand.java
@@ -242,7 +242,7 @@ public abstract class AbstractCommand<R extends Result> implements Command<R> {
         try {
             // try a public resource URL
             contents = IOUtils.toString(URI.create(inputFile).toURL(), StandardCharsets.UTF_8);
-        } catch (MalformedURLException e) {
+        } catch (IllegalArgumentException | MalformedURLException e) {
             // assume a local file then
             URI uri = Paths.get(inputFile).toAbsolutePath().toUri();
             contents = IOUtils.toString(uri, StandardCharsets.UTF_8);


### PR DESCRIPTION
# Summary

[NIFI-12103](https://issues.apache.org/jira/browse/NIFI-12103) - URL(String) in URL has been deprecated

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
