### PR TITLE
NIFI-12175 update Docker Image builds to Java 21, rationalise base image name and tag across all components

### DIFF
--- a/minifi/minifi-c2/minifi-c2-docker/dockerhub/DockerBuild.sh
+++ b/minifi/minifi-c2/minifi-c2-docker/dockerhub/DockerBuild.sh
@@ -18,6 +18,12 @@ DOCKER_UID="${1:-1000}"
 DOCKER_GID="${2:-1000}"
 
 DOCKER_IMAGE="$(grep -Ev '(^#|^\s*$|^\s*\t*#)' DockerImage.txt)"
-MINIFI_C2_IMAGE_VERSION="$(echo "$DOCKER_IMAGE" | cut -d : -f 2)"
-echo "Building MiNiFi C2 Server Image: '$DOCKER_IMAGE' Version: $MINIFI_C2_IMAGE_VERSION"
-docker build --build-arg UID="$DOCKER_UID" --build-arg GID="$DOCKER_GID" --build-arg MINIFI_C2_VERSION="$MINIFI_C2_IMAGE_VERSION" -t "$DOCKER_IMAGE" .
+MINIFI_C2_IMAGE_VERSION="$(echo "${DOCKER_IMAGE}" | cut -d : -f 2)"
+
+root_dir="../../../.."
+mvn_cmd="${root_dir}/mvnw -f ${root_dir}/pom.xml help:evaluate -q -D forceStdout"
+IMAGE_NAME="$(${mvn_cmd} -D expression=docker.jre.image.name)"
+IMAGE_TAG="$(${mvn_cmd} -D expression=docker.image.tag)"
+
+echo "Building MiNiFi C2 Server Image: '${DOCKER_IMAGE}' Version: '${MINIFI_C2_IMAGE_VERSION}' Using: '${IMAGE_NAME}:${IMAGE_TAG}' User/Group: '${DOCKER_UID}/${DOCKER_GID}'"
+docker build --build-arg IMAGE_NAME="${IMAGE_NAME}" --build-arg IMAGE_TAG="${IMAGE_TAG}" --build-arg UID="${DOCKER_UID}" --build-arg GID="${DOCKER_GID}" --build-arg MINIFI_C2_VERSION="${MINIFI_C2_IMAGE_VERSION}" -t "${DOCKER_IMAGE}" .

--- a/minifi/minifi-c2/minifi-c2-docker/dockerhub/Dockerfile
+++ b/minifi/minifi-c2/minifi-c2-docker/dockerhub/Dockerfile
@@ -16,7 +16,9 @@
 # under the License.
 #
 
-FROM eclipse-temurin:17-jre
+ARG IMAGE_NAME
+ARG IMAGE_TAG
+FROM ${IMAGE_NAME}:${IMAGE_TAG}
 LABEL maintainer="Apache NiFi <dev@nifi.apache.org>"
 LABEL site="https://nifi.apache.org"
 
@@ -37,14 +39,14 @@ RUN mkdir -p ${MINIFI_C2_BASE_DIR}
 RUN apt-get update \
     && apt-get install -y zip \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fSL $MINIFI_C2_BINARY_URL -o $MINIFI_C2_BASE_DIR/${MINIFI_C2_BINARY} \
-    && echo "$(curl $MINIFI_C2_BINARY_URL.sha256) *$MINIFI_C2_BASE_DIR/${MINIFI_C2_BINARY}" | sha256sum -c - \
-    && unzip $MINIFI_C2_BASE_DIR/${MINIFI_C2_BINARY} -d $MINIFI_C2_BASE_DIR \
-    && rm $MINIFI_C2_BASE_DIR/${MINIFI_C2_BINARY} \
+    && curl -fSL "${MINIFI_C2_BINARY_URL}" -o "${MINIFI_C2_BASE_DIR}/${MINIFI_C2_BINARY}" \
+    && echo "$(curl ${MINIFI_C2_BINARY_URL}.sha256) *${MINIFI_C2_BASE_DIR}/${MINIFI_C2_BINARY}" | sha256sum -c - \
+    && unzip "${MINIFI_C2_BASE_DIR}/${MINIFI_C2_BINARY}" -d "${MINIFI_C2_BASE_DIR}" \
+    && rm "${MINIFI_C2_BASE_DIR}/${MINIFI_C2_BINARY}" \
     && groupadd -g ${GID} c2 \
     && useradd --shell /bin/bash -u ${UID} -g ${GID} -m c2 \
