### PR TITLE
NIFI-12284 Upgrade Frontend Maven Plugin from 1.14.0 to 1.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <docker.jre.image.name>bellsoft/liberica-openjre-debian</docker.jre.image.name>
         <docker.image.tag>21</docker.image.tag>
         <node.version>v16.13.2</node.version>
-        <frontend.mvn.plugin.version>1.14.0</frontend.mvn.plugin.version>
+        <frontend.mvn.plugin.version>1.14.2</frontend.mvn.plugin.version>
         <nifi.nar.maven.plugin.version>1.5.1</nifi.nar.maven.plugin.version>
         <project.build.outputTimestamp>1675980972</project.build.outputTimestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
# Summary

[NIFI-12284](https://issues.apache.org/jira/browse/NIFI-12284) Upgrades the Frontend Maven Plugin from 1.14.0 to [1.14.2](https://github.com/eirslett/frontend-maven-plugin/blob/master/CHANGELOG.md#1142). The upgraded version includes improvements to avoid corrupted file downloads, which impact user interface modules that require Node.js.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
