### PR TITLE
NIFI-12155 Upgrade Apache Commons IO to 2.14.0 and POI to 5.2.4

### DIFF
--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
     <properties>
         <spring.integration.version>5.5.18</spring.integration.version>
-        <poi.version>5.2.3</poi.version>
+        <poi.version>5.2.4</poi.version>
     </properties>
 
     <dependencies>

--- a/nifi-nar-bundles/nifi-media-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/pom.xml
@@ -26,7 +26,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <poi.version>5.2.3</poi.version>
+        <poi.version>5.2.4</poi.version>
     </properties>
 
     <modules>

--- a/nifi-nar-bundles/nifi-poi-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-poi-bundle/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>nifi-poi-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <poi.version>5.2.3</poi.version>
+        <poi.version>5.2.4</poi.version>
     </properties>
     <modules>
         <module>nifi-poi-nar</module>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <org.apache.commons.compress.version>1.24.0</org.apache.commons.compress.version>
         <org.apache.commons.lang3.version>3.13.0</org.apache.commons.lang3.version>
         <org.apache.commons.net.version>3.9.0</org.apache.commons.net.version>
-        <org.apache.commons.io.version>2.13.0</org.apache.commons.io.version>
+        <org.apache.commons.io.version>2.14.0</org.apache.commons.io.version>
         <org.apache.commons.text.version>1.10.0</org.apache.commons.text.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>


### PR DESCRIPTION
# Summary

[NIFI-12155](https://issues.apache.org/jira/browse/NIFI-12155) Upgrades Apache Commons IO from 2.13.0 to [2.14.0](https://commons.apache.org/proper/commons-io/changes-report.html#a2.14.0) and Apache POI from 5.2.3 to [5.2.4](https://commons.apache.org/proper/commons-io/changes-report.html#a2.14.0) incorporating bug fixes and transitive dependency upgrades.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
