### PR TITLE
NIFI-11463 Allow IdentifyMimeType to use custom MIME types in addition to defaults

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/IdentifyMimeType.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/IdentifyMimeType.java
@@ -101,8 +101,8 @@ import org.apache.tika.mime.MimeTypeException;
 }
 )
 public class IdentifyMimeType extends AbstractProcessor {
-    static final AllowableValue REPLACE = new AllowableValue("replace", "replace", "Use config MIME Types only.");
-    static final AllowableValue ADD = new AllowableValue("add", "add",
+    static final AllowableValue REPLACE = new AllowableValue("Replace", "Replace", "Use config MIME Types only.");
+    static final AllowableValue ADD = new AllowableValue("Add", "Add",
             "Use config in addition to default NiFi MIME Types.  If match is found among config MIME Types, default NiFi Mime Types will not be checked.");
 
     public static final PropertyDescriptor USE_FILENAME_IN_DETECTION = new PropertyDescriptor.Builder()
@@ -135,11 +135,12 @@ public class IdentifyMimeType extends AbstractProcessor {
     public static final PropertyDescriptor CONFIG_STRATEGY = new PropertyDescriptor.Builder()
             .displayName("Config Strategy")
             .name("config-strategy")
-            .description("Replace default NiFi MIME Types or add to them.  "
+            .description("Select the loading strategy for MIME Type configuration provided "
+                    + "in Config Body or Config File properties.  "
                     + "Only applicable if Config File or Config Body is used.")
-            .required(false)
+            .required(true)
             .allowableValues(REPLACE, ADD)
-            .defaultValue(REPLACE.getDisplayName())
+            .defaultValue(REPLACE.getValue())
             .build();
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -269,8 +270,8 @@ public class IdentifyMimeType extends AbstractProcessor {
                 try {
                     MimeType mimetype = mimeTypes.forName(mediatype.toString());
                     extension = mimetype.getExtension();
-                } catch (MimeTypeException ex) {
-                    logger.warn("MIME type extension lookup failed: {}", new Object[]{ex});
+                } catch (MimeTypeException e) {
+                    logger.warn("MIME type extension lookup failed", e);
                 }
 
                 mimeTypeRef.set(mediatype.toString());

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/IdentifyMimeType.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/IdentifyMimeType.java
@@ -47,6 +47,7 @@ import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
@@ -170,6 +171,15 @@ public class IdentifyMimeType extends AbstractProcessor {
         final Set<Relationship> rels = new HashSet<>();
         rels.add(REL_SUCCESS);
         this.relationships = Collections.unmodifiableSet(rels);
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        if (!config.hasProperty(CONFIG_STRATEGY)) {
+            if (config.isPropertySet(MIME_CONFIG_FILE) || config.isPropertySet(MIME_CONFIG_BODY)) {
+                config.setProperty(CONFIG_STRATEGY, REPLACE.getValue());
+            }
+        }
     }
 
     @OnScheduled

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestIdentifyMimeType.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestIdentifyMimeType.java
@@ -288,7 +288,7 @@ public class TestIdentifyMimeType {
     }
 
     @Test
-    public void testAddWithConfigBody() throws IOException {
+    public void testMergeWithConfigBody() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new IdentifyMimeType());
 
         final File dir = new File("src/test/resources/TestIdentifyMimeType");
@@ -300,7 +300,7 @@ public class TestIdentifyMimeType {
         }
 
         runner.setProperty(IdentifyMimeType.MIME_CONFIG_BODY, CONFIG_BODY);
-        runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.ADD);
+        runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.MERGE);
 
         runner.setThreadCount(1);
         runner.run(fileCount);
@@ -334,7 +334,7 @@ public class TestIdentifyMimeType {
     }
 
     @Test
-    public void testAddWithConfigFile() throws IOException {
+    public void testMergeWithConfigFile() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new IdentifyMimeType());
 
         final File dir = new File("src/test/resources/TestIdentifyMimeType");
@@ -346,7 +346,7 @@ public class TestIdentifyMimeType {
         }
 
         runner.setProperty(IdentifyMimeType.MIME_CONFIG_FILE, CONFIG_FILE);
-        runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.ADD);
+        runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.MERGE);
 
         runner.setThreadCount(1);
         runner.run(fileCount);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestIdentifyMimeType.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestIdentifyMimeType.java
@@ -35,6 +35,26 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestIdentifyMimeType {
 
+    private static final String CONFIG_FILE = "src/test/resources/TestIdentifyMimeType/.customConfig.xml";
+    private static final String CONFIG_BODY =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<mime-info>\n" +
+            "  <mime-type type=\"custom/abcd\">\n" +
+            "    <magic priority=\"50\">\n" +
+            "      <match value=\"abcd\" type=\"string\" offset=\"0\"/>\n" +
+            "    </magic>\n" +
+            "    <glob pattern=\"*.abcd\" />\n" +
+            "  </mime-type>\n" +
+            "  <mime-type type=\"image/png\">\n" +
+            "    <acronym>PNG</acronym>\n" +
+            "    <_comment>Portable Network Graphics</_comment>\n" +
+            "    <magic priority=\"50\">\n" +
+            "      <match value=\"\\x89PNG\\x0d\\x0a\\x1a\\x0a\" type=\"string\" offset=\"0\"/>\n" +
+            "    </magic>\n" +
+            "    <glob pattern=\"*.customPng\"/>\n" +
+            "  </mime-type>\n" +
+            "</mime-info>";
+
     @Test
     public void testFiles() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new IdentifyMimeType());
@@ -56,50 +76,16 @@ public class TestIdentifyMimeType {
 
         runner.assertAllFlowFilesTransferred(IdentifyMimeType.REL_SUCCESS, fileCount);
 
-        final Map<String, String> expectedMimeTypes = new HashMap<>();
-        expectedMimeTypes.put("1.7z", "application/x-7z-compressed");
-        expectedMimeTypes.put("1.mdb", "application/x-msaccess");
-        expectedMimeTypes.put("1.txt", "text/plain");
-        expectedMimeTypes.put("1.csv", "text/csv");
-        expectedMimeTypes.put("1.txt.bz2", "application/x-bzip2");
-        expectedMimeTypes.put("1.txt.gz", "application/gzip");
-        expectedMimeTypes.put("1.zip", "application/zip");
+        final Map<String, String> expectedMimeTypes = getCommonExpectedMimeTypes();
         expectedMimeTypes.put("bgBannerFoot.png", "image/png");
         expectedMimeTypes.put("blueBtnBg.jpg", "image/jpeg");
-        expectedMimeTypes.put("1.pdf", "application/pdf");
         expectedMimeTypes.put("grid.gif", "image/gif");
-        expectedMimeTypes.put("1.tar", "application/x-tar");
-        expectedMimeTypes.put("1.tar.gz", "application/gzip");
-        expectedMimeTypes.put("1.jar", "application/java-archive");
-        expectedMimeTypes.put("1.xml", "application/xml");
-        expectedMimeTypes.put("1.xhtml", "application/xhtml+xml");
-        expectedMimeTypes.put("flowfilev3", StandardFlowFileMediaType.VERSION_3.getMediaType());
-        expectedMimeTypes.put("flowfilev3WithXhtml", StandardFlowFileMediaType.VERSION_3.getMediaType());
-        expectedMimeTypes.put("flowfilev1.tar", StandardFlowFileMediaType.VERSION_1.getMediaType());
-        expectedMimeTypes.put("fake.csv", "text/csv");
         expectedMimeTypes.put("2.custom", "text/plain");
 
-        final Map<String, String> expectedExtensions = new HashMap<>();
-        expectedExtensions.put("1.7z", ".7z");
-        expectedExtensions.put("1.mdb", ".mdb");
-        expectedExtensions.put("1.txt", ".txt");
-        expectedExtensions.put("1.csv", ".csv");
-        expectedExtensions.put("1.txt.bz2", ".bz2");
-        expectedExtensions.put("1.txt.gz", ".gz");
-        expectedExtensions.put("1.zip", ".zip");
+        final Map<String, String> expectedExtensions = getCommonExpectedExtensions();
         expectedExtensions.put("bgBannerFoot.png", ".png");
         expectedExtensions.put("blueBtnBg.jpg", ".jpg");
-        expectedExtensions.put("1.pdf", ".pdf");
         expectedExtensions.put("grid.gif", ".gif");
-        expectedExtensions.put("1.tar", ".tar");
-        expectedExtensions.put("1.tar.gz", ".gz");
-        expectedExtensions.put("1.jar", ".jar");
-        expectedExtensions.put("1.xml", ".xml");
-        expectedExtensions.put("1.xhtml", ".xhtml");
-        expectedExtensions.put("flowfilev3", "");
-        expectedExtensions.put("flowfilev3WithXhtml", "");
-        expectedExtensions.put("flowfilev1.tar", "");
-        expectedExtensions.put("fake.csv", ".csv");
         expectedExtensions.put("2.custom", ".txt");
 
         final List<MockFlowFile> filesOut = runner.getFlowFilesForRelationship(IdentifyMimeType.REL_SUCCESS);
@@ -131,7 +117,7 @@ public class TestIdentifyMimeType {
     }
 
     @Test
-    public void testConfigBody() throws IOException {
+    public void testReplaceWithConfigBody() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new IdentifyMimeType());
 
 
@@ -148,24 +134,7 @@ public class TestIdentifyMimeType {
         }
 
 
-        String configBody = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                            "<mime-info>\n" +
-                            "  <mime-type type=\"custom/abcd\">\n" +
-                            "    <magic priority=\"50\">\n" +
-                            "      <match value=\"abcd\" type=\"string\" offset=\"0\"/>\n" +
-                            "    </magic>\n" +
-                            "    <glob pattern=\"*.abcd\" />\n" +
-                            "  </mime-type>\n" +
-                            "  <mime-type type=\"image/png\">\n" +
-                            "    <acronym>PNG</acronym>\n" +
-                            "    <_comment>Portable Network Graphics</_comment>\n" +
-                            "    <magic priority=\"50\">\n" +
-                            "      <match value=\"\\x89PNG\\x0d\\x0a\\x1a\\x0a\" type=\"string\" offset=\"0\"/>\n" +
-                            "    </magic>\n" +
-                            "    <glob pattern=\"*.customPng\"/>\n" +
-                            "  </mime-type>\n" +
-                            "</mime-info>";
-        runner.setProperty(IdentifyMimeType.MIME_CONFIG_BODY, configBody);
+        runner.setProperty(IdentifyMimeType.MIME_CONFIG_BODY, CONFIG_BODY);
 
         runner.setThreadCount(1);
         runner.run(fileCount);
@@ -234,7 +203,7 @@ public class TestIdentifyMimeType {
     }
 
     @Test
-    public void testConfigFile() throws IOException {
+    public void testReplaceWithConfigFile() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new IdentifyMimeType());
 
 
@@ -250,9 +219,7 @@ public class TestIdentifyMimeType {
             fileCount++;
         }
 
-
-        String configFile = "src/test/resources/TestIdentifyMimeType/.customConfig.xml";
-        runner.setProperty(IdentifyMimeType.MIME_CONFIG_FILE, configFile);
+        runner.setProperty(IdentifyMimeType.MIME_CONFIG_FILE, CONFIG_FILE);
 
         runner.setThreadCount(1);
         runner.run(fileCount);
@@ -321,11 +288,102 @@ public class TestIdentifyMimeType {
     }
 
     @Test
+    public void testAddWithConfigBody() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new IdentifyMimeType());
+
+        final File dir = new File("src/test/resources/TestIdentifyMimeType");
+        final File[] files = dir.listFiles((ldir,name)-> name != null && !name.startsWith(".") && new File(ldir, name).isFile());
+        int fileCount = 0;
+        for (final File file : files) {
+            runner.enqueue(file.toPath());
+            fileCount++;
+        }
+
+        runner.setProperty(IdentifyMimeType.MIME_CONFIG_BODY, CONFIG_BODY);
+        runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.ADD);
+
+        runner.setThreadCount(1);
+        runner.run(fileCount);
+
+        runner.assertAllFlowFilesTransferred(IdentifyMimeType.REL_SUCCESS, fileCount);
+
+        final Map<String, String> expectedMimeTypes = getCommonExpectedMimeTypes();
+        expectedMimeTypes.put("bgBannerFoot.png", "image/png");
+        expectedMimeTypes.put("blueBtnBg.jpg", "image/jpeg");
+        expectedMimeTypes.put("grid.gif", "image/gif");
+        expectedMimeTypes.put("2.custom", "custom/abcd");
+
+        final Map<String, String> expectedExtensions = getCommonExpectedExtensions();
+        expectedExtensions.put("bgBannerFoot.png", ".customPng");
+        expectedExtensions.put("blueBtnBg.jpg", ".jpg");
+        expectedExtensions.put("grid.gif", ".gif");
+        expectedExtensions.put("2.custom", ".abcd");
+
+        final List<MockFlowFile> filesOut = runner.getFlowFilesForRelationship(IdentifyMimeType.REL_SUCCESS);
+        for (final MockFlowFile file : filesOut) {
+            final String filename = file.getAttribute(CoreAttributes.FILENAME.key());
+            final String mimeType = file.getAttribute(CoreAttributes.MIME_TYPE.key());
+            final String expected = expectedMimeTypes.get(filename);
+
+            final String extension = file.getAttribute("mime.extension");
+            final String expectedExtension = expectedExtensions.get(filename);
+
+            assertEquals(expected, mimeType, "Expected " + file + " to have MIME Type " + expected + ", but it was " + mimeType);
+            assertEquals(expectedExtension, extension, "Expected " + file + " to have extension " + expectedExtension + ", but it was " + extension);
+        }
+    }
+
+    @Test
+    public void testAddWithConfigFile() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new IdentifyMimeType());
+
+        final File dir = new File("src/test/resources/TestIdentifyMimeType");
+        final File[] files = dir.listFiles((ldir,name)-> name != null && !name.startsWith(".") && new File(ldir, name).isFile());
+        int fileCount = 0;
+        for (final File file : files) {
+            runner.enqueue(file.toPath());
+            fileCount++;
+        }
+
+        runner.setProperty(IdentifyMimeType.MIME_CONFIG_FILE, CONFIG_FILE);
+        runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.ADD);
+
+        runner.setThreadCount(1);
+        runner.run(fileCount);
+
+        runner.assertAllFlowFilesTransferred(IdentifyMimeType.REL_SUCCESS, fileCount);
+
+        final Map<String, String> expectedMimeTypes = getCommonExpectedMimeTypes();
+        expectedMimeTypes.put("bgBannerFoot.png", "my/png");
+        expectedMimeTypes.put("blueBtnBg.jpg", "my/jpeg");
+        expectedMimeTypes.put("grid.gif", "my/gif");
+        expectedMimeTypes.put("2.custom", "text/plain");
+
+        final Map<String, String> expectedExtensions = getCommonExpectedExtensions();
+        expectedExtensions.put("bgBannerFoot.png", ".mypng");
+        expectedExtensions.put("blueBtnBg.jpg", ".myjpg");
+        expectedExtensions.put("grid.gif", ".mygif");
+        expectedExtensions.put("2.custom", ".txt");
+
+        final List<MockFlowFile> filesOut = runner.getFlowFilesForRelationship(IdentifyMimeType.REL_SUCCESS);
+        for (final MockFlowFile file : filesOut) {
+            final String filename = file.getAttribute(CoreAttributes.FILENAME.key());
+            final String mimeType = file.getAttribute(CoreAttributes.MIME_TYPE.key());
+            final String expected = expectedMimeTypes.get(filename);
+
+            final String extension = file.getAttribute("mime.extension");
+            final String expectedExtension = expectedExtensions.get(filename);
+
+            assertEquals(expected, mimeType, "Expected " + file + " to have MIME Type " + expected + ", but it was " + mimeType);
+            assertEquals(expectedExtension, extension, "Expected " + file + " to have extension " + expectedExtension + ", but it was " + extension);
+        }
+    }
+
+    @Test
     public void testOnlyOneCustomMimeConfigSpecified() {
         final TestRunner runner = TestRunners.newTestRunner(new IdentifyMimeType());
 
-        String configFile = "src/test/resources/TestIdentifyMimeType/.customConfig.xml";
-        runner.setProperty(IdentifyMimeType.MIME_CONFIG_FILE, configFile);
+        runner.setProperty(IdentifyMimeType.MIME_CONFIG_FILE, CONFIG_FILE);
 
         String configBody = "foo";
         runner.setProperty(IdentifyMimeType.MIME_CONFIG_BODY, configBody);
@@ -334,6 +392,54 @@ public class TestIdentifyMimeType {
         assertThrows(AssertionError.class, () -> {
             runner.run();
         });
+    }
+
+    private Map<String, String> getCommonExpectedMimeTypes() {
+        Map<String, String> expectedMimeTypes = new HashMap<>();
+
+        expectedMimeTypes.put("1.7z", "application/x-7z-compressed");
+        expectedMimeTypes.put("1.mdb", "application/x-msaccess");
+        expectedMimeTypes.put("1.txt", "text/plain");
+        expectedMimeTypes.put("1.csv", "text/csv");
+        expectedMimeTypes.put("1.txt.bz2", "application/x-bzip2");
+        expectedMimeTypes.put("1.txt.gz", "application/gzip");
+        expectedMimeTypes.put("1.zip", "application/zip");
+        expectedMimeTypes.put("1.pdf", "application/pdf");
+        expectedMimeTypes.put("1.tar", "application/x-tar");
+        expectedMimeTypes.put("1.tar.gz", "application/gzip");
+        expectedMimeTypes.put("1.jar", "application/java-archive");
+        expectedMimeTypes.put("1.xml", "application/xml");
+        expectedMimeTypes.put("1.xhtml", "application/xhtml+xml");
+        expectedMimeTypes.put("flowfilev3", StandardFlowFileMediaType.VERSION_3.getMediaType());
+        expectedMimeTypes.put("flowfilev3WithXhtml", StandardFlowFileMediaType.VERSION_3.getMediaType());
+        expectedMimeTypes.put("flowfilev1.tar", StandardFlowFileMediaType.VERSION_1.getMediaType());
+        expectedMimeTypes.put("fake.csv", "text/csv");
+
+        return expectedMimeTypes;
+    }
+
+    private Map<String, String> getCommonExpectedExtensions() {
+        Map<String, String> expectedExtensions = new HashMap<>();
+
+        expectedExtensions.put("1.7z", ".7z");
+        expectedExtensions.put("1.mdb", ".mdb");
+        expectedExtensions.put("1.txt", ".txt");
+        expectedExtensions.put("1.csv", ".csv");
+        expectedExtensions.put("1.txt.bz2", ".bz2");
+        expectedExtensions.put("1.txt.gz", ".gz");
+        expectedExtensions.put("1.zip", ".zip");
+        expectedExtensions.put("1.pdf", ".pdf");
+        expectedExtensions.put("1.tar", ".tar");
+        expectedExtensions.put("1.tar.gz", ".gz");
+        expectedExtensions.put("1.jar", ".jar");
+        expectedExtensions.put("1.xml", ".xml");
+        expectedExtensions.put("1.xhtml", ".xhtml");
+        expectedExtensions.put("flowfilev3", "");
+        expectedExtensions.put("flowfilev3WithXhtml", "");
+        expectedExtensions.put("flowfilev1.tar", "");
+        expectedExtensions.put("fake.csv", ".csv");
+
+        return expectedExtensions;
     }
 
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestIdentifyMimeType.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestIdentifyMimeType.java
@@ -133,7 +133,7 @@ public class TestIdentifyMimeType {
             fileCount++;
         }
 
-
+        runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.REPLACE);
         runner.setProperty(IdentifyMimeType.MIME_CONFIG_BODY, CONFIG_BODY);
 
         runner.setThreadCount(1);
