### PR TITLE
NIFI-12108 Deprecate SpringContextProcessor for removal

### DIFF
--- a/nifi-nar-bundles/nifi-spring-bundle/nifi-spring-processors/src/main/java/org/apache/nifi/spring/SpringContextProcessor.java
+++ b/nifi-nar-bundles/nifi-spring-bundle/nifi-spring-processors/src/main/java/org/apache/nifi/spring/SpringContextProcessor.java
@@ -19,6 +19,7 @@ package org.apache.nifi.spring;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.TriggerWhenEmpty;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
@@ -133,6 +134,7 @@ import java.util.concurrent.TimeUnit;
  * representation of the content that is being exchanged between NiFi and
  * Spring.
  */
+@DeprecationNotice(reason = "Alternative event-handling solutions should be used")
 @TriggerWhenEmpty
 @Tags({ "Spring", "Message", "Get", "Put", "Integration" })
 @CapabilityDescription("A Processor that supports sending and receiving data from application defined in "


### PR DESCRIPTION
# Summary

[NIFI-12108](https://issues.apache.org/jira/browse/NIFI-12108) Deprecates the `SpringContextProcessor` for subsequent removal. Alternative event-handling solutions should be used.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
