### PR TITLE
NIFI-12265 Fix StandardPGPPublicKeyService key search issue with subkey starts with 0

### DIFF
--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/DecryptContentPGP.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/DecryptContentPGP.java
@@ -38,7 +38,7 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.pgp.attributes.DecryptionStrategy;
 import org.apache.nifi.processors.pgp.exception.PGPDecryptionException;
 import org.apache.nifi.processors.pgp.exception.PGPProcessException;
-import org.apache.nifi.processors.pgp.io.KeyIdentifierConverter;
+import org.apache.nifi.pgp.service.api.KeyIdentifierConverter;
 import org.apache.nifi.stream.io.StreamUtils;
 
 import org.apache.nifi.util.StringUtils;

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/SignContentPGP.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/SignContentPGP.java
@@ -39,7 +39,7 @@ import org.apache.nifi.processors.pgp.attributes.HashAlgorithm;
 import org.apache.nifi.processors.pgp.attributes.SigningStrategy;
 import org.apache.nifi.processors.pgp.exception.PGPProcessException;
 import org.apache.nifi.processors.pgp.io.EncodingStreamCallback;
-import org.apache.nifi.processors.pgp.io.KeyIdentifierConverter;
+import org.apache.nifi.pgp.service.api.KeyIdentifierConverter;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPLiteralDataGenerator;
 import org.bouncycastle.openpgp.PGPOnePassSignature;

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/VerifyContentPGP.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/VerifyContentPGP.java
@@ -31,7 +31,7 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.io.StreamCallback;
 import org.apache.nifi.processors.pgp.exception.PGPProcessException;
