### PR TITLE
NIFI-12287 Standardize skipping Source and Javadoc for NAR modules

### DIFF
--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework-nar/pom.xml
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework-nar/pom.xml
@@ -27,10 +27,7 @@ limitations under the License.
     <packaging>nar</packaging>
 
     <description>MiNiFi: Framework NAR</description>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi.minifi</groupId>

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-server-nar/pom.xml
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-server-nar/pom.xml
@@ -22,10 +22,6 @@
     <artifactId>minifi-server-nar</artifactId>
     <packaging>nar</packaging>
     <description>MiNiFi server NAR</description>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi.minifi</groupId>

--- a/minifi/minifi-nar-bundles/minifi-standard-nar/pom.xml
+++ b/minifi/minifi-nar-bundles/minifi-standard-nar/pom.xml
@@ -26,10 +26,7 @@ limitations under the License.
     <artifactId>minifi-standard-nar</artifactId>
     <packaging>nar</packaging>
     <description>MiNiFi Standard Extensions NAR</description>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-maven-archetypes/nifi-processor-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__-nar/pom.xml
+++ b/nifi-maven-archetypes/nifi-processor-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__-nar/pom.xml
@@ -25,10 +25,6 @@
     <artifactId>nifi-${artifactBaseName}-nar</artifactId>
     <version>${version}</version>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-maven-archetypes/nifi-service-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__-api-nar/pom.xml
+++ b/nifi-maven-archetypes/nifi-service-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__-api-nar/pom.xml
@@ -25,10 +25,6 @@
     <artifactId>nifi-${artifactBaseName}-api-nar</artifactId>
     <version>${version}</version>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-maven-archetypes/nifi-service-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__-nar/pom.xml
+++ b/nifi-maven-archetypes/nifi-service-bundle-archetype/src/main/resources/archetype-resources/nifi-__artifactBaseName__-nar/pom.xml
@@ -25,10 +25,6 @@
     <artifactId>nifi-${artifactBaseName}-nar</artifactId>
     <version>${version}</version>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-accumulo-bundle/nifi-accumulo-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-accumulo-bundle/nifi-accumulo-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-accumulo-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>false</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-nar/pom.xml
@@ -22,10 +22,6 @@
     </parent>
     <artifactId>nifi-amqp-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-asana-bundle/nifi-asana-processors-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-asana-bundle/nifi-asana-processors-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-asana-processors-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-asana-bundle/nifi-asana-services-api-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-asana-bundle/nifi-asana-services-api-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-asana-services-api-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-asana-bundle/nifi-asana-services-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-asana-bundle/nifi-asana-services-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-asana-services-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-asn1-bundle/nifi-asn1-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-asn1-bundle/nifi-asn1-nar/pom.xml
@@ -23,10 +23,6 @@
 
     <artifactId>nifi-asn1-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-atlas-bundle/nifi-atlas-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-atlas-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-box-bundle/nifi-box-services-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-box-bundle/nifi-box-services-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-box-services-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>false</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-nar/pom.xml
@@ -22,10 +22,6 @@
     <artifactId>nifi-cdc-mysql-nar</artifactId>
     <packaging>nar</packaging>
     <description>NiFi MySQL Change Data Capture (CDC) NAR</description>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-nar/pom.xml
@@ -22,10 +22,6 @@
     <artifactId>nifi-compress-nar</artifactId>
     <packaging>nar</packaging>
     <description>NiFi Compression NAR</description>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-couchbase-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-couchbase-services-api-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-nar/pom.xml
@@ -20,8 +20,6 @@ language governing permissions and limitations under the License. -->
     <artifactId>nifi-elasticsearch-restapi-nar</artifactId>
     <packaging>nar</packaging>
     <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
         <lucene.version>6.2.1</lucene.version>
     </properties>
 

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-email-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-nar/pom.xml
@@ -17,13 +17,8 @@ language governing permissions and limitations under the License. -->
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.apache.nifi</groupId>
     <artifactId>nifi-evtx-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework-nar/pom.xml
@@ -21,11 +21,8 @@
     </parent>
     <artifactId>nifi-framework-nar</artifactId>
     <packaging>nar</packaging>
-    <description>NiFi: Framework Nar</description>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
+    <description>NiFi: Framework NAR</description>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
@@ -22,10 +22,7 @@
     </parent>
     <artifactId>nifi-web-api</artifactId>
     <packaging>war</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
+
     <build>
         <resources>
             <resource>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/pom.xml
@@ -21,10 +21,6 @@
     </parent>
     <artifactId>nifi-web-content-viewer</artifactId>
     <packaging>war</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-docs/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-docs/pom.xml
@@ -21,10 +21,6 @@
     </parent>
     <artifactId>nifi-web-docs</artifactId>
     <packaging>war</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-error/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-error/pom.xml
@@ -21,10 +21,7 @@
     </parent>
     <artifactId>nifi-web-error</artifactId>
     <packaging>war</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
