### PR TITLE
NIFI-12264 Upgrade Apache Tika from 2.9.0 to 2.9.1

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <curator.version>5.5.0</curator.version>
         <guava.version>32.1.2-jre</guava.version>
-        <tika.version>2.9.0</tika.version>
+        <tika.version>2.9.1</tika.version>
         <org.opensaml.version>4.3.0</org.opensaml.version>
     </properties>
     <modules>

--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tika.version>2.9.0</tika.version>
+        <tika.version>2.9.1</tika.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -37,7 +37,7 @@
         <yammer.metrics.version>2.2.0</yammer.metrics.version>
         <jolt.version>0.1.8</jolt.version>
         <org.apache.sshd.version>2.11.0</org.apache.sshd.version>
-        <tika.version>2.9.0</tika.version>
+        <tika.version>2.9.1</tika.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
# Summary

[NIFI-12264](https://issues.apache.org/jira/browse/NIFI-12264) Upgrades Apache Tika from 2.9.0 to [2.9.1](https://dist.apache.org/repos/dist/release/tika/2.9.1/CHANGES-2.9.1.txt) incorporate transitive dependency upgrades and other fixes.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
