### PR TITLE
NIFI-12239 - Add OS/Java details at startup in bootstrap log

### DIFF
--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/RunNiFi.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/RunNiFi.java
@@ -38,7 +38,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.lang.management.ManagementFactory;
-import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -1416,10 +1415,9 @@ public class RunNiFi {
 
         // max file descriptor count + total physical memory
         try {
-            final OperatingSystemMXBean osStats = ManagementFactory.getOperatingSystemMXBean();
-            final ObjectName osObjectName = osStats.getObjectName();
+            final ObjectName osObjectName = ManagementFactory.getOperatingSystemMXBean().getObjectName();
             final Object maxOpenFileCount = ManagementFactory.getPlatformMBeanServer().getAttribute(osObjectName, "MaxFileDescriptorCount");
-            details.put("maxOpenFileDescriptors", String.valueOf((maxOpenFileCount)));
+            details.put("maxOpenFileDescriptors", String.valueOf(maxOpenFileCount));
             final Object totalPhysicalMemory = ManagementFactory.getPlatformMBeanServer().getAttribute(osObjectName, "TotalPhysicalMemorySize");
             details.put("totalPhysicalMemoryMB", String.valueOf(((Long) totalPhysicalMemory) / (1024*1024)));
         } catch (final Throwable t) {


### PR DESCRIPTION
# Summary

[NIFI-12239](https://issues.apache.org/jira/browse/NIFI-12239) - Add OS/Java details at startup in bootstrap log

Example of the added log:

````
2023-10-17 17:26:33,501 INFO [main] org.apache.nifi.bootstrap.RunNiFi {"javaVersion":"21","cores":16,"totalPhysicalMemoryMB":16384,"maxOpenFileDescriptors":10240,"xms":"1g","xmx":"1g"}
````

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
