### PR TITLE
NIFI-12214 ConsumeElasticsearch Query Builder properties do not dependOn the Query Definition Style

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
@@ -414,6 +414,16 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
         }
 
         /**
+         * Clears all Allowable Values from this Property
+         *
+         * @return the builder
+         */
+        public Builder clearAllowableValues() {
+            this.allowableValues = null;
+            return this;
+        }
+
+        /**
          * Sets the Allowable Values for this Property
          *
          * @param values contrained set of values
@@ -452,6 +462,16 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
             if (validator != null) {
                 validators.add(validator);
             }
+            return this;
+        }
+
+        /**
+         * Clear all Validators from this Property
+         *
+         * @return the builder
+         */
+        public Builder clearValidators() {
+            validators.clear();
             return this;
         }
 
@@ -605,6 +625,16 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
             }
 
             return dependsOn(property, dependentValues);
+        }
+
+        /**
+         * Clear all Dependencies from this Property
+         *
+         * @return the builder
+         */
+        public Builder clearDependsOn() {
+            this.dependencies = new HashSet<>();
+            return this;
         }
 
         private AllowableValue toAllowableValue(DescribedValue describedValue) {

--- a/nifi-api/src/test/java/org/apache/nifi/components/TestPropertyDescriptor.java
+++ b/nifi-api/src/test/java/org/apache/nifi/components/TestPropertyDescriptor.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -187,5 +188,37 @@ public class TestPropertyDescriptor {
 
         // Test the literal value 'target'
         assertTrue(withElNotAllowed.validate("target", validationContext).isValid());
+    }
+
+    @Test
+    void testClearingValues() {
+        final PropertyDescriptor dep1 = new PropertyDescriptor.Builder()
+                .name("dep1")
+                .allowableValues("delVal1")
+                .build();
+
+        final PropertyDescriptor pd1 = new PropertyDescriptor.Builder()
+                .name("test")
+                .addValidator(Validator.VALID)
+                .allowableValues("val1")
+                .dependsOn(dep1, "depVal1")
+                .build();
+
+        final PropertyDescriptor pd2 = new PropertyDescriptor.Builder()
+                .fromPropertyDescriptor(pd1)
+                .clearValidators()
+                .clearAllowableValues()
+                .clearDependsOn()
+                .build();
+
+        assertEquals("test", pd1.getName());
+        assertFalse(pd1.getValidators().isEmpty());
+        assertFalse(pd1.getDependencies().isEmpty());
+        assertNotNull(pd1.getAllowableValues());
+
+        assertEquals("test", pd2.getName());
+        assertTrue(pd2.getValidators().isEmpty());
+        assertTrue(pd2.getDependencies().isEmpty());
+        assertNull(pd2.getAllowableValues());
     }
 }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/ConsumeElasticsearch.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/ConsumeElasticsearch.java
