### PR TITLE
NIFI-12255 refactor PutElasticsearchRecord and PutElasticsearchJson relationships to be more consistent with other processors

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-nar/pom.xml
@@ -20,10 +20,6 @@ language governing permissions and limitations under the License. -->
     <artifactId>nifi-elasticsearch-restapi-nar</artifactId>
     <packaging>nar</packaging>
 
-    <properties>
-        <lucene.version>6.2.1</lucene.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
@@ -38,6 +38,8 @@ import org.apache.nifi.elasticsearch.IndexOperationResponse;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.migration.PropertyConfiguration;
+import org.apache.nifi.migration.RelationshipConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
@@ -116,16 +118,6 @@ import java.util.concurrent.atomic.AtomicLong;
         resource = SystemResource.MEMORY,
         description = "The Batch of Records will be stored in memory until the bulk operation is performed.")
 public class PutElasticsearchRecord extends AbstractPutElasticsearch {
-    static final Relationship REL_FAILED_RECORDS = new Relationship.Builder()
-            .name("errors").description("If a \"Result Record Writer\" is set, any Record(s) corresponding to Elasticsearch document(s) " +
-                    "that resulted in an \"error\" (within Elasticsearch) will be routed here.")
-            .autoTerminateDefault(true).build();
-
-    static final Relationship REL_SUCCESSFUL_RECORDS = new Relationship.Builder()
-            .name("successful_records").description("If a \"Result Record Writer\" is set, any Record(s) corresponding to Elasticsearch document(s) " +
-                    "that did not result in an \"error\" (within Elasticsearch) will be routed here.")
-            .autoTerminateDefault(true).build();
-
     static final PropertyDescriptor RECORD_READER = new PropertyDescriptor.Builder()
         .name("put-es-record-reader")
         .displayName("Record Reader")
@@ -260,37 +252,22 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
     static final PropertyDescriptor RESULT_RECORD_WRITER = new PropertyDescriptor.Builder()
         .name("put-es-record-error-writer")
         .displayName("Result Record Writer")
-        .description("If this configuration property is set, the response from Elasticsearch will be examined for failed records " +
+        .description("The response from Elasticsearch will be examined for failed records " +
                 "and the failed records will be written to a record set with this record writer service and sent to the \"" +
-                REL_FAILED_RECORDS.getName() + "\" relationship. Successful records will be written to a record set " +
-                "with this record writer service and sent to the \"" + REL_SUCCESSFUL_RECORDS.getName() + "\" relationship.")
+                REL_ERRORS.getName() + "\" relationship. Successful records will be written to a record set " +
+                "with this record writer service and sent to the \"" + REL_SUCCESSFUL.getName() + "\" relationship.")
         .identifiesControllerService(RecordSetWriterFactory.class)
         .addValidator(Validator.VALID)
-        .required(false)
-        .build();
-
-    static final PropertyDescriptor NOT_FOUND_IS_SUCCESSFUL = new PropertyDescriptor.Builder()
-        .name("put-es-record-not_found-is-error")
-        .displayName("Treat \"Not Found\" as Success")
-        .description("If true, \"not_found\" Elasticsearch Document associated Records will be routed to the \"" +
-                REL_SUCCESSFUL_RECORDS.getName() + "\" relationship, otherwise to the \"" + REL_FAILED_RECORDS.getName() + "\" relationship. " +
-                "If " + OUTPUT_ERROR_RESPONSES.getDisplayName() + " is \"true\" then \"not_found\" responses from Elasticsearch " +
-                "will be sent to the " + REL_ERROR_RESPONSES.getName() + " relationship.")
-        .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
-        .allowableValues("true", "false")
-        .defaultValue("true")
-        .required(false)
-        .dependsOn(RESULT_RECORD_WRITER)
+        .required(true)
         .build();
 
     static final PropertyDescriptor GROUP_BULK_ERRORS_BY_TYPE = new PropertyDescriptor.Builder()
             .name("put-es-record-bulk-error-groups")
             .displayName("Group Results by Bulk Error Type")
-            .description("If this configuration property is set, the response from Elasticsearch will be examined for _bulk errors. " +
-                    "The failed records written to the \"" + REL_FAILED_RECORDS.getName() + "\" relationship will be grouped by error type " +
+            .description("The errored records written to the \"" + REL_ERRORS.getName() + "\" relationship will be grouped by error type " +
                     "and the error related to the first record within the FlowFile added to the FlowFile as \"elasticsearch.bulk.error\". " +
                     "If \"" + NOT_FOUND_IS_SUCCESSFUL.getDisplayName() +"\" is \"false\" then records associated with \"not_found\" " +
-                    "Elasticsearch document responses will also be send to the \"" + REL_FAILED_RECORDS.getName() + "\" relationship.")
+                    "Elasticsearch document responses will also be send to the \"" + REL_ERRORS.getName() + "\" relationship.")
             .allowableValues("true", "false")
             .defaultValue("false")
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
@@ -343,7 +320,7 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
         GROUP_BULK_ERRORS_BY_TYPE
     );
     static final Set<Relationship> BASE_RELATIONSHIPS =
-            Set.of(REL_SUCCESS, REL_FAILURE, REL_RETRY, REL_FAILED_RECORDS, REL_SUCCESSFUL_RECORDS);
+            Set.of(REL_ORIGINAL, REL_FAILURE, REL_RETRY, REL_ERRORS, REL_SUCCESSFUL);
 
     private static final String OUTPUT_TYPE_SUCCESS = "success";
     private static final String OUTPUT_TYPE_ERROR = "error";
@@ -367,6 +344,25 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return DESCRIPTORS;
+    }
+
+    @Override
+    public void migrateProperties(final PropertyConfiguration config) {
+        super.migrateProperties(config);
+
+        config.renameProperty("put-es-record-not_found-is-error", AbstractPutElasticsearch.NOT_FOUND_IS_SUCCESSFUL.getName());
+        if (config.getPropertyValue(RESULT_RECORD_WRITER).isEmpty()) {
+            final String resultRecordWriterId = config.createControllerService("org.apache.nifi.json.JsonRecordSetWriter", Collections.emptyMap());
+            config.setProperty(RESULT_RECORD_WRITER, resultRecordWriterId);
+        }
+    }
+
+    @Override
+    public void migrateRelationships(final RelationshipConfiguration config) {
+        super.migrateRelationships(config);
+
+        config.renameRelationship("success", AbstractPutElasticsearch.REL_ORIGINAL.getName());
+        config.renameRelationship("successful_records", AbstractPutElasticsearch.REL_SUCCESSFUL.getName());
     }
 
     @Override
@@ -463,12 +459,12 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
                 stopWatch.getDuration(TimeUnit.MILLISECONDS)
         );
 
