### PR TITLE
NIFI-4172: Renamed ClusteSummaryEntity to ClusterSummaryEntity

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ClusterSummaryEntity.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ClusterSummaryEntity.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * A serialized representation of this class can be placed in the entity body of a request or response to or from the API. This particular entity holds a reference to a ClusterSummaryDTO.
  */
 @XmlRootElement(name = "clusterSummaryEntity")
-public class ClusteSummaryEntity extends Entity {
+public class ClusterSummaryEntity extends Entity {
 
     private ClusterSummaryDTO clusterSummary;
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowResource.java
@@ -75,8 +75,8 @@ import org.apache.nifi.web.api.entity.ActionEntity;
 import org.apache.nifi.web.api.entity.ActivateControllerServicesEntity;
 import org.apache.nifi.web.api.entity.BannerEntity;
 import org.apache.nifi.web.api.entity.BulletinBoardEntity;
-import org.apache.nifi.web.api.entity.ClusteSummaryEntity;
 import org.apache.nifi.web.api.entity.ClusterSearchResultsEntity;
+import org.apache.nifi.web.api.entity.ClusterSummaryEntity;
 import org.apache.nifi.web.api.entity.ComponentHistoryEntity;
 import org.apache.nifi.web.api.entity.ConnectionStatisticsEntity;
 import org.apache.nifi.web.api.entity.ConnectionStatusEntity;
@@ -1211,7 +1211,7 @@ public class FlowResource extends ApplicationResource {
     @Path("cluster/summary")
     @ApiOperation(
             value = "The cluster summary for this NiFi",
-            response = ClusteSummaryEntity.class,
+        response = ClusterSummaryEntity.class,
             authorizations = {
                     @Authorization(value = "Read - /flow")
             }
@@ -1249,7 +1249,7 @@ public class FlowResource extends ApplicationResource {
         clusterConfiguration.setConnectedToCluster(isConnectedToCluster());
 
         // create the response entity
-        final ClusteSummaryEntity entity = new ClusteSummaryEntity();
+        final ClusterSummaryEntity entity = new ClusterSummaryEntity();
         entity.setClusterSummary(clusterConfiguration);
 
         // generate the response

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiSystemIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiSystemIT.java
@@ -26,8 +26,8 @@ import org.apache.nifi.toolkit.cli.impl.client.nifi.impl.JerseyNiFiClient;
 import org.apache.nifi.web.api.dto.NodeDTO;
 import org.apache.nifi.web.api.dto.status.ConnectionStatusSnapshotDTO;
 import org.apache.nifi.web.api.dto.status.ProcessGroupStatusSnapshotDTO;
-import org.apache.nifi.web.api.entity.ClusteSummaryEntity;
 import org.apache.nifi.web.api.entity.ClusterEntity;
+import org.apache.nifi.web.api.entity.ClusterSummaryEntity;
 import org.apache.nifi.web.api.entity.ConnectionEntity;
 import org.apache.nifi.web.api.entity.ConnectionStatusEntity;
 import org.apache.nifi.web.api.entity.ConnectionStatusSnapshotEntity;
@@ -268,7 +268,7 @@ public abstract class NiFiSystemIT implements NiFiInstanceProvider {
         while (true) {
             int connectedNodeCount = -1;
             try {
-                final ClusteSummaryEntity clusterSummary = client.getFlowClient().getClusterSummary();
+                final ClusterSummaryEntity clusterSummary = client.getFlowClient().getClusterSummary();
                 connectedNodeCount = clusterSummary.getClusterSummary().getConnectedNodeCount();
                 if (connectedNodeCount == expectedNumberOfNodes) {
                     logger.info("Wait successful, {} nodes connected", expectedNumberOfNodes);

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/NodeRestartWithNewNodeIdIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/NodeRestartWithNewNodeIdIT.java
@@ -21,7 +21,7 @@ import org.apache.nifi.tests.system.NiFiInstanceFactory;
 import org.apache.nifi.tests.system.NiFiSystemIT;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
 import org.apache.nifi.web.api.dto.NodeDTO;
-import org.apache.nifi.web.api.entity.ClusteSummaryEntity;
+import org.apache.nifi.web.api.entity.ClusterSummaryEntity;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -57,7 +57,7 @@ public class NodeRestartWithNewNodeIdIT extends NiFiSystemIT {
         // Wait for the second node to reconnect.
         waitForAllNodesConnected();
 
-        final ClusteSummaryEntity clusterSummary = getNifiClient().getFlowClient().getClusterSummary();
+        final ClusterSummaryEntity clusterSummary = getNifiClient().getFlowClient().getClusterSummary();
         // 2/2 because we replaced the state directory with a different state that had a different identifier. This will result in
         // 2 nodes each with a different UUID but the same hostname & port, but we should see that the cluster removes the old Node
         // Identifier, so we will have only 2 nodes total.

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/RestartWithDifferentPort.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/RestartWithDifferentPort.java
@@ -21,8 +21,8 @@ import org.apache.nifi.tests.system.NiFiInstanceFactory;
 import org.apache.nifi.tests.system.NiFiSystemIT;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
 import org.apache.nifi.web.api.dto.NodeDTO;
-import org.apache.nifi.web.api.entity.ClusteSummaryEntity;
 import org.apache.nifi.web.api.entity.ClusterEntity;
+import org.apache.nifi.web.api.entity.ClusterSummaryEntity;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -58,7 +58,7 @@ public class RestartWithDifferentPort extends NiFiSystemIT {
         waitForAllNodesConnected(getNumberOfNodes(true), 2000L);
 
         // Wait for the second node to reconnect.
-        final ClusteSummaryEntity clusterSummary = getNifiClient().getFlowClient().getClusterSummary();
+        final ClusterSummaryEntity clusterSummary = getNifiClient().getFlowClient().getClusterSummary();
         assertEquals("2 / 2", clusterSummary.getClusterSummary().getConnectedNodes());
 
         // Ensure that the Node UUID's are the same and that we now have 2 nodes: localhost:5671 and localhost:5673, but NOT localhost:5672

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/SimpleNodeRestartIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/SimpleNodeRestartIT.java
@@ -20,7 +20,7 @@ import org.apache.nifi.tests.system.NiFiInstance;
 import org.apache.nifi.tests.system.NiFiInstanceFactory;
 import org.apache.nifi.tests.system.NiFiSystemIT;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
-import org.apache.nifi.web.api.entity.ClusteSummaryEntity;
+import org.apache.nifi.web.api.entity.ClusterSummaryEntity;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -43,7 +43,7 @@ public class SimpleNodeRestartIT extends NiFiSystemIT {
         secondNode.start();
         waitForAllNodesConnected();
 
-        final ClusteSummaryEntity clusterSummary = getNifiClient().getFlowClient().getClusterSummary();
+        final ClusterSummaryEntity clusterSummary = getNifiClient().getFlowClient().getClusterSummary();
         assertEquals("2 / 2", clusterSummary.getClusterSummary().getConnectedNodes());
     }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/FlowClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/FlowClient.java
@@ -18,7 +18,7 @@ package org.apache.nifi.toolkit.cli.impl.client.nifi;
 
 import org.apache.nifi.flow.VersionedReportingTaskSnapshot;
 import org.apache.nifi.web.api.entity.ActivateControllerServicesEntity;
-import org.apache.nifi.web.api.entity.ClusteSummaryEntity;
+import org.apache.nifi.web.api.entity.ClusterSummaryEntity;
 import org.apache.nifi.web.api.entity.ConnectionStatusEntity;
 import org.apache.nifi.web.api.entity.ControllerServicesEntity;
 import org.apache.nifi.web.api.entity.CurrentUserEntity;
@@ -107,7 +107,7 @@ public interface FlowClient {
      *
      * @return cluster summary response
      */
-    ClusteSummaryEntity getClusterSummary() throws NiFiClientException, IOException;
+    ClusterSummaryEntity getClusterSummary() throws NiFiClientException, IOException;
 
     /**
      * Retrieves the controller services for the reporting tasks.

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyFlowClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyFlowClient.java
@@ -26,7 +26,7 @@ import org.apache.nifi.web.api.dto.PositionDTO;
 import org.apache.nifi.web.api.dto.flow.FlowDTO;
 import org.apache.nifi.web.api.dto.flow.ProcessGroupFlowDTO;
 import org.apache.nifi.web.api.entity.ActivateControllerServicesEntity;
-import org.apache.nifi.web.api.entity.ClusteSummaryEntity;
+import org.apache.nifi.web.api.entity.ClusterSummaryEntity;
 import org.apache.nifi.web.api.entity.ComponentEntity;
 import org.apache.nifi.web.api.entity.ConnectionStatusEntity;
 import org.apache.nifi.web.api.entity.ControllerServicesEntity;
@@ -224,10 +224,10 @@ public class JerseyFlowClient extends AbstractJerseyClient implements FlowClient
     }
 
     @Override
-    public ClusteSummaryEntity getClusterSummary() throws NiFiClientException, IOException {
+    public ClusterSummaryEntity getClusterSummary() throws NiFiClientException, IOException {
         return executeAction("Error retrieving cluster summary", () -> {
             final WebTarget target = flowTarget.path("cluster/summary");
-            return getRequestBuilder(target).get(ClusteSummaryEntity.class);
+            return getRequestBuilder(target).get(ClusterSummaryEntity.class);
         });
     }
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/flow/ClusterSummary.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/flow/ClusterSummary.java
@@ -21,7 +21,7 @@ import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClient;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
 import org.apache.nifi.toolkit.cli.impl.result.nifi.ClusterSummaryEntityResult;
-import org.apache.nifi.web.api.entity.ClusteSummaryEntity;
+import org.apache.nifi.web.api.entity.ClusterSummaryEntity;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -41,7 +41,7 @@ public class ClusterSummary extends AbstractNiFiCommand<ClusterSummaryEntityResu
     public ClusterSummaryEntityResult doExecute(NiFiClient client, Properties properties)
             throws NiFiClientException, IOException {
         final FlowClient flowClient = client.getFlowClient();
-        final ClusteSummaryEntity clusterSummary = flowClient.getClusterSummary();
+        final ClusterSummaryEntity clusterSummary = flowClient.getClusterSummary();
         return new ClusterSummaryEntityResult(getResultType(properties), clusterSummary);
     }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/ClusterSummaryEntityResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/ClusterSummaryEntityResult.java
@@ -18,7 +18,7 @@ package org.apache.nifi.toolkit.cli.impl.result.nifi;
 
 import org.apache.nifi.toolkit.cli.api.ResultType;
 import org.apache.nifi.toolkit.cli.impl.result.AbstractWritableResult;
-import org.apache.nifi.web.api.entity.ClusteSummaryEntity;
+import org.apache.nifi.web.api.entity.ClusterSummaryEntity;
 
 import java.io.PrintStream;
 import java.util.Objects;
@@ -26,17 +26,17 @@ import java.util.Objects;
 /**
  * Result for CurrentUserEntity from NiFi.
  */
-public class ClusterSummaryEntityResult extends AbstractWritableResult<ClusteSummaryEntity> {
+public class ClusterSummaryEntityResult extends AbstractWritableResult<ClusterSummaryEntity> {
 
-    private final ClusteSummaryEntity clusteSummaryEntity;
+    private final ClusterSummaryEntity clusteSummaryEntity;
 
-    public ClusterSummaryEntityResult(final ResultType resultType, final ClusteSummaryEntity clusteSummaryEntity) {
+    public ClusterSummaryEntityResult(final ResultType resultType, final ClusterSummaryEntity clusteSummaryEntity) {
         super(resultType);
         this.clusteSummaryEntity = Objects.requireNonNull(clusteSummaryEntity);
     }
 
     @Override
-    public ClusteSummaryEntity getResult() {
+    public ClusterSummaryEntity getResult() {
         return clusteSummaryEntity;
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
