### PR TITLE
NIFI-12277: Add SSLContextService to Slack processors

### DIFF
--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
@@ -96,7 +96,6 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-ssl-context-service-api</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PostSlack.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PostSlack.java
@@ -33,10 +33,17 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonString;
 import javax.json.stream.JsonParsingException;
+import javax.net.ssl.SSLContext;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
@@ -65,6 +72,7 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.ssl.SSLContextService;
 
 @Tags({"slack", "post", "notify", "upload", "message"})
 @CapabilityDescription("Sends a message on Slack. The FlowFile content (e.g. an image) can be uploaded and attached to the message.")
@@ -180,6 +188,13 @@ public class PostSlack extends AbstractProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
+    public static final PropertyDescriptor SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
+            .name("SSL Context Service")
+            .description("If specified, indicates the SSL Context Service that is used to communicate with the "
+                    + "remote server. If not specified, communications will not be encrypted")
+            .identifiesControllerService(SSLContextService.class)
+            .build();
+
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
             .description("FlowFiles are routed to success after being successfully sent to Slack")
@@ -199,7 +214,8 @@ public class PostSlack extends AbstractProcessor {
         UPLOAD_FLOWFILE,
         FILE_TITLE,
         FILE_NAME,
-        FILE_MIME_TYPE);
+        FILE_MIME_TYPE,
+        SSL_CONTEXT_SERVICE);
 
     public static final Set<Relationship> relationships = Set.of(REL_SUCCESS, REL_FAILURE);
 
@@ -235,18 +251,27 @@ public class PostSlack extends AbstractProcessor {
     }
 
     @OnScheduled
