### PR TITLE
NIFI-12121 added the ability to modify the output filter in …

### DIFF
--- a/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/main/java/org/apache/nifi/processors/jslt/JSLTTransformJSON.java
+++ b/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/main/java/org/apache/nifi/processors/jslt/JSLTTransformJSON.java
@@ -115,7 +115,7 @@ public class JSLTTransformJSON extends AbstractProcessor {
             .displayName("Transform Result Filter")
             .description("A filter of output results using another JSLT. This property allows you to change the built-in filter,"
                     + " which removes objects with null values, empty objects and empty arrays from the output."
-                    + " Use a filter such as \"1 == 1\" to disable all filtering.")
+                    + " Use a filter such as \"true\" to disable all filtering.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .identifiesExternalResource(ResourceCardinality.SINGLE, ResourceType.TEXT, ResourceType.FILE)
             .required(true)

--- a/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/main/java/org/apache/nifi/processors/jslt/JSLTTransformJSON.java
+++ b/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/main/java/org/apache/nifi/processors/jslt/JSLTTransformJSON.java
@@ -114,8 +114,8 @@ public class JSLTTransformJSON extends AbstractProcessor {
             .name("jslt-transform-result-filter")
             .displayName("Transform Result Filter")
             .description("A filter of output results using another JSLT. This property allows you to change the built-in filter,"
-                    + " which removes objects with null values, empty objects and empty arrays from the output."
-                    + " This JSLT must return true/false"
+                    + " which removes JSON objects with null values, empty objects and empty arrays from the output."
+                    + " This JSLT must return true for each JSON object to be included and false for each object to be removed."
                     + " Use a filter such as \"true\" to disable all filtering.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .required(true)

--- a/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/main/java/org/apache/nifi/processors/jslt/JSLTTransformJSON.java
+++ b/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/main/java/org/apache/nifi/processors/jslt/JSLTTransformJSON.java
@@ -115,9 +115,9 @@ public class JSLTTransformJSON extends AbstractProcessor {
             .displayName("Transform Result Filter")
             .description("A filter of output results using another JSLT. This property allows you to change the built-in filter,"
                     + " which removes objects with null values, empty objects and empty arrays from the output."
+                    + " This JSLT must return true/false"
                     + " Use a filter such as \"true\" to disable all filtering.")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .identifiesExternalResource(ResourceCardinality.SINGLE, ResourceType.TEXT, ResourceType.FILE)
             .required(true)
             .defaultValue(JSLT_FILTER_DEFAULT)
             .build();
@@ -357,6 +357,9 @@ public class JSLTTransformJSON extends AbstractProcessor {
 
     private String readTransform(final PropertyValue propertyValue) {
         final ResourceReference resourceReference = propertyValue.asResource();
+        if (resourceReference == null) {
+            return propertyValue.getValue();
+        }
         try (final BufferedReader reader = new BufferedReader(new InputStreamReader(resourceReference.read()))) {
             return reader.lines().collect(Collectors.joining());
         } catch (final IOException e) {

--- a/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
+++ b/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
@@ -163,6 +163,12 @@ public class TestJSLTTransformJSON {
         runTransform("inputWithNull.json", "simpleTransform.json", "simpleOutputWithNull.json");
     }
 
+    @Test
+    public void testTransformWithNoFilter() {
+        runner.setProperty(JSLTTransformJSON.RESULT_FILTER, "1 == 1");
+        runTransform("inputWithNull.json", "simpleTransform.json", "simpleOutputWithNull.json");
+    }
+
     // This test verifies transformCache cleanup does not throw an exception
     @Test
     public void testShutdown() {

--- a/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
+++ b/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
@@ -151,6 +151,24 @@ public class TestJSLTTransformJSON {
         flowFile.assertContentEquals(new byte[0]);
     }
 
+    @Test
+    public void testTransformWithNullValueRemoved() {
+        runner.setProperty(JSLTTransformJSON.RESULT_FILTER, ". != null and . != {} and . != []");
+        runTransform("inputWithNull.json", "simpleTransform.json", "simpleOutputWithoutNull.json");
+    }
+
+    @Test
+    public void testTransformWithNullValueIncluded() {
+        runner.setProperty(JSLTTransformJSON.RESULT_FILTER, ". != {} and . != []");
+        runTransform("inputWithNull.json", "simpleTransform.json", "simpleOutputWithNull.json");
+    }
+
+    // This test verifies transformCache cleanup does not throw an exception
+    @Test
+    public void testShutdown() {
+        runner.stop();
+    }
+
     private void runTransform(final String inputFileName, final String transformFileName, final String outputFileName) {
         setTransformEnqueueJson(transformFileName, inputFileName);
 

--- a/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
+++ b/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
@@ -165,7 +165,7 @@ public class TestJSLTTransformJSON {
 
     @Test
     public void testTransformWithNoFilter() {
-        runner.setProperty(JSLTTransformJSON.RESULT_FILTER, "1 == 1");
+        runner.setProperty(JSLTTransformJSON.RESULT_FILTER, "true");
         runTransform("inputWithNull.json", "simpleTransform.json", "simpleOutputWithNull.json");
     }
 

--- a/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/resources/inputWithNull.json
+++ b/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/resources/inputWithNull.json
@@ -1,0 +1,13 @@
+{
+  "rating": {
+    "primary": {
+      "value": 3
+    },
+    "series": {
+      "value": [5,4]
+    },
+    "quality": {
+      "value": null
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/resources/simpleOutputWithNull.json
+++ b/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/resources/simpleOutputWithNull.json
@@ -1,0 +1,8 @@
+{
+  "SecondaryRatings" : {
+    "quality" : {
+      "Value" : 3,
+      "RatingRange" : null
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/resources/simpleOutputWithoutNull.json
+++ b/nifi-nar-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/resources/simpleOutputWithoutNull.json
@@ -1,0 +1,7 @@
+{
+  "SecondaryRatings" : {
+    "quality" : {
+      "Value" : 3
+    }
+  }
+}


### PR DESCRIPTION
… JSLTTransformJSON, which can be used to keep null values or empty arrays

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

The JSLT java library supports a filter on the results of a JSLT transform.  By default, that filter removes
all objects with a null value, all empty objects, and all empty arrays.  This PR supports a new Property
on the JSLTTransformJSON processor that lets users configure that filter, in case the default behavior
is not desired.

Also, this PR fixes a potential NPE in OnShutdown if the cache has never been created.

[NIFI-12121](https://issues.apache.org/jira/browse/NIFI-12121)

This PR should cherry-pick cleanly to the nifi-1.x support branch, though I don't know if it's wanted there.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
