### PR TITLE
NIFI-12238 Fix SplitText endline trimming with max fragment size

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitText.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitText.java
@@ -459,13 +459,6 @@ public class SplitText extends AbstractProcessor {
         while ((offsetInfo = demarcator.nextOffsetInfo()) != null) {
             lastCrlfLength = offsetInfo.getCrlfLength();
 
-            if (offsetInfo.getLength() == offsetInfo.getCrlfLength()) {
-                trailingCrlfLength += offsetInfo.getCrlfLength();
-                trailingLineCount++;
-            } else if (offsetInfo.getLength() > offsetInfo.getCrlfLength()) {
-                trailingCrlfLength = 0; // non-empty line came in, thus resetting counter
-            }
-
             if (length + offsetInfo.getLength() + startingLength > this.maxSplitSize) {
                 if (length == 0) { // single line per split
                     length += offsetInfo.getLength();
@@ -474,12 +467,19 @@ public class SplitText extends AbstractProcessor {
                     remaningOffsetInfo = offsetInfo;
                 }
                 break;
-            } else {
-                length += offsetInfo.getLength();
-                actualLineCount++;
-                if (splitMaxLineCount > 0 && actualLineCount >= splitMaxLineCount) {
-                    break;
-                }
+            }
+
+            if (offsetInfo.getLength() == offsetInfo.getCrlfLength()) {
+                trailingCrlfLength += offsetInfo.getCrlfLength();
+                trailingLineCount++;
+            } else if (offsetInfo.getLength() > offsetInfo.getCrlfLength()) {
+                trailingCrlfLength = 0; // non-empty line came in, thus resetting counter
+            }
+
+            length += offsetInfo.getLength();
+            actualLineCount++;
+            if (splitMaxLineCount > 0 && actualLineCount >= splitMaxLineCount) {
+                break;
             }
         }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSplitText.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSplitText.java
@@ -890,4 +890,25 @@ public class TestSplitText {
         splits.get(1).assertContentEquals("\n");
     }
 
+    @Test
+    public void testMaxFragmentSizeWithTrimmedEndlines() {
+        final TestRunner splitRunner = TestRunners.newTestRunner(new SplitText());
+        splitRunner.setProperty(SplitText.HEADER_LINE_COUNT, "2");
+        splitRunner.setProperty(SplitText.LINE_SPLIT_COUNT, "0");
+        splitRunner.setProperty(SplitText.FRAGMENT_MAX_SIZE, "30 B");
+        splitRunner.setProperty(SplitText.REMOVE_TRAILING_NEWLINES, "true");
+
+        splitRunner.enqueue("header1\nheader2\nline1 longer than limit\nline2\nline3\n\n\n\n\n");
+
+        splitRunner.run();
+        splitRunner.assertTransferCount(SplitText.REL_SPLITS, 3);
+        splitRunner.assertTransferCount(SplitText.REL_ORIGINAL, 1);
+        splitRunner.assertTransferCount(SplitText.REL_FAILURE, 0);
+
+        final List<MockFlowFile> splits = splitRunner.getFlowFilesForRelationship(SplitText.REL_SPLITS);
+        splits.get(0).assertContentEquals("header1\nheader2\nline1 longer than limit");
+        splits.get(1).assertContentEquals("header1\nheader2\nline2\nline3");
+        splits.get(2).assertContentEquals("header1\nheader2");
+    }
+
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12238](https://issues.apache.org/jira/browse/NIFI-12238)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
