### PR TITLE
Nifi-12193 Implement boolean switch for python processor support

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -314,6 +314,7 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String DIAGNOSTICS_ON_SHUTDOWN_MAX_DIRECTORY_SIZE = "nifi.diagnostics.on.shutdown.max.directory.size";
 
     // python properties
+    public static final String PYTHON_SUPPORT_ENABLED = "nifi.python.enabled";
     public static final String PYTHON_COMMAND = "nifi.python.command";
     public static final String PYTHON_FRAMEWORK_SOURCE_DIRECTORY = "nifi.python.framework.source.directory";
     public static final String PYTHON_EXTENSION_DIRECTORY_PREFIX = "nifi.python.extensions.source.directory.";
@@ -1789,6 +1790,15 @@ public class NiFiProperties extends ApplicationProperties {
      */
     public Path getQuestDbStatusRepositoryPath() {
         return Paths.get(getProperty(STATUS_REPOSITORY_QUESTDB_PERSIST_LOCATION, DEFAULT_COMPONENT_STATUS_REPOSITORY_PERSIST_LOCATION));
+    }
+
+    /**
+     * Returns true if python processor support is enabled.
+     *
+     * @return true if python processor support is enabled.
+     */
+    public boolean isPythonProcessorsDisabled() {
+        return this.getProperty(PYTHON_SUPPORT_ENABLED, Boolean.FALSE.toString()).equals(Boolean.FALSE.toString());
     }
 
     /**

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -245,8 +245,9 @@ The following properties may be used to configure the Python 3 installation and 
 [options="header,footer"]
 |==================================================================================================================================================
 | Property Name | Default Value | Description
-| nifi.python.command | python3 | The command used to launch Python. By default, this property is set to "python3" but commented out. In order to enable Python-based Processors,
-uncomment this line and set it to the command that should be used to invoke Python 3.
+| nifi.python.enabled | false | The command used to launch Python. By default, this property is set to "false". In order to enable Python-based Processors,
+set this property to true.
+| nifi.python.command | python3 | The command used to launch Python. By default, this property is set to "python3". In order to work, set the command that should be used to invoke Python 3.
 | nifi.python.framework.source.directory | ./python/framework | The directory that contains the Python framework for communicating between the Python and Java processes. The API is expected to be
 located as a sibling of this directory. For example, if the value of this property is `./python/framework`, then the API should be located at `./python/api`.
 | nifi.python.extensions.source.directory.default | ./python/extensions | The directory that NiFi should look in to find Python-based Processors. Note that this property is supplied

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/pom.xml
@@ -295,6 +295,12 @@
             <version>2.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-py4j-bridge</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -177,11 +177,7 @@ import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.provenance.ProvenanceRepository;
 import org.apache.nifi.provenance.StandardProvenanceAuthorizableFactory;
 import org.apache.nifi.provenance.StandardProvenanceEventRecord;
-import org.apache.nifi.python.ControllerServiceTypeLookup;
-import org.apache.nifi.python.DisabledPythonBridge;
 import org.apache.nifi.python.PythonBridge;
-import org.apache.nifi.python.PythonBridgeInitializationContext;
-import org.apache.nifi.python.PythonProcessConfig;
 import org.apache.nifi.registry.flow.mapping.NiFiRegistryFlowMapper;
 import org.apache.nifi.registry.flow.mapping.VersionedComponentStateLookup;
 import org.apache.nifi.registry.flow.mapping.InstantiatedVersionedProcessGroup;
@@ -229,7 +225,6 @@ import java.io.OutputStream;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.net.InetSocketAddress;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -255,9 +250,9 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.nifi.controller.python.PythonBridgeFactory.createPythonBridge;
 
 public class FlowController implements ReportingTaskProvider, FlowAnalysisRuleProvider, Authorizable, NodeTypeProvider {
-    private static final String STANDARD_PYTHON_BRIDGE_IMPLEMENTATION_CLASS = "org.apache.nifi.py4j.StandardPythonBridge";
 
     // default repository implementations
     public static final String DEFAULT_FLOWFILE_REPO_IMPLEMENTATION = "org.apache.nifi.controller.repository.WriteAheadFlowFileRepository";
@@ -584,7 +579,7 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
         controllerServiceResolver = new StandardControllerServiceResolver(authorizer, flowManager, new NiFiRegistryFlowMapper(extensionManager),
                 controllerServiceProvider, new StandardControllerServiceApiLookup(extensionManager));
 
-        final PythonBridge rawPythonBridge = createPythonBridge(nifiProperties, controllerServiceProvider);
+        final PythonBridge rawPythonBridge = createPythonBridge(nifiProperties, controllerServiceProvider, extensionManager);
         final ClassLoader pythonBridgeClassLoader = rawPythonBridge.getClass().getClassLoader();
         final PythonBridge classloaderAwareBridge = new ClassLoaderAwarePythonBridge(rawPythonBridge, pythonBridgeClassLoader);
         this.pythonBridge = classloaderAwareBridge;
@@ -871,89 +866,6 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
             throw new RuntimeException(e);
         }
     }
-
-
-    private PythonBridge createPythonBridge(final NiFiProperties nifiProperties, final ControllerServiceProvider serviceProvider) {
-        final String pythonCommand = nifiProperties.getProperty(NiFiProperties.PYTHON_COMMAND);
-        if (pythonCommand == null) {
-            LOG.info("Python Extensions disabled because the nifi.python.command property has not been configured in nifi.properties");
-            return new DisabledPythonBridge();
-        }
-
-        final String commsTimeout = nifiProperties.getProperty(NiFiProperties.PYTHON_COMMS_TIMEOUT);
-        final File pythonFrameworkSourceDirectory = nifiProperties.getPythonFrameworkSourceDirectory();
-        final List<File> pythonExtensionsDirectories = nifiProperties.getPythonExtensionsDirectories();
-        final File pythonWorkingDirectory = new File(nifiProperties.getProperty(NiFiProperties.PYTHON_WORKING_DIRECTORY));
-        final File pythonLogsDirectory = new File(nifiProperties.getProperty(NiFiProperties.PYTHON_LOGS_DIRECTORY));
-
-        int maxProcesses = nifiProperties.getIntegerProperty(NiFiProperties.PYTHON_MAX_PROCESSES, 20);
-        int maxProcessesPerType = nifiProperties.getIntegerProperty(NiFiProperties.PYTHON_MAX_PROCESSES_PER_TYPE, 2);
-
-        final boolean enableControllerDebug = Boolean.parseBoolean(nifiProperties.getProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_ENABLED, "false"));
-        final int debugPort = nifiProperties.getIntegerProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_PORT, 5678);
-        final String debugHost = nifiProperties.getProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_HOST, "localhost");
-        final String debugLogs = nifiProperties.getProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_LOGS_DIR, "logs");
-
-        // Validate configuration for max numbers of processes.
-        if (maxProcessesPerType < 1) {
-            LOG.warn("Configured value for {} in nifi.properties is {}, which is invalid. Defaulting to 2.", NiFiProperties.PYTHON_MAX_PROCESSES_PER_TYPE, maxProcessesPerType);
-            maxProcessesPerType = 2;
-        }
-        if (maxProcesses < 0) {
-            LOG.warn("Configured value for {} in nifi.properties is {}, which is invalid. Defaulting to 20.", NiFiProperties.PYTHON_MAX_PROCESSES, maxProcessesPerType);
-            maxProcesses = 20;
-        }
-        if (maxProcesses == 0) {
-            LOG.warn("Will not enable Python Extensions because the {} property in nifi.properties is set to 0.", NiFiProperties.PYTHON_MAX_PROCESSES);
-            return new DisabledPythonBridge();
-        }
-        if (maxProcessesPerType > maxProcesses) {
-            LOG.warn("Configured values for {} and {} in nifi.properties are {} and {} (respectively), which is invalid. " +
-                "Cannot set max process count per extension type greater than the max number of processors. Setting both to {}",
-                NiFiProperties.PYTHON_MAX_PROCESSES_PER_TYPE, NiFiProperties.PYTHON_MAX_PROCESSES, maxProcessesPerType, maxProcesses, maxProcesses);
-
-            maxProcessesPerType = maxProcesses;
-        }
-
-        final PythonProcessConfig pythonProcessConfig = new PythonProcessConfig.Builder()
-            .pythonCommand(pythonCommand)
-            .pythonFrameworkDirectory(pythonFrameworkSourceDirectory)
-            .pythonExtensionsDirectories(pythonExtensionsDirectories)
-            .pythonLogsDirectory(pythonLogsDirectory)
-            .pythonWorkingDirectory(pythonWorkingDirectory)
-            .commsTimeout(commsTimeout == null ? null : Duration.ofMillis(FormatUtils.getTimeDuration(commsTimeout, TimeUnit.MILLISECONDS)))
-            .maxPythonProcesses(maxProcesses)
-            .maxPythonProcessesPerType(maxProcessesPerType)
-            .enableControllerDebug(enableControllerDebug)
-            .debugPort(debugPort)
-            .debugHost(debugHost)
-            .debugLogsDirectory(new File(debugLogs))
-            .build();
-
-        final ControllerServiceTypeLookup serviceTypeLookup = serviceProvider::getControllerServiceType;
-
-        try {
-            final PythonBridge bridge = NarThreadContextClassLoader.createInstance(extensionManager, STANDARD_PYTHON_BRIDGE_IMPLEMENTATION_CLASS, PythonBridge.class, null);
-
-            final PythonBridgeInitializationContext initializationContext = new PythonBridgeInitializationContext() {
-                @Override
-                public PythonProcessConfig getPythonProcessConfig() {
-                    return pythonProcessConfig;
-                }
-
-                @Override
-                public ControllerServiceTypeLookup getControllerServiceTypeLookup() {
-                    return serviceTypeLookup;
-                }
-            };
-
-            bridge.initialize(initializationContext);
-            return bridge;
-        } catch (final Exception e) {
-            throw new RuntimeException("Python Bridge initialization failed", e);
-        }
-    }
-
 
     public FlowFileSwapManager createSwapManager() {
         final String implementationClassName = isEncryptionProtocolVersionConfigured(nifiProperties)

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/python/PythonBridgeFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/python/PythonBridgeFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller.python;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.controller.service.ControllerServiceProvider;
+import org.apache.nifi.nar.ExtensionManager;
+import org.apache.nifi.nar.NarThreadContextClassLoader;
+import org.apache.nifi.python.ControllerServiceTypeLookup;
+import org.apache.nifi.python.DisabledPythonBridge;
+import org.apache.nifi.python.PythonBridge;
+import org.apache.nifi.python.PythonBridgeInitializationContext;
+import org.apache.nifi.python.PythonProcessConfig;
+import org.apache.nifi.util.FormatUtils;
+import org.apache.nifi.util.NiFiProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PythonBridgeFactory {
+
+    public static final String STANDARD_PYTHON_BRIDGE_IMPLEMENTATION_CLASS = "org.apache.nifi.py4j.StandardPythonBridge";
+    private static final Logger LOG = LoggerFactory.getLogger(PythonBridgeFactory.class);
+
+    public static PythonBridge createPythonBridge(final NiFiProperties nifiProperties, final ControllerServiceProvider serviceProvider, ExtensionManager extensionManager) {
+        if (nifiProperties.isPythonProcessorsDisabled()) {
+            LOG.info("Python Extensions disabled because the nifi.python.enabled property has been configured to false in nifi.properties");
+            return new DisabledPythonBridge();
+        }
+
+        final String pythonCommand = nifiProperties.getProperty(NiFiProperties.PYTHON_COMMAND);
+        if (StringUtils.isEmpty(pythonCommand)) {
+            throw new RuntimeException("nifi.python.command is not configured properly!");
+        }
+
+        final String commsTimeout = nifiProperties.getProperty(NiFiProperties.PYTHON_COMMS_TIMEOUT);
+        final File pythonFrameworkSourceDirectory = nifiProperties.getPythonFrameworkSourceDirectory();
+        final List<File> pythonExtensionsDirectories = nifiProperties.getPythonExtensionsDirectories();
+        final File pythonWorkingDirectory = new File(nifiProperties.getProperty(NiFiProperties.PYTHON_WORKING_DIRECTORY));
+        final File pythonLogsDirectory = new File(nifiProperties.getProperty(NiFiProperties.PYTHON_LOGS_DIRECTORY));
+
+        int maxProcesses = nifiProperties.getIntegerProperty(NiFiProperties.PYTHON_MAX_PROCESSES, 20);
+        int maxProcessesPerType = nifiProperties.getIntegerProperty(NiFiProperties.PYTHON_MAX_PROCESSES_PER_TYPE, 2);
+
+        final boolean enableControllerDebug = Boolean.parseBoolean(nifiProperties.getProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_ENABLED, "false"));
+        final int debugPort = nifiProperties.getIntegerProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_PORT, 5678);
+        final String debugHost = nifiProperties.getProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_HOST, "localhost");
+        final String debugLogs = nifiProperties.getProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_LOGS_DIR, "logs");
+
+        // Validate configuration for max numbers of processes.
+        if (maxProcessesPerType < 1) {
+            LOG.warn("Configured value for {} in nifi.properties is {}, which is invalid. Defaulting to 2.", NiFiProperties.PYTHON_MAX_PROCESSES_PER_TYPE, maxProcessesPerType);
+            maxProcessesPerType = 2;
+        }
+        if (maxProcesses < 0) {
+            LOG.warn("Configured value for {} in nifi.properties is {}, which is invalid. Defaulting to 20.", NiFiProperties.PYTHON_MAX_PROCESSES, maxProcessesPerType);
+            maxProcesses = 20;
+        }
+        if (maxProcesses == 0) {
+            LOG.warn("Will not enable Python Extensions because the {} property in nifi.properties is set to 0.", NiFiProperties.PYTHON_MAX_PROCESSES);
+            return new DisabledPythonBridge();
+        }
+        if (maxProcessesPerType > maxProcesses) {
+            LOG.warn("Configured values for {} and {} in nifi.properties are {} and {} (respectively), which is invalid. " +
+                            "Cannot set max process count per extension type greater than the max number of processors. Setting both to {}",
+                    NiFiProperties.PYTHON_MAX_PROCESSES_PER_TYPE, NiFiProperties.PYTHON_MAX_PROCESSES, maxProcessesPerType, maxProcesses, maxProcesses);
+
+            maxProcessesPerType = maxProcesses;
+        }
+
+        final PythonProcessConfig pythonProcessConfig = new PythonProcessConfig.Builder()
+                .pythonCommand(pythonCommand)
+                .pythonFrameworkDirectory(pythonFrameworkSourceDirectory)
+                .pythonExtensionsDirectories(pythonExtensionsDirectories)
+                .pythonLogsDirectory(pythonLogsDirectory)
+                .pythonWorkingDirectory(pythonWorkingDirectory)
+                .commsTimeout(commsTimeout == null ? null : Duration.ofMillis(FormatUtils.getTimeDuration(commsTimeout, TimeUnit.MILLISECONDS)))
+                .maxPythonProcesses(maxProcesses)
+                .maxPythonProcessesPerType(maxProcessesPerType)
+                .enableControllerDebug(enableControllerDebug)
+                .debugPort(debugPort)
+                .debugHost(debugHost)
+                .debugLogsDirectory(new File(debugLogs))
+                .build();
+
+        final ControllerServiceTypeLookup serviceTypeLookup = serviceProvider::getControllerServiceType;
+
+        try {
+            final PythonBridge bridge = NarThreadContextClassLoader.createInstance(extensionManager, STANDARD_PYTHON_BRIDGE_IMPLEMENTATION_CLASS, PythonBridge.class, null);
+
+            final PythonBridgeInitializationContext initializationContext = new PythonBridgeInitializationContext() {
+                @Override
+                public PythonProcessConfig getPythonProcessConfig() {
+                    return pythonProcessConfig;
+                }
+
+                @Override
+                public ControllerServiceTypeLookup getControllerServiceTypeLookup() {
+                    return serviceTypeLookup;
+                }
+            };
+
+            bridge.initialize(initializationContext);
+            return bridge;
+        } catch (final Exception e) {
+            throw new RuntimeException("Python Bridge initialization failed", e);
+        }
+    }
+
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/python/TestPythonBridgeFactory.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/python/TestPythonBridgeFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller.python;
+
+import org.apache.nifi.bundle.Bundle;
+import org.apache.nifi.controller.service.ControllerServiceProvider;
+import org.apache.nifi.nar.StandardExtensionDiscoveringManager;
+import org.apache.nifi.nar.SystemBundle;
+import org.apache.nifi.python.DisabledPythonBridge;
+import org.apache.nifi.python.PythonBridge;
+import org.apache.nifi.util.NiFiProperties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Answers.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+
+public class TestPythonBridgeFactory {
+
+    private NiFiProperties properties;
+    private StandardExtensionDiscoveringManager extensionManager;
+    private ControllerServiceProvider serviceProvider;
+
+    @Test
+    public void shouldReturnDisabledPythonBridgeIfPythonSupportNotEnabled() {
+        giveANifiProperties(Map.of(NiFiProperties.PYTHON_SUPPORT_ENABLED, "false"));
+
+        PythonBridge bridge = PythonBridgeFactory.createPythonBridge(properties, null, null);
+
+        Assertions.assertInstanceOf(DisabledPythonBridge.class, bridge, "Python bridge should be disabled");
+    }
+
+    @Test
+    public void shouldThrowExceptionIfPythonCommandIsNotDefined() {
+        giveANifiProperties(Map.of(NiFiProperties.PYTHON_SUPPORT_ENABLED, "true"));
+
+        assertThrows(RuntimeException.class, () -> PythonBridgeFactory.createPythonBridge(properties, null, null));
+    }
+
+    @Test
+    public void shouldCreatePythonBridege() throws ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchMethodException {
+        giveANifiProperties(Map.of(NiFiProperties.PYTHON_SUPPORT_ENABLED, "true",
+                NiFiProperties.PYTHON_COMMAND, "python3",
+                NiFiProperties.PYTHON_WORKING_DIRECTORY, "python_working_dir",
+                NiFiProperties.PYTHON_LOGS_DIRECTORY, "python_log_dir"));
+        giveAnExtensionManager();
+        giveAControllerServiceProvider();
+
+        PythonBridge bridge = PythonBridgeFactory.createPythonBridge(properties, serviceProvider, extensionManager);
+    }
+
+    private void giveANifiProperties(Map<String, String> properties) {
+        this.properties = NiFiProperties.createBasicNiFiProperties("src/test/resources/pythonbridgefactory/pythonbridegefactorytest.nifi.properties", properties);
+    }
+
+    private void giveAnExtensionManager() {
+        Bundle systemBundle = SystemBundle.create(properties);
+        extensionManager = new StandardExtensionDiscoveringManager();
+        extensionManager.discoverExtensions(systemBundle, Collections.emptySet());
+    }
+
+    private void giveAControllerServiceProvider() {
+        serviceProvider = mock(ControllerServiceProvider.class, RETURNS_MOCKS);
+    }
+
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/pythonbridgefactory/pythonbridegefactorytest.nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/pythonbridgefactory/pythonbridegefactorytest.nifi.properties
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Core Properties #
+nifi.flow.configuration.file=./target/flowcontrollertest/flow.xml.gz
+nifi.flow.configuration.archive.dir=./target/flowcontrollertest/archive/
+nifi.flowcontroller.autoResumeState=true
+nifi.flowcontroller.graceful.shutdown.period=10 sec
+nifi.flowservice.writedelay.interval=2 sec
+nifi.administrative.yield.duration=500 millis
+
+nifi.reporting.task.configuration.file=./target/flowcontrollertest/reporting-tasks.xml
+nifi.controller.service.configuration.file=./target/flowcontrollertest/controller-services.xml
+nifi.ui.banner.text=UI Banner Text
+nifi.ui.autorefresh.interval=30 sec
+nifi.nar.library.directory=./lib/
+
+nifi.state.management.configuration.file=src/test/resources/state-management.xml
+nifi.state.management.provider.local=local-provider
+
+# H2 Settings
+nifi.database.directory=./target/flowcontrollertest/database_repository
+nifi.h2.url.append=;LOCK_TIMEOUT=25000;WRITE_DELAY=0;AUTO_SERVER=FALSE
+
+# FlowFile Repository
+nifi.flowfile.repository.directory=./target/flowcontrollertest/test-repo
+nifi.flowfile.repository.partitions=1
+nifi.flowfile.repository.checkpoint.interval=2 mins
+nifi.queue.swap.threshold=20000
+nifi.swap.storage.directory=./target/flowcontrollertest/test-repo/swap
+nifi.swap.in.period=5 sec
+nifi.swap.in.threads=1
+nifi.swap.out.period=5 sec
+nifi.swap.out.threads=4
+
+# Content Repository
+nifi.content.repository.implementation=org.apache.nifi.controller.repository.FileSystemRepository
+nifi.volatile.content.repository.max.size=1 KB
+nifi.volatile.content.repository.block.size=1 KB
+nifi.content.claim.max.appendable.size=10 MB
+nifi.content.claim.max.flow.files=100
+nifi.content.repository.directory.default=./target/flowcontrollertest/content_repository
+nifi.content.repository.archive.enabled=true
+nifi.content.repository.archive.max.usage.percentage=95%
+
+# Provenance Repository Properties
+nifi.provenance.repository.storage.directory=./target/flowcontrollertest/provenance_repository
+nifi.provenance.repository.max.storage.time=24 hours
+nifi.provenance.repository.max.storage.size=1 GB
+nifi.provenance.repository.rollover.time=30 secs
+nifi.provenance.repository.rollover.size=100 MB
+
+# Site to Site properties
+nifi.remote.input.socket.port=9990
+nifi.remote.input.secure=true
+
+# web properties #
+nifi.web.war.directory=./target/flowcontrollertest/lib
+nifi.web.http.host=
+nifi.web.http.port=8080
+nifi.web.https.host=
+nifi.web.https.port=
+nifi.web.jetty.working.directory=./target/flowcontrollertest/work/jetty
+
+# security properties #
+nifi.sensitive.props.key=SENSITIVE_PROPS_KEY
+nifi.sensitive.props.algorithm=NIFI_PBKDF2_AES_GCM
+
+nifi.security.keystore=
+nifi.security.keystoreType=
+nifi.security.keystorePasswd=
+nifi.security.keyPasswd=
+nifi.security.truststore=
+nifi.security.truststoreType=
+nifi.security.truststorePasswd=
+nifi.security.user.authorizer=
+
+# cluster common properties (cluster manager and nodes must have same values) #
+nifi.cluster.protocol.heartbeat.interval=5 sec
+nifi.cluster.protocol.is.secure=false
+nifi.cluster.protocol.socket.timeout=30 sec
+nifi.cluster.protocol.connection.handshake.timeout=45 sec
+# if multicast is used, then nifi.cluster.protocol.multicast.xxx properties must be configured #
+nifi.cluster.protocol.use.multicast=false
+nifi.cluster.protocol.multicast.address=
+nifi.cluster.protocol.multicast.port=
+nifi.cluster.protocol.multicast.service.broadcast.delay=500 ms
+nifi.cluster.protocol.multicast.service.locator.attempts=3
+nifi.cluster.protocol.multicast.service.locator.attempts.delay=1 sec
+
+# cluster node properties (only configure for cluster nodes) #
+nifi.cluster.is.node=false
+nifi.cluster.node.address=
+nifi.cluster.node.protocol.port=
+nifi.cluster.node.protocol.threads=2
+# if multicast is not used, nifi.cluster.node.unicast.xxx must have same values as nifi.cluster.manager.xxx #
+nifi.cluster.node.unicast.manager.address=
+nifi.cluster.node.unicast.manager.protocol.port=
+nifi.cluster.node.unicast.manager.authority.provider.port=
+
+# cluster manager properties (only configure for cluster manager) #
+nifi.cluster.is.manager=false
+nifi.cluster.manager.address=
+nifi.cluster.manager.protocol.port=
+nifi.cluster.manager.authority.provider.port=
+nifi.cluster.manager.authority.provider.threads=10
+nifi.cluster.manager.node.firewall.file=
+nifi.cluster.manager.node.event.history.size=10
+nifi.cluster.manager.node.api.connection.timeout=30 sec
+nifi.cluster.manager.node.api.read.timeout=30 sec
+nifi.cluster.manager.node.api.request.threads=10
+nifi.cluster.manager.flow.retrieval.delay=5 sec
+nifi.cluster.manager.protocol.threads=10
+nifi.cluster.manager.safemode.duration=0 sec
+
+# analytics properties #
+nifi.analytics.predict.interval=3 mins

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -264,6 +264,7 @@
         <nifi.monitor.long.running.task.threshold>5 mins</nifi.monitor.long.running.task.threshold>
 
         <!-- python properties -->
+        <nifi.python.enabled>false</nifi.python.enabled>
         <nifi.python.command>python3</nifi.python.command>
         <nifi.python.source.directory>python</nifi.python.source.directory>
         <nifi.python.framework.source.directory>./python/framework</nifi.python.framework.source.directory>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -44,7 +44,8 @@ nifi.nar.unpack.uber.jar=${nifi.nar.unpack.uber.jar}
 # Python Extensions #
 #####################
 # Uncomment in order to enable Python Extensions.
-#nifi.python.command=${nifi.python.command}
+nifi.python.enabled=${nifi.python.enabled}
+nifi.python.command=${nifi.python.command}
 nifi.python.framework.source.directory=${nifi.python.framework.source.directory}
 nifi.python.extensions.source.directory.default=${nifi.python.extensions.source.directory.default}
 nifi.python.working.directory=${nifi.python.working.directory}

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/nifi.properties
@@ -46,6 +46,7 @@ nifi.documentation.working.directory=./work/docs/components
 # Python Extensions #
 #####################
 # Uncomment in order to enable Python Extensions.
+nifi.python.enabled=true
 nifi.python.command=python3
 nifi.python.framework.source.directory=./python/framework
 nifi.python.extensions.source.directory.default=./python/extensions


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12193](https://issues.apache.org/jira/browse/NIFI-12193)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-12193) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
