### PR TITLE
NIFI-12163 Improve Syslog 5424 Line Handling

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-syslog-utils/src/main/java/org/apache/nifi/syslog/parsers/StrictSyslog5424Parser.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-syslog-utils/src/main/java/org/apache/nifi/syslog/parsers/StrictSyslog5424Parser.java
@@ -21,29 +21,18 @@ import com.github.palindromicity.syslog.NilPolicy;
 import com.github.palindromicity.syslog.StructuredDataPolicy;
 import com.github.palindromicity.syslog.SyslogParserBuilder;
 import org.apache.nifi.syslog.events.Syslog5424Event;
-import org.apache.nifi.syslog.keyproviders.SyslogPrefixedKeyProvider;
 import org.apache.nifi.syslog.utils.NifiStructuredDataPolicy;
 import org.apache.nifi.syslog.utils.NilHandlingPolicy;
-
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Parses a Syslog message from a ByteBuffer into a Syslog5424Event instance.
  * For 5424 we use simple-syslog-5424 since it parsers out structured data.
  */
 public class StrictSyslog5424Parser {
-    private Charset charset;
-    private com.github.palindromicity.syslog.SyslogParser parser;
+    private final com.github.palindromicity.syslog.SyslogParser parser;
 
-    public StrictSyslog5424Parser() {
-        this(StandardCharsets.UTF_8, NilHandlingPolicy.NULL, NifiStructuredDataPolicy.FLATTEN, new SyslogPrefixedKeyProvider());
-    }
-
-    public StrictSyslog5424Parser(final Charset charset, final NilHandlingPolicy nilPolicy,
-                                  NifiStructuredDataPolicy structuredDataPolicy, KeyProvider keyProvider) {
-        this.charset = charset;
+    public StrictSyslog5424Parser(final NilHandlingPolicy nilPolicy,
+                                  final NifiStructuredDataPolicy structuredDataPolicy, final KeyProvider keyProvider) {
         parser = new SyslogParserBuilder()
                 .withNilPolicy(NilPolicy.valueOf(nilPolicy.name()))
                 .withStructuredDataPolicy(StructuredDataPolicy.valueOf(structuredDataPolicy.name()))
@@ -52,54 +41,17 @@ public class StrictSyslog5424Parser {
     }
 
     /**
-     * Parses a Syslog5424Event from a {@code ByteBuffer}.
+     * Parses a Syslog5424Event from a String
      *
-     * @param buffer a {@code ByteBuffer} containing a syslog message
-     * @return a Syslog5424Event parsed from the {@code {@code byte array}}
+     * @param line a {@code String} containing a syslog message
+     * @return a Syslog5424Event parsed from the input line
      */
-    public Syslog5424Event parseEvent(final ByteBuffer buffer) {
-        return parseEvent(buffer, null);
-    }
-
-    /**
-     * Parses a Syslog5424Event from a {@code ByteBuffer}.
-     *
-     * @param buffer a {@code ByteBuffer} containing a syslog message
-     * @param sender the hostname of the syslog server that sent the message
-     * @return a Syslog5424Event parsed from the {@code byte array}
-     */
-    public Syslog5424Event parseEvent(final ByteBuffer buffer, final String sender) {
-        if (buffer == null) {
-            return null;
-        }
-        return parseEvent(bufferToBytes(buffer), sender);
-    }
-
-    /**
-     * Parses a Syslog5424Event from a {@code byte array}.
-     *
-     * @param bytes  a {@code byte array} containing a syslog message
-     * @param sender the hostname of the syslog server that sent the message
-     * @return a Syslog5424Event parsed from the {@code byte array}
-     */
-    public Syslog5424Event parseEvent(final byte[] bytes, final String sender) {
-        if (bytes == null || bytes.length == 0) {
-            return null;
-        }
-
-        // remove trailing new line before parsing
-        int length = bytes.length;
-        if (bytes[length - 1] == '\n') {
-            length = length - 1;
-        }
-
-        final String message = new String(bytes, 0, length, charset);
-
+    public Syslog5424Event parseEvent(final String line) {
         final Syslog5424Event.Builder builder = new Syslog5424Event.Builder()
-                .valid(false).fullMessage(message).rawMessage(bytes).sender(sender);
+                .valid(false).fullMessage(line);
 
         try {
-            parser.parseLine(message, builder::fieldMap);
+            parser.parseLine(line, builder::fieldMap);
             builder.valid(true);
         } catch (Exception e) {
             // this is not a valid 5424 message
@@ -109,22 +61,5 @@ public class StrictSyslog5424Parser {
 
         // either invalid w/original msg, or fully parsed event
         return builder.build();
-    }
-
-    public String getCharsetName() {
-        return charset == null ? StandardCharsets.UTF_8.name() : charset.name();
-    }
-
-
-    private byte[] bufferToBytes(ByteBuffer buffer) {
-        if (buffer == null) {
-            return null;
-        }
-        if (buffer.position() != 0) {
-            buffer.flip();
-        }
-        byte bytes[] = new byte[buffer.limit()];
-        buffer.get(bytes, 0, buffer.limit());
-        return bytes;
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-12163](https://issues.apache.org/jira/browse/NIFI-12163) Improves Syslog handling in the `ParseSyslog5424` and `Syslog5424Reader` components with the elimination of unnecessary String to byte conversion.

Primary changes include streamlining the event parsing method to take a String instead of `ByteBuffer` created from a String. The supporting SyslogParser method accepts a String, so this approach avoids the intermediate conversion steps. Additional changes include providing the configured character set to the appropriate `InputStreamReader`, instead of having it default to platform encoding. 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
