### PR TITLE
NIFI-12151 Fixed StandardPrivateKeyService fails due to missing Bounc…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-key-service-bundle/nifi-key-service/src/main/java/org/apache/nifi/key/service/reader/BouncyCastlePrivateKeyReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-key-service-bundle/nifi-key-service/src/main/java/org/apache/nifi/key/service/reader/BouncyCastlePrivateKeyReader.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.key.service.reader;
 
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMDecryptorProvider;
 import org.bouncycastle.openssl.PEMEncryptedKeyPair;
 import org.bouncycastle.openssl.PEMException;
@@ -41,6 +42,8 @@ import java.security.PrivateKey;
  */
 public class BouncyCastlePrivateKeyReader implements PrivateKeyReader {
     private static final String INVALID_PEM = "Invalid PEM";
+
+    private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
 
     /**
      * Read Private Key using Bouncy Castle PEM Parser
@@ -81,7 +84,9 @@ public class BouncyCastlePrivateKeyReader implements PrivateKeyReader {
 
     private PrivateKeyInfo readEncryptedPrivateKey(final PKCS8EncryptedPrivateKeyInfo encryptedPrivateKeyInfo, final char[] keyPassword) {
         try {
-            final InputDecryptorProvider provider = new JceOpenSSLPKCS8DecryptorProviderBuilder().build(keyPassword);
+            final InputDecryptorProvider provider = new JceOpenSSLPKCS8DecryptorProviderBuilder()
+                    .setProvider(BOUNCY_CASTLE_PROVIDER)
+                    .build(keyPassword);
             return encryptedPrivateKeyInfo.decryptPrivateKeyInfo(provider);
         } catch (final OperatorCreationException e) {
             throw new PrivateKeyException("Preparing Private Key Decryption failed", e);
@@ -91,7 +96,9 @@ public class BouncyCastlePrivateKeyReader implements PrivateKeyReader {
     }
 
     private PrivateKeyInfo readEncryptedPrivateKey(final PEMEncryptedKeyPair encryptedKeyPair, final char[] keyPassword) {
-        final PEMDecryptorProvider provider = new JcePEMDecryptorProviderBuilder().build(keyPassword);
+        final PEMDecryptorProvider provider = new JcePEMDecryptorProviderBuilder()
+                .setProvider(BOUNCY_CASTLE_PROVIDER)
+                .build(keyPassword);
         try {
             final PEMKeyPair pemKeyPair = encryptedKeyPair.decryptKeyPair(provider);
             return pemKeyPair.getPrivateKeyInfo();

--- a/nifi-nar-bundles/nifi-standard-services/nifi-key-service-bundle/nifi-key-service/src/test/java/org/apache/nifi/key/service/StandardPrivateKeyServiceTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-key-service-bundle/nifi-key-service/src/test/java/org/apache/nifi/key/service/StandardPrivateKeyServiceTest.java
@@ -21,7 +21,8 @@ import org.apache.nifi.util.NoOpProcessor;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 
-import org.bouncycastle.openssl.PKCS8Generator;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
 import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder;
@@ -30,6 +31,8 @@ import org.bouncycastle.operator.OutputEncryptor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -42,10 +45,22 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.util.UUID;
 
+import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.AES_128_CBC;
+import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.AES_192_CBC;
+import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.AES_256_CBC;
+import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.DES3_CBC;
+import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_2DES;
+import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_3DES;
+import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_RC2_128;
+import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_RC2_40;
+import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_RC4_128;
+import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_RC4_40;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class StandardPrivateKeyServiceTest {
     private static final String SERVICE_ID = StandardPrivateKeyServiceTest.class.getSimpleName();
+
+    private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
 
     private static final String PATH_NOT_FOUND = "/path/not/found";
 
@@ -103,10 +118,11 @@ class StandardPrivateKeyServiceTest {
         assertEquals(generatedPrivateKey, privateKey);
     }
 
-    @Test
-    void testGetPrivateKeyEncryptedKey() throws Exception {
+    @ParameterizedTest
+    @MethodSource("encryptionAlgorithms")
+    void testGetPrivateKeyEncryptedKey(final String encryptionAlgorithm) throws Exception {
         final String password = UUID.randomUUID().toString();
-        final OutputEncryptor outputEncryptor = getOutputEncryptor(password);
+        final OutputEncryptor outputEncryptor = getOutputEncryptor(encryptionAlgorithm, password);
         final String encryptedPrivateKey = getEncodedPrivateKey(generatedPrivateKey, outputEncryptor);
         final Path keyPath = writeKey(encryptedPrivateKey);
 
@@ -116,6 +132,21 @@ class StandardPrivateKeyServiceTest {
 
         final PrivateKey privateKey = service.getPrivateKey();
         assertEquals(generatedPrivateKey, privateKey);
+    }
+
+    private static String[] encryptionAlgorithms() {
+        return new String[] {
+                AES_128_CBC,
+                AES_192_CBC,
+                AES_256_CBC,
+                DES3_CBC,
+                PBE_SHA1_RC4_128,
+                PBE_SHA1_RC4_40,
+                PBE_SHA1_3DES,
+                PBE_SHA1_2DES,
+                PBE_SHA1_RC2_128,
+                PBE_SHA1_RC2_40
+        };
     }
 
     private Path writeKey(final String encodedPrivateKey) throws IOException {
@@ -137,8 +168,9 @@ class StandardPrivateKeyServiceTest {
         return stringWriter.toString();
     }
 
-    private OutputEncryptor getOutputEncryptor(final String password) throws OperatorCreationException {
-        return new JceOpenSSLPKCS8EncryptorBuilder(PKCS8Generator.PBE_SHA1_3DES)
+    private OutputEncryptor getOutputEncryptor(final String encryptionAlgorithm, final String password) throws OperatorCreationException {
+        return new JceOpenSSLPKCS8EncryptorBuilder(new ASN1ObjectIdentifier(encryptionAlgorithm))
+                .setProvider(BOUNCY_CASTLE_PROVIDER)
                 .setPassword(password.toCharArray())
                 .build();
     }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-key-service-bundle/nifi-key-service/src/test/java/org/apache/nifi/key/service/StandardPrivateKeyServiceTest.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-key-service-bundle/nifi-key-service/src/test/java/org/apache/nifi/key/service/StandardPrivateKeyServiceTest.java
@@ -45,16 +45,9 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.util.UUID;
 
-import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.AES_128_CBC;
-import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.AES_192_CBC;
 import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.AES_256_CBC;
 import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.DES3_CBC;
-import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_2DES;
 import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_3DES;
-import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_RC2_128;
-import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_RC2_40;
-import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_RC4_128;
-import static org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder.PBE_SHA1_RC4_40;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class StandardPrivateKeyServiceTest {
@@ -136,16 +129,9 @@ class StandardPrivateKeyServiceTest {
 
     private static String[] encryptionAlgorithms() {
         return new String[] {
-                AES_128_CBC,
-                AES_192_CBC,
                 AES_256_CBC,
                 DES3_CBC,
-                PBE_SHA1_RC4_128,
-                PBE_SHA1_RC4_40,
-                PBE_SHA1_3DES,
-                PBE_SHA1_2DES,
-                PBE_SHA1_RC2_128,
-                PBE_SHA1_RC2_40
+                PBE_SHA1_3DES
         };
     }
 


### PR DESCRIPTION
…yCastleProvider

# Summary

[NIFI-12151](https://issues.apache.org/jira/browse/NIFI-12151)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
