### PR TITLE
NIFI-10425: change StoreScanner scanner instantiation to not report r…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/util/StoreScanner.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/util/StoreScanner.java
@@ -62,11 +62,6 @@ public class StoreScanner extends ContainerLifeCycle implements Scanner.Discrete
                 throw new IllegalArgumentException(String.format("expected %s file not directory", resourceName));
             }
 
-            if (resource.getAlias() != null) {
-                // this resource has an alias, use the alias, as that's what's returned in the Scanner
-                monitoredFile = new File(resource.getAlias());
-            }
-
             file = monitoredFile;
             if (LOG.isDebugEnabled()) {
                 LOG.debug("File monitoring started {} [{}]", resourceName, monitoredFile);
@@ -80,7 +75,7 @@ public class StoreScanner extends ContainerLifeCycle implements Scanner.Discrete
             throw new IllegalArgumentException(String.format("error obtaining %s dir", resourceName));
         }
 
-        scanner = new Scanner();
+        scanner = new Scanner(null, false);
         scanner.setScanDirs(Collections.singletonList(parentFile));
         scanner.setScanInterval(1);
         scanner.setReportDirs(false);


### PR DESCRIPTION
…eal paths

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10425](https://issues.apache.org/jira/browse/NIFI-10425)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
