### PR TITLE
NIFI-12249 FetchFTP and FetchSFTP processors now write failure reason to 'failure' attribute

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFTP.java
@@ -48,7 +48,7 @@ import org.apache.nifi.processors.standard.util.FileTransfer;
     @WritesAttribute(attribute = "ftp.remote.filename", description = "The name of the remote file that was pulled"),
     @WritesAttribute(attribute = "filename", description = "The filename is updated to point to the filename fo the remote file"),
     @WritesAttribute(attribute = "path", description = "If the Remote File contains a directory name, that directory name will be added to the FlowFile using the 'path' attribute"),
-    @WritesAttribute(attribute = "failure", description = "If the transfer failed, the failure reason is written to this attribute")
+    @WritesAttribute(attribute = "fetch.failure.reason", description = "The name of the failure relationship applied when routing to any failure relationship")
 })
 @MultiProcessorUseCase(
     description = "Retrieve all files in a directory of an FTP Server",

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFTP.java
@@ -47,7 +47,8 @@ import org.apache.nifi.processors.standard.util.FileTransfer;
     @WritesAttribute(attribute = "ftp.remote.port", description = "The port that was used to communicate with the remote FTP server"),
     @WritesAttribute(attribute = "ftp.remote.filename", description = "The name of the remote file that was pulled"),
     @WritesAttribute(attribute = "filename", description = "The filename is updated to point to the filename fo the remote file"),
-    @WritesAttribute(attribute = "path", description = "If the Remote File contains a directory name, that directory name will be added to the FlowFile using the 'path' attribute")
+    @WritesAttribute(attribute = "path", description = "If the Remote File contains a directory name, that directory name will be added to the FlowFile using the 'path' attribute"),
+    @WritesAttribute(attribute = "failure", description = "If the transfer failed, the failure reason is written to this attribute")
 })
 @MultiProcessorUseCase(
     description = "Retrieve all files in a directory of an FTP Server",

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchSFTP.java
@@ -48,7 +48,7 @@ import org.apache.nifi.processors.standard.util.SFTPTransfer;
     @WritesAttribute(attribute = "sftp.remote.filename", description = "The name of the remote file that was pulled"),
     @WritesAttribute(attribute = "filename", description = "The filename is updated to point to the filename fo the remote file"),
     @WritesAttribute(attribute = "path", description = "If the Remote File contains a directory name, that directory name will be added to the FlowFile using the 'path' attribute"),
-    @WritesAttribute(attribute = "failure", description = "If the transfer failed, the failure reason is written to this attribute")
+    @WritesAttribute(attribute = "fetch.failure.reason", description = "The name of the failure relationship applied when routing to any failure relationship")
 })
 @MultiProcessorUseCase(
     description = "Retrieve all files in a directory of an SFTP Server",

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchSFTP.java
@@ -47,7 +47,8 @@ import org.apache.nifi.processors.standard.util.SFTPTransfer;
     @WritesAttribute(attribute = "sftp.remote.port", description = "The port that was used to communicate with the remote SFTP server"),
     @WritesAttribute(attribute = "sftp.remote.filename", description = "The name of the remote file that was pulled"),
     @WritesAttribute(attribute = "filename", description = "The filename is updated to point to the filename fo the remote file"),
-    @WritesAttribute(attribute = "path", description = "If the Remote File contains a directory name, that directory name will be added to the FlowFile using the 'path' attribute")
+    @WritesAttribute(attribute = "path", description = "If the Remote File contains a directory name, that directory name will be added to the FlowFile using the 'path' attribute"),
+    @WritesAttribute(attribute = "failure", description = "If the transfer failed, the failure reason is written to this attribute")
 })
 @MultiProcessorUseCase(
     description = "Retrieve all files in a directory of an SFTP Server",

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFTP.java
@@ -269,6 +269,7 @@ public class TestFTP {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(FetchFTP.REL_NOT_FOUND);
+        runner.assertAllFlowFilesContainAttribute("failure");
     }
 
     @Test
@@ -290,6 +291,7 @@ public class TestFTP {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(FetchFTP.REL_PERMISSION_DENIED);
+        runner.assertAllFlowFilesContainAttribute("failure");
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFTP.java
@@ -269,7 +269,7 @@ public class TestFTP {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(FetchFTP.REL_NOT_FOUND);
-        runner.assertAllFlowFilesContainAttribute("failure");
+        runner.assertAllFlowFilesContainAttribute(FetchFileTransfer.FAILURE_REASON_ATTRIBUTE);
     }
 
     @Test
@@ -291,7 +291,7 @@ public class TestFTP {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(FetchFTP.REL_PERMISSION_DENIED);
-        runner.assertAllFlowFilesContainAttribute("failure");
+        runner.assertAllFlowFilesContainAttribute(FetchFileTransfer.FAILURE_REASON_ATTRIBUTE);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFetchFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFetchFTP.java
@@ -113,10 +113,9 @@ public class TestFetchFTP {
 
         runner.run(1, false, false);
         runner.assertAllFlowFilesTransferred(FetchFileTransfer.REL_NOT_FOUND, 1);
-        runner.assertAllFlowFilesContainAttribute(FetchFileTransfer.REL_NOT_FOUND, "failure");
-        runner.assertAllFlowFilesContainAttribute("failure");
+        runner.assertAllFlowFilesContainAttribute(FetchFileTransfer.FAILURE_REASON_ATTRIBUTE);
         MockFlowFile transferredFlowFile = runner.getPenalizedFlowFiles().get(0);
-        assertTrue(transferredFlowFile.getAttribute("failure").contains(FetchFileTransfer.REL_NOT_FOUND.getName()));
+        assertEquals(FetchFileTransfer.REL_NOT_FOUND.getName(), transferredFlowFile.getAttribute(FetchFileTransfer.FAILURE_REASON_ATTRIBUTE));
     }
 
     @Test
@@ -126,9 +125,9 @@ public class TestFetchFTP {
 
         runner.run(1, false, false);
         runner.assertAllFlowFilesTransferred(FetchFileTransfer.REL_PERMISSION_DENIED, 1);
-        runner.assertAllFlowFilesContainAttribute("failure");
+        runner.assertAllFlowFilesContainAttribute(FetchFileTransfer.FAILURE_REASON_ATTRIBUTE);
         MockFlowFile transferredFlowFile = runner.getPenalizedFlowFiles().get(0);
-        assertTrue(transferredFlowFile.getAttribute("failure").contains(FetchFileTransfer.REL_PERMISSION_DENIED.getName()));
+        assertEquals(FetchFileTransfer.REL_PERMISSION_DENIED.getName(), transferredFlowFile.getAttribute(FetchFileTransfer.FAILURE_REASON_ATTRIBUTE));
     }
 
     @Test
@@ -139,7 +138,7 @@ public class TestFetchFTP {
 
         runner.run(2, false, false);
         runner.assertAllFlowFilesTransferred(FetchFileTransfer.REL_PERMISSION_DENIED, 2);
-        runner.assertAllFlowFilesContainAttribute("failure");
+        runner.assertAllFlowFilesContainAttribute(FetchFileTransfer.FAILURE_REASON_ATTRIBUTE);
 
         assertEquals(1, proc.numberOfFileTransfers);
         assertFalse(proc.isClosed);
@@ -153,7 +152,7 @@ public class TestFetchFTP {
 
         runner.run(2, false, false);
         runner.assertAllFlowFilesTransferred(FetchFileTransfer.REL_NOT_FOUND, 2);
-        runner.assertAllFlowFilesContainAttribute("failure");
+        runner.assertAllFlowFilesContainAttribute(FetchFileTransfer.FAILURE_REASON_ATTRIBUTE);
 
         assertEquals(1, proc.numberOfFileTransfers);
         assertFalse(proc.isClosed);
@@ -166,9 +165,9 @@ public class TestFetchFTP {
 
         runner.run(1, false, false);
         runner.assertAllFlowFilesTransferred(FetchFileTransfer.REL_COMMS_FAILURE, 1);
-        runner.assertAllFlowFilesContainAttribute("failure");
+        runner.assertAllFlowFilesContainAttribute(FetchFileTransfer.FAILURE_REASON_ATTRIBUTE);
         MockFlowFile transferredFlowFile = runner.getPenalizedFlowFiles().get(0);
-        assertTrue(transferredFlowFile.getAttribute("failure").contains(FetchFileTransfer.REL_COMMS_FAILURE.getName()));
+        assertEquals(FetchFileTransfer.REL_COMMS_FAILURE.getName(), transferredFlowFile.getAttribute(FetchFileTransfer.FAILURE_REASON_ATTRIBUTE));
 
         assertTrue(proc.isClosed);
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFetchFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFetchFTP.java
@@ -113,6 +113,10 @@ public class TestFetchFTP {
 
         runner.run(1, false, false);
         runner.assertAllFlowFilesTransferred(FetchFileTransfer.REL_NOT_FOUND, 1);
+        runner.assertAllFlowFilesContainAttribute(FetchFileTransfer.REL_NOT_FOUND, "failure");
+        runner.assertAllFlowFilesContainAttribute("failure");
+        MockFlowFile transferredFlowFile = runner.getPenalizedFlowFiles().get(0);
+        assertTrue(transferredFlowFile.getAttribute("failure").contains(FetchFileTransfer.REL_NOT_FOUND.getName()));
     }
 
     @Test
@@ -122,6 +126,9 @@ public class TestFetchFTP {
 
         runner.run(1, false, false);
         runner.assertAllFlowFilesTransferred(FetchFileTransfer.REL_PERMISSION_DENIED, 1);
+        runner.assertAllFlowFilesContainAttribute("failure");
+        MockFlowFile transferredFlowFile = runner.getPenalizedFlowFiles().get(0);
+        assertTrue(transferredFlowFile.getAttribute("failure").contains(FetchFileTransfer.REL_PERMISSION_DENIED.getName()));
     }
 
     @Test
@@ -132,6 +139,7 @@ public class TestFetchFTP {
 
         runner.run(2, false, false);
         runner.assertAllFlowFilesTransferred(FetchFileTransfer.REL_PERMISSION_DENIED, 2);
+        runner.assertAllFlowFilesContainAttribute("failure");
 
         assertEquals(1, proc.numberOfFileTransfers);
         assertFalse(proc.isClosed);
@@ -145,6 +153,7 @@ public class TestFetchFTP {
 
         runner.run(2, false, false);
         runner.assertAllFlowFilesTransferred(FetchFileTransfer.REL_NOT_FOUND, 2);
+        runner.assertAllFlowFilesContainAttribute("failure");
 
         assertEquals(1, proc.numberOfFileTransfers);
         assertFalse(proc.isClosed);
@@ -157,6 +166,9 @@ public class TestFetchFTP {
 
         runner.run(1, false, false);
         runner.assertAllFlowFilesTransferred(FetchFileTransfer.REL_COMMS_FAILURE, 1);
+        runner.assertAllFlowFilesContainAttribute("failure");
+        MockFlowFile transferredFlowFile = runner.getPenalizedFlowFiles().get(0);
+        assertTrue(transferredFlowFile.getAttribute("failure").contains(FetchFileTransfer.REL_COMMS_FAILURE.getName()));
 
         assertTrue(proc.isClosed);
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12249](https://issues.apache.org/jira/browse/NIFI-12249)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Unit tests updated to ensure failure attribute is set on the flow file.  Some tests were updated to check for specific error conditions cited in the failure reasons written to the attribute.

Also, verified by creating the following flow:
GenerateFlowFile -> success -> FetchFTP
FetchFTP -> comms.failure, not.found, permission.denied -> LogAttribute
FetchFTP -> success -> funnel
LogAttribute -> success -> funnel

Configure FetchFTP with a bogus Hostname, Username, and Remote File
Ran the flow the saw the attribute 'failure' get logged:

Key: 'failure'
        Value: 'Failed to fetch content for StandardFlowFileRecord[uuid=a363e000-3c24-429a-8c0b-4e2d12a37345,claim=,offset=0,name=a363e000-3c24-429a-8c0b-4e2d12a37345,size=0] from filename file1 on remote host somehost:21 due to org.apache.nifi.processors.standard.socket.ClientConnectException: FTP Client connection failed [somehost:21]; routing to comms.failure'


### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