-import org.apache.nifi.processors.pgp.io.KeyIdentifierConverter;
+import org.apache.nifi.pgp.service.api.KeyIdentifierConverter;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.bouncycastle.openpgp.PGPCompressedData;
 import org.bouncycastle.openpgp.PGPException;

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/io/KeyIdentifierConverter.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/io/KeyIdentifierConverter.java
@@ -23,6 +23,7 @@ import java.math.BigInteger;
  */
 public class KeyIdentifierConverter {
     private static final int HEXADECIMAL_RADIX = 16;
+    private static final int KEY_ID_LENGTH = 16;
 
     /**
      * Format numeric key identifier as uppercase hexadecimal string
@@ -31,7 +32,7 @@ public class KeyIdentifierConverter {
      * @return Uppercase hexadecimal string
      */
     public static String format(final long keyId) {
-        return Long.toHexString(keyId).toUpperCase();
+        return String.format("%0" + KEY_ID_LENGTH + "X", keyId);
     }
 
     /**

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/EncryptContentPGPTest.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/EncryptContentPGPTest.java
@@ -21,7 +21,7 @@ import org.apache.nifi.pgp.util.PGPOperationUtils;
 import org.apache.nifi.processors.pgp.attributes.DecryptionStrategy;
 import org.apache.nifi.processors.pgp.attributes.FileEncoding;
 import org.apache.nifi.processors.pgp.attributes.SymmetricKeyAlgorithm;
-import org.apache.nifi.processors.pgp.io.KeyIdentifierConverter;
+import org.apache.nifi.pgp.service.api.KeyIdentifierConverter;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.apache.nifi.util.MockFlowFile;

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/SignContentPGPTest.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/SignContentPGPTest.java
@@ -21,7 +21,7 @@ import org.apache.nifi.pgp.util.PGPSecretKeyGenerator;
 import org.apache.nifi.processors.pgp.attributes.FileEncoding;
 import org.apache.nifi.processors.pgp.attributes.HashAlgorithm;
 import org.apache.nifi.processors.pgp.attributes.SigningStrategy;
-import org.apache.nifi.processors.pgp.io.KeyIdentifierConverter;
+import org.apache.nifi.pgp.service.api.KeyIdentifierConverter;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.LogMessage;
 import org.apache.nifi.util.MockFlowFile;

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/VerifyContentPGPTest.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/VerifyContentPGPTest.java
@@ -20,7 +20,7 @@ import org.apache.nifi.pgp.service.api.PGPPublicKeyService;
 import org.apache.nifi.pgp.util.PGPFileUtils;
 import org.apache.nifi.pgp.util.PGPSecretKeyGenerator;
 import org.apache.nifi.pgp.util.PGPOperationUtils;
-import org.apache.nifi.processors.pgp.io.KeyIdentifierConverter;
+import org.apache.nifi.pgp.service.api.KeyIdentifierConverter;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.LogMessage;
 import org.apache.nifi.util.MockFlowFile;

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service-api/src/main/java/org/apache/nifi/pgp/service/api/KeyIdentifierConverter.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service-api/src/main/java/org/apache/nifi/pgp/service/api/KeyIdentifierConverter.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.processors.pgp.io;
+package org.apache.nifi.pgp.service.api;
 
 import java.math.BigInteger;
 
@@ -23,7 +23,8 @@ import java.math.BigInteger;
  */
 public class KeyIdentifierConverter {
     private static final int HEXADECIMAL_RADIX = 16;
-    private static final int KEY_ID_LENGTH = 16;
+
+    private static final String KEY_ID_FORMAT = "%016X";
 
     /**
      * Format numeric key identifier as uppercase hexadecimal string
@@ -32,7 +33,7 @@ public class KeyIdentifierConverter {
      * @return Uppercase hexadecimal string
      */
     public static String format(final long keyId) {
-        return String.format("%0" + KEY_ID_LENGTH + "X", keyId);
+        return String.format(KEY_ID_FORMAT, keyId);
     }
 
     /**

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service-api/src/test/java/org/apache/nifi/pgp/service/api/KeyIdentifierConverterTest.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service-api/src/test/java/org/apache/nifi/pgp/service/api/KeyIdentifierConverterTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.processors.pgp.io;
+package org.apache.nifi.pgp.service.api;
 
 import org.junit.jupiter.api.Test;
 

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPrivateKeyService.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPrivateKeyService.java
@@ -27,6 +27,7 @@ import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.pgp.service.api.KeyIdentifierConverter;
 import org.apache.nifi.pgp.service.api.PGPPrivateKeyService;
 import org.apache.nifi.pgp.service.standard.exception.PGPConfigurationException;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -142,7 +143,7 @@ public class StandardPGPPrivateKeyService extends AbstractControllerService impl
      */
     @Override
     public Optional<PGPPrivateKey> findPrivateKey(final long keyIdentifier) {
-        getLogger().debug("Find Private Key [{}]", String.format("%016X", keyIdentifier));
+        getLogger().debug("Find Private Key [{}]", KeyIdentifierConverter.format(keyIdentifier));
         return Optional.ofNullable(privateKeys.get(keyIdentifier));
     }
 
@@ -256,7 +257,7 @@ public class StandardPGPPrivateKeyService extends AbstractControllerService impl
         for (final PGPSecretKeyRing keyRing : keyRings) {
             for (final PGPSecretKey secretKey : keyRing) {
                 final long keyId = secretKey.getKeyID();
-                final String keyIdentifier = String.format("%016X", keyId);
+                final String keyIdentifier = KeyIdentifierConverter.format(keyId);
                 try {
                     final PGPPrivateKey privateKey = secretKey.extractPrivateKey(keyDecryptor);
                     extractedPrivateKeys.add(privateKey);

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPrivateKeyService.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPrivateKeyService.java
@@ -142,7 +142,7 @@ public class StandardPGPPrivateKeyService extends AbstractControllerService impl
      */
     @Override
     public Optional<PGPPrivateKey> findPrivateKey(final long keyIdentifier) {
-        getLogger().debug("Find Private Key [{}]", Long.toHexString(keyIdentifier).toUpperCase());
+        getLogger().debug("Find Private Key [{}]", String.format("%016X", keyIdentifier));
         return Optional.ofNullable(privateKeys.get(keyIdentifier));
     }
 
@@ -256,7 +256,7 @@ public class StandardPGPPrivateKeyService extends AbstractControllerService impl
         for (final PGPSecretKeyRing keyRing : keyRings) {
             for (final PGPSecretKey secretKey : keyRing) {
                 final long keyId = secretKey.getKeyID();
-                final String keyIdentifier = Long.toHexString(keyId).toUpperCase();
+                final String keyIdentifier = String.format("%016X", keyId);
                 try {
                     final PGPPrivateKey privateKey = secretKey.extractPrivateKey(keyDecryptor);
                     extractedPrivateKeys.add(privateKey);

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPublicKeyService.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPublicKeyService.java
@@ -27,6 +27,7 @@ import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.pgp.service.api.KeyIdentifierConverter;
 import org.apache.nifi.pgp.service.api.PGPPublicKeyService;
 import org.apache.nifi.pgp.service.standard.exception.PGPConfigurationException;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -186,7 +187,7 @@ public class StandardPGPPublicKeyService extends AbstractControllerService imple
 
     private boolean isPublicKeyMatched(final PGPPublicKey publicKey, final String search) {
         boolean matched = false;
-        final String keyId = String.format("%016X", publicKey.getKeyID());
+        final String keyId = KeyIdentifierConverter.format(publicKey.getKeyID());
         if (keyId.equals(search)) {
             matched = true;
         } else {

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPublicKeyService.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPublicKeyService.java
@@ -186,7 +186,7 @@ public class StandardPGPPublicKeyService extends AbstractControllerService imple
 
     private boolean isPublicKeyMatched(final PGPPublicKey publicKey, final String search) {
         boolean matched = false;
-        final String keyId = Long.toHexString(publicKey.getKeyID()).toUpperCase();
+        final String keyId = String.format("%016X", publicKey.getKeyID());
         if (keyId.equals(search)) {
             matched = true;
         } else {

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/test/java/org/apche/nifi/pgp/service/standard/StandardPGPPublicKeyServiceTest.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/test/java/org/apche/nifi/pgp/service/standard/StandardPGPPublicKeyServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.apche.nifi.pgp.service.standard;
 
+import org.apache.nifi.pgp.service.api.KeyIdentifierConverter;
 import org.apache.nifi.pgp.service.standard.StandardPGPPublicKeyService;
 import org.apache.nifi.pgp.util.PGPFileUtils;
 import org.apache.nifi.pgp.util.PGPSecretKeyGenerator;
@@ -129,7 +130,7 @@ public class StandardPGPPublicKeyServiceTest {
 
     private void assertPublicKeyFound(final PGPSecretKey secretKey) {
         final long keyIdentifier = secretKey.getKeyID();
-        final String publicKeySearch = String.format("%016X", keyIdentifier);
+        final String publicKeySearch = KeyIdentifierConverter.format(keyIdentifier);
         final Optional<PGPPublicKey> optionalPublicKey = service.findPublicKey(publicKeySearch);
         assertTrue(optionalPublicKey.isPresent());
         final PGPPublicKey publicKey = optionalPublicKey.get();

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/test/java/org/apche/nifi/pgp/service/standard/StandardPGPPublicKeyServiceTest.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service/src/test/java/org/apche/nifi/pgp/service/standard/StandardPGPPublicKeyServiceTest.java
@@ -129,7 +129,7 @@ public class StandardPGPPublicKeyServiceTest {
 
     private void assertPublicKeyFound(final PGPSecretKey secretKey) {
         final long keyIdentifier = secretKey.getKeyID();
-        final String publicKeySearch = Long.toHexString(keyIdentifier).toUpperCase();
+        final String publicKeySearch = String.format("%016X", keyIdentifier);
         final Optional<PGPPublicKey> optionalPublicKey = service.findPublicKey(publicKeySearch);
         assertTrue(optionalPublicKey.isPresent());
         final PGPPublicKey publicKey = optionalPublicKey.get();


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12265](https://issues.apache.org/jira/browse/NIFI-12265)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