-        input = session.putAllAttributes(input, new HashMap<String, String>() {{
+        input = session.putAllAttributes(input, new HashMap<>() {{
             put("elasticsearch.put.error.count", String.valueOf(erroredRecords.get()));
             put("elasticsearch.put.success.count", String.valueOf(successfulRecords.get()));
         }});
 
-        session.transfer(input, REL_SUCCESS);
+        session.transfer(input, REL_ORIGINAL);
     }
 
     private void addOperation(final List<IndexOperationRequest> operationList, final Record record, final IndexOperationParameters indexOperationParameters,
@@ -512,9 +508,9 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
         final BulkOperation bundle = new BulkOperation(operationList, originals, reader.getSchema());
         final ResponseDetails responseDetails = indexDocuments(bundle, session, input, requestParameters);
 
-        successfulRecords.getAndAdd(responseDetails.getSuccessCount());
-        erroredRecords.getAndAdd(responseDetails.getErrorCount());
-        resultRecords.addAll(responseDetails.getOutputs().values().stream().map(Output::getFlowFile).toList());
+        successfulRecords.getAndAdd(responseDetails.successCount());
+        erroredRecords.getAndAdd(responseDetails.errorCount());
+        resultRecords.addAll(responseDetails.outputs().values().stream().map(Output::getFlowFile).toList());
 
         operationList.clear();
         originals.clear();
@@ -541,47 +537,45 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
         final int numSuccessful = response.getItems() == null ? 0 : response.getItems().size() - numErrors;
         final Map<String, Output> outputs = new HashMap<>();
 
-        if (writerFactory != null) {
-            try {
-                for (int o = 0; o < bundle.getOriginalRecords().size(); o++) {
-                    final String type;
-                    final Relationship relationship;
-                    final Map<String, Object> error;
-                    if (errors.containsKey(o)) {
-                        relationship = REL_FAILED_RECORDS;
-                        error = errors.get(o);
-                        if (groupBulkErrors) {
-                            if (isElasticsearchNotFound().test(error)) {
-                                type = OUTPUT_TYPE_NOT_FOUND;
-                            } else {
-                                type = getErrorType(error);
-                            }
+        try {
+            for (int o = 0; o < bundle.getOriginalRecords().size(); o++) {
+                final String type;
+                final Relationship relationship;
+                final Map<String, Object> error;
+                if (errors.containsKey(o)) {
+                    relationship = REL_ERRORS;
+                    error = errors.get(o);
+                    if (groupBulkErrors) {
+                        if (isElasticsearchNotFound().test(error)) {
+                            type = OUTPUT_TYPE_NOT_FOUND;
                         } else {
-                            type = OUTPUT_TYPE_ERROR;
+                            type = getErrorType(error);
                         }
                     } else {
-                        relationship = REL_SUCCESSFUL_RECORDS;
-                        error = null;
-                        type = OUTPUT_TYPE_SUCCESS;
+                        type = OUTPUT_TYPE_ERROR;
                     }
-                    final Output output = getOutputByType(outputs, type, session, relationship, input, bundle.getSchema());
-                    output.write(bundle.getOriginalRecords().get(o), error);
+                } else {
+                    relationship = REL_SUCCESSFUL;
+                    error = null;
+                    type = OUTPUT_TYPE_SUCCESS;
                 }
-
-                for (final Output output : outputs.values()) {
-                    output.transfer(session);
-                }
-            } catch (final IOException | SchemaNotFoundException ex) {
-                getLogger().error("Unable to write error/successful records", ex);
-                outputs.values().forEach(o -> {
-                    try {
-                        o.remove(session);
-                    } catch (IOException ioe) {
-                        getLogger().warn("Error closing RecordSetWriter for FlowFile", ioe);
-                    }
-                });
-                throw ex;
+                final Output output = getOutputByType(outputs, type, session, relationship, input, bundle.getSchema());
+                output.write(bundle.getOriginalRecords().get(o), error);
             }
+
+            for (final Output output : outputs.values()) {
+                output.transfer(session);
+            }
+        } catch (final IOException | SchemaNotFoundException ex) {
+            getLogger().error("Unable to write error/successful records", ex);
+            outputs.values().forEach(o -> {
+                try {
+                    o.remove(session);
+                } catch (IOException ioe) {
+                    getLogger().warn("Error closing RecordSetWriter for FlowFile", ioe);
+                }
+            });
+            throw ex;
         }
 
         return new ResponseDetails(outputs, numSuccessful, numErrors);
@@ -734,29 +728,7 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
         }
     }
 
-    private static class ResponseDetails {
-        final Map<String, Output> outputs;
-        final int errorCount;
-        final int successCount;
-
-        ResponseDetails(final Map<String, Output> outputs, final int successCount, final int errorCount) {
-            this.outputs = outputs;
-            this.successCount = successCount;
-            this.errorCount = errorCount;
-        }
-
-        public Map<String, Output> getOutputs() {
-            return outputs;
-        }
-
-        public int getErrorCount() {
-            return errorCount;
-        }
-
-        public int getSuccessCount() {
-            return successCount;
-        }
-    }
+    private record ResponseDetails(Map<String, Output> outputs, int successCount, int errorCount) {}
 
     private String determineDateFormat(final RecordFieldType recordFieldType) {
         return switch (recordFieldType) {

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJsonTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJsonTest.java
@@ -168,9 +168,9 @@ public class PutElasticsearchJsonTest extends AbstractPutElasticsearchTest<PutEl
         assertTrue(runner.getProcessContext().hasConnection(AbstractPutElasticsearch.REL_ORIGINAL));
         assertTrue(((MockProcessContext) runner.getProcessContext()).getAllRelationships().stream().noneMatch(r -> "success".equals(r.getName())));
 
-        assertEquals(1, result.getRelationshipsRenamed().size());
-        assertEquals(AbstractPutElasticsearch.REL_ORIGINAL.getName(), result.getRelationshipsRenamed().get("success"));
-        assertEquals(0, result.getRelationshipsSplit().size());
+        assertEquals(1, result.getRenamedRelationships().size());
+        assertEquals(AbstractPutElasticsearch.REL_ORIGINAL.getName(), result.getRenamedRelationships().get("success"));
+        assertEquals(0, result.getPreviousRelationships().size());
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.java
@@ -237,10 +237,10 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         assertTrue(runner.getProcessContext().hasConnection(AbstractPutElasticsearch.REL_SUCCESSFUL));
         assertTrue(((MockProcessContext) runner.getProcessContext()).getAllRelationships().stream().noneMatch(r -> "successful_records".equals(r.getName())));
 
-        assertEquals(2, result.getRelationshipsRenamed().size());
-        assertEquals(AbstractPutElasticsearch.REL_ORIGINAL.getName(), result.getRelationshipsRenamed().get("success"));
-        assertEquals(AbstractPutElasticsearch.REL_SUCCESSFUL.getName(), result.getRelationshipsRenamed().get("successful_records"));
-        assertEquals(0, result.getRelationshipsSplit().size());
+        assertEquals(2, result.getRenamedRelationships().size());
+        assertEquals(AbstractPutElasticsearch.REL_ORIGINAL.getName(), result.getRenamedRelationships().get("success"));
+        assertEquals(AbstractPutElasticsearch.REL_SUCCESSFUL.getName(), result.getRenamedRelationships().get("successful_records"));
+        assertEquals(0, result.getPreviousRelationships().size());
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.java
@@ -22,18 +22,19 @@ import org.apache.nifi.elasticsearch.IndexOperationRequest;
 import org.apache.nifi.elasticsearch.IndexOperationResponse;
 import org.apache.nifi.json.JsonRecordSetWriter;
 import org.apache.nifi.json.JsonTreeReader;
-import org.apache.nifi.processors.elasticsearch.mock.MockBulkLoadClientService;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.schema.access.SchemaAccessUtils;
 import org.apache.nifi.serialization.RecordReaderFactory;
+import org.apache.nifi.serialization.RecordSetWriterFactory;
 import org.apache.nifi.serialization.record.MockRecordParser;
 import org.apache.nifi.serialization.record.MockSchemaRegistry;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.MockProcessContext;
+import org.apache.nifi.util.PropertyMigrationResult;
+import org.apache.nifi.util.RelationshipMigrationResult;
 import org.apache.nifi.util.StringUtils;
-import org.apache.nifi.util.TestRunner;
-import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -71,7 +73,6 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
     private static final LocalDate LOCAL_DATE = LocalDate.of(DATE_YEAR, DATE_MONTH, DATE_DAY);
     private static final LocalTime LOCAL_TIME = LocalTime.of(TIME_HOUR, TIME_MINUTE, TIME_SECOND);
     private static final String TEST_DIR = "src/test/resources/PutElasticsearchRecordTest";
-    private static final String TEST_COMMON_DIR = "src/test/resources/common";
     private static final String RECORD_PATH_TEST_SCHEMA = "recordPathTest";
     private static final String DATE_TIME_FORMATTING_TEST_SCHEMA = "dateTimeFormattingTest";
     private static final String SCHEMA_NAME_ATTRIBUTE = "schema.name";
@@ -81,9 +82,9 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
     private static RecordSchema recordPathTestSchema;
     private static RecordSchema dateTimeFormattingTestSchema;
     private static RecordSchema errorTestSchema;
-    private MockBulkLoadClientService clientService;
+
     private MockSchemaRegistry registry;
-    private TestRunner runner;
+    private JsonRecordSetWriter writer;
 
     @Override
     public Class<? extends AbstractPutElasticsearch> getTestProcessor() {
@@ -101,32 +102,36 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
 
     @BeforeEach
     public void setup() throws Exception {
-        clientService = new MockBulkLoadClientService();
-        clientService.setResponse(new IndexOperationResponse(1500));
+        super.setup();
+
         registry = new MockSchemaRegistry();
         registry.addSchema("simple", simpleSchema);
-        final RecordReaderFactory reader = new JsonTreeReader();
-        runner = TestRunners.newTestRunner(getTestProcessor());
         runner.addControllerService("registry", registry);
+        runner.assertValid(registry);
+        runner.enableControllerService(registry);
+
+        final RecordReaderFactory reader = new JsonTreeReader();
         runner.addControllerService("reader", reader);
-        runner.addControllerService("clientService", clientService);
         runner.setProperty(reader, SchemaAccessUtils.SCHEMA_REGISTRY, "registry");
         runner.setProperty(reader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_NAME_PROPERTY);
-        runner.setProperty(PutElasticsearchRecord.RECORD_READER, "reader");
-        runner.setProperty(PutElasticsearchRecord.INDEX_OP, IndexOperationRequest.Operation.Index.getValue());
-        runner.setProperty(PutElasticsearchRecord.INDEX, "test_index");
-        runner.setProperty(PutElasticsearchRecord.TYPE, "test_type");
-        runner.setProperty(PutElasticsearchRecord.AT_TIMESTAMP, "test_timestamp");
-        runner.setProperty(PutElasticsearchRecord.CLIENT_SERVICE, "clientService");
-        runner.setProperty(PutElasticsearchRecord.NOT_FOUND_IS_SUCCESSFUL, "true");
-        runner.enableControllerService(registry);
+        runner.assertValid(reader);
         runner.enableControllerService(reader);
-        runner.enableControllerService(clientService);
+        runner.setProperty(PutElasticsearchRecord.RECORD_READER, "reader");
+
+        writer = new JsonRecordSetWriter();
+        runner.addControllerService("writer", writer);
+        runner.setProperty(writer, SchemaAccessUtils.SCHEMA_REGISTRY, "registry");
+        runner.setProperty(writer, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_NAME_PROPERTY);
+        runner.assertValid(writer);
+        runner.enableControllerService(writer);
+        runner.setProperty(PutElasticsearchRecord.RESULT_RECORD_WRITER, "writer");
+
+        runner.setProperty(PutElasticsearchRecord.AT_TIMESTAMP, "test_timestamp");
 
         runner.assertValid();
     }
 
-    public void basicTest(final int failure, final int retry, final int success) {
+    void basicTest(final int failure, final int retry, final int successful) {
         final Consumer<List<IndexOperationRequest>> consumer = (final List<IndexOperationRequest> items) -> {
             final long timestampDefaultCount = items.stream().filter(item -> "test_timestamp".equals(item.getFields().get("@timestamp"))).count();
             final long indexCount = items.stream().filter(item -> "test_index".equals(item.getIndex())).count();
@@ -146,45 +151,106 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
             assertEquals(2, emptyHeaderFields);
         };
 
-        basicTest(failure, retry, success, consumer);
+        basicTest(failure, retry, successful, consumer);
     }
 
-    public void basicTest(final int failure, final int retry, final int success, final Consumer<List<IndexOperationRequest>> consumer) {
-        basicTest(failure, retry, success, consumer, null);
+    void basicTest(final int failure, final int retry, final int successful, final Consumer<List<IndexOperationRequest>> consumer) {
+        basicTest(failure, retry, successful, consumer, null);
     }
 
-    public void basicTest(final int failure, final int retry, final int success, final Consumer<List<IndexOperationRequest>> consumer, final Map<String, String> attributes) {
+    void basicTest(final int failure, final int retry, final int successful, final Consumer<List<IndexOperationRequest>> consumer, final Map<String, String> attributes) {
         clientService.setEvalConsumer(consumer);
         runner.enqueue(flowFileContentMaps, attributes != null && !attributes.isEmpty() ? attributes : Collections.singletonMap(SCHEMA_NAME_ATTRIBUTE, "simple"));
         runner.run();
 
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, failure);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, retry);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, success);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, failure);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, retry);
+        // for the "basic test"s, all original FlowFiles should be successful
+        runner.assertTransferCount(PutElasticsearchJson.REL_ORIGINAL, successful);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, successful);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
 
-        if (success > 0) {
-            runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_SUCCESS).forEach(ff -> {
+        if (successful > 0) {
+            runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ORIGINAL).forEach(ff -> {
                 ff.assertAttributeEquals("elasticsearch.put.success.count", "0");
-                ff.assertAttributeEquals("elasticsearch.put.error.count", "0");});
+                ff.assertAttributeEquals("elasticsearch.put.error.count", "0");
+            });
 
-            assertEquals(success,
+            assertEquals(successful,
                     runner.getProvenanceEvents().stream().filter(
                                     e -> ProvenanceEventType.SEND.equals(e.getEventType()) && "1 Elasticsearch _bulk operation batch(es) [0 error(s), 0 success(es)]".equals(e.getDetails()))
                             .count());
+
+            assertEquals(successful,
+                    runner.getProvenanceEvents().stream().filter(
+                                    e -> ProvenanceEventType.FORK.equals(e.getEventType()) && e.getParentUuids().contains(
+                                            runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ORIGINAL).getFirst().getAttribute("uuid")
+                                    )
+                            ).count());
         }
     }
 
     @Test
-    public void simpleTest() {
+    void testMigrateProperties() {
+        runner.removeProperty(AbstractPutElasticsearch.NOT_FOUND_IS_SUCCESSFUL);
+        runner.setProperty("put-es-record-not_found-is-error", "true");
+
+        runner.disableControllerService(writer);
+        runner.removeProperty(PutElasticsearchRecord.RESULT_RECORD_WRITER);
+        runner.removeControllerService(writer);
+        runner.assertNotValid();
+
+        final PropertyMigrationResult result = runner.migrateProperties();
+
+        runner.assertValid();
+        assertEquals("true", runner.getProcessContext().getProperty(AbstractPutElasticsearch.NOT_FOUND_IS_SUCCESSFUL).getValue());
+        assertTrue(runner.getProcessContext().getProperties().keySet().stream().noneMatch(pd -> "put-es-record-not_found-is-error".equals(pd.getName())));
+
+        assertTrue(runner.getProcessContext().getProperties().containsKey(PutElasticsearchRecord.RESULT_RECORD_WRITER));
+        final RecordSetWriterFactory writer = runner.getControllerService(
+                runner.getProcessContext().getProperty(PutElasticsearchRecord.RESULT_RECORD_WRITER.getName()).getValue(),
+                RecordSetWriterFactory.class
+        );
+        assertNotNull(writer);
+        assertTrue(runner.isControllerServiceEnabled(writer));
+
+        assertEquals(1, result.getPropertiesRenamed().size());
+        assertEquals(AbstractPutElasticsearch.NOT_FOUND_IS_SUCCESSFUL.getName(), result.getPropertiesRenamed().get("put-es-record-not_found-is-error"));
+        assertEquals(0, result.getPropertiesRemoved().size());
+        assertEquals(1, result.getPropertiesUpdated().size());
+        assertTrue(result.getPropertiesUpdated().contains(PutElasticsearchRecord.RESULT_RECORD_WRITER.getName()));
+
+    }
+
+    @Test
+    void testMigrateRelationships() {
+        runner.addConnection("success");
+        assertFalse(runner.getProcessContext().hasConnection(AbstractPutElasticsearch.REL_ORIGINAL));
+        runner.addConnection("successful_records");
+        assertFalse(runner.getProcessContext().hasConnection(AbstractPutElasticsearch.REL_SUCCESSFUL));
+
+        final RelationshipMigrationResult result = runner.migrateRelationships();
+
+        assertTrue(runner.getProcessContext().hasConnection(AbstractPutElasticsearch.REL_ORIGINAL));
+        assertTrue(((MockProcessContext) runner.getProcessContext()).getAllRelationships().stream().noneMatch(r -> "success".equals(r.getName())));
+        assertTrue(runner.getProcessContext().hasConnection(AbstractPutElasticsearch.REL_SUCCESSFUL));
+        assertTrue(((MockProcessContext) runner.getProcessContext()).getAllRelationships().stream().noneMatch(r -> "successful_records".equals(r.getName())));
+
+        assertEquals(2, result.getRelationshipsRenamed().size());
+        assertEquals(AbstractPutElasticsearch.REL_ORIGINAL.getName(), result.getRelationshipsRenamed().get("success"));
+        assertEquals(AbstractPutElasticsearch.REL_SUCCESSFUL.getName(), result.getRelationshipsRenamed().get("successful_records"));
+        assertEquals(0, result.getRelationshipsSplit().size());
+    }
+
+    @Test
+    void simpleTest() {
         clientService.setEvalParametersConsumer((Map<String, String> params) -> assertTrue(params.isEmpty()));
         basicTest(0, 0, 1);
     }
 
     @Test
-    public void simpleTestCoercedDefaultTimestamp() {
+    void simpleTestCoercedDefaultTimestamp() {
         final Consumer<List<IndexOperationRequest>> consumer = (List<IndexOperationRequest> items) ->
                 assertEquals(2L, items.stream().filter(item -> Long.valueOf(100).equals(item.getFields().get("@timestamp"))).count());
 
@@ -193,7 +259,7 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
     }
 
     @Test
-    public void simpleTestWithRequestParametersAndBulkHeaders() {
+    void simpleTestWithRequestParametersAndBulkHeaders() {
         runner.setProperty("another", "${blank}");
         runner.setEnvironmentVariableValue("slices", "auto");
         runner.setEnvironmentVariableValue("version", "/version");
@@ -201,7 +267,7 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
     }
 
     @Test
-    public void simpleTestWithRequestParametersAndBulkHeadersFlowFileEL() {
+    void simpleTestWithRequestParametersAndBulkHeadersFlowFileEL() {
         final Map<String, String> attributes = new LinkedHashMap<>();
         attributes.put(SCHEMA_NAME_ATTRIBUTE, "simple");
         attributes.put("version", "/version");
@@ -211,7 +277,7 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
     }
 
     @Test
-    public void simpleTestWithMockReader() throws Exception{
+    void simpleTestWithMockReader() throws Exception{
         final MockRecordParser mockReader = new MockRecordParser();
         mockReader.addSchemaField("msg", RecordFieldType.STRING);
         mockReader.addSchemaField("from", RecordFieldType.STRING);
@@ -226,19 +292,19 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
     }
 
     @Test
-    public void testFatalError() {
+    void testFatalError() {
         clientService.setThrowFatalError(true);
         basicTest(1, 0, 0);
     }
 
     @Test
-    public void testRetriable() {
+    void testRetriable() {
         clientService.setThrowRetriableError(true);
         basicTest(0, 1, 0);
     }
 
     @Test
-    public void testRecordPathFeatures() throws Exception {
+    void testRecordPathFeatures() throws Exception {
         final Map<String, Object> script =
                 JsonUtils.readMap(JsonUtils.readString(Paths.get(TEST_DIR, "script.json")));
         final Map<String, Object> dynamicTemplates =
@@ -302,16 +368,16 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         runner.enqueue(flowFileContents, Collections.singletonMap(SCHEMA_NAME_ATTRIBUTE, RECORD_PATH_TEST_SCHEMA));
 
         runner.run();
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
     }
 
     @Test
-    public void testTimestampDateFormatAndScriptRecordPath() throws Exception {
+    void testTimestampDateFormatAndScriptRecordPath() throws Exception {
         final Map<String, Object> script =
                 JsonUtils.readMap(JsonUtils.readString(Paths.get(TEST_DIR, "script.json")));
         clientService.setEvalConsumer((final List<IndexOperationRequest> items) -> {
@@ -360,16 +426,16 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         flowFileContents = flowFileContents.replaceFirst("\\d{13}", String.valueOf(Date.valueOf(LOCAL_DATE).getTime()));
         runner.enqueue(flowFileContents, attributes);
         runner.run();
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
     }
 
     @Test
-    public void testNullRecordPaths() throws Exception {
+    void testNullRecordPaths() throws Exception {
         clientService.setEvalConsumer((final List<IndexOperationRequest> items) -> {
             final long nullTypeCount = items.stream().filter(item -> item.getType() == null).count();
             final long messageTypeCount = items.stream().filter(item -> "message".equals(item.getType())).count();
@@ -395,16 +461,16 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         flowFileContents = flowFileContents.replaceFirst("\\d{8}", String.valueOf(Time.valueOf(LOCAL_TIME).getTime()));
         runner.enqueue(flowFileContents, Collections.singletonMap(SCHEMA_NAME_ATTRIBUTE, RECORD_PATH_TEST_SCHEMA));
         runner.run();
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
     }
 
     @Test
-    public void testIndexOperationRecordPath() throws Exception {
+    void testIndexOperationRecordPath() throws Exception {
         clientService.setEvalConsumer((final List<IndexOperationRequest> items) -> {
             final long index = items.stream().filter(item ->  IndexOperationRequest.Operation.Index.equals(item.getOperation())).count();
             final long create = items.stream().filter(item ->  IndexOperationRequest.Operation.Create.equals(item.getOperation())).count();
@@ -428,16 +494,16 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         runner.removeProperty(PutElasticsearchRecord.AT_TIMESTAMP);
         runner.enqueue(Paths.get(TEST_DIR, "4_flowFileContents.json"), Collections.singletonMap(SCHEMA_NAME_ATTRIBUTE, RECORD_PATH_TEST_SCHEMA));
         runner.run();
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
     }
 
     @Test
-    public void testIncompatibleTimestampRecordPath() throws Exception {
+    void testIncompatibleTimestampRecordPath() throws Exception {
         clientService.setEvalConsumer((final List<IndexOperationRequest> items) -> {
             final long timestampCount = items.stream().filter(item ->  "Hello".equals(item.getFields().get("@timestamp"))).count();
             assertEquals(1, timestampCount);
@@ -447,22 +513,22 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         runner.setProperty(PutElasticsearchRecord.AT_TIMESTAMP_RECORD_PATH, "/msg");
         runner.enqueue(Paths.get(TEST_DIR, "5_flowFileContents.json"), Collections.singletonMap(SCHEMA_NAME_ATTRIBUTE, RECORD_PATH_TEST_SCHEMA));
         runner.run();
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
     }
 
     @Test
-    public void testNotFoundELRecordPaths() throws Exception {
+    void testNotFoundELRecordPaths() throws Exception {
         testInvalidELRecordPaths("${id_not_exist}", "${not_exist}",
                 Paths.get(TEST_DIR, "6_flowFileContents.json"), Collections.singletonMap(SCHEMA_NAME_ATTRIBUTE, RECORD_PATH_TEST_SCHEMA));
     }
 
     @Test
-    public void testEmptyELRecordPaths() throws Exception {
+    void testEmptyELRecordPaths() throws Exception {
         final Map<String, String> attributes = new LinkedHashMap<>();
         attributes.put(SCHEMA_NAME_ATTRIBUTE, RECORD_PATH_TEST_SCHEMA);
         attributes.put("will_be_empty", "/empty");
@@ -471,24 +537,24 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
     }
 
     @Test
-    public void testInvalidDynamicTemplatesRecordPath() throws Exception {
+    void testInvalidDynamicTemplatesRecordPath() throws Exception {
         registry.addSchema(RECORD_PATH_TEST_SCHEMA, recordPathTestSchema);
         runner.setProperty(PutElasticsearchRecord.DYNAMIC_TEMPLATES_RECORD_PATH, "/dynamic_templates");
         runner.enqueue(Paths.get(TEST_DIR, "8_flowFileContents.json"), Collections.singletonMap(SCHEMA_NAME_ATTRIBUTE, RECORD_PATH_TEST_SCHEMA));
         runner.run();
 
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
-        final MockFlowFile failure = runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILURE).getFirst();
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
+        final MockFlowFile failure = runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_FAILURE).getFirst();
         failure.assertAttributeEquals("elasticsearch.put.error", String.format("Field referenced by %s must be Map-type compatible or a String parsable into a JSON Object", "/dynamic_templates"));
     }
 
     @Test
-    public void testRecordPathFieldDefaults() throws Exception {
+    void testRecordPathFieldDefaults() throws Exception {
         clientService.setEvalConsumer((final List<IndexOperationRequest> items) -> {
             final long idNotNull = items.stream().filter(item ->  item.getId() != null).count();
             final long opIndex = items.stream().filter(item ->  IndexOperationRequest.Operation.Index.equals(item.getOperation())).count();
@@ -519,16 +585,16 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         runner.enqueue(Paths.get(TEST_DIR, "9_flowFileContents.json"), Collections.singletonMap(SCHEMA_NAME_ATTRIBUTE, RECORD_PATH_TEST_SCHEMA));
         runner.run();
 
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
     }
 
     @Test
-    public void testDefaultDateTimeFormatting() throws Exception{
+    void testDefaultDateTimeFormatting() throws Exception{
         clientService.setEvalConsumer((final List<IndexOperationRequest> items) -> {
             final long msg = items.stream().filter(item ->  (item.getFields().get("msg") != null)).count();
             final long timestamp = items.stream().filter(item ->
@@ -562,16 +628,16 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         runner.enqueue(getDateTimeFormattingJson(), Collections.singletonMap(SCHEMA_NAME_ATTRIBUTE, DATE_TIME_FORMATTING_TEST_SCHEMA));
         runner.run();
 
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
     }
 
     @Test
-    public void testCustomDateTimeFormatting() throws Exception {
+    void testCustomDateTimeFormatting() throws Exception {
         final String timestampFormat = "yy MMM d H";
         final String dateFormat = "dd/MM/yyyy";
         final String timeFormat = "HHmmss";
@@ -615,16 +681,16 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         runner.enqueue(getDateTimeFormattingJson(), Collections.singletonMap(SCHEMA_NAME_ATTRIBUTE, DATE_TIME_FORMATTING_TEST_SCHEMA));
         runner.run();
 
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
     }
 
     @Test
-    public void testInvalidIndexOperation() {
+    void testInvalidIndexOperation() {
         runner.setProperty(PutElasticsearchRecord.INDEX_OP, "not-valid");
         runner.assertNotValid();
         final AssertionError ae = assertThrows(AssertionError.class, runner::run);
@@ -636,122 +702,127 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         runner.enqueue(flowFileContentMaps, Collections.singletonMap("operation", "not-valid2"));
         runner.run();
 
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
     }
 
     @Test
-    public void testInputRequired() {
+    void testInputRequired() {
         runner.run();
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
     }
 
     @Test
-    public void testFailedRecordsOutput() throws Exception {
+    void testFailedRecordsOutput() throws Exception {
         runner.setProperty(PutElasticsearchRecord.NOT_FOUND_IS_SUCCESSFUL, "true");
         runner.setProperty(PutElasticsearchRecord.LOG_ERROR_RESPONSES, "true");
         final int errorCount = 3;
         final int successCount = 4;
-        testErrorRelationship(errorCount, successCount, true);
+        testErrorRelationship(errorCount, 1, successCount);
 
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
-        runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).getFirst().assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, String.valueOf(errorCount));
-        runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS).getFirst().assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT,
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
+        runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).getFirst().assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, String.valueOf(errorCount));
+        runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_SUCCESSFUL).getFirst().assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT,
                 String.valueOf(successCount));
     }
 
     @Test
-    public void testFailedRecordsOutputGroupedByErrorType() throws Exception {
+    void testFailedRecordsOutputGroupedByErrorType() throws Exception {
         runner.setProperty(PutElasticsearchRecord.NOT_FOUND_IS_SUCCESSFUL, "true");
         runner.setProperty(PutElasticsearchRecord.LOG_ERROR_RESPONSES, "true");
         runner.setProperty(PutElasticsearchRecord.GROUP_BULK_ERRORS_BY_TYPE, "true");
         final int successCount = 4;
-        testErrorRelationship(3, successCount, true);
+        testErrorRelationship(3, 2, successCount);
 
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 2);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 2);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
 
-        runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).get(0)
+        runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).get(0)
                 .assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, "2");
-        assertTrue(runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).get(0)
+        assertTrue(runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).get(0)
                 .getAttribute("elasticsearch.bulk.error").contains("mapper_parsing_exception"));
-        runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).get(1)
+        runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).get(1)
                 .assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, "1");
-        assertTrue(runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).get(1)
+        assertTrue(runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).get(1)
                 .getAttribute("elasticsearch.bulk.error").contains("some_other_exception"));
-        runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS).getFirst()
+        runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_SUCCESSFUL).getFirst()
                 .assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, String.valueOf(successCount));
     }
 
     @Test
-    public void testNotFoundResponsesTreatedAsFailedRecords() throws Exception {
+    void testNotFoundResponsesTreatedAsFailedRecords() throws Exception {
         runner.setProperty(PutElasticsearchRecord.NOT_FOUND_IS_SUCCESSFUL, "false");
         runner.setProperty(PutElasticsearchRecord.GROUP_BULK_ERRORS_BY_TYPE, "false");
         final int errorCount = 4;
         final int successCount = 3;
-        testErrorRelationship(errorCount, successCount, true);
+        testErrorRelationship(errorCount, 1, successCount);
 
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
 
-        runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).getFirst()
+        runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).getFirst()
                 .assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, String.valueOf(errorCount));
-        runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS).getFirst()
+        runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_SUCCESSFUL).getFirst()
                 .assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, String.valueOf(successCount));
     }
 
     @Test
-    public void testNotFoundFailedRecordsGroupedAsErrorType() throws Exception {
+    void testNotFoundFailedRecordsGroupedAsErrorType() throws Exception {
         runner.setProperty(PutElasticsearchRecord.NOT_FOUND_IS_SUCCESSFUL, "false");
         runner.setProperty(PutElasticsearchRecord.GROUP_BULK_ERRORS_BY_TYPE, "true");
         final int errorCount = 4;
         final int successCount = 3;
-        testErrorRelationship(errorCount, successCount, true);
+        testErrorRelationship(errorCount, 3, successCount);
 
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 3);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 3);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
 
-        runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).get(0)
+        runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).get(0)
                 .assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, "2");
-        assertTrue(runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).get(0)
+        assertTrue(runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).get(0)
                 .getAttribute("elasticsearch.bulk.error").contains("mapper_parsing_exception"));
-        runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).get(1)
+        runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).get(1)
                 .assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, "1");
-        assertTrue(runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).get(1)
+        assertTrue(runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).get(1)
                 .getAttribute("elasticsearch.bulk.error").contains("some_other_exception"));
-        runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).get(2)
+        runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).get(2)
                 .assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, "1");
-        assertTrue(runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_FAILED_RECORDS).get(2)
+        assertTrue(runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).get(2)
                 .getAttribute("elasticsearch.bulk.error").contains("not_found"));
-        runner.getFlowFilesForRelationship(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS).getFirst()
+        runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_SUCCESSFUL).getFirst()
                 .assertAttributeEquals(PutElasticsearchRecord.ATTR_RECORD_COUNT, String.valueOf(successCount));
     }
 
     @Test