+
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/pom.xml
@@ -23,8 +23,6 @@
     <artifactId>nifi-web-ui</artifactId>
     <packaging>war</packaging>
     <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
         <staging.dir>${project.build.directory}/tmp</staging.dir>
         <canvas.filter>canvas.properties</canvas.filter>
         <history.filter>history.properties</history.filter>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-headless-server-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-headless-server-nar/pom.xml
@@ -22,10 +22,6 @@
     <artifactId>nifi-headless-server-nar</artifactId>
     <packaging>nar</packaging>
     <description>Headless server NAR</description>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-server-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-server-nar/pom.xml
@@ -22,10 +22,6 @@
     <artifactId>nifi-server-nar</artifactId>
     <packaging>nar</packaging>
     <description>NiFi: Web/UI Nar</description>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-graph-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hadoop-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hadoop-nar/pom.xml
@@ -21,10 +21,6 @@
     </parent>
     <artifactId>nifi-hadoop-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-services-api-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-services-api-nar/pom.xml
@@ -24,12 +24,6 @@
 
     <artifactId>nifi-hive-services-api-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-        <!-- Need to override hadoop.version here, for Hive and hadoop-client transitive dependencies -->
-        <hadoop.version>${hive.hadoop.version}</hadoop.version>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-services-api/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-services-api/pom.xml
@@ -25,11 +25,6 @@
     <artifactId>nifi-hive-services-api</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <!-- Need to override hadoop.version here, for Hive and hadoop-client transitive dependencies -->
-        <hadoop.version>${hive.hadoop.version}</hadoop.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-hive3-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors-nar/pom.xml
@@ -24,11 +24,6 @@
     <artifactId>nifi-iceberg-processors-nar</artifactId>
     <packaging>nar</packaging>
 
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-influxdb-bundle/nifi-influxdb-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-influxdb-bundle/nifi-influxdb-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-influxdb-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-jetty-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-jetty-bundle/pom.xml
@@ -22,10 +22,6 @@
     <artifactId>nifi-jetty-bundle</artifactId>
     <packaging>nar</packaging>
     <description>NiFi: Jetty Bundle</description>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <!-- The Jetty Bundle doesn't contain any code that actually depends on nifi-api, but the NAR Maven plugin writes a
              descriptor for each NAR which contains the version of the system API, so we need to make the version available by

--- a/nifi-nar-bundles/nifi-kerberos-iaa-providers-bundle/nifi-kerberos-iaa-providers-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-kerberos-iaa-providers-bundle/nifi-kerberos-iaa-providers-nar/pom.xml
@@ -22,10 +22,6 @@
     </parent>
     <artifactId>nifi-kerberos-iaa-providers-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers-nar/pom.xml
@@ -22,10 +22,6 @@
     </parent>
     <artifactId>nifi-ldap-iaa-providers-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-media-bundle/nifi-image-viewer-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-image-viewer-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-image-viewer-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-media-bundle/nifi-image-viewer/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-image-viewer/pom.xml
@@ -23,10 +23,6 @@
     <artifactId>nifi-image-viewer</artifactId>
     <description>NiFi image viewer</description>
     <packaging>war</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-media-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-mongodb-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-pgp-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-service-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-pgp-service-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-nar/pom.xml
@@ -21,10 +21,6 @@
     </parent>
     <artifactId>nifi-prometheus-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-provenance-repository-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-provenance-repository-nar/pom.xml
@@ -21,10 +21,6 @@
     </parent>
     <artifactId>nifi-provenance-repository-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/nifi-ranger-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-ranger-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-redis-bundle/nifi-redis-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-redis-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-single-user-iaa-providers-bundle/nifi-single-user-iaa-providers-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-single-user-iaa-providers-bundle/nifi-single-user-iaa-providers-nar/pom.xml
@@ -22,10 +22,6 @@
     </parent>
     <artifactId>nifi-single-user-iaa-providers-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-smb-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-smbj-client-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-smbj-client-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-smb-smbj-client-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-sql-reporting-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-jolt-transform-json-ui/pom.xml
@@ -21,8 +21,6 @@ language governing permissions and limitations under the License. -->
 
     <packaging>war</packaging>
     <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
         <frontend.dependency.configs>${basedir}/src/main/frontend</frontend.dependency.configs>
         <frontend.working.dir>${project.build.directory}/frontend-working-directory</frontend.working.dir>
         <frontend.assets>${project.build.directory}/${project.build.finalName}/assets</frontend.assets>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service-nar/pom.xml
@@ -22,10 +22,7 @@
     
     <artifactId>nifi-dbcp-service-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-services-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-services-nar/pom.xml
@@ -21,10 +21,6 @@
     </parent>
     <artifactId>nifi-distributed-cache-services-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hadoop-dbcp-service-bundle/nifi-hadoop-dbcp-service-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hadoop-dbcp-service-bundle/nifi-hadoop-dbcp-service-nar/pom.xml
@@ -22,10 +22,7 @@
     
     <artifactId>nifi-hadoop-dbcp-service-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-http-context-map-bundle/nifi-http-context-map-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-http-context-map-bundle/nifi-http-context-map-nar/pom.xml
