### PR TITLE
NIFI-12282 Move Hadoop and other NARs to Optional Profiles

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -372,7 +372,7 @@ language governing permissions and limitations under the License. -->
             <version>2.0.0-SNAPSHOT</version>
             <type>nar</type>
         </dependency>
-	<dependency>
+        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mongodb-client-service-api-nar</artifactId>
             <version>2.0.0-SNAPSHOT</version>
@@ -744,7 +744,7 @@ language governing permissions and limitations under the License. -->
             <version>2.0.0-SNAPSHOT</version>
             <type>nar</type>
         </dependency>
-	    <dependency>
+        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-kerberos-user-service-nar</artifactId>
             <version>2.0.0-SNAPSHOT</version>
@@ -1127,7 +1127,7 @@ language governing permissions and limitations under the License. -->
                     <type>nar</type>
                 </dependency>
             </dependencies>
-    	</profile>
+        </profile>
         <profile>
             <id>headless</id>
             <!-- This profile excludes the nifi-server artifacts, such as the Web/UI NAR(s) and instead uses the nifi-headless-server-nar. -->
@@ -1150,7 +1150,7 @@ language governing permissions and limitations under the License. -->
                 </dependency>
             </dependencies>
         </profile>
-	    <profile>
+        <profile>
             <id>include-accumulo</id>
             <!-- This profile handles the inclusion of nifi-accumulo artifacts. -->
             <activation>
@@ -1165,14 +1165,14 @@ language governing permissions and limitations under the License. -->
                     <artifactId>nifi-accumulo-nar</artifactId>
                     <version>2.0.0-SNAPSHOT</version>
                     <type>nar</type>
-	    	    </dependency>
-		        <dependency>
+                </dependency>
+                <dependency>
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-accumulo-services-api-nar</artifactId>
                     <version>2.0.0-SNAPSHOT</version>
                     <type>nar</type>
-		        </dependency>
-		        <dependency>
+                </dependency>
+                <dependency>
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-accumulo-services-nar</artifactId>
                     <version>2.0.0-SNAPSHOT</version>

--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -314,18 +314,6 @@ language governing permissions and limitations under the License. -->
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-hadoop-libraries-nar</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>nar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-hadoop-nar</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>nar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-kafka-2-6-nar</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <type>nar</type>
@@ -351,12 +339,6 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-poi-nar</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>nar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-kudu-nar</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <type>nar</type>
         </dependency>
@@ -405,12 +387,6 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mongodb-services-nar</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>nar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-solr-nar</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <type>nar</type>
         </dependency>
@@ -482,19 +458,7 @@ language governing permissions and limitations under the License. -->
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-hbase-nar</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>nar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hl7-nar</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>nar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-hbase_2-client-service-nar</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <type>nar</type>
         </dependency>
@@ -711,12 +675,6 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-cdc-mysql-nar</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <type>nar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-parquet-nar</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <type>nar</type>
         </dependency>
@@ -999,6 +957,98 @@ language governing permissions and limitations under the License. -->
             </dependencies>
         </profile>
         <profile>
+            <id>include-hadoop</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>allProfiles</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-hadoop-libraries-nar</artifactId>
+                    <version>2.0.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-hadoop-nar</artifactId>
+                    <version>2.0.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-parquet-nar</artifactId>
+                    <version>2.0.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>include-kudu</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>allProfiles</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-hadoop-libraries-nar</artifactId>
+                    <version>2.0.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-kudu-nar</artifactId>
+                    <version>2.0.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>include-hbase</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>allProfiles</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-hbase-nar</artifactId>
+                    <version>2.0.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-hbase_2-client-service-nar</artifactId>
+                    <version>2.0.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>include-solr</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>allProfiles</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-solr-nar</artifactId>
+                    <version>2.0.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>include-hive3</id>
             <!-- This profile handles the inclusion of Hive 3 artifacts. The NAR
             is quite large and makes the resultant binary distribution significantly
@@ -1100,7 +1150,7 @@ language governing permissions and limitations under the License. -->
                 </dependency>
             </dependencies>
         </profile>
