### PR TITLE
NIFI-12283 add include-swagger-ui profile with activation by default.

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
@@ -148,70 +148,6 @@
             </dependencies>
             </plugin>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
-                <artifactId>download-maven-plugin</artifactId>
-                <version>1.7.1</version>
-                <executions>
-                    <execution>
-                        <id>download-swagger-ui</id>
-                        <!-- This plugin downloads swagger UI static assets during the build, to be
-                             served by the web app to render the dynamically generated Swagger spec.
-                             For offline development, or to build without the swagger UI, activate
-                             the "no-swagger-ui" maven profile during the build with the "-P" flag -->
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <configuration>
-                            <url>https://github.com/swagger-api/swagger-ui/archive/v${swagger.ui.version}.tar.gz</url>
-                            <unpack>true</unpack>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>bundle-swagger-ui</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <sequential>
-                                    <echo>Copy static Swagger UI files to target</echo>
-                                    <copy todir="${project.build.directory}/classes/static/swagger">
-                                        <fileset dir="${project.build.directory}/swagger-ui-${swagger.ui.version}/dist">
-                                            <include name="**" />
-                                        </fileset>
-                                    </copy>
-                                    <echo>Disable schema validation by removing validatorUrl</echo>
-                                    <replace token="https://online.swagger.io/validator" value="" dir="${project.build.directory}/classes/static/swagger">
-                                        <include name="swagger-ui-bundle.js" />
-                                        <include name="swagger-ui-standalone-preset.js" />
-                                    </replace>
-                                    <echo>Rename 'index.html' to 'ui.html'</echo>
-                                    <move file="${project.build.directory}/classes/static/swagger/index.html" tofile="${project.build.directory}/classes/static/swagger/ui.html" />
-                                    <echo>Replace default swagger.json location</echo>
-                                    <replace token="http://petstore.swagger.io/v2/swagger.json" value="/nifi-registry-api/swagger/swagger.json" dir="${project.build.directory}/classes/static/swagger">
-                                        <include name="ui.html" />
-                                    </replace>
-                                    <echo>Copy swagger.json into static assets folder</echo>
-                                    <copy todir="${project.build.directory}/classes/static/swagger">
-                                        <fileset dir="${project.build.directory}/swagger">
-                                            <include name="*.json" />
-                                        </fileset>
-                                    </copy>
-                                </sequential>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <configuration>
@@ -222,6 +158,84 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>include-swagger-ui</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <version>1.7.1</version>
+                        <executions>
+                            <execution>
+                                <id>download-swagger-ui</id>
+                                <!-- This plugin downloads swagger UI static assets during the build, to be
+                                     served by the web app to render the dynamically generated Swagger spec.
+                                     For offline development, or to build without the swagger UI, deactivate
+                                     the "include-swagger-ui" maven profile during the build with the following
+                                     profile option: -P'!include-swagger-ui' -->
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <url>https://github.com/swagger-api/swagger-ui/archive/v${swagger.ui.version}.tar.gz</url>
+                                    <unpack>true</unpack>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>bundle-swagger-ui</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <sequential>
+                                            <echo>Copy static Swagger UI files to target</echo>
+                                            <copy todir="${project.build.directory}/classes/static/swagger">
+                                                <fileset dir="${project.build.directory}/swagger-ui-${swagger.ui.version}/dist">
+                                                    <include name="**" />
+                                                </fileset>
+                                            </copy>
+                                            <echo>Disable schema validation by removing validatorUrl</echo>
+                                            <replace token="https://online.swagger.io/validator" value="" dir="${project.build.directory}/classes/static/swagger">
+                                                <include name="swagger-ui-bundle.js" />
+                                                <include name="swagger-ui-standalone-preset.js" />
+                                            </replace>
+                                            <echo>Rename 'index.html' to 'ui.html'</echo>
+                                            <move file="${project.build.directory}/classes/static/swagger/index.html" tofile="${project.build.directory}/classes/static/swagger/ui.html" />
+                                            <echo>Replace default swagger.json location</echo>
+                                            <replace token="http://petstore.swagger.io/v2/swagger.json" value="/nifi-registry-api/swagger/swagger.json" dir="${project.build.directory}/classes/static/swagger">
+                                                <include name="ui.html" />
+                                            </replace>
+                                            <echo>Copy swagger.json into static assets folder</echo>
+                                            <copy todir="${project.build.directory}/classes/static/swagger">
+                                                <fileset dir="${project.build.directory}/swagger">
+                                                    <include name="*.json" />
+                                                </fileset>
+                                            </copy>
+                                        </sequential>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Deactivating prevents attempt to download swagger asset from the Internet allowing for offline builds.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Re-instating a profile which was removed in a previous commit. Although, this profile is named differently because it is now active by default. Instead of "no-swagger-ui" it is now called "include-swagger-ui". Deactivating the profile (non-default option) is achieved using `-P'!include-swagger-ui'`. Deactivating the profile will prevent the build from attempting to download swagger assets if network connectivity is not available at build time.

[NIFI-12283](https://issues.apache.org/jira/browse/NIFI-12283)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
