### PR TITLE
NIFI-12152 Refactored addProvider() Bouncy Castle references

### DIFF
--- a/nifi-commons/nifi-security-ssl/src/main/java/org/apache/nifi/security/ssl/StandardKeyStoreBuilder.java
+++ b/nifi-commons/nifi-security-ssl/src/main/java/org/apache/nifi/security/ssl/StandardKeyStoreBuilder.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
+import java.security.Provider;
 import java.security.cert.CertificateException;
 import java.util.Objects;
 
@@ -29,7 +29,7 @@ import java.util.Objects;
  * Standard implementation of Key Store Builder
  */
 public class StandardKeyStoreBuilder implements KeyStoreBuilder {
-    private String provider;
+    private Provider provider;
 
     private String type = KeyStore.getDefaultType();
 
@@ -65,7 +65,7 @@ public class StandardKeyStoreBuilder implements KeyStoreBuilder {
      * @param provider Key Store Provider
      * @return Builder
      */
-    public StandardKeyStoreBuilder provider(final String provider) {
+    public StandardKeyStoreBuilder provider(final Provider provider) {
         this.provider = Objects.requireNonNull(provider, "Key Store Provider required");
         return this;
     }
@@ -108,9 +108,6 @@ public class StandardKeyStoreBuilder implements KeyStoreBuilder {
             return provider == null ? KeyStore.getInstance(type) : KeyStore.getInstance(type, provider);
         } catch (final KeyStoreException e) {
             final String message = String.format("Key Store Type [%s] creation failed", type);
-            throw new BuilderConfigurationException(message, e);
-        } catch (final NoSuchProviderException e) {
-            final String message = String.format("Key Store Type [%s] Provider [%s] creation failed", type, provider);
             throw new BuilderConfigurationException(message, e);
         }
     }

--- a/nifi-nar-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/test/java/org/apache/nifi/processors/snowflake/SnowflakePipeIT.java
+++ b/nifi-nar-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/test/java/org/apache/nifi/processors/snowflake/SnowflakePipeIT.java
@@ -17,7 +17,6 @@
 
 package org.apache.nifi.processors.snowflake;
 
-import java.security.Security;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,16 +28,9 @@ import org.apache.nifi.processors.snowflake.util.SnowflakeAttributes;
 import org.apache.nifi.processors.snowflake.util.SnowflakeInternalStageType;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class SnowflakePipeIT implements SnowflakeConfigAware {
-
-    @BeforeAll
-    static void setUpOnce() {
-        Security.addProvider(new BouncyCastleProvider());
-    }
 
     @Test
     void shouldPutIntoInternalStage() throws Exception {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/CryptographicHashContentTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/CryptographicHashContentTest.java
@@ -22,15 +22,12 @@ import org.apache.nifi.security.util.crypto.HashService;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.Security;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -40,11 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class CryptographicHashContentTest {
     private TestRunner runner;
-
-    @BeforeAll
-    static void setUpOnce() {
-        Security.addProvider(new BouncyCastleProvider());
-    }
 
     @BeforeEach
     void setupRunner() {

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryPropertiesLoader.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryPropertiesLoader.java
@@ -21,14 +21,12 @@ import org.apache.nifi.properties.SensitivePropertyProvider;
 import org.apache.nifi.properties.SensitivePropertyProviderFactory;
 import org.apache.nifi.properties.StandardSensitivePropertyProviderFactory;
 import org.apache.nifi.registry.properties.util.NiFiRegistryBootstrapUtils;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.security.Security;
 import java.util.Properties;
 
 public class NiFiRegistryPropertiesLoader {
@@ -125,7 +123,6 @@ public class NiFiRegistryPropertiesLoader {
     public NiFiRegistryProperties load(final File file) {
         final ProtectedNiFiRegistryProperties protectedNiFiProperties = readProtectedPropertiesFromDisk(file);
         if (protectedNiFiProperties.hasProtectedKeys()) {
-            Security.addProvider(new BouncyCastleProvider());
             getSensitivePropertyProviderFactory()
                     .getSupportedProviders()
                     .forEach(protectedNiFiProperties::addSensitivePropertyProvider);

--- a/nifi-registry/nifi-registry-core/nifi-registry-security-utils/src/main/java/org/apache/nifi/registry/security/util/KeyStoreUtils.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-security-utils/src/main/java/org/apache/nifi/registry/security/util/KeyStoreUtils.java
@@ -17,42 +17,13 @@
 
 package org.apache.nifi.registry.security.util;
 
-import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.security.KeyStore;
 import java.security.KeyStoreException;
-import java.security.Security;
-import java.util.HashMap;
-import java.util.Map;
 
 public class KeyStoreUtils {
-    private static final Logger logger = LoggerFactory.getLogger(KeyStoreUtils.class);
-
-    private static final String SUN_SECURITY_PROVIDER = "SUN";
-
-    private static final Map<String, String> KEY_STORE_TYPE_PROVIDERS = new HashMap<>();
-
-    static {
-        Security.addProvider(new BouncyCastleProvider());
-
-        KEY_STORE_TYPE_PROVIDERS.put(KeystoreType.JKS.toString(), SUN_SECURITY_PROVIDER);
-        KEY_STORE_TYPE_PROVIDERS.put(KeystoreType.PKCS12.toString(), BouncyCastleProvider.PROVIDER_NAME);
-        KEY_STORE_TYPE_PROVIDERS.put(KeystoreType.BCFKS.toString(), BouncyCastleProvider.PROVIDER_NAME);
-    }
-
-    /**
-     * Returns the provider that will be used for the given keyStoreType
-     *
-     * @param keyStoreType the keyStoreType
-     * @return the provider that will be used
-     */
-    public static String getKeyStoreProvider(final String keyStoreType) {
-        final String storeType = StringUtils.upperCase(keyStoreType);
-        return KEY_STORE_TYPE_PROVIDERS.get(storeType);
-    }
+    private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
 
     /**
      * Returns an empty KeyStore backed by the appropriate provider
@@ -62,15 +33,10 @@ public class KeyStoreUtils {
      * @throws KeyStoreException if a KeyStore of the given type cannot be instantiated
      */
     public static KeyStore getKeyStore(final String keyStoreType) throws KeyStoreException {
-        final String keyStoreProvider = getKeyStoreProvider(keyStoreType);
-        if (StringUtils.isNotEmpty(keyStoreProvider)) {
-            try {
-                return KeyStore.getInstance(keyStoreType, keyStoreProvider);
-            } catch (Exception e) {
-                logger.error("Unable to load " + keyStoreProvider + " " + keyStoreType
-                        + " keystore.  This may cause issues getting trusted CA certificates as well as Certificate Chains for use in TLS.", e);
-            }
+        if (KeystoreType.BCFKS.toString().equals(keyStoreType)) {
+            return KeyStore.getInstance(keyStoreType, BOUNCY_CASTLE_PROVIDER);
+        } else {
+            return KeyStore.getInstance(keyStoreType);
         }
-        return KeyStore.getInstance(keyStoreType);
     }
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-security-utils/src/test/java/org/apache/nifi/registry/security/util/KeyStoreUtilsTest.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-security-utils/src/test/java/org/apache/nifi/registry/security/util/KeyStoreUtilsTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.registry.security.util;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Test;
 
 import java.security.KeyStore;
@@ -24,7 +23,6 @@ import java.security.KeyStoreException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class KeyStoreUtilsTest {
 
@@ -35,17 +33,5 @@ public class KeyStoreUtilsTest {
             assertNotNull(keyStore, String.format("KeyStore not found for Keystore Type [%s]", keystoreType));
             assertEquals(keystoreType.name(), keyStore.getType());
         }
-    }
-
-    @Test
-    public void testGetKeyStoreProviderNullType() {
-        final String keyStoreProvider = KeyStoreUtils.getKeyStoreProvider(null);
-        assertNull(keyStoreProvider);
-    }
-
-    @Test
-    public void testGetKeyStoreProviderBouncyCastleProvider() {
-        final String keyStoreProvider = KeyStoreUtils.getKeyStoreProvider(KeystoreType.PKCS12.name());
-        assertEquals(BouncyCastleProvider.PROVIDER_NAME, keyStoreProvider);
     }
 }

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/main/groovy/org/apache/nifi/properties/ConfigEncryptionTool.groovy
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/main/groovy/org/apache/nifi/properties/ConfigEncryptionTool.groovy
@@ -43,7 +43,6 @@ import org.apache.nifi.util.NiFiProperties
 import org.apache.nifi.util.console.TextDevice
 import org.apache.nifi.util.console.TextDevices
 import org.bouncycastle.crypto.generators.SCrypt
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.xml.sax.SAXException
@@ -56,7 +55,6 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import java.security.KeyException
-import java.security.Security
 import java.util.function.Supplier
 import java.util.regex.Matcher
 import java.util.zip.GZIPInputStream
@@ -1348,8 +1346,6 @@ class ConfigEncryptionTool {
      * @param args the command-line arguments
      */
     static void main(String[] args) {
-        Security.addProvider(new BouncyCastleProvider())
-
         ConfigEncryptionTool tool = new ConfigEncryptionTool()
 
         try {

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/main/groovy/org/apache/nifi/toolkit/encryptconfig/EncryptConfigMain.groovy
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/main/groovy/org/apache/nifi/toolkit/encryptconfig/EncryptConfigMain.groovy
@@ -19,11 +19,8 @@ package org.apache.nifi.toolkit.encryptconfig
 import org.apache.commons.cli.HelpFormatter
 import org.apache.commons.cli.Options
 import org.apache.nifi.properties.ConfigEncryptionTool
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-
-import java.security.Security
 
 class EncryptConfigMain {
 
@@ -90,8 +87,6 @@ class EncryptConfigMain {
     }
 
     static void main(String[] args) {
-        Security.addProvider(new BouncyCastleProvider())
-
         if (args.length < 1) {
             printUsageAndExit(EXIT_STATUS_FAILURE)
         }

--- a/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/util/TlsHelperTest.java
+++ b/nifi-toolkit/nifi-toolkit-tls/src/test/java/org/apache/nifi/toolkit/tls/util/TlsHelperTest.java
@@ -28,10 +28,8 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
-import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
 import org.bouncycastle.util.IPAddress;
 import org.junit.jupiter.api.BeforeAll;
@@ -59,7 +57,6 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.Security;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -89,25 +86,11 @@ public class TlsHelperTest {
     private int keySize;
     private String keyPairAlgorithm;
 
-    public static KeyPair loadKeyPair(final Reader reader) throws IOException {
-        try (PEMParser pemParser = new PEMParser(reader)) {
-            Object object = pemParser.readObject();
-            assertEquals(PEMKeyPair.class, object.getClass());
-            return new JcaPEMKeyConverter().getKeyPair((PEMKeyPair) object);
-        }
-    }
-
-    public static KeyPair loadKeyPair(File file) throws IOException {
-        try (final FileReader fileReader = new FileReader(file)) {
-            return loadKeyPair(fileReader);
-        }
-    }
-
     public static X509Certificate loadCertificate(final Reader reader) throws IOException, CertificateException {
         try (PEMParser pemParser = new PEMParser(reader)) {
             Object object = pemParser.readObject();
             assertEquals(X509CertificateHolder.class, object.getClass());
-            return new JcaX509CertificateConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME).getCertificate((X509CertificateHolder) object);
+            return new JcaX509CertificateConverter().getCertificate((X509CertificateHolder) object);
         }
     }
 
@@ -310,8 +293,6 @@ public class TlsHelperTest {
 
     @Test
     public void testOutputToFileTwoCertsAsPem(@TempDir final File folder) throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException {
-        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
-
         KeyStore keyStore = setupKeystore();
         HashMap<String, Certificate> certs = TlsHelper.extractCerts(keyStore);
         TlsHelper.outputCertsAsPem(certs, folder,".crt");


### PR DESCRIPTION
# Summary

[NIFI-12152](https://issues.apache.org/jira/browse/NIFI-12152) Refactors references to `Security.addProvider()` with global registration of the Bouncy Castle Provider.

Changes include removing unnecessary registration from multiple test classes and adjusting references to use an instance of `BouncyCastleProvider` instead of the `BC` provider name string that requires global registration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