-    && ln -s ${MINIFI_C2_BASE_DIR}/minifi-c2-${MINIFI_C2_VERSION} $MINIFI_C2_HOME \
-    && chown -R -L c2:c2 ${MINIFI_C2_BASE_DIR}
+    && ln -s "${MINIFI_C2_BASE_DIR}/minifi-c2-${MINIFI_C2_VERSION}" "${MINIFI_C2_HOME}" \
+    && chown -R -L c2:c2 "${MINIFI_C2_BASE_DIR}"
 
 USER c2
 

--- a/minifi/minifi-c2/minifi-c2-docker/dockermaven/Dockerfile
+++ b/minifi/minifi-c2/minifi-c2-docker/dockermaven/Dockerfile
@@ -16,9 +16,9 @@
 # under the License.
 #
 
-ARG IMAGE_NAME=eclipse-temurin
-ARG IMAGE_TAG=17-jre
-FROM ${IMAGE_NAME}:${IMAGE_TAG} as builder
+ARG IMAGE_NAME
+ARG IMAGE_TAG
+FROM ${IMAGE_NAME}:${IMAGE_TAG} AS builder
 LABEL stage=builder
 
 ARG UID=1000

--- a/minifi/minifi-c2/minifi-c2-docker/pom.xml
+++ b/minifi/minifi-c2/minifi-c2-docker/pom.xml
@@ -65,7 +65,7 @@ limitations under the License.
                         <executions>
                             <execution>
                                 <id>build-docker-image</id>
-                                <phase>install</phase>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
@@ -80,6 +80,8 @@ limitations under the License.
                                                 <dockerFile>dockermaven/Dockerfile</dockerFile>
                                                 <contextDir>${project.basedir}</contextDir>
                                                 <args>
+                                                    <IMAGE_NAME>${docker.jre.image.name}</IMAGE_NAME>
+                                                    <IMAGE_TAG>${docker.image.tag}</IMAGE_TAG>
                                                     <UID>1000</UID>
                                                     <GID>1000</GID>
                                                     <MINIFI_C2_VERSION>${minifi.c2.version}</MINIFI_C2_VERSION>

--- a/minifi/minifi-docker/dockerhub/DockerBuild.sh
+++ b/minifi/minifi-docker/dockerhub/DockerBuild.sh
@@ -18,6 +18,12 @@ DOCKER_UID="${1:-1000}"
 DOCKER_GID="${2:-1000}"
 
 DOCKER_IMAGE="$(grep -Ev '(^#|^\s*$|^\s*\t*#)' DockerImage.txt)"
-MINIFI_IMAGE_VERSION="$(echo "$DOCKER_IMAGE" | cut -d : -f 2)"
-echo "Building MiNiFi Image: '$DOCKER_IMAGE' Version: $MINIFI_IMAGE_VERSION"
-docker build --build-arg UID="$DOCKER_UID" --build-arg GID="$DOCKER_GID" --build-arg MINIFI_VERSION="$MINIFI_IMAGE_VERSION" -t "$DOCKER_IMAGE" .
+MINIFI_IMAGE_VERSION="$(echo "${DOCKER_IMAGE}" | cut -d : -f 2)"
+
+root_dir="../../.."
+mvn_cmd="${root_dir}/mvnw -f ${root_dir}/pom.xml help:evaluate -q -D forceStdout"
+IMAGE_NAME="$(${mvn_cmd} -D expression=docker.jre.image.name)"
+IMAGE_TAG="$(${mvn_cmd} -D expression=docker.image.tag)"
+
+echo "Building MiNiFi Image: '${DOCKER_IMAGE}' Version: '${MINIFI_IMAGE_VERSION}' Using: '${IMAGE_NAME}:${IMAGE_TAG}' User/Group: '${DOCKER_UID}/${DOCKER_GID}'"
+docker build --build-arg IMAGE_NAME="${IMAGE_NAME}" --build-arg IMAGE_TAG="${IMAGE_TAG}" --build-arg UID="${DOCKER_UID}" --build-arg GID="${DOCKER_GID}" --build-arg MINIFI_VERSION="${MINIFI_IMAGE_VERSION}" -t "${DOCKER_IMAGE}" .

