### PR TITLE
NIFI-12221: Be more lenient about which Disconnection Codes we allow …

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
@@ -254,20 +254,22 @@ public abstract class AbstractHeartbeatMonitor implements HeartbeatMonitor {
                 case LACK_OF_HEARTBEAT:
                 case UNABLE_TO_COMMUNICATE:
                 case NOT_YET_CONNECTED:
-                case STARTUP_FAILURE: {
+                case MISMATCHED_FLOWS:
+                case MISSING_BUNDLE:
+                case NODE_SHUTDOWN:
+                case FAILED_TO_SERVICE_REQUEST:
+                case STARTUP_FAILURE:
                     clusterCoordinator.reportEvent(nodeId, Severity.INFO, "Received heartbeat from node previously "
                             + "disconnected due to " + disconnectionCode + ". Issuing reconnection request.");
 
                     clusterCoordinator.requestNodeConnect(nodeId, null);
                     break;
-                }
-                default: {
+                default:
                     // disconnected nodes should not heartbeat, so we need to issue a disconnection request.
-                    logger.info("Ignoring received heartbeat from disconnected node " + nodeId + ".  Issuing disconnection request.");
+                    logger.info("Ignoring received heartbeat from disconnected node {}. Node was disconnected due to [{}]. Issuing disconnection request.", nodeId, disconnectionCode);
                     clusterCoordinator.requestNodeDisconnect(nodeId, disconnectionCode, connectionStatus.getReason());
                     removeHeartbeat(nodeId);
                     break;
-                }
             }
 
             return;

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/OffloadIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/OffloadIT.java
@@ -25,11 +25,13 @@ import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
 import org.apache.nifi.web.api.entity.ConnectionEntity;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 public class OffloadIT extends NiFiSystemIT {
     private static final Logger logger = LoggerFactory.getLogger(OffloadIT.class);
@@ -40,6 +42,9 @@ public class OffloadIT extends NiFiSystemIT {
     }
 
     @Test
+    @Timeout(value = 10, unit = TimeUnit.MINUTES)
+    // Test to ensure that node can be offloaded, reconnected, offloaded several times. This test typically takes only about 1-2 minutes
+    // but can occasionally take 5-6 minutes on Github Actions so we set the timeout to 10 minutes to allow for these occasions
     public void testOffload() throws InterruptedException, IOException, NiFiClientException {
         for (int i=0; i < 5; i++) {
             logger.info("Running iteration {}", i);


### PR DESCRIPTION
…a node to be reconnected to a cluster vs. when we notify the node to disconnect again. Also updated the timeout for OffloadIT because it occasionally times ou out while running properly.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
