### PR TITLE
NIFI-12273: Fix references to command.argument dynamic properties in ExecuteStreamCommand documentation

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.ExecuteStreamCommand/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.ExecuteStreamCommand/additionalDetails.html
@@ -53,7 +53,7 @@
         <p><b>NOTE:</b> the command should be on <code>$PATH</code> or it should be in the working directory, otherwise path also should be specified.</p>
 
         <h4>Dynamic Properties</h4>
-        <p>Arguments can be specified with Dynamic Properties. Dynamic Properties with the pattern of 'command.arguments.&lt;commandIndex&gt;' will be appended
+        <p>Arguments can be specified with Dynamic Properties. Dynamic Properties with the pattern of 'command.argument.&lt;commandIndex&gt;' will be appended
         to the command in ascending order.</p>
 
         <p>The above example with dynamic properties would look like this:</p>
@@ -64,11 +64,11 @@
                 <th>Property Value</th>
             </tr>
             <tr>
-                <td>command.arguments.0</td>
+                <td>command.argument.0</td>
                 <td>-lah</td>
             </tr>
             <tr>
-                <td>command.arguments.1</td>
+                <td>command.argument.1</td>
                 <td>/path/to/dir</td>
             </tr>
         </table>
@@ -76,7 +76,7 @@
         <h3>Configuring environment variables</h3>
         <p>In addition to specifying command arguments using the Command Argument field or Dynamic Properties, users can also use environment variables with
         the ExecuteStreamCommand processor. Environment variables are a set of key-value pairs that can be accessed by processes running on the system.
-        ExecuteStreamCommand will treat every Dynamic Property as an environment variable that doesn't match the pattern 'command.arguments.&lt;commandIndex&gt;'.</p>
+        ExecuteStreamCommand will treat every Dynamic Property as an environment variable that doesn't match the pattern 'command.argument.&lt;commandIndex&gt;'.</p>
 
         <p>Consider that we want to execute a Maven command with the processor. If there are multiple Java versions installed on the system, you can specify
         which version will be used by setting the <code>JAVA_HOME</code> environment variable. The output FlowFile will looke like this if we run


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12273](https://issues.apache.org/jira/browse/NIFI-12273) Minor fix to correct documentation as reported by the community.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
