### PR TITLE
NIFI-12272 Add Formatter for Certificate Distinguished Names

### DIFF
--- a/minifi/minifi-c2/minifi-c2-service/pom.xml
+++ b/minifi/minifi-c2/minifi-c2-service/pom.xml
@@ -38,6 +38,11 @@ limitations under the License.
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-security-cert</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <exclusions>

--- a/minifi/minifi-c2/minifi-c2-service/src/main/java/org/apache/nifi/minifi/c2/security/authentication/X509AuthenticationToken.java
+++ b/minifi/minifi-c2/minifi-c2-service/src/main/java/org/apache/nifi/minifi/c2/security/authentication/X509AuthenticationToken.java
@@ -20,6 +20,8 @@ package org.apache.nifi.minifi.c2.security.authentication;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
+
+import org.apache.nifi.security.cert.StandardPrincipalFormatter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 
@@ -36,7 +38,7 @@ public class X509AuthenticationToken extends AbstractAuthenticationToken {
         super(grantedAuthorities);
         this.x509Certificates = Arrays.copyOf(x509Certificates, x509Certificates.length, X509Certificate[].class);
         X509Certificate x509Certificate = x509Certificates[0];
-        this.subjectDn = x509Certificate.getSubjectX500Principal().getName().trim();
+        this.subjectDn = StandardPrincipalFormatter.getInstance().getSubject(x509Certificate);
     }
 
     @Override

--- a/nifi-commons/nifi-security-cert/src/main/java/org/apache/nifi/security/cert/PrincipalFormatter.java
+++ b/nifi-commons/nifi-security-cert/src/main/java/org/apache/nifi/security/cert/PrincipalFormatter.java
@@ -14,20 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.web.security.x509;
+package org.apache.nifi.security.cert;
 
 import java.security.cert.X509Certificate;
 
-import org.apache.nifi.security.cert.StandardPrincipalFormatter;
-import org.springframework.security.web.authentication.preauth.x509.X509PrincipalExtractor;
-
 /**
- * Principal extractor for extracting a DN.
+ * Abstraction for retrieving and formatting X.509 Certificate Subject and Issuer Principal Distinguished Names
  */
