### PR TITLE
NIFI-12142 Correct Cluster Pool Size Method Reference

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/resources/nifi-cluster-protocol-context.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/resources/nifi-cluster-protocol-context.xml
@@ -43,7 +43,7 @@
         <constructor-arg ref="protocolSocketConfiguration"/>
         <constructor-arg ref="protocolContext"/>
         <constructor-arg>
-            <bean factory-bean="nifiProperties" factory-method="getClusterNodeProtocolThreads"/>
+            <bean factory-bean="nifiProperties" factory-method="getClusterNodeProtocolMaxPoolSize"/>
         </constructor-arg>
         <property name="handshakeTimeout">
             <bean factory-bean="nifiProperties" factory-method="getClusterNodeConnectionTimeout"/>
@@ -73,7 +73,7 @@
     <!-- protocol listener -->
     <bean id="protocolListener" class="org.apache.nifi.cluster.protocol.impl.SocketProtocolListener">
         <constructor-arg index="0">
-            <bean factory-bean="nifiProperties" factory-method="getClusterNodeProtocolThreads"/>
+            <bean factory-bean="nifiProperties" factory-method="getClusterNodeProtocolMaxPoolSize"/>
         </constructor-arg>
         <constructor-arg index="1">
             <bean factory-bean="nifiProperties" factory-method="getClusterNodeProtocolPort"/>


### PR DESCRIPTION
# Summary

[NIFI-12142](https://issues.apache.org/jira/browse/NIFI-12142) Corrects Cluster Pool Size method reference in the Spring configuration for Cluster Protocol communication, replacing the deprecated and removed method.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
