### PR TITLE
NIFI-12258 Upgrade MINA SSHD from 2.10.0 to 2.11.0 for Main Branch

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <yammer.metrics.version>2.2.0</yammer.metrics.version>
         <jolt.version>0.1.8</jolt.version>
-        <org.apache.sshd.version>2.10.0</org.apache.sshd.version>
+        <org.apache.sshd.version>2.11.0</org.apache.sshd.version>
         <tika.version>2.9.0</tika.version>
     </properties>
     <dependencyManagement>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -42,7 +42,7 @@
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jaxb.version>2.3.2</jaxb.version>
         <jgit.version>6.7.0.202309050840-r</jgit.version>
-        <org.apache.sshd.version>2.10.0</org.apache.sshd.version>
+        <org.apache.sshd.version>2.11.0</org.apache.sshd.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-12258](https://issues.apache.org/jira/browse/NIFI-12258) Upgrades Apache MINA SSHD dependencies from 2.10.0 to 2.11.0 for the main branch.

This upgrade mitigates CVE-2023-35887, which applies to SFTP server implementations and is not directly applicable to transitive usage in NiFi Registry.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