-public class SubjectDnX509PrincipalExtractor implements X509PrincipalExtractor {
+public interface PrincipalFormatter {
+    /**
+     * Get Subject Distinguished Name formatted as a string according to standard implementation conventions
+     *
+     * @param certificate X.509 Certificate
+     * @return Formatted Subject Distinguished Name
+     */
+    String getSubject(X509Certificate certificate);
 
-    @Override
-    public Object extractPrincipal(final X509Certificate cert) {
-        return StandardPrincipalFormatter.getInstance().getSubject(cert);
-    }
+    /**
+     * Get Issuer Distinguished Name formatted as a string according to standard implementation conventions
+     *
+     * @param certificate X.509 Certificate
+     * @return Formatted Issuer Distinguished Name
+     */
+    String getIssuer(X509Certificate certificate);
 }

--- a/nifi-commons/nifi-security-cert/src/main/java/org/apache/nifi/security/cert/StandardPrincipalFormatter.java
+++ b/nifi-commons/nifi-security-cert/src/main/java/org/apache/nifi/security/cert/StandardPrincipalFormatter.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.security.cert;
+
+import javax.security.auth.x500.X500Principal;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+
+/**
+ * Standard Principal Formatter implementation returns Subject and Issuer formatted according to RFC 1779 following the convention of getSubjectDN and getIssuerDN methods
+ */
+public class StandardPrincipalFormatter implements PrincipalFormatter {
+    private static final PrincipalFormatter INSTANCE = new StandardPrincipalFormatter();
+
+    private StandardPrincipalFormatter() {
+
+    }
+
+    /**
+     * Get singleton instance of Principal Formatter
+     *
+     * @return Standard Principal Formatter
+     */
+    public static PrincipalFormatter getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Get Subject Distinguished Name formatted as a string according to RFC 1779 with spaces between elements
+     *
+     * @param certificate X.509 Certificate
+     * @return Subject Distinguished Name formatted according to RFC 1779
+     */
+    @Override
+    public String getSubject(final X509Certificate certificate) {
+        Objects.requireNonNull(certificate, "Certificate required");
+        return getFormatted(certificate.getSubjectX500Principal());
+    }
+
+    /**
+     * Get Issuer Distinguished Name formatted as a string according to RFC 1779 with spaces between elements
+     *
+     * @param certificate X.509 Certificate
+     * @return Issuer Distinguished Name formatted according to RFC 1779
+     */
+    @Override
+    public String getIssuer(final X509Certificate certificate) {
+        Objects.requireNonNull(certificate, "Certificate required");
+        return getFormatted(certificate.getIssuerX500Principal());
+    }
+
+    private String getFormatted(final X500Principal principal) {
+        return principal.getName(X500Principal.RFC1779);
+    }
+}

--- a/nifi-commons/nifi-security-cert/src/test/java/org/apache/nifi/security/cert/StandardPrincipalFormatterTest.java
+++ b/nifi-commons/nifi-security-cert/src/test/java/org/apache/nifi/security/cert/StandardPrincipalFormatterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.security.cert;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.security.auth.x500.X500Principal;
+import java.security.cert.X509Certificate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StandardPrincipalFormatterTest {
+
+    private static final String SUBJECT_CANONICAL = "CN=Subject,O=Organization,C=US";
+
+    private static final String SUBJECT_FORMATTED = "CN=Subject, O=Organization, C=US";
+
+    private static final X500Principal SUBJECT_PRINCIPAL = new X500Principal(SUBJECT_CANONICAL);
+
+    private static final String ISSUER_CANONICAL = "CN=Certificate Authority,O=Organization,C=US";
+
+    private static final String ISSUER_FORMATTED = "CN=Certificate Authority, O=Organization, C=US";
+
+    private static final X500Principal ISSUER_PRINCIPAL = new X500Principal(ISSUER_CANONICAL);
+
+    @Mock
+    private X509Certificate certificate;
+
+    @Test
+    void testGetSubject() {
+        when(certificate.getSubjectX500Principal()).thenReturn(SUBJECT_PRINCIPAL);
+
+        final String subject = StandardPrincipalFormatter.getInstance().getSubject(certificate);
+
+        assertEquals(SUBJECT_FORMATTED, subject);
+    }
+
+    @Test
+    void testGetIssuer() {
+        when(certificate.getIssuerX500Principal()).thenReturn(ISSUER_PRINCIPAL);
+
+        final String issuer = StandardPrincipalFormatter.getInstance().getIssuer(certificate);
+
+        assertEquals(ISSUER_FORMATTED, issuer);
+    }
+}

--- a/nifi-commons/nifi-site-to-site-client/pom.xml
+++ b/nifi-commons/nifi-site-to-site-client/pom.xml
@@ -49,6 +49,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-security-cert</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-xml-processing</artifactId>
         </dependency>
         <dependency>

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/socket/StandardSocketPeerIdentityProvider.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/socket/StandardSocketPeerIdentityProvider.java
@@ -17,13 +17,14 @@
 package org.apache.nifi.remote.client.socket;
 
 import java.net.Socket;
-import java.security.Principal;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
+
+import org.apache.nifi.security.cert.StandardPrincipalFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,8 +61,7 @@ public class StandardSocketPeerIdentityProvider implements SocketPeerIdentityPro
                 logger.warn("Peer Identity not found: Peer Certificates not provided [{}:{}]", peerHost, peerPort);
             } else {
                 final X509Certificate peerCertificate = (X509Certificate) peerCertificates[0];
-                final Principal subjectDistinguishedName = peerCertificate.getSubjectX500Principal();
-                peerIdentity = subjectDistinguishedName.getName();
+                peerIdentity = StandardPrincipalFormatter.getInstance().getSubject(peerCertificate);
             }
         } catch (final SSLPeerUnverifiedException e) {
             logger.warn("Peer Identity not found: Peer Unverified [{}:{}]", peerHost, peerPort);

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/util/SiteToSiteRestApiClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/util/SiteToSiteRestApiClient.java
@@ -116,6 +116,7 @@ import org.apache.nifi.remote.protocol.ResponseCode;
 import org.apache.nifi.remote.protocol.http.HttpHeaders;
 import org.apache.nifi.remote.protocol.http.HttpProxy;
 import org.apache.nifi.reporting.Severity;
+import org.apache.nifi.security.cert.StandardPrincipalFormatter;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.apache.nifi.web.api.dto.ControllerDTO;
 import org.apache.nifi.web.api.dto.remote.PeerDTO;
@@ -317,7 +318,7 @@ public class SiteToSiteRestApiClient implements Closeable {
 
                 try {
                     final X509Certificate cert = (X509Certificate) certChain[0];
-                    trustedPeerDn = cert.getSubjectX500Principal().getName().trim();
+                    trustedPeerDn = StandardPrincipalFormatter.getInstance().getSubject(cert);
                 } catch (final RuntimeException e) {
                     final String msg = "Could not extract subject DN from SSL session peer certificate";
                     logger.warn(msg);

--- a/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/client/socket/StandardSocketPeerIdentityProviderTest.java
+++ b/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/client/socket/StandardSocketPeerIdentityProviderTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class StandardSocketPeerIdentityProviderTest {
-    private static final String DISTINGUISHED_NAME = "CN=Common Name,OU=Organizational Unit,O=Organization";
+    private static final String DISTINGUISHED_NAME = "CN=Common Name, OU=Organizational Unit, O=Organization";
 
     @Mock
     SSLSocket sslSocket;

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-security-cert</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-oauth2-provider-api</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/smtp/SmtpConsumer.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/smtp/SmtpConsumer.java
@@ -38,6 +38,7 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.ProcessSessionFactory;
 import org.apache.nifi.processor.exception.FlowFileAccessException;
 import org.apache.nifi.processors.email.ListenSMTP;
+import org.apache.nifi.security.cert.StandardPrincipalFormatter;
 import org.apache.nifi.stream.io.LimitingInputStream;
 import org.apache.nifi.util.StopWatch;
 import org.subethamail.smtp.MessageContext;
@@ -141,7 +142,7 @@ public class SmtpConsumer implements MessageHandler {
             for (int i = 0; i < tlsPeerCertificates.length; i++) {
                 if (tlsPeerCertificates[i] instanceof final X509Certificate x509Cert) {
                     attributes.put("smtp.certificate." + i + ".serial", x509Cert.getSerialNumber().toString());
-                    attributes.put("smtp.certificate." + i + ".subjectName", x509Cert.getSubjectX500Principal().getName());
+                    attributes.put("smtp.certificate." + i + ".subjectName", StandardPrincipalFormatter.getInstance().getSubject(x509Cert));
                 }
             }
         }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/pom.xml
@@ -53,6 +53,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-security-cert</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
         </dependency>
     </dependencies>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/SocketRemoteSiteListener.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/SocketRemoteSiteListener.java
@@ -27,7 +27,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.security.GeneralSecurityException;
-import java.security.Principal;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -54,6 +53,7 @@ import org.apache.nifi.remote.io.socket.SocketCommunicationsSession;
 import org.apache.nifi.remote.protocol.CommunicationsSession;
 import org.apache.nifi.remote.protocol.RequestType;
 import org.apache.nifi.remote.protocol.ServerProtocol;
+import org.apache.nifi.security.cert.StandardPrincipalFormatter;
 import org.apache.nifi.security.util.TlsPlatform;
 import org.apache.nifi.util.NiFiProperties;
 import org.slf4j.Logger;
@@ -350,8 +350,7 @@ public class SocketRemoteSiteListener implements RemoteSiteListener {
         }
 
         final X509Certificate peerCertificate = (X509Certificate) peerCertificates[0];
-        final Principal subjectDistinguishedName = peerCertificate.getSubjectX500Principal();
-        return subjectDistinguishedName.getName();
+        return StandardPrincipalFormatter.getInstance().getSubject(peerCertificate);
     }
 
     private boolean handleTlsError(String msg) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
@@ -108,6 +108,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-security-cert</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-framework-core</artifactId>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/x509/X509AuthenticationProviderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/x509/X509AuthenticationProviderTest.java
@@ -277,7 +277,7 @@ public class X509AuthenticationProviderTest {
         final X509Certificate certificate = mock(X509Certificate.class);
         when(certificate.getSubjectX500Principal()).then(invocation -> {
             final X500Principal principal = mock(X500Principal.class);
-            when(principal.getName()).thenReturn(identity);
+            when(principal.getName(any())).thenReturn(identity);
             return principal;
         });
         return certificate;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCPRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCPRecord.java
@@ -67,6 +67,8 @@ import org.apache.nifi.processor.util.listen.ListenerProperties;
 import org.apache.nifi.record.listen.SSLSocketChannelRecordReader;
 import org.apache.nifi.record.listen.SocketChannelRecordReader;
 import org.apache.nifi.record.listen.SocketChannelRecordReaderDispatcher;
+import org.apache.nifi.security.cert.PrincipalFormatter;
+import org.apache.nifi.security.cert.StandardPrincipalFormatter;
 import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
@@ -486,8 +488,9 @@ public class ListenTCPRecord extends AbstractProcessor {
                 final Certificate[] certificates = sslSession.getPeerCertificates();
                 if (certificates.length > 0) {
                     final X509Certificate certificate = (X509Certificate) certificates[0];
-                    attributes.put(CLIENT_CERTIFICATE_SUBJECT_DN_ATTRIBUTE, certificate.getSubjectX500Principal().toString());
-                    attributes.put(CLIENT_CERTIFICATE_ISSUER_DN_ATTRIBUTE, certificate.getIssuerX500Principal().toString());
+                    final PrincipalFormatter principalFormatter = StandardPrincipalFormatter.getInstance();
+                    attributes.put(CLIENT_CERTIFICATE_SUBJECT_DN_ATTRIBUTE, principalFormatter.getSubject(certificate));
+                    attributes.put(CLIENT_CERTIFICATE_ISSUER_DN_ATTRIBUTE, principalFormatter.getIssuer(certificate));
                 }
             } catch (final SSLPeerUnverifiedException peerUnverifiedException) {
                 getLogger().debug("Remote Peer [{}] not verified: client certificates not provided",

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/HandleHttpRequestCertificateAttributesProvider.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/http/HandleHttpRequestCertificateAttributesProvider.java
@@ -17,7 +17,9 @@
 package org.apache.nifi.processors.standard.http;
 
 import org.apache.nifi.security.cert.CertificateAttributeReader;
+import org.apache.nifi.security.cert.PrincipalFormatter;
 import org.apache.nifi.security.cert.StandardCertificateAttributeReader;
+import org.apache.nifi.security.cert.StandardPrincipalFormatter;
 import org.apache.nifi.security.cert.SubjectAlternativeName;
 
 import javax.servlet.http.HttpServletRequest;
@@ -65,8 +67,9 @@ public class HandleHttpRequestCertificateAttributesProvider implements Certifica
     private Map<String, String> getCertificateAttributes(final X509Certificate certificate) {
         final Map<String, String> attributes = new LinkedHashMap<>();
 
-        final String subjectPrincipal = certificate.getSubjectX500Principal().getName();
-        final String issuerPrincipal = certificate.getIssuerX500Principal().getName();
+        final PrincipalFormatter principalFormatter = StandardPrincipalFormatter.getInstance();
+        final String subjectPrincipal = principalFormatter.getSubject(certificate);
+        final String issuerPrincipal = principalFormatter.getIssuer(certificate);
 
         attributes.put(CertificateAttribute.HTTP_SUBJECT_DN.getName(), subjectPrincipal);
         attributes.put(CertificateAttribute.HTTP_ISSUER_DN.getName(), issuerPrincipal);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ContentAcknowledgmentServlet.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ContentAcknowledgmentServlet.java
@@ -34,6 +34,7 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processors.standard.ListenHTTP;
 import org.apache.nifi.processors.standard.ListenHTTP.FlowFileEntryTimeWrapper;
+import org.apache.nifi.security.cert.StandardPrincipalFormatter;
 import org.apache.nifi.util.FormatUtils;
 
 @Path("/holds/*")
@@ -71,12 +72,12 @@ public class ContentAcknowledgmentServlet extends HttpServlet {
         String foundSubject = DEFAULT_FOUND_SUBJECT;
         if (certs != null) {
             for (final X509Certificate cert : certs) {
-                foundSubject = cert.getSubjectX500Principal().getName();
+                foundSubject = StandardPrincipalFormatter.getInstance().getSubject(cert);
 
                 if (authorizedPattern.matcher(foundSubject).matches()) {
                     break;
                 } else {
-                    logger.warn(processor + " rejecting transfer attempt from " + foundSubject + " because the DN is not authorized");
+                    logger.warn("rejecting transfer attempt from [{}] because the DN is not authorized", foundSubject);
                     response.sendError(HttpServletResponse.SC_FORBIDDEN, "not allowed based on dn");
                     return;
                 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
@@ -61,6 +61,8 @@ import org.apache.nifi.processors.standard.ListenHTTP;
 import org.apache.nifi.processors.standard.ListenHTTP.FlowFileEntryTimeWrapper;
 import org.apache.nifi.processors.standard.exception.ListenHttpException;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
+import org.apache.nifi.security.cert.PrincipalFormatter;
+import org.apache.nifi.security.cert.StandardPrincipalFormatter;
 import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
@@ -204,9 +206,10 @@ public class ListenHTTPServlet extends HttpServlet {
             foundSubject = DEFAULT_FOUND_SUBJECT;
             foundIssuer = DEFAULT_FOUND_ISSUER;
             if (certs != null) {
+                final PrincipalFormatter principalFormatter = StandardPrincipalFormatter.getInstance();
                 for (final X509Certificate cert : certs) {
-                    foundSubject = cert.getSubjectX500Principal().getName();
-                    foundIssuer = cert.getIssuerX500Principal().getName();
+                    foundSubject = principalFormatter.getSubject(cert);
+                    foundIssuer = principalFormatter.getIssuer(cert);
                     if (authorizedPattern.matcher(foundSubject).matches()) {
                         if (authorizedIssuerPattern.matcher(foundIssuer).matches()) {
                             break;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/http/HandleHttpRequestCertificateAttributesProviderTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/http/HandleHttpRequestCertificateAttributesProviderTest.java
@@ -39,9 +39,13 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class HandleHttpRequestCertificateAttributesProviderTest {
-    private static final X500Principal SUBJECT_PRINCIPAL = new X500Principal("CN=subject, OU=users");
+    private static final String SUBJECT_FORMATTED = "CN=subject, OU=users";
 
-    private static final X500Principal ISSUER_PRINCIPAL = new X500Principal("CN=issuer, OU=authorities");
+    private static final X500Principal SUBJECT_PRINCIPAL = new X500Principal(SUBJECT_FORMATTED);
+
+    private static final String ISSUER_FORMATTED = "CN=issuer, OU=authorities";
+
+    private static final X500Principal ISSUER_PRINCIPAL = new X500Principal(ISSUER_FORMATTED);
 
     private static final String RFC_822_NAME_GENERAL_NAME = "rfc822Name";
 
@@ -143,7 +147,7 @@ class HandleHttpRequestCertificateAttributesProviderTest {
     }
 
     private void assertSubjectIssuerFound(final Map<String, String> attributes) {
-        assertEquals(SUBJECT_PRINCIPAL.getName(), attributes.get(CertificateAttribute.HTTP_SUBJECT_DN.getName()));
-        assertEquals(ISSUER_PRINCIPAL.getName(), attributes.get(CertificateAttribute.HTTP_ISSUER_DN.getName()));
+        assertEquals(SUBJECT_FORMATTED, attributes.get(CertificateAttribute.HTTP_SUBJECT_DN.getName()));
+        assertEquals(ISSUER_FORMATTED, attributes.get(CertificateAttribute.HTTP_ISSUER_DN.getName()));
     }
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
@@ -332,6 +332,11 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-security-cert</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/x509/SubjectDnX509PrincipalExtractor.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/x509/SubjectDnX509PrincipalExtractor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.registry.web.security.authentication.x509;
 
+import org.apache.nifi.security.cert.StandardPrincipalFormatter;
 import org.springframework.security.web.authentication.preauth.x509.X509PrincipalExtractor;
 import org.springframework.stereotype.Component;
 
@@ -28,8 +29,7 @@ import java.security.cert.X509Certificate;
 public class SubjectDnX509PrincipalExtractor implements X509PrincipalExtractor {
 
     @Override
-    public Object extractPrincipal(X509Certificate cert) {
-        return cert.getSubjectX500Principal().getName().trim();
+    public Object extractPrincipal(final X509Certificate cert) {
+        return StandardPrincipalFormatter.getInstance().getSubject(cert);
     }
-
 }


### PR DESCRIPTION
# Summary

[NIFI-12272](https://issues.apache.org/jira/browse/NIFI-12272) Adds a `PrincipalFormatter` interface and `StandardPrincipalFormatter` implementation that retrieves and formats Certificate Subject and Issuer Distinguished Names according to [RFC 1779](https://www.rfc-editor.org/rfc/rfc1779).

This approach preserves compatibility with the historical `getSubjectDN()` and `getIssuerDN()` methods from `X509Certificate` while using the recommended `getSubjectX500Principal()` and `getIssuerX500Principal()` methods.

These changes restore compatibility with existing NiFi versions, recently changed for [NIFI-12142](https://issues.apache.org/jira/browse/NIFI-12142).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
