### PR TITLE
NIFI-12276 Address Recent Dependency Check Findings

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: dependency-check
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  push:
+    paths:
+      - '**/pom.xml'
+  pull_request:
+    paths:
+      - '**/pom.xml'
+
+env:
+  DEFAULT_MAVEN_OPTS: >-
+    -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
+    -Daether.connector.http.retryHandler.count=5
+    -Daether.connector.http.connectionMaxTtl=30
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    name: Dependency Check
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Set up Java Zulu 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: 'maven'
+      - name: Run Dependency Check
+        env:
+          MAVEN_OPTS: >-
+            ${{ env.DEFAULT_MAVEN_OPTS }}
+        run: >
+          ./mvnw
+          --no-transfer-progress
+          --activate-profiles dependency-check
+          validate
+      - name: Upload Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: dependency-check-report
+          path: |
+            target/dependency-check-report.html
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![system-tests](https://github.com/apache/nifi/workflows/system-tests/badge.svg)](https://github.com/apache/nifi/actions/workflows/system-tests.yml)
 [![integration-tests](https://github.com/apache/nifi/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/apache/nifi/actions/workflows/integration-tests.yml)
 [![docker-tests](https://github.com/apache/nifi/actions/workflows/docker-tests.yml/badge.svg)](https://github.com/apache/nifi/actions/workflows/docker-tests.yml)
+[![dependency-check](https://github.com/apache/nifi/workflows/dependency-check/badge.svg)](https://github.com/apache/nifi/actions/workflows/dependency-check.yml)
 [![Docker pulls](https://img.shields.io/docker/pulls/apache/nifi.svg)](https://hub.docker.com/r/apache/nifi/)
 [![Version](https://img.shields.io/maven-central/v/org.apache.nifi/nifi-utils.svg)](https://nifi.apache.org/download.html)
 [![Slack](https://img.shields.io/badge/chat-on%20Slack-brightgreen.svg)](https://s.apache.org/nifi-community-slack)

--- a/minifi/minifi-c2/minifi-c2-assembly/pom.xml
+++ b/minifi/minifi-c2/minifi-c2-assembly/pom.xml
@@ -155,6 +155,13 @@ limitations under the License.
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-jetty-http</artifactId>
+            <exclusions>
+                <!-- jetty-continuation is not included in Jetty 10 -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-continuation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>

--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -451,6 +451,18 @@ limitations under the License.
                 <artifactId>guava</artifactId>
                 <version>32.1.2-jre</version>
             </dependency>
+
+            <!-- Override Commons Compiler 3.1.9 from calcite-core -->
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>3.1.10</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-commons/nifi-calcite-utils/pom.xml
+++ b/nifi-commons/nifi-calcite-utils/pom.xml
@@ -25,6 +25,22 @@
     <artifactId>nifi-calcite-utils</artifactId>
     <name>nifi-calcite-utils</name>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override Commons Compiler 3.1.9 from calcite-core -->
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-commons/nifi-property-protection-azure/pom.xml
+++ b/nifi-commons/nifi-property-protection-azure/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.16</version>
+                <version>1.2.17</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/nifi-commons/nifi-property-protection-gcp/pom.xml
+++ b/nifi-commons/nifi-property-protection-gcp/pom.xml
@@ -22,7 +22,7 @@
     </parent>
     <artifactId>nifi-property-protection-gcp</artifactId>
     <properties>
-        <gcp.sdk.version>26.17.0</gcp.sdk.version>
+        <gcp.sdk.version>26.25.0</gcp.sdk.version>
         <guava.version>32.1.2-jre</guava.version>
     </properties>
     <dependencyManagement>

--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -35,36 +35,6 @@
         <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
     </suppress>
     <suppress>
-        <notes>Apache Hive vulnerabilities do not apply to Flume Hive Sink</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.flume\.flume\-ng\-sinks/flume\-hive\-sink@.*$</packageUrl>
-        <cpe>cpe:/a:apache:hive</cpe>
-    </suppress>
-    <suppress>
-        <notes>Apache Kafka vulnerabilities do not apply to Flume Kafka Sink</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.flume\.flume\-ng\-sinks/flume\-ng\-kafka\-sink@.*$</packageUrl>
-        <cpe>cpe:/a:apache:kafka</cpe>
-    </suppress>
-    <suppress>
-        <notes>Apache Kafka vulnerabilities do not apply to Flume Kafka Source</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.flume\.flume\-ng\-sources/flume\-kafka\-source@.*$</packageUrl>
-        <cpe>cpe:/a:apache:kafka</cpe>
-    </suppress>
-    <suppress>
-        <notes>Apache Kafka vulnerabilities do not apply to Flume Shared Kafka</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.flume\.flume\-shared/flume\-shared\-kafka@.*$</packageUrl>
-        <cpe>cpe:/a:apache:kafka</cpe>
-    </suppress>
-    <suppress>
-        <notes>Apache HBase vulnerabilities do not apply to Flume HBase Sink</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.flume\.flume\-ng\-sinks/flume\-ng\-hbase\-sink@.*$</packageUrl>
-        <cpe>cpe:/a:apache:hbase</cpe>
-    </suppress>
-    <suppress>
-        <notes>Apache Solr vulnerabilities do not apply to Flume Solr Sink</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.flume\.flume\-ng\-sinks/flume\-ng\-morphline\-solr\-sink@.*$</packageUrl>
-        <cpe>cpe:/a:apache:solr</cpe>
-    </suppress>
-    <suppress>
         <notes>CVE-2017-10355 does not apply to Xerces 2.12.2</notes>
         <packageUrl regex="true">^pkg:maven/xerces/xercesImpl@.*$</packageUrl>
         <cve>CVE-2017-10355</cve>
@@ -75,24 +45,9 @@
         <cve>CVE-2020-13955</cve>
     </suppress>
     <suppress>
-        <notes>CVE-2018-8025 applies to HBase Server not HBase Client</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase\-client@.*$</packageUrl>
-        <cve>CVE-2018-8025</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2019-0212 applies to HBase Server not HBase Client</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase\-client@.*$</packageUrl>
-        <cve>CVE-2019-0212</cve>
-    </suppress>
-    <suppress>
         <notes>CVE-2007-6465 applies to Ganglia Server not Ganglia client libraries</notes>
         <packageUrl regex="true">^pkg:maven/com\.yammer\.metrics/metrics\-ganglia@.*$</packageUrl>
         <cve>CVE-2007-6465</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2021-43045 applies to the Apache Avro .NET SDK and not to the Java SDK</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.avro/avro@.*$</packageUrl>
-        <cve>CVE-2021-43045</cve>
     </suppress>
     <suppress>
         <notes>CVE-2022-31159 applies to AWS S3 library not the SWF libraries</notes>
@@ -113,16 +68,6 @@
         <notes>Elasticsearch Server vulnerabilities do not apply to elasticsearch</notes>
         <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch@7.*$</packageUrl>
         <cpe regex="true">^cpe:/a:elastic.*$</cpe>
-    </suppress>
-    <suppress>
-        <notes>Elasticsearch Server CVE-2020-7009 does not apply to elasticsearch client libraries</notes>
-        <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch.*$</packageUrl>
-        <cve>CVE-2020-7009</cve>
-    </suppress>
-    <suppress>
-        <notes>Elasticsearch Server CVE-2020-7014 does not apply to elasticsearch client libraries</notes>
-        <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch.*$</packageUrl>
-        <cve>CVE-2020-7014</cve>
     </suppress>
     <suppress>
         <notes>CVE-2021-22145 applies to Elasticsearch Server not client libraries</notes>
@@ -153,11 +98,6 @@
         <notes>CVE-2022-39135 applies to Apache Calcite core not the Calcite Druid library</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.calcite/calcite\-druid@.*$</packageUrl>
         <cve>CVE-2022-39135</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2018-1000873 applies to Jackson Java 8 Time modules not Jackson Annotations</notes>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-annotations@.*$</packageUrl>
-        <cve>CVE-2018-1000873</cve>
     </suppress>
     <suppress>
         <notes>CVE-2010-1151 applies to mod_auth_shadow in Apache HTTP Server not the FTP server library</notes>
@@ -205,29 +145,9 @@
         <cve>CVE-2021-34538</cve>
     </suppress>
     <suppress>
-        <notes>CVE-2018-8025 applies to HBase server not the shaded libraries</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.hbase\.thirdparty/hbase\-shaded\-.*$</packageUrl>
-        <cve>CVE-2018-8025</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2018-8025 applies to HBase Server not HBase libraries</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase\-.*$</packageUrl>
-        <cve>CVE-2018-8025</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2019-0212 applies to HBase Server not HBase libraries</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase\-.*$</packageUrl>
-        <cve>CVE-2019-0212</cve>
-    </suppress>
-    <suppress>
         <notes>Hadoop vulnerabilities do not apply to HBase Hadoop2 compatibility library</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.hbase/hbase\-hadoop2\-compat@.*$</packageUrl>
         <cpe>cpe:/a:apache:hadoop</cpe>
-    </suppress>
-    <suppress>
-        <notes>CVE-2022-45688 applies to hutools-json not org.json</notes>
-        <packageUrl regex="true">^pkg:maven/org\.json/json@.*$</packageUrl>
-        <cve>CVE-2022-45688</cve>
     </suppress>
     <suppress>
         <notes>The Jackson maintainers dispute the applicability of CVE-2023-35116 based on cyclic nature of reported concern</notes>
@@ -258,5 +178,270 @@
         <notes>CVE-2022-41915 applies to Netty HTTP decoding which is not applicable to Apache Kudu clients</notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty.*?@.*$</packageUrl>
         <cve>CVE-2022-41915</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-34462 applies to Netty servers using SniHandler not Netty 4.1 shaded for Couchbase and HBase 2</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*$</packageUrl>
+        <cve>CVE-2023-34462</cve>
+    </suppress>
+    <suppress>
+        <notes>The Square Wire framework is not the same as the Wire secure communication application</notes>
+        <packageUrl regex="true">^pkg:maven/com\.squareup\.wire/.*$</packageUrl>
+        <cpe>cpe:/a:wire:wire</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-44487 applies to Solr Server not Solr client libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.solr/solr\-solrj@.*$</packageUrl>
+        <cve>CVE-2023-44487</cve>
+    </suppress>
+    <suppress>
+        <notes>Quartz maintainers dispute CVE-2023-39017 because it requires code injection from external users</notes>
+        <packageUrl regex="true">^pkg:maven/org\.quartz\-scheduler/quartz@.*$</packageUrl>
+        <cve>CVE-2023-39017</cve>
+    </suppress>
+    <suppress>
+        <notes>Avro project vulnerabilities do not apply to Parquet Avro</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.parquet/parquet\-avro@.*$</packageUrl>
+        <cpe>cpe:/a:avro_project:avro</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-4759 is resolved in 6.7.0 which is already upgraded in nifi-registry</notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jgit/.*$</packageUrl>
+        <cve>CVE-2023-4759</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-4586 is resolved in Netty 4.1.100 which is already upgraded</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-35887 applies to MINA SSHD not MINA core libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.mina/mina\-core@.*$</packageUrl>
+        <cve>CVE-2023-35887</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2016-5397 applies to Apache Thrift Go not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+        <cve>CVE-2016-5397</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-0210 applies to Apache Thrift Go server not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+        <cve>CVE-2019-0210</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2018-11798 applies Apache Thrift Node.js not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+        <cve>CVE-2018-11798</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-11939 applies to Thrift Servers in Go not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-11939</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3552 applies to Thrift Servers in CPP not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3552</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3553 applies to Thrift Servers in CPP not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3553</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3558 applies to Thrift Servers in Python not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3558</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3564 applies to Thrift Servers in Go not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3564</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3565 applies to Thrift Servers in CPP not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3565</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2021-24028 applies to Facebook Thrift CPP</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2021-24028</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-11938 applies to Facebook Thrift Servers</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-11938</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3559 applies to Facebook Thrift Servers</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3559</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-36479 was resolved in Jetty 10.0.16</notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-servlets@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-36479</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>The jetty-servlet-api is versioned according to the Java Servlet API version not the Jetty version</notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-servlet\-api@.*$</packageUrl>
+        <cpe>cpe:/a:eclipse:jetty</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-31419 applies to Elasticsearch Server not client libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-31419</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-37475 applies to Hamba Avro in Go not Apache Avro for Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.avro/.*$</packageUrl>
+        <cve>CVE-2023-37475</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-45860 is resolved in Hazelcast 5.3.5</notes>
+        <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-45860</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-36414 applies to Azure Identity for .NET not Java</notes>
+        <packageUrl regex="true">^pkg:maven/com\.azure/azure\-identity@.*$</packageUrl>
+        <cve>CVE-2023-36414</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-36415 applies to Azure Identity for Python not Java</notes>
+        <packageUrl regex="true">^pkg:maven/com\.azure/azure\-identity@.*$</packageUrl>
+        <cve>CVE-2023-36415</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-13949 applies to Thrift and not to Hive</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.hive.*$</packageUrl>
+        <cve>CVE-2020-13949</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-44487 applies to netty-codec-http2 as a Server</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*$</packageUrl>
+        <cve>CVE-2023-44487</cve>
+    </suppress>
+    <suppress>
+        <notes>Parquet MR vulnerabilities do not apply to other Parquet libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.parquet/parquet\-(?!mr).*$</packageUrl>
+        <cpe>cpe:/a:apache:parquet-mr</cpe>
+    </suppress>
+    <suppress>
+        <notes>Apache Hadoop vulnerabilities do not apply to Parquet Hadoop Bundle library</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.parquet/parquet\-hadoop\-bundle@.*$</packageUrl>
+        <cpe>cpe:/a:apache:hadoop</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2017-7525 applies to Jackson 2 not Jackson 1</notes>
+        <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson\-mapper\-asl@.*$</packageUrl>
+        <vulnerabilityName>CVE-2017-7525</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-11358 applies to bundled copies of jQuery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2019-11358</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-11022 applies to bundled copies of jQuery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2020-11022</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-11023 applies to bundled copies of jQuery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2020-11023</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-23064 applies to bundled copies of jQuery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2020-23064</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2011-4969 applies to bundled copies of jQUery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2011-4969</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2012-6708 applies to bundled copies of jQUery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2012-6708</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2015-9251 applies to bundled copies of jQUery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2015-9251</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-7656 applies to bundled copies of jQUery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2020-7656</cve>
+    </suppress>
+    <suppress>
+        <notes>jQuery vulnerability warning for historical versions</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <vulnerabilityName>jQuery 1.x and 2.x are End-of-Life and no longer receiving security updates</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-28458 applies to bundled copies of jQuery datatables not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery\.datatables@.*$</packageUrl>
+        <cve>CVE-2020-28458</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2021-23445 applies to bundled copies of jQuery datatables not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery\.datatables@.*$</packageUrl>
+        <cve>CVE-2021-23445</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-44487 references gRPC for Go</notes>
+        <packageUrl regex="true">^pkg:maven/io\.grpc/grpc.*$</packageUrl>
+        <cve>CVE-2023-44487</cve>
+    </suppress>
+    <suppress>
+        <notes>Guava temporary directory file creation is not used</notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <cve>CVE-2023-2976</cve>
+    </suppress>
+    <suppress>
+        <notes>Guava temporary directory file creation is not used</notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <cve>CVE-2020-8908</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2021-44521 applies to Apache Cassandra Server</notes>
+        <packageUrl regex="true">^pkg:maven/com\.datastax\.cassandra/cassandra\-driver\-extras@.*$</packageUrl>
+        <cve>CVE-2021-44521</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-17516 applies to Apache Cassandra Server</notes>
+        <packageUrl regex="true">^pkg:maven/com\.datastax\.cassandra/cassandra\-driver\-extras@.*$</packageUrl>
+        <cve>CVE-2020-17516</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-2684 applies to Apache Cassandra Server</notes>
+        <packageUrl regex="true">^pkg:maven/com\.datastax\.cassandra/cassandra\-driver\-extras@.*$</packageUrl>
+        <cve>CVE-2019-2684</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-13946 applies to Apache Cassandra Server</notes>
+        <packageUrl regex="true">^pkg:maven/com\.datastax\.cassandra/cassandra\-driver\-extras@.*$</packageUrl>
+        <cve>CVE-2020-13946</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-10172 applies to Jackson 1 XmlMapper not JSON mapper used in Ranger plugins</notes>
+        <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson\-mapper\-asl@.*$</packageUrl>
+        <cve>CVE-2019-10172</cve>
+    </suppress>
+    <suppress>
+        <notes>Bundled versions of jQuery DataTables are not used</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery\.datatables@.*$</packageUrl>
+        <vulnerabilityName>prototype pollution</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>Bundled versions of jQuery DataTables are not used</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery\.datatables@.*$</packageUrl>
+        <vulnerabilityName>possible XSS</vulnerabilityName>
     </suppress>
 </suppressions>

--- a/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
@@ -59,18 +59,6 @@
                 <artifactId>hadoop-client-runtime</artifactId>
                 <version>${hadoop.version}</version>
             </dependency>
-            <!-- Override ZooKeeper from accumulo-core -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <dependency>
                 <groupId>org.apache.accumulo</groupId>
                 <artifactId>accumulo-core</artifactId>

--- a/nifi-nar-bundles/nifi-asana-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-asana-bundle/pom.xml
@@ -67,6 +67,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- Override grpc-context from Asana -->
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-context</artifactId>
+                <version>1.59.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
@@ -117,6 +117,12 @@
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
+            <!-- Override Jettison from Atlas -->
+            <dependency>
+                <groupId>org.codehaus.jettison</groupId>
+                <artifactId>jettison</artifactId>
+                <version>1.5.4</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -27,7 +27,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <azure.sdk.bom.version>1.2.16</azure.sdk.bom.version>
+        <azure.sdk.bom.version>1.2.17</azure.sdk.bom.version>
         <msal4j.version>1.13.10</msal4j.version>
         <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>

--- a/nifi-nar-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-box-bundle/pom.xml
@@ -34,4 +34,15 @@
         <module>nifi-box-services-api</module>
         <module>nifi-box-services-nar</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override jose4j 0.9.0 from box-java-sdk -->
+            <dependency>
+                <groupId>org.bitbucket.b_c</groupId>
+                <artifactId>jose4j</artifactId>
+                <version>0.9.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -476,11 +476,6 @@
                 <version>4.2.19</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-framework</artifactId>
                 <version>${curator.version}</version>

--- a/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
@@ -27,7 +27,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.22.0</google.libraries.version>
+        <google.libraries.version>26.25.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -28,6 +28,7 @@
         <gremlin.version>3.7.0</gremlin.version>
         <janusgraph.version>0.6.3</janusgraph.version>
         <guava.version>32.1.2-jre</guava.version>
+        <amqp-client.version>5.19.0</amqp-client.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -53,6 +54,12 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <!-- Override AMQP Client from JanusGraph -->
+            <dependency>
+                <groupId>com.rabbitmq</groupId>
+                <artifactId>amqp-client</artifactId>
+                <version>${amqp-client.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/pom.xml
+++ b/nifi-nar-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/pom.xml
@@ -26,41 +26,28 @@
     <packaging>jar</packaging>
 
     <dependencies>
-        <!-- Internal dependencies -->
-
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hazelcast-services-api</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-distributed-cache-client-service-api</artifactId>
         </dependency>
-
-        <!-- External dependencies -->
-
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>5.3.2</version>
+            <version>5.3.5</version>
         </dependency>
-
-        <!-- Test dependencies -->
-
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/pom.xml
@@ -99,6 +99,12 @@
                 <artifactId>guava</artifactId>
                 <version>32.1.2-jre</version>
             </dependency>
+            <!-- Override Jettison from Hive -->
+            <dependency>
+                <groupId>org.codehaus.jettison</groupId>
+                <artifactId>jettison</artifactId>
+                <version>1.5.4</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/pom.xml
@@ -144,6 +144,27 @@
                     <groupId>org.eclipse.jetty.websocket</groupId>
                     <artifactId>websocket-client</artifactId>
                 </exclusion>
+                <!-- Exclude HBase -->
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-mapreduce</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-hadoop2-compat</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-hadoop-compat</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -58,6 +58,17 @@
                 <artifactId>calcite-core</artifactId>
                 <version>${calcite.version}</version>
             </dependency>
+            <!-- Override Commons Compiler 3.1.9 from calcite-core -->
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>3.1.10</version>
+            </dependency>
             <!-- Override Apache Calcite Avatica subproject version for Hive 3 -->
             <dependency>
                 <groupId>org.apache.calcite.avatica</groupId>
@@ -76,18 +87,6 @@
                 <artifactId>derby</artifactId>
                 <version>${derby.version}</version>
             </dependency>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <!-- Override ant -->
             <dependency>
                 <groupId>org.apache.ant</groupId>
@@ -104,6 +103,12 @@
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.33</version>
+            </dependency>
+            <!-- Override Groovy from hive-exec -->
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>2.4.21</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/pom.xml
@@ -187,6 +187,14 @@
                     <artifactId>hbase-client</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-mapreduce</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-hadoop2-compat</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>co.cask.tephra</groupId>
                     <artifactId>tephra-api</artifactId>
                 </exclusion>

--- a/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
@@ -64,18 +64,6 @@
                 <artifactId>derby</artifactId>
                 <version>${derby.version}</version>
             </dependency>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <!-- Override ant -->
             <dependency>
                 <groupId>org.apache.ant</groupId>
@@ -115,6 +103,12 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>32.1.2-jre</version>
+            </dependency>
+            <!-- Override Groovy from hive-exec -->
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>2.4.21</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
@@ -37,12 +37,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-            </dependency>
             <!-- Override commons-beanutils -->
             <dependency>
                 <groupId>commons-beanutils</groupId>
@@ -95,6 +89,12 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>32.1.2-jre</version>
+            </dependency>
+            <!-- Override Jettison from Ranger -->
+            <dependency>
+                <groupId>org.codehaus.jettison</groupId>
+                <artifactId>jettison</artifactId>
+                <version>1.5.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-salesforce</artifactId>
-            <version>3.14.5</version>
+            <version>3.14.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/nifi-nar-bundles/nifi-spark-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-spark-bundle/pom.xml
@@ -65,18 +65,6 @@
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.33</version>
             </dependency>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
@@ -41,6 +41,17 @@
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
+            <!-- Override Commons Compiler 3.1.9 from calcite-core -->
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>3.1.10</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -274,6 +274,17 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- Override Commons Compiler 3.1.9 from calcite-core -->
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>3.1.10</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.sshd</groupId>
                 <artifactId>sshd-core</artifactId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/nifi-hbase_2-client-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/nifi-hbase_2-client-service/pom.xml
@@ -113,6 +113,10 @@
                     <groupId>jdk.tools</groupId>
                     <artifactId>jdk.tools</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
@@ -62,18 +62,6 @@
                 <artifactId>commons-beanutils</artifactId>
                 <version>1.9.4</version>
             </dependency>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <!-- Override nimbus-jose-jwt 9.8.1 from hadoop-auth -->
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
@@ -48,12 +48,6 @@
                 <artifactId>jetty-webapp</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-            </dependency>
             <!-- Override SolrJ 8.6.3 from Ranger -->
             <dependency>
                 <groupId>org.apache.solr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
-        <com.amazonaws.version>1.12.550</com.amazonaws.version>
+        <com.amazonaws.version>1.12.573</com.amazonaws.version>
         <software.amazon.awssdk.version>2.20.148</software.amazon.awssdk.version>
         <gson.version>2.10.1</gson.version>
         <io.fabric8.kubernetes.client.version>6.8.1</io.fabric8.kubernetes.client.version>
@@ -140,7 +140,7 @@
         <ozone.version>1.2.1</ozone.version>
         <gcs.version>2.1.5</gcs.version>
         <aspectj.version>1.9.20.1</aspectj.version>
-        <jersey.bom.version>2.40</jersey.bom.version>
+        <jersey.bom.version>2.41</jersey.bom.version>
         <log4j2.version>2.20.0</log4j2.version>
         <logback.version>1.3.11</logback.version>
         <mockito.version>5.5.0</mockito.version>
@@ -706,6 +706,22 @@
                 <artifactId>caffeine</artifactId>
                 <version>${caffeine.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper-jute</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
+            <!-- Managed JUnit 4 version for transitive dependencies such as OkHttp MockWebServer -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1227,7 +1243,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>8.4.0</version>
+                        <version>8.4.2</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>


### PR DESCRIPTION
# Summary

[NIFI-12276](https://issues.apache.org/jira/browse/NIFI-12276) Upgrades the OWASP Dependency Check Plugin from 8.4.0 to 8.4.2 and addresses a number of vulnerability findings.

Changes include introducing a new `dependency-check` GitHub workflow that runs on a daily schedule to evaluate project dependencies against published vulnerabilities. The workflow prints findings at the end of the build step and also produces an HTML report that can be downloaded for review.

Addressing current findings for the main project branch resulted in the following incremental dependency changes:

- Upgraded Janino Commons Compiler from 3.1.9 to 3.1.10
- Upgraded Azure SDK BOM from 1.2.16 to 1.2.17
- Upgraded GCP SDK BOM from 26.17.0 to 26.25.0
- Upgraded AWS SDK from 1.12.550 to 1.12.573
- Upgraded Hazelcast from 5.3.2 to 5.3.5
- Upgraded Jersey from 2.40 to 2.41
- Upgraded Camel Salesforce from 3.14.5 to 3.14.9
- Unified ZooKeeper versioning on 3.9.1
- Applied Groovy 2.4.21 to Hive 3 and Iceberg components
- Applied gRPC version 1.59.0 to Asana components
- Applied Jettison 1.5.4 to Atlas and Hive 3 components
- Managed JUnit 4 version to 4.13.2 for MockWebServer
- Excluded HBase libraries from Hive 3 following Iceberg approach
- Excluded Htrace from HBase components

Additional changes include removing non-applicable suppression settings and adding new suppression settings for vulnerabilities that do not have a direct impact on project components.

At the time of this writing, the dependency check report flags the following dependencies with associated vulnerabilities:

```
guava-19.0.jar (pkg:maven/com.google.guava/guava@19.0, cpe:2.3:a:google:guava:19.0:*:*:*:*:*:*:*) : CVE-2018-10237
hadoop-client-runtime-3.3.6.jar/META-INF/maven/com.google.protobuf/protobuf-java/pom.xml (pkg:maven/com.google.protobuf/protobuf-java@3.7.1, cpe:2.3:a:google:protobuf-java:3.7.1:*:*:*:*:*:*:*, cpe:2.3:a:protobuf:protobuf:3.7.1:*:*:*:*:*:*:*) : CVE-2022-3171, CVE-2022-3509, CVE-2021-22569
hadoop-client-runtime-3.3.6.jar/META-INF/maven/net.minidev/json-smart/pom.xml (pkg:maven/net.minidev/json-smart@1.3.2, cpe:2.3:a:json-smart_project:json-smart:1.3.2:*:*:*:*:*:*:*, cpe:2.3:a:json-smart_project:json-smart-v1:1.3.2:*:*:*:*:*:*:*) : CVE-2021-31684, CVE-2023-1370
hadoop-client-runtime-3.3.6.jar/META-INF/maven/org.apache.avro/avro/pom.xml (pkg:maven/org.apache.avro/avro@1.7.7) : CVE-2023-39410
hadoop-client-runtime-3.3.6.jar/META-INF/maven/org.eclipse.jetty/jetty-io/pom.xml (pkg:maven/org.eclipse.jetty/jetty-io@9.4.51.v20230217, cpe:2.3:a:eclipse:jetty:9.4.51:20230217:*:*:*:*:*:*, cpe:2.3:a:jetty:jetty:9.4.51:20230217:*:*:*:*:*:*) : CVE-2023-44487, CVE-2023-40167, CVE-2023-36479, CVE-2023-41900
hive-exec-3.1.3.jar/META-INF/maven/com.google.guava/guava/pom.xml (pkg:maven/com.google.guava/guava@11.0.2, cpe:2.3:a:google:guava:11.0.2:*:*:*:*:*:*:*) : CVE-2018-10237
hive-exec-3.1.3.jar/META-INF/maven/org.apache.avro/avro/pom.xml (pkg:maven/org.apache.avro/avro@1.8.2) : CVE-2023-39410
json-io-2.5.1.jar (pkg:maven/com.cedarsoftware/json-io@2.5.1) : CVE-2023-34610
kaml-0.20.0.jar (pkg:maven/com.charleskorn.kaml/kaml@0.20.0, cpe:2.3:a:kaml_project:kaml:0.20.0:*:*:*:*:*:*:*) : CVE-2023-28118, CVE-2021-39194
libthrift-0.9.3.jar (pkg:maven/org.apache.thrift/libthrift@0.9.3, cpe:2.3:a:apache:thrift:0.9.3:*:*:*:*:*:*:*) : CVE-2018-1320, CVE-2019-0205, CVE-2020-13949
netty-3.10.6.Final.jar (pkg:maven/io.netty/netty@3.10.6.Final, cpe:2.3:a:netty:netty:3.10.6:*:*:*:*:*:*:*) : CVE-2019-20444, CVE-2019-20445, CVE-2019-16869, CVE-2020-11612, CVE-2021-37136, CVE-2021-37137, CVE-2021-43797, CVE-2021-21295, CVE-2021-21409, CVE-2021-21290
protobuf-java-2.5.0.jar (pkg:maven/com.google.protobuf/protobuf-java@2.5.0, cpe:2.3:a:google:protobuf-java:2.5.0:*:*:*:*:*:*:*, cpe:2.3:a:protobuf:protobuf:2.5.0:*:*:*:*:*:*:*) : CVE-2022-3171, CVE-2022-3509, CVE-2021-22569
```

As shown in the dependency names, most of the findings relate to shaded dependencies included in Hadoop and Hive 3 libraries. These libraries are already upgraded to the latest available versions.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
