### PR TITLE
NIFI-12154 Upgrade Apache Avro from 1.11.2 to 1.11.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <ranger.version>2.4.0</ranger.version>
         <jetty.version>10.0.16</jetty.version>
         <jackson.bom.version>2.15.2</jackson.bom.version>
-        <avro.version>1.11.2</avro.version>
+        <avro.version>1.11.3</avro.version>
         <jaxb.runtime.version>2.3.8</jaxb.runtime.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>


### PR DESCRIPTION
# Summary

[NIFI-12154](https://issues.apache.org/jira/browse/NIFI-12154) Upgrades Apache Avro from 1.11.2 to [1.11.3](https://github.com/apache/avro/releases/tag/release-1.11.3) incorporating a resolution for [CVE-2023-39410](https://www.cve.org/CVERecord?id=CVE-2023-39410) related to potential memory exhaustion when read a crafted input stream. 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
