### PR TITLE
NIFI-12111 Deprecate Unmaintained Components for Removal

### DIFF
--- a/nifi-nar-bundles/nifi-cybersecurity-bundle/nifi-cybersecurity-processors/src/main/java/org/apache/nifi/processors/cybersecurity/CompareFuzzyHash.java
+++ b/nifi-nar-bundles/nifi-cybersecurity-bundle/nifi-cybersecurity-processors/src/main/java/org/apache/nifi/processors/cybersecurity/CompareFuzzyHash.java
@@ -17,6 +17,7 @@
 
 package org.apache.nifi.processors.cybersecurity;
 
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.behavior.EventDriven;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
@@ -70,7 +71,7 @@ import java.util.Set;
                 "by the <Hash Attribute Name> property. Note that: 'XXX' gets replaced with the <Hash Attribute Name>"),
         @WritesAttribute(attribute = "XXXX.N.similarity", description = "The similarity score between this flowfile" +
                 "and its match of the same number N. Note that: 'XXX' gets replaced with the <Hash Attribute Name>")})
-
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class CompareFuzzyHash extends AbstractFuzzyHashProcessor {
     public static final AllowableValue singleMatch = new AllowableValue(
             "single",

--- a/nifi-nar-bundles/nifi-cybersecurity-bundle/nifi-cybersecurity-processors/src/main/java/org/apache/nifi/processors/cybersecurity/FuzzyHashContent.java
+++ b/nifi-nar-bundles/nifi-cybersecurity-bundle/nifi-cybersecurity-processors/src/main/java/org/apache/nifi/processors/cybersecurity/FuzzyHashContent.java
@@ -18,6 +18,7 @@ package org.apache.nifi.processors.cybersecurity;
 
 import com.idealista.tlsh.exceptions.InsufficientComplexityException;
 
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.behavior.EventDriven;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
@@ -70,7 +71,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @SeeAlso(classNames = {"org.apache.nifi.processors.standard.HashContent"}, value = {CompareFuzzyHash.class})
 @WritesAttributes({@WritesAttribute(attribute = "<Hash Attribute Name>", description = "This Processor adds an attribute whose value is the result of Hashing the "
         + "existing FlowFile content. The name of this attribute is specified by the <Hash Attribute Name> property")})
-
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class FuzzyHashContent extends AbstractFuzzyHashProcessor {
 
 

--- a/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/GetHTMLElement.java
+++ b/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/GetHTMLElement.java
@@ -17,6 +17,7 @@
 package org.apache.nifi;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -66,6 +67,7 @@ import java.util.Collections;
 @SeeAlso({ModifyHTMLElement.class, PutHTMLElement.class})
 @WritesAttributes({@WritesAttribute(attribute="HTMLElement", description="Flowfile attribute where the element result" +
         " parsed from the HTML using the CSS selector syntax are placed if the destination is a flowfile attribute.")})
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class GetHTMLElement
         extends AbstractHTMLProcessor {
 

--- a/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/ModifyHTMLElement.java
+++ b/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/ModifyHTMLElement.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi;
 
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
@@ -62,6 +63,7 @@ import java.util.Collections;
 @SeeAlso({GetHTMLElement.class, PutHTMLElement.class})
 @WritesAttributes({@WritesAttribute(attribute="NumElementsModified", description="Total number of HTML " +
         "element modifications made")})
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class ModifyHTMLElement extends AbstractHTMLProcessor {
 
     public static final String NUM_ELEMENTS_MODIFIED_ATTR = "NumElementsModified";

--- a/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/PutHTMLElement.java
+++ b/nifi-nar-bundles/nifi-html-bundle/nifi-html-processors/src/main/java/org/apache/nifi/PutHTMLElement.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi;
 
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
@@ -56,6 +57,7 @@ import java.util.Collections;
         " content with the updated HTML. A more thorough reference for the CSS selector syntax can be found at" +
         " \"http://jsoup.org/apidocs/org/jsoup/select/Selector.html\"")
 @SeeAlso({GetHTMLElement.class, ModifyHTMLElement.class})
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class PutHTMLElement extends AbstractHTMLProcessor {
 
     public static final String APPEND_ELEMENT = "append-html";

--- a/nifi-nar-bundles/nifi-metrics-reporting-bundle/nifi-metrics-reporting-task/src/main/java/org/apache/nifi/metrics/reporting/reporter/service/GraphiteMetricReporterService.java
+++ b/nifi-nar-bundles/nifi-metrics-reporting-bundle/nifi-metrics-reporting-task/src/main/java/org/apache/nifi/metrics/reporting/reporter/service/GraphiteMetricReporterService.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.ScheduledReporter;
 import com.codahale.metrics.graphite.Graphite;
 import com.codahale.metrics.graphite.GraphiteReporter;
 import com.codahale.metrics.graphite.GraphiteSender;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnDisabled;
@@ -47,6 +48,7 @@ import java.util.List;
 @Tags({"metrics", "reporting", "graphite"})
 @CapabilityDescription("A controller service that provides metric reporters for graphite. " +
         "Used by MetricsReportingTask.")
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class GraphiteMetricReporterService extends AbstractControllerService implements MetricReporterService {
 
     /**

--- a/nifi-nar-bundles/nifi-metrics-reporting-bundle/nifi-metrics-reporting-task/src/main/java/org/apache/nifi/metrics/reporting/task/MetricsReportingTask.java
+++ b/nifi-nar-bundles/nifi-metrics-reporting-bundle/nifi-metrics-reporting-task/src/main/java/org/apache/nifi/metrics/reporting/task/MetricsReportingTask.java
@@ -19,6 +19,7 @@ package org.apache.nifi.metrics.reporting.task;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
@@ -52,6 +53,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @CapabilityDescription("This reporting task reports a set of metrics regarding the JVM and the NiFi instance" +
         "to a reporter. The reporter is provided by a MetricReporterService. It can be optionally used for a specific" +
         "process group if a property with the group id is provided.")
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class MetricsReportingTask extends AbstractReportingTask {
 
     /**

--- a/nifi-nar-bundles/nifi-riemann-bundle/nifi-riemann-processors/src/main/java/org/apache/nifi/processors/riemann/PutRiemann.java
+++ b/nifi-nar-bundles/nifi-riemann-bundle/nifi-riemann-processors/src/main/java/org/apache/nifi/processors/riemann/PutRiemann.java
@@ -20,6 +20,7 @@ import io.riemann.riemann.Proto;
 import io.riemann.riemann.Proto.Event;
 import io.riemann.riemann.client.RiemannClient;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -58,6 +59,7 @@ import java.util.concurrent.TimeUnit;
   "events support the NiFi Expression Language.")
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class PutRiemann extends AbstractProcessor {
   protected enum Transport {
     TCP, UDP

--- a/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/src/main/java/org/apache/nifi/rules/handlers/ActionHandlerLookup.java
+++ b/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/src/main/java/org/apache/nifi/rules/handlers/ActionHandlerLookup.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.rules.handlers;
 
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -44,6 +45,7 @@ import java.util.Map;
 "This service will allow multiple ActionHandlers to be defined and registered by action type.  When actions are provided the handlers can " +
 "be dynamically determined and executed at runtime.")
 @DynamicProperty(name = "actionType ", value = "Action Handler Service", expressionLanguageScope = ExpressionLanguageScope.NONE, description = "")
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class ActionHandlerLookup extends AbstractActionHandlerService{
 
     private volatile Map<String, PropertyContextActionHandler> actionHandlerMap;

--- a/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/src/main/java/org/apache/nifi/rules/handlers/AlertHandler.java
+++ b/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/src/main/java/org/apache/nifi/rules/handlers/AlertHandler.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.rules.handlers;
 
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
@@ -40,6 +41,7 @@ import java.util.Set;
 @Tags({"rules", "rules engine", "action", "action handler", "logging", "alerts", "bulletins"})
 @CapabilityDescription("Creates alerts as bulletins based on a provided action (usually created by a rules engine).  " +
         "Action objects executed with this Handler should contain \"category\", \"message\", and \"logLevel\" attributes.")
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class AlertHandler extends AbstractActionHandlerService {
 
     public static final PropertyDescriptor DEFAULT_LOG_LEVEL = new PropertyDescriptor.Builder()

--- a/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/src/main/java/org/apache/nifi/rules/handlers/ExpressionHandler.java
+++ b/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/src/main/java/org/apache/nifi/rules/handlers/ExpressionHandler.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.rules.handlers;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
@@ -41,6 +42,7 @@ import java.util.Map;
 @Tags({"rules", "rules engine", "action", "action handler", "expression language","MVEL","SpEL"})
 @CapabilityDescription("Executes an action containing an expression written in MVEL or SpEL. The action " +
 "is usually created by a rules engine. Action objects executed with this Handler should contain \"command\" and \"type\" attributes.")
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class ExpressionHandler extends AbstractActionHandlerService {
 
     enum ExpresssionType {

--- a/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/src/main/java/org/apache/nifi/rules/handlers/LogHandler.java
+++ b/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/src/main/java/org/apache/nifi/rules/handlers/LogHandler.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.rules.handlers;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
@@ -41,6 +42,7 @@ import java.util.Set;
 @Tags({"rules", "rules engine", "action", "action handler", "logging"})
 @CapabilityDescription("Logs messages and fact information based on a provided action (usually created by a rules engine).  " +
         " Action objects executed with this Handler should contain \"logLevel\" and \"message\" attributes.")
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class LogHandler extends AbstractActionHandlerService {
 
     public static final PropertyDescriptor DEFAULT_LOG_LEVEL = new PropertyDescriptor.Builder()

--- a/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/src/main/java/org/apache/nifi/rules/handlers/RecordSinkHandler.java
+++ b/nifi-nar-bundles/nifi-rules-action-handler-bundle/nifi-rules-action-handler-service/src/main/java/org/apache/nifi/rules/handlers/RecordSinkHandler.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.rules.handlers;
 
 import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
@@ -47,6 +48,7 @@ import java.util.stream.Collectors;
 @Tags({"rules", "rules engine", "action", "action handler", "record", "record sink"})
 @CapabilityDescription("Sends fact information to sink based on a provided action (usually created by a rules engine)." +
         "  Action objects executed with this Handler should contain \"sendZeroResult\" attribute.")
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class RecordSinkHandler extends AbstractActionHandlerService{
 
     static final PropertyDescriptor RECORD_SINK_SERVICE = new PropertyDescriptor.Builder()

--- a/nifi-nar-bundles/nifi-tcp-bundle/nifi-tcp-processors/src/main/java/org/apache/nifi/processors/gettcp/GetTCP.java
+++ b/nifi-nar-bundles/nifi-tcp-bundle/nifi-tcp-processors/src/main/java/org/apache/nifi/processors/gettcp/GetTCP.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processors.gettcp;
 
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
@@ -59,6 +60,7 @@ import java.util.concurrent.TimeUnit;
 @DynamicProperty(name = "A FlowFile attribute to set", value = "The value to set it to",
         description = "Sets a FlowFile attribute specified by the Dynamic Property's key with the value specified by the Dynamic Property's value")
 @WritesAttribute(attribute = "source.endpoint", description = "The address of the source endpoint the message came from")
+@DeprecationNotice(reason = "Unmaintained and planned for removal in version 2.0")
 public class GetTCP extends AbstractSessionFactoryProcessor {
 
     private static String SOURCE_ENDPOINT_ATTRIBUTE = "source.endpoint";


### PR DESCRIPTION
# Summary

[NIFI-12111](https://issues.apache.org/jira/browse/NIFI-12111) Deprecates unmaintained extension components in the following modules for subsequent removal in the next major release version:

- nifi-cybersecurity-bundle
- nifi-html-bundle
- nifi-metrics-reporting-bundle
- nifi-riemann-bundle
- nifi-tcp-bundle
- nifi-rules-action-handler-bundle

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