@@ -85,6 +85,31 @@ import java.util.stream.Collectors;
 public class ConsumeElasticsearch extends SearchElasticsearch {
     static final String STATE_RANGE_VALUE = "trackingRangeValue";
 
+    public static final PropertyDescriptor SIZE = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(ElasticsearchRestProcessor.SIZE)
+            .clearDependsOn() // always show the Query Builder properties for ConsumeElasticsearch
+            .build();
+
+    public static final PropertyDescriptor AGGREGATIONS = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(ElasticsearchRestProcessor.AGGREGATIONS)
+            .clearDependsOn() // always show the Query Builder properties for ConsumeElasticsearch
+            .build();
+
+    public static final PropertyDescriptor SORT = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(ElasticsearchRestProcessor.SORT)
+            .clearDependsOn() // always show the Query Builder properties for ConsumeElasticsearch
+            .build();
+
+    public static final PropertyDescriptor FIELDS = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(ElasticsearchRestProcessor.FIELDS)
+            .clearDependsOn() // always show the Query Builder properties for ConsumeElasticsearch
+            .build();
+
+    public static final PropertyDescriptor SCRIPT_FIELDS = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(ElasticsearchRestProcessor.SCRIPT_FIELDS)
+            .clearDependsOn() // always show the Query Builder properties for ConsumeElasticsearch
+            .build();
+
     public static final PropertyDescriptor RANGE_FIELD = new PropertyDescriptor.Builder()
             .name("es-rest-range-field")
             .displayName("Range Query Field")
@@ -162,6 +187,13 @@ public class ConsumeElasticsearch extends SearchElasticsearch {
         descriptors.addAll(scrollPropertyDescriptors.stream()
                 .filter(pd -> !QUERY.equals(pd) && !QUERY_CLAUSE.equals(pd) && !QUERY_DEFINITION_STYLE.equals(pd))
                 .collect(Collectors.toList()));
+
+        // replace Query Builder properties with updated version without the property dependencies that are invalid for ConsumeElasticsearch
+        descriptors.set(descriptors.indexOf(ElasticsearchRestProcessor.SIZE), ConsumeElasticsearch.SIZE);
+        descriptors.set(descriptors.indexOf(ElasticsearchRestProcessor.AGGREGATIONS), ConsumeElasticsearch.AGGREGATIONS);
+        descriptors.set(descriptors.indexOf(ElasticsearchRestProcessor.SORT), ConsumeElasticsearch.SORT);
+        descriptors.set(descriptors.indexOf(ElasticsearchRestProcessor.FIELDS), ConsumeElasticsearch.FIELDS);
+        descriptors.set(descriptors.indexOf(ElasticsearchRestProcessor.SCRIPT_FIELDS), ConsumeElasticsearch.SCRIPT_FIELDS);
 
         propertyDescriptors = Collections.unmodifiableList(descriptors);
     }

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/ConsumeElasticsearchTest.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/ConsumeElasticsearchTest.java
@@ -175,7 +175,7 @@ public class ConsumeElasticsearchTest extends SearchElasticsearchTest {
     @Test
     void testNoSorts() throws IOException {
         final TestRunner runner = createRunner(false);
-        runner.removeProperty(ElasticsearchRestProcessor.SORT);
+        runner.removeProperty(ConsumeElasticsearch.SORT);
 
         final Map<String, Object> query = new HashMap<>();
         ((ConsumeElasticsearch) runner.getProcessor()).addSortClause(query, null, runner.getProcessContext());
@@ -186,7 +186,7 @@ public class ConsumeElasticsearchTest extends SearchElasticsearchTest {
     @Test
     void testSingleAdditionalSort() throws IOException {
         final TestRunner runner = createRunner(false);
-        runner.setProperty(ElasticsearchRestProcessor.SORT, "{\"foo\":\"bar\"}");
+        runner.setProperty(ConsumeElasticsearch.SORT, "{\"foo\":\"bar\"}");
 
         final Map<String, Object> query = new HashMap<>();
         ((ConsumeElasticsearch) runner.getProcessor()).addSortClause(query, null, runner.getProcessContext());
@@ -200,7 +200,7 @@ public class ConsumeElasticsearchTest extends SearchElasticsearchTest {
     @Test
     void testMultipleAdditionalSorts() throws IOException {
         final TestRunner runner = createRunner(false);
-        runner.setProperty(ElasticsearchRestProcessor.SORT, "[{\"foo\":\"bar\"},{\"baz\":\"biz\"}]");
+        runner.setProperty(ConsumeElasticsearch.SORT, "[{\"foo\":\"bar\"},{\"baz\":\"biz\"}]");
 
         final Map<String, Object> query = new HashMap<>();
         ((ConsumeElasticsearch) runner.getProcessor()).addSortClause(query, null, runner.getProcessContext());
@@ -216,7 +216,7 @@ public class ConsumeElasticsearchTest extends SearchElasticsearchTest {
     void testTrackingFieldSortAlreadyPresent() throws IOException {
         final TestRunner runner = createRunner(false);
         final String existingRangeFieldSort = String.format("{\"%s\":\"bar\"}", RANGE_FIELD_NAME);
-        runner.setProperty(ElasticsearchRestProcessor.SORT, existingRangeFieldSort);
+        runner.setProperty(ConsumeElasticsearch.SORT, existingRangeFieldSort);
 
         final Map<String, Object> query = new HashMap<>();
         ((ConsumeElasticsearch) runner.getProcessor()).addSortClause(query, null, runner.getProcessContext());

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
@@ -52,7 +52,7 @@ import static org.apache.http.auth.AuthScope.ANY;
 public abstract class AbstractElasticsearchITBase {
     // default Elasticsearch version should (ideally) match that in the nifi-elasticsearch-bundle#pom.xml for the integration-tests profile
     protected static final DockerImageName IMAGE = DockerImageName
-            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.10.2"));
+            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.10.3"));
     protected static final String ELASTIC_USER_PASSWORD = System.getProperty("elasticsearch.elastic_user.password", RandomStringUtils.randomAlphanumeric(10, 20));
     private static final int PORT = 9200;
     protected static final ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer(IMAGE)

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -94,7 +94,7 @@ language governing permissions and limitations under the License. -->
             </activation>
             <properties>
                 <!-- also update the default Elasticsearch version in nifi-elasticsearch-test-utils#src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java-->
-                <elasticsearch_docker_image>8.10.2</elasticsearch_docker_image>
+                <elasticsearch_docker_image>8.10.3</elasticsearch_docker_image>
                 <elasticsearch.elastic.password>s3cret</elasticsearch.elastic.password>
             </properties>
             <build>
@@ -125,7 +125,7 @@ language governing permissions and limitations under the License. -->
         <profile>
             <id>elasticsearch7</id>
             <properties>
-                <elasticsearch_docker_image>7.17.13</elasticsearch_docker_image>
+                <elasticsearch_docker_image>7.17.14</elasticsearch_docker_image>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12214](https://issues.apache.org/jira/browse/NIFI-12214) ConsumeElasticsearch Query Builder properties do not dependOn the Query Definition Style

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