--- a/minifi/minifi-docker/dockerhub/Dockerfile
+++ b/minifi/minifi-docker/dockerhub/Dockerfile
@@ -16,7 +16,9 @@
 # under the License.
 #
 
-FROM eclipse-temurin:17-jre
+ARG IMAGE_NAME
+ARG IMAGE_TAG
+FROM ${IMAGE_NAME}:${IMAGE_TAG}
 LABEL maintainer="Apache NiFi <dev@nifi.apache.org>"
 LABEL site="https://nifi.apache.org"
 
@@ -31,22 +33,22 @@ ENV MINIFI_BINARY minifi-${MINIFI_VERSION}-bin.zip
 ENV MINIFI_BINARY_PATH nifi/${MINIFI_VERSION}/${MINIFI_BINARY}
 ENV MINIFI_BINARY_URL ${MIRROR}/${MINIFI_BINARY_PATH}
 
-RUN mkdir -p $MINIFI_BASE_DIR
-ADD sh/ ${MINIFI_BASE_DIR}/scripts/
+RUN mkdir -p "${MINIFI_BASE_DIR}"
+ADD sh/ "${MINIFI_BASE_DIR}/scripts/"
 
 # Download, validate, and expand Apache MiNiFi binary.
 RUN apt-get update \
     && apt-get install -y zip \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fSL $MINIFI_BINARY_URL -o $MINIFI_BASE_DIR/${MINIFI_BINARY} \
-    && echo "$(curl $MINIFI_BINARY_URL.sha256) *$MINIFI_BASE_DIR/${MINIFI_BINARY}" | sha256sum -c - \
-    && unzip $MINIFI_BASE_DIR/${MINIFI_BINARY} -d $MINIFI_BASE_DIR \
-    && rm $MINIFI_BASE_DIR/${MINIFI_BINARY} \
+    && curl -fSL "${MINIFI_BINARY_URL}" -o "${MINIFI_BASE_DIR}/${MINIFI_BINARY}" \
+    && echo "$(curl ${MINIFI_BINARY_URL}.sha256) *${MINIFI_BASE_DIR}/${MINIFI_BINARY}" | sha256sum -c - \
+    && unzip "${MINIFI_BASE_DIR}/${MINIFI_BINARY}" -d "${MINIFI_BASE_DIR}" \
+    && rm "${MINIFI_BASE_DIR}/${MINIFI_BINARY}" \
     && groupadd -g ${GID} minifi \
     && useradd --shell /bin/bash -u ${UID} -g ${GID} -m minifi \
