### PR TITLE
NIFI-12278 Add CodeQL to Static Analysis Job

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -79,11 +79,12 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  security-events: write
   contents: read
 
 jobs:
   static-analysis:
-    timeout-minutes: 30
+    timeout-minutes: 120
     name: Static Analysis
     runs-on: ubuntu-latest
     steps:
@@ -109,6 +110,19 @@ jobs:
           --no-transfer-progress
           --fail-fast
           -P contrib-check
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: java
+      - name: Maven Compile
+        env:
+          MAVEN_OPTS: >-
+            ${{ env.COMPILE_MAVEN_OPTS }}
+        run: >
+          ${{ env.MAVEN_COMMAND }}
+          ${{ env.MAVEN_COMPILE_COMMAND }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
 
   ubuntu-build-en:
     timeout-minutes: 120


### PR DESCRIPTION
# Summary

[NIFI-12278](https://issues.apache.org/jira/browse/NIFI-12278) Adds GitHub [CodeQL](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql) security scanning to the Static Analysis job in the standard build workflow.

The initial configuration uses the [default](https://docs.github.com/en/code-security/code-scanning/managing-your-code-scanning-configuration/built-in-codeql-query-suites) query suite which limits the scope to avoid false positives.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
