### PR TITLE
NIFI-12247: Reverting to the initial value if there is no selected parameter in the combo editor

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -768,8 +768,8 @@
                 if (parametersSupported && _.isUndefined(selectedValue)) {
                     selectedOption = parameterCombo.combo('getSelectedOption');
 
-                    // if the parameters are still loading, revert to the initial value, otherwise use the selected parameter
-                    if (selectedOption === LOADING_PARAMETERS_OPTION) {
+                    // if there are no parameters, or they are still loading, revert to the initial value otherwise use the selected parameter
+                    if (_.isUndefined(selectedOption) || selectedOption === LOADING_PARAMETERS_OPTION) {
                         selectedValue = initialValue;
                     } else {
                         selectedValue = selectedOption.value;


### PR DESCRIPTION
NIFI-12247:
- Reverting to the initial value if there is no selected parameter in the combo editor.