-	<profile>
+	    <profile>
             <id>include-accumulo</id>
             <!-- This profile handles the inclusion of nifi-accumulo artifacts. -->
             <activation>
@@ -1115,14 +1165,14 @@ language governing permissions and limitations under the License. -->
                     <artifactId>nifi-accumulo-nar</artifactId>
                     <version>2.0.0-SNAPSHOT</version>
                     <type>nar</type>
-	    	</dependency>
-		<dependency>
+	    	    </dependency>
+		        <dependency>
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-accumulo-services-api-nar</artifactId>
                     <version>2.0.0-SNAPSHOT</version>
                     <type>nar</type>
-		</dependency>
-		<dependency>
+		        </dependency>
+		        <dependency>
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-accumulo-services-nar</artifactId>
                     <version>2.0.0-SNAPSHOT</version>

--- a/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -2703,9 +2703,13 @@ deprecationLogger.warn(
 | Package                | Maven Profile         | Description
 | Apache Accumulo Bundle | include-accumulo      | Adds support for https://accumulo.apache.org[Apache Accumulo].
 | Apache Atlas Bundle    | include-atlas         | Adds support for the Apache Atlas data governance tool. The functionality from this bundle is based around reporting tasks that integrate with https://atlas.apache.org[Apache Atlas].
+| Apache Hadoop Bundle   | include-hadoop        | Adds support for Apache Hadoop with HDFS and Parquet components
+| Apache HBase Bundle    | include-hbase         | Adds support for Apache HBase
 | Apache Hive 3 Bundle   | include-hive3         | Adds support for Apache Hive 3.X
 | Apache IoTDB Bundle    | include-iotdb         | Adds support for Apache IoTDB
+| Apache Kudu Bundle     | include-kudu          | Adds support for Apache Kudu
 | Apache Ranger Bundle   | include-ranger        | Adds support for https://ranger.apache.org[Apache Ranger].
+| Apache Solr Bundle     | include-solr          | Adds support for Apache Solr
 | ASN.1 Support          | include-asn1          | Adds support for ASN.1
 | Contribution Check     | contrib-check         | Runs various quality checks that are required to be accepted before a contribution can be accepted into the core NiFi code base.
 | Graph Database Bundle  | include-graph         | Adds support for various common graph database scenarios. Support is currently for https://neo4j.com/developer/cypher[Cypher] and https://tinkerpop.apache.org/gremlin.html[Gremlin]-compatible databases such as Neo4J and JanusGraph. Includes controller services that provide driver functionality and a suite of processors for ingestion and querying.

--- a/nifi-manifest/nifi-runtime-manifest-test/src/test/java/org/apache/nifi/runtime/manifest/TestRuntimeManifest.java
+++ b/nifi-manifest/nifi-runtime-manifest-test/src/test/java/org/apache/nifi/runtime/manifest/TestRuntimeManifest.java
@@ -24,15 +24,12 @@ import org.apache.nifi.c2.protocol.component.api.ComponentManifest;
 import org.apache.nifi.c2.protocol.component.api.ProcessorDefinition;
 import org.apache.nifi.c2.protocol.component.api.PropertyDependency;
 import org.apache.nifi.c2.protocol.component.api.PropertyDescriptor;
-import org.apache.nifi.c2.protocol.component.api.PropertyResourceDefinition;
 import org.apache.nifi.c2.protocol.component.api.Relationship;
 import org.apache.nifi.c2.protocol.component.api.ReportingTaskDefinition;
 import org.apache.nifi.c2.protocol.component.api.Restriction;
 import org.apache.nifi.c2.protocol.component.api.RuntimeManifest;
 import org.apache.nifi.c2.protocol.component.api.SchedulingDefaults;
 import org.apache.nifi.components.RequiredPermission;
-import org.apache.nifi.components.resource.ResourceCardinality;
-import org.apache.nifi.components.resource.ResourceType;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.scheduling.SchedulingStrategy;
 import org.junit.jupiter.api.Test;
@@ -51,8 +48,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestRuntimeManifest {
-
-    public static final String LIST_HDFS_DEFAULT_SCHEDULE_TIME = "1 min";
 
     private static final String REPORTING_TASK_DEFAULT_SCHEDULE_TIME = "60 sec";
 
@@ -93,96 +88,10 @@ class TestRuntimeManifest {
 
         final List<Bundle> bundles = runtimeManifest.getBundles();
         assertNotNull(bundles);
-        assertTrue(bundles.size() > 0);
+        assertFalse(bundles.isEmpty());
 
-        // Verify ListHDFS definition
-        final ProcessorDefinition listHdfsDefinition = getProcessorDefinition(bundles, "nifi-hadoop-nar", "org.apache.nifi.processors.hadoop.ListHDFS");
-        assertNotNull(listHdfsDefinition);
-        assertTrue(listHdfsDefinition.getPrimaryNodeOnly());
-        assertTrue(listHdfsDefinition.getTriggerSerially());
-        assertTrue(listHdfsDefinition.getTriggerWhenEmpty());
-        assertFalse(listHdfsDefinition.getSupportsBatching());
-        assertFalse(listHdfsDefinition.getSideEffectFree());
-        assertFalse(listHdfsDefinition.getTriggerWhenAnyDestinationAvailable());
-        assertFalse(listHdfsDefinition.getSupportsDynamicProperties());
-        assertFalse(listHdfsDefinition.getSupportsSensitiveDynamicProperties());
-        assertNull(listHdfsDefinition.getDynamicProperties());
-        assertFalse(listHdfsDefinition.getSupportsDynamicRelationships());
-        assertNull(listHdfsDefinition.getDynamicRelationship());
-        assertEquals(InputRequirement.Requirement.INPUT_FORBIDDEN, listHdfsDefinition.getInputRequirement());
-        assertTrue(listHdfsDefinition.isAdditionalDetails());
-        assertNull(listHdfsDefinition.getReadsAttributes());
-        assertNotNull(listHdfsDefinition.getWritesAttributes());
-        assertFalse(listHdfsDefinition.getWritesAttributes().isEmpty());
-        assertNotNull(listHdfsDefinition.getWritesAttributes().get(0).getName());
-        assertNotNull(listHdfsDefinition.getWritesAttributes().get(0).getDescription());
-        assertNotNull(listHdfsDefinition.getSeeAlso());
-        assertFalse(listHdfsDefinition.getSeeAlso().isEmpty());
-        assertNull(listHdfsDefinition.getSystemResourceConsiderations());
-        assertNull(listHdfsDefinition.getDeprecated());
-        assertNull(listHdfsDefinition.getDeprecationReason());
-        assertNull(listHdfsDefinition.getDeprecationAlternatives());
-
-        assertEquals("30 sec", listHdfsDefinition.getDefaultPenaltyDuration());
-        assertEquals("1 sec", listHdfsDefinition.getDefaultYieldDuration());
-        assertEquals("WARN", listHdfsDefinition.getDefaultBulletinLevel());
-
-        assertEquals(SchedulingStrategy.TIMER_DRIVEN.name(), listHdfsDefinition.getDefaultSchedulingStrategy());
-
-        final List<String> listHdfsSchedulingStrategies = listHdfsDefinition.getSupportedSchedulingStrategies();
-        assertNotNull(listHdfsSchedulingStrategies);
-        assertEquals(2, listHdfsSchedulingStrategies.size());
-        assertTrue(listHdfsSchedulingStrategies.contains(SchedulingStrategy.TIMER_DRIVEN.name()));
-        assertTrue(listHdfsSchedulingStrategies.contains(SchedulingStrategy.CRON_DRIVEN.name()));
-
-        final Map<String, Integer> listHdfsDefaultConcurrentTasks = listHdfsDefinition.getDefaultConcurrentTasksBySchedulingStrategy();
-        assertNotNull(listHdfsDefaultConcurrentTasks);
-        assertEquals(2, listHdfsDefaultConcurrentTasks.size());
-        assertEquals(SchedulingStrategy.TIMER_DRIVEN.getDefaultConcurrentTasks(), listHdfsDefaultConcurrentTasks.get(SchedulingStrategy.TIMER_DRIVEN.name()).intValue());
-        assertEquals(SchedulingStrategy.CRON_DRIVEN.getDefaultConcurrentTasks(), listHdfsDefaultConcurrentTasks.get(SchedulingStrategy.CRON_DRIVEN.name()).intValue());
-
-        final Map<String, String> listHdfsDefaultSchedulingPeriods = listHdfsDefinition.getDefaultSchedulingPeriodBySchedulingStrategy();
-        assertNotNull(listHdfsDefaultSchedulingPeriods);
-        assertEquals(2, listHdfsDefaultSchedulingPeriods.size());
-        assertEquals("1 min", listHdfsDefaultSchedulingPeriods.get(SchedulingStrategy.TIMER_DRIVEN.name()));
-        assertEquals(SchedulingStrategy.CRON_DRIVEN.getDefaultSchedulingPeriod(), listHdfsDefaultSchedulingPeriods.get(SchedulingStrategy.CRON_DRIVEN.name()));
-
-        final List<Relationship> relationships = listHdfsDefinition.getSupportedRelationships();
-        assertNotNull(relationships);
-        assertEquals(1, relationships.size());
-        assertEquals("success", relationships.get(0).getName());
-
-        final PropertyDescriptor configResourcesProp = getPropertyDescriptor(listHdfsDefinition, "Hadoop Configuration Resources");
-
-        final PropertyResourceDefinition resourceDefinition = configResourcesProp.getResourceDefinition();
-        assertNotNull(resourceDefinition);
-        assertEquals(ResourceCardinality.MULTIPLE, resourceDefinition.getCardinality());
-        assertNotNull(resourceDefinition.getResourceTypes());
-        assertEquals(1, resourceDefinition.getResourceTypes().size());
-        assertEquals(ResourceType.FILE, resourceDefinition.getResourceTypes().stream().findFirst().get());
-
-        assertNull(listHdfsDefinition.isRestricted());
-        assertNull(listHdfsDefinition.getRestrictedExplanation());
-        assertNull(listHdfsDefinition.getExplicitRestrictions());
-        assertNotNull(listHdfsDefinition.getStateful());
-        assertNotNull(listHdfsDefinition.getStateful().getDescription());
-        assertNotNull(listHdfsDefinition.getStateful().getScopes());
-        assertEquals(Scope.CLUSTER, listHdfsDefinition.getStateful().getScopes().stream().findFirst().get());
-
-        // Verify FetchHDFS definition has restrictions
-        final ProcessorDefinition fetchHdfsDefinition = getProcessorDefinition(bundles, "nifi-hadoop-nar",
-                "org.apache.nifi.processors.hadoop.FetchHDFS");
-        assertNotNull(fetchHdfsDefinition.isRestricted());
-        assertTrue(fetchHdfsDefinition.isRestricted());
-        assertFalse(fetchHdfsDefinition.isAdditionalDetails());
-
-        final Set<Restriction> restrictions = fetchHdfsDefinition.getExplicitRestrictions();
-        assertNotNull(restrictions);
-        assertEquals(1, restrictions.size());
-
-        final Restriction restriction = restrictions.stream().findFirst().orElse(null);
-        assertEquals(RequiredPermission.READ_DISTRIBUTED_FILESYSTEM.getPermissionLabel(), restriction.getRequiredPermission());
-        assertNotNull(restriction.getExplanation());
+        assertProcessorDefinitionFound(bundles);
+        assertRestrictionsFound(bundles);
 
         // Verify ConsumeKafka_2_6 definition which has properties with dependencies
         final ProcessorDefinition consumeKafkaDefinition = getProcessorDefinition(bundles, "nifi-kafka-2-6-nar",
@@ -235,10 +144,10 @@ class TestRuntimeManifest {
         assertEquals(SchedulingStrategy.TIMER_DRIVEN.getDefaultConcurrentTasks(), joltTransformDefaultConcurrentTasks.get(SchedulingStrategy.TIMER_DRIVEN.name()).intValue());
         assertEquals(SchedulingStrategy.CRON_DRIVEN.getDefaultConcurrentTasks(), joltTransformDefaultConcurrentTasks.get(SchedulingStrategy.CRON_DRIVEN.name()).intValue());
 
-        final Map<String, String> joltTransformDefaultSchedulingPeriods = listHdfsDefinition.getDefaultSchedulingPeriodBySchedulingStrategy();
+        final Map<String, String> joltTransformDefaultSchedulingPeriods = joltTransformDef.getDefaultSchedulingPeriodBySchedulingStrategy();
         assertNotNull(joltTransformDefaultSchedulingPeriods);
         assertEquals(2, joltTransformDefaultSchedulingPeriods.size());
-        assertEquals(LIST_HDFS_DEFAULT_SCHEDULE_TIME, joltTransformDefaultSchedulingPeriods.get(SchedulingStrategy.TIMER_DRIVEN.name()));
+        assertEquals("0 sec", joltTransformDefaultSchedulingPeriods.get(SchedulingStrategy.TIMER_DRIVEN.name()));
         assertEquals(SchedulingStrategy.CRON_DRIVEN.getDefaultSchedulingPeriod(), joltTransformDefaultSchedulingPeriods.get(SchedulingStrategy.CRON_DRIVEN.name()));
 
         // Verify ExecuteSQL has readsAttributes
@@ -275,6 +184,87 @@ class TestRuntimeManifest {
         assertFalse(splitJsonDef.getSystemResourceConsiderations().isEmpty());
         assertNotNull(splitJsonDef.getSystemResourceConsiderations().get(0).getResource());
         assertNotNull(splitJsonDef.getSystemResourceConsiderations().get(0).getDescription());
+    }
+
+    private void assertProcessorDefinitionFound(final List<Bundle> bundles) {
+        final ProcessorDefinition definition = getProcessorDefinition(bundles, "nifi-standard-nar", "org.apache.nifi.processors.standard.ListFile");
+        assertNotNull(definition);
+        assertFalse(definition.getPrimaryNodeOnly());
+        assertTrue(definition.getTriggerSerially());
+        assertFalse(definition.getTriggerWhenEmpty());
+        assertFalse(definition.getSupportsBatching());
+        assertFalse(definition.getSideEffectFree());
+        assertFalse(definition.getTriggerWhenAnyDestinationAvailable());
+        assertFalse(definition.getSupportsDynamicProperties());
+        assertFalse(definition.getSupportsSensitiveDynamicProperties());
+        assertNull(definition.getDynamicProperties());
+        assertFalse(definition.getSupportsDynamicRelationships());
+        assertNull(definition.getDynamicRelationship());
+        assertEquals(InputRequirement.Requirement.INPUT_FORBIDDEN, definition.getInputRequirement());
+        assertTrue(definition.isAdditionalDetails());
+        assertNull(definition.getReadsAttributes());
+        assertNotNull(definition.getWritesAttributes());
+        assertFalse(definition.getWritesAttributes().isEmpty());
+        assertNotNull(definition.getWritesAttributes().get(0).getName());
+        assertNotNull(definition.getWritesAttributes().get(0).getDescription());
+        assertNotNull(definition.getSeeAlso());
+        assertFalse(definition.getSeeAlso().isEmpty());
+        assertNull(definition.getSystemResourceConsiderations());
+        assertNull(definition.getDeprecated());
+        assertNull(definition.getDeprecationReason());
+        assertNull(definition.getDeprecationAlternatives());
+
+        assertEquals("30 sec", definition.getDefaultPenaltyDuration());
+        assertEquals("1 sec", definition.getDefaultYieldDuration());
+        assertEquals("WARN", definition.getDefaultBulletinLevel());
+
+        assertEquals(SchedulingStrategy.TIMER_DRIVEN.name(), definition.getDefaultSchedulingStrategy());
+
+        final List<String> schedulingStrategies = definition.getSupportedSchedulingStrategies();
+        assertNotNull(schedulingStrategies);
+        assertEquals(2, schedulingStrategies.size());
+        assertTrue(schedulingStrategies.contains(SchedulingStrategy.TIMER_DRIVEN.name()));
+        assertTrue(schedulingStrategies.contains(SchedulingStrategy.CRON_DRIVEN.name()));
+
+        final Map<String, Integer> defaultConcurrentTasks = definition.getDefaultConcurrentTasksBySchedulingStrategy();
+        assertNotNull(defaultConcurrentTasks);
+        assertEquals(2, defaultConcurrentTasks.size());
+        assertEquals(SchedulingStrategy.TIMER_DRIVEN.getDefaultConcurrentTasks(), defaultConcurrentTasks.get(SchedulingStrategy.TIMER_DRIVEN.name()).intValue());
+        assertEquals(SchedulingStrategy.CRON_DRIVEN.getDefaultConcurrentTasks(), defaultConcurrentTasks.get(SchedulingStrategy.CRON_DRIVEN.name()).intValue());
+
+        final Map<String, String> defaultSchedulingPeriods = definition.getDefaultSchedulingPeriodBySchedulingStrategy();
+        assertNotNull(defaultSchedulingPeriods);
+        assertEquals(2, defaultSchedulingPeriods.size());
+        assertEquals("1 min", defaultSchedulingPeriods.get(SchedulingStrategy.TIMER_DRIVEN.name()));
+        assertEquals(SchedulingStrategy.CRON_DRIVEN.getDefaultSchedulingPeriod(), defaultSchedulingPeriods.get(SchedulingStrategy.CRON_DRIVEN.name()));
+
+        final List<Relationship> relationships = definition.getSupportedRelationships();
+        assertNotNull(relationships);
+        assertEquals(1, relationships.size());
+        assertEquals("success", relationships.get(0).getName());
+
+        assertNull(definition.isRestricted());
+        assertNull(definition.getRestrictedExplanation());
+        assertNull(definition.getExplicitRestrictions());
+        assertNotNull(definition.getStateful());
+        assertNotNull(definition.getStateful().getDescription());
+        assertNotNull(definition.getStateful().getScopes());
+        assertEquals(Set.of(Scope.LOCAL, Scope.CLUSTER), definition.getStateful().getScopes());
+    }
+
+    private void assertRestrictionsFound(final List<Bundle> bundles) {
+        final ProcessorDefinition processorDefinition = getProcessorDefinition(bundles, "nifi-standard-nar", "org.apache.nifi.processors.standard.GetFile");
+        assertNotNull(processorDefinition.isRestricted());
+        assertTrue(processorDefinition.isRestricted());
+        assertFalse(processorDefinition.isAdditionalDetails());
+
+        final Set<Restriction> restrictions = processorDefinition.getExplicitRestrictions();
+        assertNotNull(restrictions);
+        assertEquals(2, restrictions.size());
+
+        final Restriction restriction = restrictions.stream().findFirst().orElse(null);
+        assertEquals(RequiredPermission.READ_FILESYSTEM.getPermissionLabel(), restriction.getRequiredPermission());
+        assertNotNull(restriction.getExplanation());
     }
 
     private PropertyDescriptor getPropertyDescriptor(final ProcessorDefinition processorDefinition, final String propName) {


### PR DESCRIPTION
# Summary

[NIFI-12282](https://issues.apache.org/jira/browse/NIFI-12282) Moves Apache Hadoop extensions and several other components to optional build profiles.

Changes include the following:

- Moved Hadoop and Parquet NARs to include-hadoop
- Moved HBase NARs to include-hbase
- Moved Kudu NAR to include-kudu
- Moved Solr NAR to include-solr

Apache Hadoop support varies between different vendors, which already requires custom build profiles. Both Apache Kudu and Apache Parquet components depend on several Hadoop libraries. Apache HBase and Apache Solr components each exceed 50 MB for the size of bundled NARs.

Moving these selected extensions to optional build profiles reduces the convenience binary build to around 950 MB.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
