### PR TITLE
NIFI-12268 Upgrade OkHttp from 4.11.0 to 4.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,9 @@
         <software.amazon.awssdk.version>2.20.148</software.amazon.awssdk.version>
         <gson.version>2.10.1</gson.version>
         <io.fabric8.kubernetes.client.version>6.8.1</io.fabric8.kubernetes.client.version>
-        <kotlin.version>1.9.0</kotlin.version>
-        <okhttp.version>4.11.0</okhttp.version>
-        <okio.version>3.5.0</okio.version>
+        <kotlin.version>1.9.10</kotlin.version>
+        <okhttp.version>4.12.0</okhttp.version>
+        <okio.version>3.6.0</okio.version>
         <org.apache.commons.cli.version>1.5.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.16.0</org.apache.commons.codec.version>
         <org.apache.commons.compress.version>1.24.0</org.apache.commons.compress.version>


### PR DESCRIPTION
# Summary

[NIFI-12268](https://issues.apache.org/jira/browse/NIFI-12268) Upgrades OkHttp from 4.11.0 to [4.12.0](https://square.github.io/okhttp/changelogs/changelog_4x/#version-4120) as well as upgrading Okio from 3.5.0 to 3.6.0, and Kotlin from 1.9.0 to 1.9.10.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
