### PR TITLE
NIFI-12262 Remove unused Groovy plugin repository

### DIFF
--- a/nifi-toolkit/pom.xml
+++ b/nifi-toolkit/pom.xml
@@ -32,30 +32,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.apache.groovy</groupId>
-                <artifactId>groovy-all</artifactId>
-                <type>pom</type>
-                <scope>compile</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.groovy</groupId>
-                        <artifactId>groovy-test</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.groovy</groupId>
-                        <artifactId>groovy-test-junit5</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.ant</groupId>
-                        <artifactId>ant-junit</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
                 <version>${netty.3.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,12 +154,6 @@
         <zookeeper.version>3.9.1</zookeeper.version>
         <caffeine.version>3.1.8</caffeine.version>
     </properties>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>groovy-plugins-release</id>
-            <url>https://groovy.jfrog.io/artifactory/plugins-release</url>
-        </pluginRepository>
-    </pluginRepositories>
     <dependencyManagement>
         <dependencies>
             <!-- The following dependency management entries exist because these are jars
@@ -342,7 +336,6 @@
                 <artifactId>groovy-all</artifactId>
                 <version>${nifi.groovy.version}</version>
                 <type>pom</type>
-                <scope>test</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.groovy</groupId>
@@ -357,12 +350,6 @@
                         <artifactId>ant-junit</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.groovy</groupId>
-                <artifactId>groovy-test</artifactId>
-                <version>${nifi.groovy.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -971,6 +958,8 @@
                                         <exclude>org.apache.sshd:*:[,2.9.1]</exclude>
                                         <!-- The Spock Framework should not be used for testing -->
                                         <exclude>org.spockframework:*</exclude>
+                                        <!-- Groovy should not be used for testing -->
+                                        <exclude>org.apache.groovy:groovy-test</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>


### PR DESCRIPTION
# Summary

[NIFI-12262](https://issues.apache.org/jira/browse/NIFI-12262) Removes unused Groovy plugin repository references no longer necessary following the removal of Groovy-based components in PR #7901. Changes include removing and excluding the `groovy-test` dependency and removing the unused `groovy-all` dependency management section from the `nifi-toolkit` module.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