@@ -22,10 +22,6 @@
 	
     <artifactId>nifi-http-context-map-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 	
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services-nar/pom.xml
@@ -21,10 +21,6 @@
     </parent>
     <artifactId>nifi-record-serialization-services-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service-nar/pom.xml
@@ -21,10 +21,6 @@
     </parent>
     <artifactId>nifi-ssl-context-service-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-standard-services-api-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-standard-services-api-nar/pom.xml
@@ -21,10 +21,6 @@
     </parent>
     <artifactId>nifi-standard-services-api-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-nar/pom.xml
@@ -22,10 +22,6 @@
     <artifactId>nifi-stateful-analysis-nar</artifactId>
     <packaging>nar</packaging>
     <description>NiFi NAR for doing stateful analysis</description>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-nar/pom.xml
@@ -21,10 +21,6 @@
     </parent>
     <artifactId>nifi-update-attribute-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-ui/pom.xml
+++ b/nifi-nar-bundles/nifi-update-attribute-bundle/nifi-update-attribute-ui/pom.xml
@@ -22,10 +22,6 @@
     </parent>
     <artifactId>nifi-update-attribute-ui</artifactId>
     <packaging>war</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
     <build>
         <plugins>
             <plugin>

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-processors-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-processors-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-websocket-processors-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-api-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-api-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-websocket-services-api-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty-nar/pom.xml
@@ -24,10 +24,6 @@
 
     <artifactId>nifi-websocket-services-jetty-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-nar/pom.xml
@@ -19,10 +19,6 @@ language governing permissions and limitations under the License. -->
 
     <artifactId>nifi-windows-event-log-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-nar-bundles/nifi-workday-bundle/nifi-workday-processors-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-workday-bundle/nifi-workday-processors-nar/pom.xml
@@ -26,10 +26,6 @@
 
     <artifactId>nifi-workday-processors-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-docs/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-docs/pom.xml
@@ -22,11 +22,6 @@
     <artifactId>nifi-registry-web-docs</artifactId>
     <packaging>war</packaging>
 
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/nifi-system-tests/nifi-system-test-nar-provider-bundles/nifi-nar-provider-processors-nar/pom.xml
+++ b/nifi-system-tests/nifi-system-test-nar-provider-bundles/nifi-nar-provider-processors-nar/pom.xml
@@ -25,10 +25,6 @@
     <artifactId>nifi-nar-provider-processors-nar</artifactId>
     <version>2.0.0-SNAPSHOT</version>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-system-tests/nifi-system-test-nar-provider-bundles/nifi-nar-provider-service-api-nar/pom.xml
+++ b/nifi-system-tests/nifi-system-test-nar-provider-bundles/nifi-nar-provider-service-api-nar/pom.xml
@@ -25,10 +25,6 @@
     <artifactId>nifi-nar-provider-service-api-nar</artifactId>
     <version>2.0.0-SNAPSHOT</version>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/nifi-system-tests/nifi-system-test-nar-provider-bundles/nifi-nar-provider-service-nar/pom.xml
+++ b/nifi-system-tests/nifi-system-test-nar-provider-bundles/nifi-nar-provider-service-nar/pom.xml
@@ -25,10 +25,6 @@
     <artifactId>nifi-nar-provider-service-nar</artifactId>
     <version>2.0.0-SNAPSHOT</version>
     <packaging>nar</packaging>
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <source.skip>true</source.skip>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1011,6 +1011,38 @@
         </plugins>
     </build>
     <profiles>
+        <!-- Configure build properties for modules with NAR packaging -->
+        <profile>
+            <id>nar-packaging</id>
+            <activation>
+                <property>
+                    <name>packaging</name>
+                    <value>nar</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- Skip source and javadoc plugins for NAR bundles during release process -->
+                <maven.source.skip>true</maven.source.skip>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+            </properties>
+        </profile>
+
+        <!-- Configure build properties for modules with WAR packaging -->
+        <profile>
+            <id>war-packaging</id>
+            <activation>
+                <property>
+                    <name>packaging</name>
+                    <value>war</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- Skip source and javadoc plugins for WAR bundles during release process -->
+                <maven.source.skip>true</maven.source.skip>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+            </properties>
+        </profile>
+
         <profile>
             <!-- Performs execution of Integration Tests using the Maven
                 FailSafe Plugin. The view of integration tests in this context are those


### PR DESCRIPTION
# Summary

[NIFI-12287](https://issues.apache.org/jira/browse/NIFI-12287) Standardizes skipping of Sources and Javadoc JAR generation for NAR and WAR modules.

Modern versions of the Maven Source Plugin use `maven.source.skip` as the property name for skipping sources. As a result of historical usage of `source.skip` properties in individual NAR files, recent releases published sources JAR files for each NAR.

Changes include adding `nar-packaging` and `war-packaging` profiles to the root Maven configuration, setting `maven.source.skip` and `maven.javadoc.skip` to `true` for the `nar` and `war` packaging types. Centralizing this configuration removes the need for setting these properties in individual NAR configurations.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
