### PR TITLE
NIFI-12067 MockProcessSession Removes Created FF on Rollback

### DIFF
--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
@@ -68,6 +68,7 @@ public class MockProcessSession implements ProcessSession {
     private final Map<Relationship, List<MockFlowFile>> transferMap = new ConcurrentHashMap<>();
     private final MockFlowFileQueue processorQueue;
     private final Set<Long> beingProcessed = new HashSet<>();
+    private final Set<Long> created = new HashSet<>();
     private final List<MockFlowFile> penalized = new ArrayList<>();
     private final Processor processor;
 
@@ -212,6 +213,10 @@ public class MockProcessSession implements ProcessSession {
             if (removedFlowFiles.remove(flowFile.getId())) {
                 newOwner.removedFlowFiles.add(flowFile.getId());
             }
+
+            if (created.remove(flowFile.getId())) {
+                newOwner.created.add(flowFile.getId());
+            }
         }
 
         final Set<String> flowFileIds = flowFiles.stream()
@@ -225,8 +230,7 @@ public class MockProcessSession implements ProcessSession {
     public MockFlowFile clone(FlowFile flowFile) {
         flowFile = validateState(flowFile);
         final MockFlowFile newFlowFile = new MockFlowFile(sharedState.nextFlowFileId(), flowFile);
-        currentVersions.put(newFlowFile.getId(), newFlowFile);
-        beingProcessed.add(newFlowFile.getId());
+        updateStateWithNewFlowFile(newFlowFile);
         return newFlowFile;
     }
 
@@ -241,8 +245,7 @@ public class MockProcessSession implements ProcessSession {
         final byte[] newContent = Arrays.copyOfRange(((MockFlowFile) flowFile).getData(), (int) offset, (int) (offset + size));
         newFlowFile.setData(newContent);
 
-        currentVersions.put(newFlowFile.getId(), newFlowFile);
-        beingProcessed.add(newFlowFile.getId());
+        updateStateWithNewFlowFile(newFlowFile);
         return newFlowFile;
     }
 
@@ -289,6 +292,7 @@ public class MockProcessSession implements ProcessSession {
         beingProcessed.clear();
         currentVersions.clear();
         originalVersions.clear();
+        created.clear();
 
         for (final Map.Entry<String, Long> entry : counterMap.entrySet()) {
             sharedState.adjustCounter(entry.getKey(), entry.getValue());
@@ -338,8 +342,7 @@ public class MockProcessSession implements ProcessSession {
     @Override
     public MockFlowFile create() {
         final MockFlowFile flowFile = new MockFlowFile(sharedState.nextFlowFileId());
-        currentVersions.put(flowFile.getId(), flowFile);
-        beingProcessed.add(flowFile.getId());
+        updateStateWithNewFlowFile(flowFile);
         return flowFile;
     }
 
@@ -347,8 +350,7 @@ public class MockProcessSession implements ProcessSession {
     public MockFlowFile create(final FlowFile flowFile) {
         MockFlowFile newFlowFile = create();
         newFlowFile = (MockFlowFile) inheritAttributes(flowFile, newFlowFile);
-        currentVersions.put(newFlowFile.getId(), newFlowFile);
-        beingProcessed.add(newFlowFile.getId());
+        updateStateWithNewFlowFile(newFlowFile);
         return newFlowFile;
     }
 
@@ -356,8 +358,7 @@ public class MockProcessSession implements ProcessSession {
     public MockFlowFile create(final Collection<FlowFile> flowFiles) {
         MockFlowFile newFlowFile = create();
         newFlowFile = (MockFlowFile) inheritAttributes(flowFiles, newFlowFile);
-        currentVersions.put(newFlowFile.getId(), newFlowFile);
-        beingProcessed.add(newFlowFile.getId());
+        updateStateWithNewFlowFile(newFlowFile);
         return newFlowFile;
     }
 
@@ -794,9 +795,11 @@ public class MockProcessSession implements ProcessSession {
 
         for (final List<MockFlowFile> list : transferMap.values()) {
             for (final MockFlowFile flowFile : list) {
-                processorQueue.offer(flowFile);
-                if (penalize) {
-                    penalized.add(flowFile);
+                if (!created.contains(flowFile.getId())) {
+                    processorQueue.offer(flowFile);
+                    if (penalize) {
+                        penalized.add(flowFile);
+                    }
                 }
             }
         }
@@ -804,9 +807,11 @@ public class MockProcessSession implements ProcessSession {
         for (final Long flowFileId : beingProcessed) {
             final MockFlowFile flowFile = originalVersions.get(flowFileId);
             if (flowFile != null) {
-                processorQueue.offer(flowFile);
-                if (penalize) {
-                    penalized.add(flowFile);
+                if (!created.contains(flowFile.getId())) {
+                    processorQueue.offer(flowFile);
+                    if (penalize) {
+                        penalized.add(flowFile);
+                    }
                 }
             }
         }
@@ -816,6 +821,7 @@ public class MockProcessSession implements ProcessSession {
         currentVersions.clear();
         originalVersions.clear();
         transferMap.clear();
+        created.clear();
         clearTransferState();
         if (!penalize) {
             penalized.clear();
@@ -848,6 +854,15 @@ public class MockProcessSession implements ProcessSession {
         // which is called when a flow file is transferred to a relationship.
         mockFlowFile.setLastEnqueuedDate(System.currentTimeMillis());
         mockFlowFile.setEnqueuedIndex(enqueuedIndex.incrementAndGet());
+    }
+
+    private void updateStateWithNewFlowFile(MockFlowFile newFlowFile) {
+        if (newFlowFile == null) {
+            throw new IllegalArgumentException("argument cannot be null");
+        }
+        currentVersions.put(newFlowFile.getId(), newFlowFile);
+        beingProcessed.add(newFlowFile.getId());
+        created.add(newFlowFile.getId());
     }
 
     @Override
@@ -1064,6 +1079,7 @@ public class MockProcessSession implements ProcessSession {
         final MockFlowFile newFlowFile = new MockFlowFile(destination.getId(), destination);
         newFlowFile.setData(baos.toByteArray());
         currentVersions.put(newFlowFile.getId(), newFlowFile);
+        created.add(newFlowFile.getId());
 
         return newFlowFile;
     }

--- a/nifi-mock/src/test/java/org/apache/nifi/util/TestMockProcessSession.java
+++ b/nifi-mock/src/test/java/org/apache/nifi/util/TestMockProcessSession.java
@@ -135,6 +135,40 @@ public class TestMockProcessSession {
     }
 
     @Test
+    public void testRollbackWithCreatedFlowFile() {
+        final Processor processor = new PoorlyBehavedProcessor();
+        final MockProcessSession session = new MockProcessSession(new SharedSessionState(processor, new AtomicLong(0L)), processor, new MockStateManager(processor));
+        final FlowFile ff1 = session.createFlowFile("hello, world".getBytes());
+        session.transfer(ff1, PoorlyBehavedProcessor.REL_FAILURE);
+        session.rollback();
+        session.assertQueueEmpty();
+    }
+
+    @Test
+    public void testRollbackWithClonedFlowFile() {
+        final Processor processor = new PoorlyBehavedProcessor();
+        final MockProcessSession session = new MockProcessSession(new SharedSessionState(processor, new AtomicLong(0L)), processor, new MockStateManager(processor));
+        final FlowFile ff1 = session.createFlowFile("hello, world".getBytes());
+        session.clone(ff1);
+        session.transfer(ff1, PoorlyBehavedProcessor.REL_FAILURE);
+        session.rollback();
+        session.assertQueueEmpty();
+    }
+
+    @Test
+    public void testRollbackWithMigratedFlowFile() {
+        final Processor processor = new PoorlyBehavedProcessor();
+        final MockProcessSession session = new MockProcessSession(new SharedSessionState(processor, new AtomicLong(0L)), processor, new MockStateManager(processor));
+        final MockProcessSession newSession = new MockProcessSession(new SharedSessionState(processor, new AtomicLong(0L)), processor, new MockStateManager(processor));
+        final FlowFile ff1 = session.createFlowFile("hello, world".getBytes());
+        session.migrate(newSession);
+        newSession.transfer(ff1, PoorlyBehavedProcessor.REL_FAILURE);
+        newSession.rollback();
+        session.assertQueueEmpty();
+        newSession.assertQueueEmpty();
+    }
+
+    @Test
     public void testAttributePreservedAfterWrite() throws IOException {
         final Processor processor = new PoorlyBehavedProcessor();
         final MockProcessSession session = new MockProcessSession(new SharedSessionState(processor, new AtomicLong(0L)), processor, new MockStateManager(processor));


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12067](https://issues.apache.org/jira/browse/NIFI-12067)
Flowfiles created or within a process session are removed on rollback rather than being put on the inbound queue. This behaviour is now in line with the StandardProcessSession.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

~~- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~~
~~- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~~

### Documentation

~~- [ ] Documentation formatting appears as expected in rendered files~~