-    public void testErrorsLoggedWithoutErrorRelationship() throws Exception {
+    void testErrorsLoggedWithoutErrorRelationship() throws Exception {
         runner.setProperty(PutElasticsearchRecord.NOT_FOUND_IS_SUCCESSFUL, "false");
         runner.setProperty(PutElasticsearchRecord.OUTPUT_ERROR_RESPONSES, "true");
         runner.setProperty(PutElasticsearchRecord.GROUP_BULK_ERRORS_BY_TYPE, "false");
         final int errorCount = 4;
         final int successCount = 3;
-        testErrorRelationship(errorCount, successCount, false);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 1);
+        testErrorRelationship(errorCount, 1, successCount);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 1);
         final String errorResponses = runner.getFlowFilesForRelationship(PutElasticsearchJson.REL_ERROR_RESPONSES).getFirst().getContent();
         assertTrue(errorResponses.contains("not_found"));
         assertTrue(errorResponses.contains("For input string: 20abc"));
@@ -760,7 +831,7 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
     }
 
     @Test
-    public void testInvalidBulkHeaderProperty() {
+    void testInvalidBulkHeaderProperty() {
         runner.assertValid();
         runner.setProperty(AbstractPutElasticsearch.BULK_HEADER_PREFIX + "routing", "not-record-path");
         runner.assertNotValid();
@@ -770,32 +841,29 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         return AvroTypeUtil.createSchema(new Schema.Parser().parse(Files.readString(schema)));
     }
 
-    private void testErrorRelationship(final int errorCount, final int successCount, final boolean recordWriter) throws Exception {
+    private void testErrorRelationship(final int errorCount, final int errorGroupsCount, final int successfulCount) throws Exception {
         final String schemaName = "errorTest";
-        final JsonRecordSetWriter writer = new JsonRecordSetWriter();
-        runner.addControllerService("writer", writer);
-        runner.setProperty(writer, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_NAME_PROPERTY);
-        runner.setProperty(writer, SchemaAccessUtils.SCHEMA_REGISTRY, "registry");
-        runner.enableControllerService(writer);
         clientService.setResponse(IndexOperationResponse.fromJsonResponse(JsonUtils.readString(Paths.get(TEST_COMMON_DIR, "sampleErrorResponse.json"))));
         registry.addSchema(schemaName, errorTestSchema);
-
-        if (recordWriter) {
-            runner.setProperty(PutElasticsearchRecord.RESULT_RECORD_WRITER, "writer");
-        }
 
         runner.assertValid();
 
         runner.enqueue(VALUES, Collections.singletonMap(SCHEMA_NAME_ATTRIBUTE, schemaName));
         runner.run();
 
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, successfulCount > 0 ? 1 : 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, errorGroupsCount);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
 
         assertEquals(1,
                 runner.getProvenanceEvents().stream().filter(e -> ProvenanceEventType.SEND.equals(e.getEventType())
-                        && String.format("1 Elasticsearch _bulk operation batch(es) [%d error(s), %d success(es)]", errorCount, successCount).equals(e.getDetails())).count());
+                        && String.format("1 Elasticsearch _bulk operation batch(es) [%d error(s), %d success(es)]", errorCount, successfulCount).equals(e.getDetails())).count());
+
+        assertTrue(runner.getProvenanceEvents().stream().anyMatch(e -> ProvenanceEventType.FORK.equals(e.getEventType()) && e.getParentUuids().equals(
+                Collections.singletonList(runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ORIGINAL).getFirst().getAttribute("uuid"))
+        )));
     }
 
     private void testInvalidELRecordPaths(final String idRecordPath, final String atTimestampRecordPath, final Path path, final Map<String, String> attributes) throws IOException {
@@ -812,12 +880,12 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest<Put
         runner.setProperty(PutElasticsearchRecord.AT_TIMESTAMP_RECORD_PATH, atTimestampRecordPath);
         runner.enqueue(path, attributes);
         runner.run();
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESS, 1);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILURE, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_RETRY, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_FAILED_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_SUCCESSFUL_RECORDS, 0);
-        runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ORIGINAL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_FAILURE, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_RETRY, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERROR_RESPONSES, 0);
     }
 
     private void testWithRequestParametersAndBulkHeaders(final Map<String, String> attributes) {

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/resources/PutElasticsearchJsonTest/batchWithoutError.json
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/resources/PutElasticsearchJsonTest/batchWithoutError.json
@@ -18,4 +18,12 @@
   "id" : "4",
   "field1" : "value2",
   "field2" : "30"
+}, {
+  "id" : "6",
+  "field1" : "value1",
+  "field2" : "213,456.9"
+}, {
+  "id" : "7",
+  "field1" : "value1",
+  "field2" : "unit test"
 } ]

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
@@ -52,7 +52,7 @@ import static org.apache.http.auth.AuthScope.ANY;
 public abstract class AbstractElasticsearchITBase {
     // default Elasticsearch version should (ideally) match that in the nifi-elasticsearch-bundle#pom.xml for the integration-tests profile
     protected static final DockerImageName IMAGE = DockerImageName
-            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.10.3"));
+            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.12.2"));
     protected static final String ELASTIC_USER_PASSWORD = System.getProperty("elasticsearch.elastic_user.password", RandomStringUtils.randomAlphanumeric(10, 20));
     private static final int PORT = 9200;
     protected static final ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer(IMAGE)

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
@@ -52,7 +52,7 @@ import static org.apache.http.auth.AuthScope.ANY;
 public abstract class AbstractElasticsearchITBase {
     // default Elasticsearch version should (ideally) match that in the nifi-elasticsearch-bundle#pom.xml for the integration-tests profile
     protected static final DockerImageName IMAGE = DockerImageName
-            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.12.2"));
+            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.13.3"));
     protected static final String ELASTIC_USER_PASSWORD = System.getProperty("elasticsearch.elastic_user.password", RandomStringUtils.randomAlphanumeric(10, 20));
     private static final int PORT = 9200;
     protected static final ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer(IMAGE)

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -95,7 +95,7 @@ language governing permissions and limitations under the License. -->
             </activation>
             <properties>
                 <!-- also update the default Elasticsearch version in nifi-elasticsearch-test-utils#src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java-->
-                <elasticsearch_docker_image>8.12.2</elasticsearch_docker_image>
+                <elasticsearch_docker_image>8.13.3</elasticsearch_docker_image>
                 <elasticsearch.elastic.password>s3cret</elasticsearch.elastic.password>
             </properties>
             <build>
@@ -126,7 +126,7 @@ language governing permissions and limitations under the License. -->
         <profile>
             <id>elasticsearch7</id>
             <properties>
-                <elasticsearch_docker_image>7.17.18</elasticsearch_docker_image>
+                <elasticsearch_docker_image>7.17.21</elasticsearch_docker_image>
             </properties>
         </profile>
     </profiles>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -95,7 +95,7 @@ language governing permissions and limitations under the License. -->
             </activation>
             <properties>
                 <!-- also update the default Elasticsearch version in nifi-elasticsearch-test-utils#src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java-->
-                <elasticsearch_docker_image>8.10.3</elasticsearch_docker_image>
+                <elasticsearch_docker_image>8.12.2</elasticsearch_docker_image>
                 <elasticsearch.elastic.password>s3cret</elasticsearch.elastic.password>
             </properties>
             <build>
@@ -126,7 +126,7 @@ language governing permissions and limitations under the License. -->
         <profile>
             <id>elasticsearch7</id>
             <properties>
-                <elasticsearch_docker_image>7.17.14</elasticsearch_docker_image>
+                <elasticsearch_docker_image>7.17.18</elasticsearch_docker_image>
             </properties>
         </profile>
     </profiles>

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockRelationshipConfiguration.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockRelationshipConfiguration.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.util;
+
+import org.apache.nifi.migration.RelationshipConfiguration;
+import org.apache.nifi.processor.Relationship;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class MockRelationshipConfiguration implements RelationshipConfiguration {
+    private final Map<String, Set<String>> relationshipSplits = new HashMap<>();
+    private final Map<String, String> relationshipRenames = new HashMap<>();
+    private final Map<String, Relationship> rawRelationships;
+    private final Set<Relationship> originalRelationships;
+
+    public MockRelationshipConfiguration(final Set<Relationship> relationships) {
+        this.originalRelationships = Collections.unmodifiableSet(relationships);
+        this.rawRelationships = relationships.stream().collect(Collectors.toMap(Relationship::getName, Function.identity()));
+    }
+
+    public RelationshipMigrationResult toRelationshipMigrationResult() {
+        return new RelationshipMigrationResult() {
+            @Override
+            public Map<String, Set<String>> getRelationshipsSplit() {
+                return Collections.unmodifiableMap(relationshipSplits);
+            }
+
+            @Override
+            public Map<String, String> getRelationshipsRenamed() {
+                return Collections.unmodifiableMap(relationshipRenames);
+            }
+        };
+    }
+
+    @Override
+    public boolean renameRelationship(final String relationshipName, final String newName) {
+        relationshipRenames.put(relationshipName, newName);
+
+        final boolean hasRelationship = hasRelationship(relationshipName);
+        if (!hasRelationship) {
+            return false;
+        }
+
+        rawRelationships.remove(relationshipName);
+        rawRelationships.put(relationshipName, findRelationshipByName(newName));
+        return true;
+    }
+
+    @Override
+    public boolean splitRelationship(final String relationshipName, final String newRelationshipName, final String... additionalRelationshipNames) {
+        final Set<String> newRelationships = new HashSet<>();
+        newRelationships.add(newRelationshipName);
+        if (additionalRelationshipNames != null) {
+            newRelationships.addAll(Arrays.stream(additionalRelationshipNames).toList());
+        }
+        relationshipSplits.put(relationshipName, newRelationships);
+
+        final boolean hasRelationship = hasRelationship(relationshipName);
+        if (!hasRelationship) {
+            return false;
+        }
+
+        rawRelationships.remove(relationshipName);
+        newRelationships.forEach(r -> rawRelationships.put(r, findRelationshipByName(r)));
+        return true;
+    }
+
+    @Override
+    public boolean hasRelationship(final String relationshipName) {
+        return rawRelationships.containsKey(relationshipName);
+    }
+
+    private Relationship findRelationshipByName(final String name) {
+        return originalRelationships.stream().filter(r -> name.equals(r.getName())).findFirst().orElseThrow();
+    }
+
+    public Set<Relationship> getRawRelationships() {
+        return Set.copyOf(rawRelationships.values());
+    }
+}

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockRelationshipConfiguration.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockRelationshipConfiguration.java
@@ -42,12 +42,12 @@ public class MockRelationshipConfiguration implements RelationshipConfiguration 
     public RelationshipMigrationResult toRelationshipMigrationResult() {
         return new RelationshipMigrationResult() {
             @Override
-            public Map<String, Set<String>> getRelationshipsSplit() {
+            public Map<String, Set<String>> getPreviousRelationships() {
                 return Collections.unmodifiableMap(relationshipSplits);
             }
 
             @Override
-            public Map<String, String> getRelationshipsRenamed() {
+            public Map<String, String> getRenamedRelationships() {
                 return Collections.unmodifiableMap(relationshipRenames);
             }
         };

--- a/nifi-mock/src/main/java/org/apache/nifi/util/RelationshipMigrationResult.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/RelationshipMigrationResult.java
@@ -25,10 +25,10 @@ public interface RelationshipMigrationResult {
     /**
      * @return a mapping of previous relationship names to the new names of those relationships
      */
-    Map<String, Set<String>> getRelationshipsSplit();
+    Map<String, Set<String>> getPreviousRelationships();
 
     /**
      * @return a mapping of previous relationship names to the new names of those relationships
      */
-    Map<String, String> getRelationshipsRenamed();
+    Map<String, String> getRenamedRelationships();
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/RelationshipMigrationResult.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/RelationshipMigrationResult.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.util;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface RelationshipMigrationResult {
+
+    /**
+     * @return a mapping of previous relationship names to the new names of those relationships
+     */
+    Map<String, Set<String>> getRelationshipsSplit();
+
+    /**
+     * @return a mapping of previous relationship names to the new names of those relationships
+     */
+    Map<String, String> getRelationshipsRenamed();
+}

--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -63,6 +63,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -241,8 +242,7 @@ public class StandardProcessorTestRunner implements TestRunner {
                     unscheduledRun = true;
                     unSchedule();
                 }
-            } catch (final Exception e) {
-                e.printStackTrace();
+            } catch (final InterruptedException | ExecutionException e) {
             }
         }
 

--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -202,23 +202,20 @@ public class StandardProcessorTestRunner implements TestRunner {
         }
 
         context.assertValid();
-        context.enableExpressionValidation();
 
         // Call onConfigurationRestored here, right before the test run, as all properties should have been set byt this point.
         ReflectionUtils.quietlyInvokeMethodsWithAnnotation(OnConfigurationRestored.class, processor, this.context);
 
-        try {
-            if (initialize) {
-                try {
-                    ReflectionUtils.invokeMethodsWithAnnotation(OnScheduled.class, processor, context);
-                } catch (final Exception e) {
-                    Assertions.fail("Could not invoke methods annotated with @OnScheduled annotation due to: " + e, e);
-                }
+        if (initialize) {
+            try {
+                ReflectionUtils.invokeMethodsWithAnnotation(OnScheduled.class, processor, context);
+            } catch (final Exception e) {
+                Assertions.fail("Could not invoke methods annotated with @OnScheduled annotation due to: " + e, e);
             }
+        }
 
-            final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(numThreads);
-            @SuppressWarnings("unchecked")
-            final Future<Throwable>[] futures = new Future[iterations];
+        @SuppressWarnings("unchecked") final Future<Throwable>[] futures = new Future[iterations];
+        try (final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(numThreads)) {
             for (int i = 0; i < iterations; i++) {
                 final Future<Throwable> future = executorService.schedule(new RunProcessor(), i * runSchedule, TimeUnit.MILLISECONDS);
                 futures[i] = future;
@@ -229,33 +226,32 @@ public class StandardProcessorTestRunner implements TestRunner {
                 executorService.awaitTermination(runWait, TimeUnit.MILLISECONDS);
             } catch (final InterruptedException e1) {
             }
+        }
 
-            int finishedCount = 0;
-            boolean unscheduledRun = false;
-            for (final Future<Throwable> future : futures) {
-                try {
-                    final Throwable thrown = future.get(); // wait for the result
-                    if (thrown != null) {
-                        throw new AssertionError(thrown);
-                    }
-
-                    if (++finishedCount == 1 && stopOnFinish) {
-                        unscheduledRun = true;
-                        unSchedule();
-                    }
-                } catch (final Exception e) {
+        int finishedCount = 0;
+        boolean unscheduledRun = false;
+        for (final Future<Throwable> future : futures) {
+            try {
+                final Throwable thrown = future.get(); // wait for the result
+                if (thrown != null) {
+                    throw new AssertionError(thrown);
                 }
-            }
 
-            if (!unscheduledRun && stopOnFinish) {
-                unSchedule();
+                if (++finishedCount == 1 && stopOnFinish) {
+                    unscheduledRun = true;
+                    unSchedule();
+                }
+            } catch (final Exception e) {
+                e.printStackTrace();
             }
+        }
 
-            if (stopOnFinish) {
-                stop();
-            }
-        } finally {
-            context.disableExpressionValidation();
+        if (!unscheduledRun && stopOnFinish) {
+            unSchedule();
+        }
+
+        if (stopOnFinish) {
+            stop();
         }
     }
 
@@ -331,7 +327,7 @@ public class StandardProcessorTestRunner implements TestRunner {
         assertAllFlowFiles(new FlowFileValidator() {
             @Override
             public void assertFlowFile(FlowFile f) {
-                Assertions.assertTrue(f.getAttribute(attributeName) != null);
+                Assertions.assertNotNull(f.getAttribute(attributeName));
             }
         });
     }
@@ -341,7 +337,7 @@ public class StandardProcessorTestRunner implements TestRunner {
         assertAllFlowFiles(relationship, new FlowFileValidator() {
             @Override
             public void assertFlowFile(FlowFile f) {
-                Assertions.assertTrue(f.getAttribute(attributeName) != null);
+                Assertions.assertNotNull(f.getAttribute(attributeName));
             }
         });
     }
@@ -387,7 +383,7 @@ public class StandardProcessorTestRunner implements TestRunner {
         List<MockFlowFile> flowFiles = getFlowFilesForRelationship(relationship);
 
         List<String> actualContent = flowFiles.stream()
-            .map(flowFile -> flowFile.getContent())
+            .map(MockFlowFile::getContent)
             .collect(Collectors.toList());
 
         assertEquals(expectedContent, actualContent);
@@ -664,11 +660,11 @@ public class StandardProcessorTestRunner implements TestRunner {
 
     @Override
     public void addControllerService(final String identifier, final ControllerService service, final Map<String, String> properties) throws InitializationException {
-        final MockComponentLog logger = new MockComponentLog(identifier, service);
-        controllerServiceLoggers.put(identifier, logger);
+        final MockComponentLog mockComponentLog = new MockComponentLog(identifier, service);
+        controllerServiceLoggers.put(identifier, mockComponentLog);
         final MockStateManager serviceStateManager = new MockStateManager(service);
         final MockControllerServiceInitializationContext initContext = new MockControllerServiceInitializationContext(
-                requireNonNull(service), requireNonNull(identifier), logger, serviceStateManager, kerberosContext);
+                requireNonNull(service), requireNonNull(identifier), mockComponentLog, serviceStateManager, kerberosContext);
         controllerServiceStateManagers.put(identifier, serviceStateManager);
         initContext.addControllerServices(context);
         service.initialize(initContext);
@@ -719,7 +715,7 @@ public class StandardProcessorTestRunner implements TestRunner {
 
         for (final ValidationResult result : results) {
             if (!result.isValid()) {
-                Assertions.fail("Expected Controller Service to be valid but it is invalid due to: " + result.toString());
+                Assertions.fail("Expected Controller Service to be valid but it is invalid due to: " + result);
             }
         }
     }
@@ -768,7 +764,7 @@ public class StandardProcessorTestRunner implements TestRunner {
 
         for (final ValidationResult result : results) {
             if (!result.isValid()) {
-                throw new IllegalStateException("Cannot enable Controller Service " + service + " because it is in an invalid state: " + result.toString());
+                throw new IllegalStateException("Cannot enable Controller Service " + service + " because it is in an invalid state: " + result);
             }
         }
 
@@ -1046,7 +1042,7 @@ public class StandardProcessorTestRunner implements TestRunner {
         }
 
         for (MockFlowFile flowFile : flowFiles) {
-            if (predicate.test(flowFile)==false) {
+            if (!predicate.test(flowFile)) {
                 Assertions.fail("FlowFile " + flowFile + " does not meet all condition");
             }
         }
@@ -1075,7 +1071,7 @@ public class StandardProcessorTestRunner implements TestRunner {
 
     @Override
     public PropertyMigrationResult migrateProperties() {
-        final MockPropertyConfiguration mockPropertyConfiguration = new MockPropertyConfiguration(getProcessContext().getAllProperties());
+        final MockPropertyConfiguration mockPropertyConfiguration = new MockPropertyConfiguration(context.getAllProperties());
         getProcessor().migrateProperties(mockPropertyConfiguration);
 
         final PropertyMigrationResult migrationResult = mockPropertyConfiguration.toPropertyMigrationResult();
@@ -1093,6 +1089,7 @@ public class StandardProcessorTestRunner implements TestRunner {
 
                 serviceImpl = (ControllerService) newInstance;
                 addControllerService(service.id(), serviceImpl, service.serviceProperties());
+                enableControllerService(serviceImpl);
             } catch (final Exception e) {
                 if (serviceCreationException == null) {
                     if (e instanceof RuntimeException) {
@@ -1111,10 +1108,27 @@ public class StandardProcessorTestRunner implements TestRunner {
         }
 
         final Map<String, String> updatedProperties = mockPropertyConfiguration.getRawProperties();
-        final MockProcessContext processContext = getProcessContext();
-        processContext.clearProperties();
-        updatedProperties.forEach(processContext::setProperty);
+        clearProperties();
+        updatedProperties.forEach((propertyName, propertyValue) -> {
+            if (propertyValue == null) {
+                removeProperty(propertyName);
+            } else {
+                setProperty(propertyName, propertyValue);
+            }
+        });
 
         return migrationResult;
+    }
+
+    @Override
+    public RelationshipMigrationResult migrateRelationships() {
+        final MockRelationshipConfiguration mockRelationshipConfiguration = new MockRelationshipConfiguration(context.getAllRelationships());
+        getProcessor().migrateRelationships(mockRelationshipConfiguration);
+
+        final Set<Relationship> updatedRelationships = mockRelationshipConfiguration.getRawRelationships();
+        context.clearConnections();
+        updatedRelationships.forEach(context::addConnection);
+
+        return mockRelationshipConfiguration.toRelationshipMigrationResult();
     }
 }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
@@ -24,6 +24,7 @@ import org.apache.nifi.controller.queue.QueueSize;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.migration.PropertyConfiguration;
+import org.apache.nifi.migration.RelationshipConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.ProcessSessionFactory;
@@ -345,7 +346,7 @@ public interface TestRunner {
      * @param relationship The relationship on which to check the contents of flowfiles
      * @param expectedContent The expected contents of all flowfiles
      */
-    public void assertContents(Relationship relationship, List<String> expectedContent);
+    void assertContents(Relationship relationship, List<String> expectedContent);
 
     /**
      * Assert that the number of FlowFiles transferred to the given relationship
@@ -1077,4 +1078,13 @@ public interface TestRunner {
      * @return the results of migrating properties
      */
     PropertyMigrationResult migrateProperties();
+
+    /**
+     * Causes the TestRunner to call the Processor's {@link Processor#migrateRelationships(RelationshipConfiguration)} method. The effects that are
+     * caused by calling the method are applied, as they would be in a running NiFi instance. Unlike in a running NiFi instance, though, the
+     * operations that were performed are captured so that they can be examined and assertions made about the migration that occurred.
+     *
+     * @return the results of migrating relationships
+     */
+    RelationshipMigrationResult migrateRelationships();
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12255](https://issues.apache.org/jira/browse/NIFI-12255) refactor PutElasticsearchRecord and PutElasticsearchJson relationships to be more consistent with other processors

Additionally:
- added ability to unit test `migrateRelationships` for processor refactoring
- addressed issue with `StandardTestRunner#migrateProperties` where some properties may be `null`
- addressed some warnings in `MockProcessContext` and `StandardTestRunner` implementations, improving some logging for easier test failure diagnostics

**Breaking Change**: addition of the `successfull` relationship to `PutElasticsearchJson` will require the connection to be added to a downstream processor (or terminated within the processor config). Relationship has been added for consistency with `PutElasticsearchRecord`, along with `original` (automatically renamed from `success`) and `errors`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
