### PR TITLE
NIFI-12285 allow the URL for downloading py4j to be specified by a ma…

### DIFF
--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/pom.xml
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/pom.xml
@@ -27,6 +27,7 @@
 
     <properties>
         <py4j.version>0.10.9.7</py4j.version>
+        <py4j.url>https://files.pythonhosted.org/packages/10/30/a58b32568f1623aaad7db22aa9eafc4c6c194b429ff35bdc55ca2726da47/py4j-${py4j.version}-py2.py3-none-any.whl</py4j.url>
     </properties>
 
     <build>
@@ -43,7 +44,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <url>https://files.pythonhosted.org/packages/10/30/a58b32568f1623aaad7db22aa9eafc4c6c194b429ff35bdc55ca2726da47/py4j-${py4j.version}-py2.py3-none-any.whl</url>
+                            <url>${py4j.url}</url>
                             <outputFileName>py4j-${py4j.version}.zip</outputFileName>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}/py4j-${py4j.version}</outputDirectory>


### PR DESCRIPTION
…ven command-line option

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Adds an option to use a maven command-line property to specify the URL used to downlaod py4j asset during build time. To do so, use `-Dpy4j.url={some-url-value}`

[NIFI-12285](https://issues.apache.org/jira/browse/NIFI-12285)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
