### PR TITLE
NIFI-6721: jms_expiration attribute problem fix (2nd attempt)

### DIFF
--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
@@ -85,7 +85,7 @@ import static org.apache.nifi.jms.processors.ioconcept.reader.record.ProvenanceE
         + "FlowFile attributes will be added as JMS headers and/or properties to the outgoing JMS message.")
 @ReadsAttributes({
         @ReadsAttribute(attribute = JmsHeaders.DELIVERY_MODE, description = "This attribute becomes the JMSDeliveryMode message header. Must be an integer."),
-        @ReadsAttribute(attribute = JmsHeaders.EXPIRATION, description = "This attribute becomes the JMSExpiration message header. Must be an integer."),
+        @ReadsAttribute(attribute = JmsHeaders.EXPIRATION, description = "This attribute becomes the JMSExpiration message header. Must be a long."),
         @ReadsAttribute(attribute = JmsHeaders.PRIORITY, description = "This attribute becomes the JMSPriority message header. Must be an integer."),
         @ReadsAttribute(attribute = JmsHeaders.REDELIVERED, description = "This attribute becomes the JMSRedelivered message header."),
         @ReadsAttribute(attribute = JmsHeaders.TIMESTAMP, description = "This attribute becomes the JMSTimestamp message header. Must be a long."),

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/JMSPublisherConsumerIT.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/JMSPublisherConsumerIT.java
@@ -41,6 +41,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -261,6 +262,41 @@ public class JMSPublisherConsumerIT {
         }
     }
 
+    @Test
+    public void validateNIFI6721() throws Exception {
+
+        final String destinationName = "validateNIFI6721";
+        JmsTemplate jmsTemplate = CommonTest.buildJmsTemplateForDestination(false);
+
+        try {
+            ComponentLog mockLog = mock(ComponentLog.class);
+            JMSPublisher publisher = new JMSPublisher((CachingConnectionFactory) jmsTemplate.getConnectionFactory(), jmsTemplate, mockLog);
+            Map<String, String> flowFileAttributes = new HashMap<>();
+            flowFileAttributes.put(JmsHeaders.EXPIRATION, "never"); // value expected to be long, make sure non-long doesn't cause problems
+            publisher.publish(destinationName, "hellomq-0".getBytes(), flowFileAttributes);
+            Message receivedMessage = jmsTemplate.receive(destinationName);
+            assertEquals(0, receivedMessage.getJMSExpiration());
+
+            long expiration = Instant.now().toEpochMilli() + 1000 * 120;
+            flowFileAttributes.put(JmsHeaders.EXPIRATION, Long.toString(expiration));
+            publisher.publish(destinationName, "hellomq-1".getBytes(), flowFileAttributes);
+            receivedMessage = jmsTemplate.receive(destinationName);
+            assertEquals(expiration, receivedMessage.getJMSExpiration());
+
+            flowFileAttributes.put(JmsHeaders.EXPIRATION, "-1");
+            publisher.publish(destinationName, "hellomq-3".getBytes(), flowFileAttributes);
+            receivedMessage = jmsTemplate.receive(destinationName);
+            assertTrue(receivedMessage.getJMSExpiration() > 0);
+
+            flowFileAttributes.put(JmsHeaders.EXPIRATION, "0");
+            publisher.publish(destinationName, "hellomq-2".getBytes(), flowFileAttributes);
+            //assertEquals(mockLog.getWarnMessages().size(), 0);
+            receivedMessage = jmsTemplate.receive(destinationName);
+            assertEquals(0, receivedMessage.getJMSExpiration());
+        } finally {
+            ((CachingConnectionFactory) jmsTemplate.getConnectionFactory()).destroy();
+        }
+    }
     /**
      * At the moment the only two supported message types are TextMessage and
      * BytesMessage which is sufficient for the type if JMS use cases NiFi is


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-6721](https://issues.apache.org/jira/browse/NIFI-6721)

Cherry-picked commit in this PR: https://github.com/apache/nifi/pull/4270 into this branch.  Updated JMSPublisher.java to add comments and added handling for expiration == 0.  Updated integration test to junit5 and augmented it to also verify expiration == 0 case. 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ x] Pull Request based on current revision of the `main` branch
- [ x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x ] Build completed using `mvn clean install -P contrib-check`
  - [ x] JDK 21

### Licensing

- [x ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ x] Documentation formatting appears as expected in rendered files