-    && ln -s $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION $MINIFI_HOME \
-    && chown -R -L minifi:minifi ${MINIFI_BASE_DIR} \
-    && chmod -R +x ${MINIFI_BASE_DIR}/scripts/*.sh
+    && ln -s "${MINIFI_BASE_DIR}/minifi-${MINIFI_VERSION}" "${MINIFI_HOME}" \
+    && chown -R -L minifi:minifi "${MINIFI_BASE_DIR}" \
+    && chmod -R +x "${MINIFI_BASE_DIR}/scripts"/*.sh
 
 USER minifi
 

--- a/minifi/minifi-docker/dockermaven/Dockerfile
+++ b/minifi/minifi-docker/dockermaven/Dockerfile
@@ -16,9 +16,9 @@
 # under the License.
 #
 
-ARG IMAGE_NAME=eclipse-temurin
-ARG IMAGE_TAG=17-jre
-FROM ${IMAGE_NAME}:${IMAGE_TAG} as builder
+ARG IMAGE_NAME
+ARG IMAGE_TAG
+FROM ${IMAGE_NAME}:${IMAGE_TAG} AS builder
 LABEL stage=builder
 
 # Values are set by Maven

--- a/minifi/minifi-docker/pom.xml
+++ b/minifi/minifi-docker/pom.xml
@@ -29,8 +29,6 @@ limitations under the License.
 
     <properties>
         <minifi.version>${project.version}</minifi.version>
-        <docker.image.name>eclipse-temurin</docker.image.name>
-        <docker.image.tag>17-jre</docker.image.tag>
     </properties>
 
     <profiles>
@@ -82,7 +80,7 @@ limitations under the License.
                         <executions>
                             <execution>
                                 <id>build-docker-image</id>
-                                <phase>install</phase>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
@@ -97,7 +95,7 @@ limitations under the License.
                                                 <dockerFile>dockermaven/Dockerfile</dockerFile>
                                                 <contextDir>${project.basedir}</contextDir>
                                                 <args>
-                                                    <IMAGE_NAME>${docker.image.name}</IMAGE_NAME>
+                                                    <IMAGE_NAME>${docker.jre.image.name}</IMAGE_NAME>
                                                     <IMAGE_TAG>${docker.image.tag}</IMAGE_TAG>
                                                     <UID>1000</UID>
                                                     <GID>1000</GID>

--- a/nifi-docker/dockerhub/DockerBuild.sh
+++ b/nifi-docker/dockerhub/DockerBuild.sh
@@ -30,5 +30,11 @@ if [ -z "${DISTRO_PATH}" ]; then
   DISTRO_PATH="${NIFI_IMAGE_VERSION}"
 fi
 
-echo "Building NiFi Image: '${DOCKER_IMAGE}' Version: '${NIFI_IMAGE_VERSION}' Mirror: '${MIRROR}' Base: '${BASE} Path: '${DISTRO_PATH}' User/Group: '${DOCKER_UID}/${DOCKER_GID}'"
-docker build --build-arg UID="${DOCKER_UID}" --build-arg GID="${DOCKER_GID}" --build-arg NIFI_VERSION="${NIFI_IMAGE_VERSION}" --build-arg MIRROR_BASE_URL="${MIRROR}" --build-arg BASE_URL="${BASE}" --build-arg DISTRO_PATH="${DISTRO_PATH}" -t "${DOCKER_IMAGE}" .
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+root_dir="$(dirname "$(dirname "${script_dir}")")"
+mvn_cmd=("${root_dir}/mvnw" -f "${root_dir}/pom.xml" help:evaluate -q -D forceStdout)
+IMAGE_NAME="$("${mvn_cmd[@]}" -D expression=docker.jdk.image.name)"
+IMAGE_TAG="$("${mvn_cmd[@]}" -D expression=docker.image.tag)"
+
+echo "Building NiFi Image: '${DOCKER_IMAGE}' Version: '${NIFI_IMAGE_VERSION}' Using: '${IMAGE_NAME}:${IMAGE_TAG}' Mirror: '${MIRROR}' Base: '${BASE} Path: '${DISTRO_PATH}' User/Group: '${DOCKER_UID}/${DOCKER_GID}'"
+docker build --build-arg IMAGE_NAME="${IMAGE_NAME}" --build-arg IMAGE_TAG="${IMAGE_TAG}" --build-arg UID="${DOCKER_UID}" --build-arg GID="${DOCKER_GID}" --build-arg NIFI_VERSION="${NIFI_IMAGE_VERSION}" --build-arg MIRROR_BASE_URL="${MIRROR}" --build-arg BASE_URL="${BASE}" --build-arg DISTRO_PATH="${DISTRO_PATH}" -t "${DOCKER_IMAGE}" .

--- a/nifi-docker/dockerhub/pom.xml
+++ b/nifi-docker/dockerhub/pom.xml
@@ -44,6 +44,7 @@
                         <executions>
                             <execution>
                                 <id>build-docker-image</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>

--- a/nifi-docker/dockermaven/Dockerfile
+++ b/nifi-docker/dockermaven/Dockerfile
@@ -16,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-ARG IMAGE_NAME=bellsoft/liberica-openjdk-debian
-ARG IMAGE_TAG=21
+ARG IMAGE_NAME
+ARG IMAGE_TAG
 FROM ${IMAGE_NAME}:${IMAGE_TAG} AS artifactbase
 ARG MAINTAINER="Apache NiFi <dev@nifi.apache.org>"
 LABEL maintainer="${MAINTAINER}"
@@ -37,7 +37,10 @@ ENV NIFI_LOG_DIR=${NIFI_HOME}/logs
 ADD ${NIFI_SCRIPTS} ${NIFI_BASE_DIR}/scripts/
 RUN chmod -R +x ${NIFI_BASE_DIR}/scripts/*.sh \
    && apt-get update \
-   && apt-get install -y unzip
+   && apt-get install -y unzip \
+   && apt-get -y autoremove \
+   && apt-get clean autoclean \
+   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY $NIFI_BINARY $NIFI_BASE_DIR
 RUN unzip ${NIFI_BASE_DIR}/nifi-${NIFI_VERSION}-bin.zip -d ${NIFI_BASE_DIR} \
@@ -102,7 +105,7 @@ VOLUME ${NIFI_LOG_DIR} \
 USER nifi
 
 # Clear nifi-env.sh in favour of configuring all environment variables in the Dockerfile
-RUN echo "#!/bin/sh\n" > $NIFI_HOME/bin/nifi-env.sh
+RUN echo "#!/bin/sh\n" > "${NIFI_HOME}/bin/nifi-env.sh"
 
 # Web HTTP(s) & Socket Site-to-Site Ports
 EXPOSE 8443/tcp 10000/tcp 8000/tcp

--- a/nifi-docker/dockermaven/pom.xml
+++ b/nifi-docker/dockermaven/pom.xml
@@ -54,6 +54,8 @@
                                                 <contextDir>${project.basedir}</contextDir>
                                                 <optimise>true</optimise>
                                                 <args>
+                                                    <IMAGE_NAME>${docker.jdk.image.name}</IMAGE_NAME>
+                                                    <IMAGE_TAG>${docker.image.tag}</IMAGE_TAG>
                                                     <NIFI_VERSION>${project.version}</NIFI_VERSION>
                                                     <NIFI_BINARY>target/nifi-${project.version}-bin.zip</NIFI_BINARY>
                                                     <NIFI_TOOLKIT_BINARY>target/nifi-toolkit-${project.version}-bin.zip</NIFI_TOOLKIT_BINARY>

--- a/nifi-registry/nifi-registry-core/nifi-registry-docker/dockerhub/Dockerfile
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docker/dockerhub/Dockerfile
@@ -16,7 +16,9 @@
 # under the License.
 #
 
-FROM eclipse-temurin:11-jre
+ARG IMAGE_NAME
+ARG IMAGE_TAG
+FROM ${IMAGE_NAME}:${IMAGE_TAG}
 LABEL maintainer="Apache NiFi <dev@nifi.apache.org>"
 LABEL site="https://nifi.apache.org"
 

--- a/nifi-registry/nifi-registry-docker-maven/dockermaven/Dockerfile
+++ b/nifi-registry/nifi-registry-docker-maven/dockermaven/Dockerfile
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-FROM bellsoft/liberica-openjdk-debian:21 AS artifactbase
+ARG IMAGE_NAME
+ARG IMAGE_TAG
+FROM ${IMAGE_NAME}:${IMAGE_TAG} AS artifactbase
 LABEL maintainer="Apache NiFi <dev@nifi.apache.org>"
 LABEL site="https://nifi.apache.org"
 
@@ -33,7 +34,10 @@ ENV NIFI_TOOLKIT_HOME ${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-current
 ADD $NIFI_REGISTRY_SCRIPTS ${NIFI_REGISTRY_BASE_DIR}/scripts/
 RUN chmod -R +x ${NIFI_REGISTRY_BASE_DIR}/scripts/*.sh \
    && apt-get update \
-   && apt-get install -y unzip
+   && apt-get install -y unzip \
+   && apt-get -y autoremove \
+   && apt-get clean autoclean \
+   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY $NIFI_REGISTRY_BINARY $NIFI_REGISTRY_BASE_DIR
 RUN unzip ${NIFI_REGISTRY_BASE_DIR}/${NIFI_REGISTRY_BINARY_NAME} -d ${NIFI_REGISTRY_BASE_DIR} \
@@ -47,7 +51,7 @@ RUN unzip ${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-${NIFI_REGISTRY_VERSION}-bin.zi
     && ln -s ${NIFI_TOOLKIT_HOME} ${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-${NIFI_REGISTRY_VERSION}
 
 
-FROM bellsoft/liberica-openjdk-debian:21
+FROM ${IMAGE_NAME}:${IMAGE_TAG}
 LABEL maintainer="Apache NiFi Registry <dev@nifi.apache.org>"
 LABEL site="https://nifi.apache.org"
 

--- a/nifi-registry/nifi-registry-docker-maven/dockermaven/pom.xml
+++ b/nifi-registry/nifi-registry-docker-maven/dockermaven/pom.xml
@@ -100,6 +100,8 @@
                                                 <dockerFile>Dockerfile</dockerFile>
                                                 <contextDir>${project.basedir}</contextDir>
                                                 <args>
+                                                    <IMAGE_NAME>${docker.jdk.image.name}</IMAGE_NAME>
+                                                    <IMAGE_TAG>${docker.image.tag}</IMAGE_TAG>
                                                     <NIFI_REGISTRY_VERSION>${project.version}</NIFI_REGISTRY_VERSION>
                                                     <NIFI_REGISTRY_SCRIPTS>target/sh</NIFI_REGISTRY_SCRIPTS>
                                                     <NIFI_REGISTRY_BINARY>target/nifi-registry-${project.version}-bin.zip</NIFI_REGISTRY_BINARY>

--- a/nifi-toolkit/nifi-toolkit-assembly/docker/DockerBuild.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/docker/DockerBuild.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -22,13 +23,13 @@ DOCKER_GID="${2:-1000}"
 MIRROR="${3:-https://archive.apache.org/dist}"
 
 DOCKER_IMAGE="$(grep -Ev '(^#|^\s*$|^\s*\t*#)' DockerImage.txt)"
-NIFI_REGISTRY_IMAGE_VERSION="$(echo "${DOCKER_IMAGE}" | cut -d : -f 2)"
+NIFI_IMAGE_VERSION="$(echo "${DOCKER_IMAGE}" | cut -d : -f 2)"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-root_dir="$(dirname "$(dirname "$(dirname "$(dirname "${script_dir}")")")")"
+root_dir="$(dirname "$(dirname "$(dirname "${script_dir}")")")"
 mvn_cmd=("${root_dir}/mvnw" -f "${root_dir}/pom.xml" help:evaluate -q -D forceStdout)
-IMAGE_NAME="$("${mvn_cmd[@]}" -D expression=docker.jdk.image.name)"
+IMAGE_NAME="$("${mvn_cmd[@]}" -D expression=docker.jre.image.name)"
 IMAGE_TAG="$("${mvn_cmd[@]}" -D expression=docker.image.tag)"
 
-echo "Building NiFi-Registry Image: '${DOCKER_IMAGE}' Version: '${NIFI_REGISTRY_IMAGE_VERSION}' Using: '${IMAGE_NAME}:${IMAGE_TAG}' Mirror: ${MIRROR} User/Group: '${DOCKER_UID}/${DOCKER_GID}'"
-docker build --build-arg IMAGE_NAME="${IMAGE_NAME}" --build-arg IMAGE_TAG="${IMAGE_TAG}" --build-arg UID="${DOCKER_UID}" --build-arg GID="${DOCKER_GID}" --build-arg NIFI_REGISTRY_VERSION="${NIFI_REGISTRY_IMAGE_VERSION}" --build-arg MIRROR="${MIRROR}" -t "${DOCKER_IMAGE}" .
+echo "Building NiFi-Toolkit Image: '${DOCKER_IMAGE}' Version: '${NIFI_IMAGE_VERSION}' Using: '${IMAGE_NAME}:${IMAGE_TAG}' Mirror: '${MIRROR}' User/Group: '${DOCKER_UID}/${DOCKER_GID}'"
+docker build -f "${script_dir}/Dockerfile.hub" --build-arg IMAGE_NAME="${IMAGE_NAME}" --build-arg IMAGE_TAG="${IMAGE_TAG}" --build-arg UID="${DOCKER_UID}" --build-arg GID="${DOCKER_GID}" --build-arg NIFI_TOOLKIT_VERSION="${NIFI_IMAGE_VERSION}" --build-arg MIRROR="${MIRROR}" -t "${DOCKER_IMAGE}" .

--- a/nifi-toolkit/nifi-toolkit-assembly/docker/DockerImage.txt
+++ b/nifi-toolkit/nifi-toolkit-assembly/docker/DockerImage.txt
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apache/nifi-toolkit:2.0.0

--- a/nifi-toolkit/nifi-toolkit-assembly/docker/Dockerfile
+++ b/nifi-toolkit/nifi-toolkit-assembly/docker/Dockerfile
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-FROM eclipse-temurin:11-jre
+ARG IMAGE_NAME
+ARG IMAGE_TAG
+FROM ${IMAGE_NAME}:${IMAGE_TAG}
 LABEL maintainer="Apache NiFi <dev@nifi.apache.org>"
 LABEL site="https://nifi.apache.org"
 

--- a/nifi-toolkit/nifi-toolkit-assembly/docker/Dockerfile.hub
+++ b/nifi-toolkit/nifi-toolkit-assembly/docker/Dockerfile.hub
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-FROM eclipse-temurin:11-jre
+ARG IMAGE_NAME
+ARG IMAGE_TAG
+FROM ${IMAGE_NAME}:${IMAGE_TAG}
 LABEL maintainer="Apache NiFi <dev@nifi.apache.org>"
 LABEL site="https://nifi.apache.org"
 

--- a/nifi-toolkit/nifi-toolkit-assembly/docker/tests/exit-codes.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/docker/tests/exit-codes.sh
@@ -18,6 +18,3 @@ test 255 -eq $? || exit 1
 
 docker run --rm $IMAGE tls-toolkit invalid 1>/dev/null 2>&1
 test 2 -eq $? || exit 1
-
-docker run --rm $IMAGE file-manager invalid 1>/dev/null 2>&1
-test 1 -eq $? || exit 1

--- a/nifi-toolkit/nifi-toolkit-assembly/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-assembly/pom.xml
@@ -169,6 +169,8 @@ language governing permissions and limitations under the License. -->
                                                 <dockerFile>Dockerfile</dockerFile>
                                                 <contextDir>${project.basedir}/target/docker-build</contextDir>
                                                 <args>
+                                                    <IMAGE_NAME>${docker.jre.image.name}</IMAGE_NAME>
+                                                    <IMAGE_TAG>${docker.image.tag}</IMAGE_TAG>
                                                     <UID>1000</UID>
                                                     <GID>1000</GID>
                                                     <NIFI_TOOLKIT_VERSION>${project.version}</NIFI_TOOLKIT_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,9 @@
         <maven.surefire.arguments />
         <!-- Disable maven-site-plugin from parent POM -->
         <maven.site.skip>true</maven.site.skip>
+        <docker.jdk.image.name>bellsoft/liberica-openjdk-debian</docker.jdk.image.name>
+        <docker.jre.image.name>bellsoft/liberica-openjre-debian</docker.jre.image.name>
+        <docker.image.tag>21</docker.image.tag>
         <node.version>v16.13.2</node.version>
         <frontend.mvn.plugin.version>1.14.0</frontend.mvn.plugin.version>
         <nifi.nar.maven.plugin.version>1.5.1</nifi.nar.maven.plugin.version>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12175](https://issues.apache.org/jira/browse/NIFI-12175) update Docker Image builds to Java 21, rationalise base image name and tag across all components

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
