### PR TITLE
NIFI-12110 Upgrade Spring Framework from 5.3.29 to 5.3.30

### DIFF
--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <jax.rs.api.version>2.1.1</jax.rs.api.version>
-        <spring.boot.version>2.7.15</spring.boot.version>
+        <spring.boot.version>2.7.16</spring.boot.version>
         <flyway.version>8.5.13</flyway.version>
         <flyway.tests.version>7.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <netty.4.version>4.1.97.Final</netty.4.version>
-        <spring.version>5.3.29</spring.version>
+        <spring.version>5.3.30</spring.version>
         <spring.security.version>5.8.7</spring.security.version>
         <swagger.annotations.version>1.6.11</swagger.annotations.version>
         <h2.version>2.2.224</h2.version>


### PR DESCRIPTION
# Summary

[NIFI-12110](https://issues.apache.org/jira/browse/NIFI-12110) Upgrades Spring Framework dependencies from 5.3.29 to [5.3.30](https://github.com/spring-projects/spring-framework/releases/tag/v5.3.30) and Spring Boot dependencies from 2.7.15 to [2.7.16](https://github.com/spring-projects/spring-boot/releases/tag/v2.7.16).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
