### PR TITLE
NIFI-12275 Disable Keepalive in SFTP Tests

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetSFTP.java
@@ -36,40 +36,42 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestGetSFTP {
 
-    private TestRunner getSFTPRunner;
+    private TestRunner runner;
     private static SSHTestServer sshTestServer;
 
     @BeforeAll
-    public static void setupSSHD() throws IOException {
+    public static void startServer() throws IOException {
         sshTestServer = new SSHTestServer();
         sshTestServer.startServer();
     }
 
     @AfterAll
-    public static void cleanupSSHD() throws IOException {
+    public static void stopServer() throws IOException {
         sshTestServer.stopServer();
     }
 
     @BeforeEach
     public void setup(){
-        getSFTPRunner = TestRunners.newTestRunner(GetSFTP.class);
-        getSFTPRunner.setProperty(SFTPTransfer.HOSTNAME, "localhost");
-        getSFTPRunner.setProperty(SFTPTransfer.PORT, Integer.toString(sshTestServer.getSSHPort()));
-        getSFTPRunner.setProperty(SFTPTransfer.USERNAME, sshTestServer.getUsername());
-        getSFTPRunner.setProperty(SFTPTransfer.PASSWORD, sshTestServer.getPassword());
-        getSFTPRunner.setProperty(SFTPTransfer.STRICT_HOST_KEY_CHECKING, "false");
-        getSFTPRunner.setProperty(SFTPTransfer.DATA_TIMEOUT, "30 sec");
-        getSFTPRunner.setProperty(SFTPTransfer.REMOTE_PATH, "/");
-        getSFTPRunner.removeProperty(SFTPTransfer.FILE_FILTER_REGEX);
-        getSFTPRunner.setProperty(SFTPTransfer.PATH_FILTER_REGEX, "");
-        getSFTPRunner.setProperty(SFTPTransfer.POLLING_INTERVAL, "60 sec");
-        getSFTPRunner.setProperty(SFTPTransfer.RECURSIVE_SEARCH, "false");
-        getSFTPRunner.setProperty(SFTPTransfer.IGNORE_DOTTED_FILES, "true");
-        getSFTPRunner.setProperty(SFTPTransfer.DELETE_ORIGINAL, "true");
-        getSFTPRunner.setProperty(SFTPTransfer.MAX_SELECTS, "100");
-        getSFTPRunner.setProperty(SFTPTransfer.REMOTE_POLL_BATCH_SIZE, "5000");
+        runner = TestRunners.newTestRunner(GetSFTP.class);
+        runner.setProperty(SFTPTransfer.HOSTNAME, sshTestServer.getHost());
+        runner.setProperty(SFTPTransfer.PORT, Integer.toString(sshTestServer.getSSHPort()));
+        runner.setProperty(SFTPTransfer.USERNAME, sshTestServer.getUsername());
+        runner.setProperty(SFTPTransfer.PASSWORD, sshTestServer.getPassword());
 
-        getSFTPRunner.setValidateExpressionUsage(false);
+        runner.setProperty(SFTPTransfer.USE_KEEPALIVE_ON_TIMEOUT, Boolean.FALSE.toString());
+        runner.setProperty(SFTPTransfer.STRICT_HOST_KEY_CHECKING, Boolean.FALSE.toString());
+        runner.setProperty(SFTPTransfer.DATA_TIMEOUT, "30 sec");
+        runner.setProperty(SFTPTransfer.REMOTE_PATH, "/");
+        runner.removeProperty(SFTPTransfer.FILE_FILTER_REGEX);
+        runner.setProperty(SFTPTransfer.PATH_FILTER_REGEX, "");
+        runner.setProperty(SFTPTransfer.POLLING_INTERVAL, "60 sec");
+        runner.setProperty(SFTPTransfer.RECURSIVE_SEARCH, "false");
+        runner.setProperty(SFTPTransfer.IGNORE_DOTTED_FILES, "true");
+        runner.setProperty(SFTPTransfer.DELETE_ORIGINAL, "true");
+        runner.setProperty(SFTPTransfer.MAX_SELECTS, "100");
+        runner.setProperty(SFTPTransfer.REMOTE_POLL_BATCH_SIZE, "5000");
+
+        runner.setValidateExpressionUsage(false);
     }
 
     @Test
@@ -81,17 +83,17 @@ public class TestGetSFTP {
         touchFile(sshTestServer.getVirtualFileSystemPath() + "testFile3.txt");
         touchFile(sshTestServer.getVirtualFileSystemPath() + "testFile4.txt");
 
-        getSFTPRunner.run();
+        runner.run();
 
-        getSFTPRunner.assertTransferCount(GetSFTP.REL_SUCCESS, 4);
+        runner.assertTransferCount(GetSFTP.REL_SUCCESS, 4);
 
         //Verify files deleted
-        for(int i=1;i<5;i++){
+        for (int i = 1; i < 5 ; i++) {
             Path file1 = Paths.get(sshTestServer.getVirtualFileSystemPath() + "/testFile" + i + ".txt");
             assertFalse(file1.toAbsolutePath().toFile().exists(), "File not deleted.");
         }
 
-        getSFTPRunner.clearTransferState();
+        runner.clearTransferState();
     }
 
     @Test
@@ -105,9 +107,9 @@ public class TestGetSFTP {
             touchFile(sshTestServer.getVirtualFileSystemPath() + "testFile1.txt");
             touchFile(sshTestServer.getVirtualFileSystemPath() + "testFile2.txt");
 
-            getSFTPRunner.run();
+            runner.run();
 
-            getSFTPRunner.assertTransferCount(GetSFTP.REL_SUCCESS, 2);
+            runner.assertTransferCount(GetSFTP.REL_SUCCESS, 2);
 
             // Verify files deleted
             for (int i = 1; i < 3; i++) {
@@ -115,7 +117,7 @@ public class TestGetSFTP {
                 assertFalse(file1.toAbsolutePath().toFile().exists(), "File not deleted.");
             }
 
-            getSFTPRunner.clearTransferState();
+            runner.clearTransferState();
 
         } finally {
             // set back the original value for 'user.home' system property
@@ -132,9 +134,9 @@ public class TestGetSFTP {
         touchFile(sshTestServer.getVirtualFileSystemPath() + "testFile3.txt");
         touchFile(sshTestServer.getVirtualFileSystemPath() + ".testFile4.txt");
 
-        getSFTPRunner.run();
+        runner.run();
 
-        getSFTPRunner.assertTransferCount(GetSFTP.REL_SUCCESS, 2);
+        runner.assertTransferCount(GetSFTP.REL_SUCCESS, 2);
 
         //Verify non-dotted files were deleted and dotted files were not deleted
         Path file1 = Paths.get(sshTestServer.getVirtualFileSystemPath() + "/testFile1.txt");
@@ -149,7 +151,7 @@ public class TestGetSFTP {
         file1 = Paths.get(sshTestServer.getVirtualFileSystemPath() + "/.testFile4.txt");
         assertTrue(file1.toAbsolutePath().toFile().exists(), "File deleted.");
 
-        getSFTPRunner.clearTransferState();
+        runner.clearTransferState();
     }
 
     private void touchFile(String file) throws IOException {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListSFTP.java
@@ -33,7 +33,6 @@ import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.VerifiableProcessor;
 import org.apache.nifi.processor.util.list.AbstractListProcessor;
 import org.apache.nifi.processor.util.list.ListedEntityTracker;
-import org.apache.nifi.processors.standard.util.FTPTransfer;
 import org.apache.nifi.processors.standard.util.SFTPTransfer;
 import org.apache.nifi.processors.standard.util.SSHTestServer;
 import org.apache.nifi.reporting.InitializationException;
@@ -64,11 +63,14 @@ public class TestListSFTP {
         sshServer = new SSHTestServer();
         sshServer.startServer();
         writeTempFile();
+
         runner = TestRunners.newTestRunner(ListSFTP.class);
-        runner.setProperty(ListSFTP.HOSTNAME, sshServer.getHost());
-        runner.setProperty(ListSFTP.USERNAME, sshServer.getUsername());
+        runner.setProperty(SFTPTransfer.HOSTNAME, sshServer.getHost());
+        runner.setProperty(SFTPTransfer.USERNAME, sshServer.getUsername());
         runner.setProperty(SFTPTransfer.PASSWORD, sshServer.getPassword());
-        runner.setProperty(FTPTransfer.PORT, Integer.toString(sshServer.getSSHPort()));
+        runner.setProperty(SFTPTransfer.PORT, Integer.toString(sshServer.getSSHPort()));
+        runner.setProperty(SFTPTransfer.USE_KEEPALIVE_ON_TIMEOUT, Boolean.FALSE.toString());
+
         runner.setProperty(ListSFTP.REMOTE_PATH, REMOTE_DIRECTORY);
         runner.setProperty(ListFile.TARGET_SYSTEM_TIMESTAMP_PRECISION, ListFile.PRECISION_MILLIS);
         runner.assertValid();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSFTP.java
@@ -67,6 +67,8 @@ class TestPutSFTP {
         runner.setProperty(SFTPTransfer.PORT, Integer.toString(sshTestServer.getSSHPort()));
         runner.setProperty(SFTPTransfer.USERNAME, sshTestServer.getUsername());
         runner.setProperty(SFTPTransfer.PASSWORD, sshTestServer.getPassword());
+
+        runner.setProperty(SFTPTransfer.USE_KEEPALIVE_ON_TIMEOUT, Boolean.FALSE.toString());
         runner.setProperty(SFTPTransfer.STRICT_HOST_KEY_CHECKING, Boolean.FALSE.toString());
         runner.setProperty(SFTPTransfer.BATCH_SIZE, Integer.toString(BATCH_SIZE));
         runner.setProperty(SFTPTransfer.REMOTE_PATH, REMOTE_DIRECTORY);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/SSHTestServer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/SSHTestServer.java
@@ -34,7 +34,7 @@ public class SSHTestServer {
 
     private String virtualFileSystemPath = "target/ssh_vfs/";
 
-    private String host = "127.0.0.1";
+    private final String host = "127.0.0.1";
 
     private String username = "nifiuser";
 


### PR DESCRIPTION
# Summary

[NIFI-12275](https://issues.apache.org/jira/browse/NIFI-12275) Disables the Keepalive setting for SFTP Processor test classes. Enabling connection keepalive is not necessary for test methods, and disabling keepalive simplifies internal client connection handling in SSHJ, reducing the potential for test failures.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
