### PR TITLE
NIFI-12126: Downgrade snowflake-jdbc to 3.13.33

### DIFF
--- a/nifi-nar-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-snowflake-bundle/pom.xml
@@ -40,7 +40,8 @@
             <dependency>
                 <groupId>net.snowflake</groupId>
                 <artifactId>snowflake-jdbc</artifactId>
-                <version>3.14.1</version>
+                <!-- please check snowflake-ingest-sdk compatibility before upgrade -->
+                <version>3.13.33</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
snowflake-ingest-sdk:2.0.3 is not compatible with snowflake-jdbc:3.14.x

# Summary

[NIFI-12126](https://issues.apache.org/jira/browse/NIFI-12126)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