-    public void initDynamicProperties(ProcessContext context) {
+    public void onScheduled(ProcessContext context) {
         attachmentProperties.clear();
         attachmentProperties.addAll(
                 context.getProperties().keySet()
                         .stream()
                         .filter(PropertyDescriptor::isDynamic)
                     .toList());
-    }
 
-    @OnScheduled
-    public void initHttpResources() {
-        connManager = new PoolingHttpClientConnectionManager();
+        final SSLContextService sslService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
+
+        if (sslService != null) {
+            final SSLContext sslContext = sslService.createContext();
+            final Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory>create()
+                    .register("http", PlainConnectionSocketFactory.getSocketFactory())
+                    .register("https", new SSLConnectionSocketFactory(sslContext))
+                    .build();
+
+            connManager = new PoolingHttpClientConnectionManager(socketFactoryRegistry);
+        } else {
+            connManager = new PoolingHttpClientConnectionManager();
+        }
 
         client = HttpClientBuilder.create()
                 .setConnectionManager(connManager)

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PostSlack.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PostSlack.java
@@ -190,8 +190,7 @@ public class PostSlack extends AbstractProcessor {
 
     public static final PropertyDescriptor SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
             .name("SSL Context Service")
-            .description("If specified, indicates the SSL Context Service that is used to communicate with the "
-                    + "remote server. If not specified, communications will not be encrypted")
+            .description("Specifies an optional SSL Context Service that, if provided, will be used to create connections")
             .identifiesControllerService(SSLContextService.class)
             .build();
 

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PostSlackTextMessageTest.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PostSlackTextMessageTest.java
@@ -19,12 +19,6 @@ package org.apache.nifi.processors.slack;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.apache.nifi.reporting.InitializationException;
-import org.apache.nifi.security.util.SslContextFactory;
-import org.apache.nifi.security.util.TemporaryKeyStoreBuilder;
-import org.apache.nifi.security.util.TlsConfiguration;
-import org.apache.nifi.security.util.TlsException;
-import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,13 +27,10 @@ import org.junit.jupiter.api.Test;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
-import javax.net.ssl.SSLContext;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class PostSlackTextMessageTest {
     private static final String RESPONSE_SUCCESS_TEXT_MSG = "{\"ok\": true}";
@@ -285,26 +276,6 @@ public class PostSlackTextMessageTest {
         assertEquals("Iñtërnâtiônàližætiøn", requestBodyJson.getString("text"));
     }
 
-    @Test
-    public void sendTextOnlyMessageWithSSLContext() throws TlsException, InitializationException {
-        configureSSLContextService();
-        testRunner.setProperty(PostSlack.POST_MESSAGE_URL, url);
-        testRunner.setProperty(PostSlack.ACCESS_TOKEN, "my-access-token");
-        testRunner.setProperty(PostSlack.CHANNEL, "my-channel");
-        testRunner.setProperty(PostSlack.TEXT, "my-text");
-
-        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody(RESPONSE_SUCCESS_TEXT_MSG));
-
-        testRunner.enqueue(new byte[0]);
-        testRunner.run(1);
-
-        testRunner.assertAllFlowFilesTransferred(PutSlack.REL_SUCCESS);
-
-        JsonObject requestBodyJson = getRequestBodyJson();
-        assertBasicRequest(requestBodyJson);
-        assertEquals("my-text", requestBodyJson.getString("text"));
-    }
-
     private void assertBasicRequest(JsonObject requestBodyJson) {
         assertEquals("my-channel", requestBodyJson.getString("channel"));
     }
@@ -321,19 +292,4 @@ public class PostSlackTextMessageTest {
         }
     }
 
-    private void configureSSLContextService() throws InitializationException, TlsException {
-        final TlsConfiguration tlsConfiguration = new TemporaryKeyStoreBuilder().build();
-        final SSLContext sslContext = SslContextFactory.createSslContext(tlsConfiguration);
-
-        mockWebServer.useHttps(sslContext.getSocketFactory(), false);
-        url = mockWebServer.url("/").toString();
-
-        SSLContextService sslService = mock(SSLContextService.class);
-        when(sslService.getIdentifier()).thenReturn("ssl-context");
-        when(sslService.createContext()).thenReturn(sslContext);
-
-        testRunner.addControllerService("ssl-context", sslService);
-        testRunner.enableControllerService(sslService);
-        testRunner.setProperty(PutSlack.SSL_CONTEXT_SERVICE, "ssl-context");
-    }
 }

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PutSlackTest.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PutSlackTest.java
@@ -22,17 +22,26 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.security.util.SslContextFactory;
+import org.apache.nifi.security.util.TemporaryKeyStoreBuilder;
+import org.apache.nifi.security.util.TlsConfiguration;
+import org.apache.nifi.security.util.TlsException;
+import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLContext;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PutSlackTest {
 
@@ -245,5 +254,39 @@ public class PutSlackTest {
         final RecordedRequest recordedRequest = mockWebServer.takeRequest();
         final String requestBody = recordedRequest.getBody().readString(StandardCharsets.UTF_8);
         assertEquals(expected, requestBody);
+    }
+
+    @Test
+    public void testWithSSLContext() throws InterruptedException, InitializationException, TlsException {
+        configureSSLContextService();
+        testRunner.setProperty(PutSlack.WEBHOOK_URL, url);
+        testRunner.setProperty(PutSlack.WEBHOOK_TEXT, PutSlackTest.WEBHOOK_TEST_TEXT);
+
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+        testRunner.assertAllFlowFilesTransferred(PutSlack.REL_SUCCESS, 1);
+
+        String expected = "payload=%7B%22text%22%3A%22Hello+From+Apache+NiFi%22%7D";
+        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        final String requestBody = recordedRequest.getBody().readString(StandardCharsets.UTF_8);
+        assertEquals(expected, requestBody);
+    }
+
+    private void configureSSLContextService() throws InitializationException, TlsException {
+        final TlsConfiguration tlsConfiguration = new TemporaryKeyStoreBuilder().build();
+        final SSLContext sslContext = SslContextFactory.createSslContext(tlsConfiguration);
+
+        mockWebServer.useHttps(sslContext.getSocketFactory(), false);
+        url = mockWebServer.url("/").toString();
+
+        SSLContextService sslService = mock(SSLContextService.class);
+        when(sslService.getIdentifier()).thenReturn("ssl-context");
+        when(sslService.createContext()).thenReturn(sslContext);
+
+        testRunner.addControllerService("ssl-context", sslService);
+        testRunner.enableControllerService(sslService);
+        testRunner.setProperty(PutSlack.SSL_CONTEXT_SERVICE, "ssl-context");
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12277](https://issues.apache.org/jira/browse/NIFI-12277)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