@@ -219,6 +219,7 @@ public class TestIdentifyMimeType {
             fileCount++;
         }
 
+        runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.REPLACE);
         runner.setProperty(IdentifyMimeType.MIME_CONFIG_FILE, CONFIG_FILE);
 
         runner.setThreadCount(1);
@@ -299,8 +300,8 @@ public class TestIdentifyMimeType {
             fileCount++;
         }
 
-        runner.setProperty(IdentifyMimeType.MIME_CONFIG_BODY, CONFIG_BODY);
         runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.MERGE);
+        runner.setProperty(IdentifyMimeType.MIME_CONFIG_BODY, CONFIG_BODY);
 
         runner.setThreadCount(1);
         runner.run(fileCount);
@@ -345,8 +346,8 @@ public class TestIdentifyMimeType {
             fileCount++;
         }
 
-        runner.setProperty(IdentifyMimeType.MIME_CONFIG_FILE, CONFIG_FILE);
         runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.MERGE);
+        runner.setProperty(IdentifyMimeType.MIME_CONFIG_FILE, CONFIG_FILE);
 
         runner.setThreadCount(1);
         runner.run(fileCount);
@@ -383,10 +384,23 @@ public class TestIdentifyMimeType {
     public void testOnlyOneCustomMimeConfigSpecified() {
         final TestRunner runner = TestRunners.newTestRunner(new IdentifyMimeType());
 
+        runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.REPLACE);
         runner.setProperty(IdentifyMimeType.MIME_CONFIG_FILE, CONFIG_FILE);
 
         String configBody = "foo";
         runner.setProperty(IdentifyMimeType.MIME_CONFIG_BODY, configBody);
+
+        runner.setThreadCount(1);
+        assertThrows(AssertionError.class, () -> {
+            runner.run();
+        });
+    }
+
+    @Test
+    public void testNoCustomMimeConfigSpecified() {
+        final TestRunner runner = TestRunners.newTestRunner(new IdentifyMimeType());
+
+        runner.setProperty(IdentifyMimeType.CONFIG_STRATEGY, IdentifyMimeType.REPLACE);
 
         runner.setThreadCount(1);
         assertThrows(AssertionError.class, () -> {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestIdentifyMimeType/.customConfig.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestIdentifyMimeType/.customConfig.xml
@@ -5,7 +5,7 @@
     <_comment>Graphics Interchange Format</_comment>
     <tika:link>http://en.wikipedia.org/wiki/Gif</tika:link>
     <tika:uti>com.compuserve.gif</tika:uti>
-    <magic priority="50">
+    <magic priority="80">
       <match value="GIF87a" type="string" offset="0"/>
       <match value="GIF89a" type="string" offset="0"/>
     </magic>
@@ -14,7 +14,7 @@
   <mime-type type="my/png">
     <acronym>PNG</acronym>
     <_comment>Portable Network Graphics</_comment>
-    <magic priority="50">
+    <magic priority="80">
       <match value="\x89PNG\x0d\x0a\x1a\x0a" type="string" offset="0"/>
     </magic>
     <glob pattern="*.mypng"/>
@@ -24,7 +24,7 @@
     <_comment>Joint Photographic Experts Group</_comment>
     <tika:link>http://en.wikipedia.org/wiki/Jpeg</tika:link>
     <tika:uti>public.jpeg</tika:uti>
-    <magic priority="50">
+    <magic priority="80">
       <!-- FFD8 is the SOI (Start Of Image) marker.              -->
       <!-- It is followed by another marker that starts with FF. -->
       <match value="0xffd8ff" type="string" offset="0"/>


### PR DESCRIPTION

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-11463](https://issues.apache.org/jira/browse/NIFI-11463)
This allows users to define their own mime types as well using the out of the box tika mime type definitions at the same time.

User defined mime types take precedence over the default definitions.

This also provides a workaround for [NIFI-11084](https://issues.apache.org/jira/browse/NIFI-11084) as noted in comment there.

To test,
For IdentifyMimeType Config File property, use  [.customConfig.xml](https://github.com/apache/nifi/blob/rel/nifi-1.23.2/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestIdentifyMimeType/.customConfig.xml) 

Test 1:
For Config Strategy use "add"
Pass through [jpg](https://github.com/apache/nifi/blob/rel/nifi-1.23.2/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestIdentifyMimeType/blueBtnBg.jpg) and [zip](https://github.com/apache/nifi/blob/rel/nifi-1.23.2/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestIdentifyMimeType/1.zip) files.
Verify mime.type is my/jpeg and application/zip, respectively

Test 2 (this verifies previously existing processor behaviour still works as before):
for Config Strategy use "replace"
pass through previous two files
Verify mime.type is my/jpeg and application/octet-stream, respectively.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
