### PR TITLE
NIFI-12274 Evaluate conditional ASF self-hosted run-on for ci-workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -112,7 +112,7 @@ jobs:
 
   build-en:
     timeout-minutes: 120
-    runs-on: ${{ github.repository_owner == 'apache' && '["self-hosted", "asf-runner"]' || 'ubuntu-latest' }}
+    runs-on: ["self-hosted", "asf-runner"]
     name: Corretto JDK 21 EN
     steps:
       - name: System Information
@@ -176,7 +176,7 @@ jobs:
 
   build-jp:
     timeout-minutes: 150
-    runs-on: ${{ github.repository_owner == 'apache' && '["self-hosted", "asf-arm"]' || 'macos-latest' }}
+    runs-on: ["self-hosted", "asf-arm"]
     name: Zulu JDK 21 JP
     steps:
       - name: System Information

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -110,10 +110,10 @@ jobs:
           --fail-fast
           -P contrib-check
 
-  ubuntu-build-en:
+  build-en:
     timeout-minutes: 120
-    runs-on: ubuntu-latest
-    name: Ubuntu Corretto JDK 21 EN
+    runs-on: ${{ github.repository_owner == 'apache' && '["self-hosted", "asf-runner"]' || 'ubuntu-latest' }}
+    name: Corretto JDK 21 EN
     steps:
       - name: System Information
         run: |
@@ -164,7 +164,7 @@ jobs:
       - name: Upload Test Reports
         uses: actions/upload-artifact@v3
         with:
-          name: surefire-reports-ubuntu-21
+          name: surefire-reports-en
           path: |
             ./**/target/surefire-reports/*.txt
             ./**/target/surefire-reports/*.xml
@@ -174,12 +174,20 @@ jobs:
         run: df
         if: ${{ always() }}
 
-  macos-build-jp:
+  build-jp:
     timeout-minutes: 150
-    runs-on: macos-latest
-    name: MacOS Zulu JDK 21 JP
+    runs-on: ${{ github.repository_owner == 'apache' && '["self-hosted", "asf-arm"]' || 'macos-latest' }}
+    name: Zulu JDK 21 JP
     steps:
       - name: System Information
+        if: github.repository_owner == 'apache'
+        run: |
+          hostname
+          cat /proc/cpuinfo
+          cat /proc/meminfo
+          df
+      - name: System Information
+        if: github.repository_owner != 'apache'
         run: |
           hostname
           top -l 1 | grep PhysMem
@@ -228,7 +236,7 @@ jobs:
       - name: Upload Test Reports
         uses: actions/upload-artifact@v3
         with:
-          name: surefire-reports-macos-jp
+          name: surefire-reports-jp
           path: |
             ./**/target/surefire-reports/*.txt
             ./**/target/surefire-reports/*.xml


### PR DESCRIPTION
# Summary

[NIFI-12274](https://issues.apache.org/jira/browse/NIFI-12274) Introduces conditional GitHub workflow execution on Apache Infrastructure self-hosted runners.

Infrastructure self-hosted runners are still in testing, and standard runner configuration remains necessary for executing workflows on forked repositories.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
