### PR TITLE
NIFI-12242: Added ability to route data that exceeds the configured t…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ControlRate.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ControlRate.java
@@ -73,10 +73,10 @@ import java.util.regex.Pattern;
         Set the "Time Duration" property to `1 sec`.
         Configure the "Maximum Rate" property to specify how much data should be allowed through each second.
 
-        For example, to allow through 8 MB per second, "Maximum Rate" to `8 MB`.
+        For example, to allow through 8 MB per second, set "Maximum Rate" to `8 MB`.
         """
 )
-@UseCase(description = "Limit the rate at which requests are sent to a downstream system with little to no bursts",
+@UseCase(description = "Limit the rate at which FlowFiles are sent to a downstream system with little to no bursts",
     keywords = {"throttle", "limit", "slow down", "request rate"},
     configuration = """
         Set the "Rate Control Criteria" to `flowfile count`.
@@ -94,7 +94,7 @@ import java.util.regex.Pattern;
         Set the "Rate Exceeded Strategy" property to `Route to 'rate exceeded'`.
         Configure the "Maximum Rate" property to specify how many requests should be allowed through each second.
 
-        For example, to allow through 100 requests per second, "Maximum Rate" to `100`.
+        For example, to allow through 100 requests per second, set "Maximum Rate" to `100`.
         If more than 100 requests come in during any one second, the additional requests will be routed to `rate exceeded` instead of `success`.
         """
 )
@@ -106,7 +106,7 @@ import java.util.regex.Pattern;
         Set the "Rate Exceeded Strategy" property to `Route to 'rate exceeded'`.
         Configure the "Maximum Rate" property to specify how many requests should be allowed through each minute.
 
-        For example, to allow through 100 requests per second, "Maximum Rate" to `6000`.
+        For example, to allow through 100 requests per second, set "Maximum Rate" to `6000`.
         This will allow through 6,000 FlowFiles per minute, which averages to 100 FlowFiles per second. However, those 6,000 FlowFiles may come all within the first couple of
         seconds, or they may come in over a period of 60 seconds. As a result, this gives us an average rate of 100 FlowFiles per second but allows for bursts of data.
         If more than 6,000 requests come in during any one minute, the additional requests will be routed to `rate exceeded` instead of `success`.


### PR DESCRIPTION
…hreshold in ControlRate to be routed to  'rate exceeded' instead of just staying in the queue. Added Use Case documentation to ControlRate.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
