### PR TITLE
NIFI-12194 - yield Kafka processors on initialization failures

### DIFF
--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
@@ -540,10 +540,10 @@ public class ConsumeKafkaRecord_2_6 extends AbstractProcessor implements KafkaCl
                 getLogger().warn("Was interrupted while trying to communicate with Kafka with lease {}. "
                     + "Will roll back session and discard any partially received data.", lease);
             } catch (final KafkaException kex) {
-                getLogger().error("Exception while interacting with Kafka so will close the lease {} due to {}", lease, kex, kex);
+                getLogger().error("Exception while interacting with Kafka so will close the lease {}", lease, kex);
                 context.yield();
             } catch (final Throwable t) {
-                getLogger().error("Exception while processing data from kafka so will close the lease {} due to {}", lease, t, t);
+                getLogger().error("Exception while processing data from kafka so will close the lease {}", lease, t);
                 context.yield();
             } finally {
                 activeLeases.remove(lease);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
@@ -541,8 +541,10 @@ public class ConsumeKafkaRecord_2_6 extends AbstractProcessor implements KafkaCl
                     + "Will roll back session and discard any partially received data.", lease);
             } catch (final KafkaException kex) {
                 getLogger().error("Exception while interacting with Kafka so will close the lease {} due to {}", lease, kex, kex);
+                context.yield();
             } catch (final Throwable t) {
                 getLogger().error("Exception while processing data from kafka so will close the lease {} due to {}", lease, t, t);
+                context.yield();
             } finally {
                 activeLeases.remove(lease);
             }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
@@ -484,8 +484,10 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
                     + "Will roll back session and discard any partially received data.", lease);
             } catch (final KafkaException kex) {
                 getLogger().error("Exception while interacting with Kafka so will close the lease {} due to {}", lease, kex, kex);
+                context.yield();
             } catch (final Throwable t) {
                 getLogger().error("Exception while processing data from kafka so will close the lease {} due to {}", lease, t, t);
+                context.yield();
             } finally {
                 activeLeases.remove(lease);
             }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
@@ -483,10 +483,10 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
                 getLogger().warn("Was interrupted while trying to communicate with Kafka with lease {}. "
                     + "Will roll back session and discard any partially received data.", lease);
             } catch (final KafkaException kex) {
-                getLogger().error("Exception while interacting with Kafka so will close the lease {} due to {}", lease, kex, kex);
+                getLogger().error("Exception while interacting with Kafka so will close the lease {}", lease, kex);
                 context.yield();
             } catch (final Throwable t) {
-                getLogger().error("Exception while processing data from kafka so will close the lease {} due to {}", lease, t, t);
+                getLogger().error("Exception while processing data from kafka so will close the lease {}", lease, t);
                 context.yield();
             } finally {
                 activeLeases.remove(lease);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
@@ -506,7 +506,7 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         }
 
         final long startTime = System.nanoTime();
-        try (final PublisherLease lease = pool.obtainPublisher()) {
+        try (final PublisherLease lease = obtainPublisher(context, pool)) {
             try {
                 if (useTransactions) {
                     lease.beginTransaction();
@@ -586,10 +586,16 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
                 failureStrategy.routeFlowFiles(session, flowFiles);
                 context.yield();
             }
+        }
+    }
+
+    private PublisherLease obtainPublisher(final ProcessContext context, final PublisherPool pool) {
+        try {
+            return pool.obtainPublisher();
         } catch (final KafkaException e) {
             getLogger().error("Failed to obtain Kafka Producer", e);
-            session.transfer(flowFiles);
             context.yield();
+            throw e;
         }
     }
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
@@ -587,7 +587,7 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
                 context.yield();
             }
         } catch (final KafkaException e) {
-            getLogger().error("Failed to obtain Kafka publisher; will yield Processor", e);
+            getLogger().error("Failed to obtain Kafka Producer", e);
             session.transfer(flowFiles);
             context.yield();
         }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
@@ -18,6 +18,7 @@
 package org.apache.nifi.processors.kafka.pubsub;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
 import org.apache.kafka.common.errors.ProducerFencedException;
@@ -585,6 +586,10 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
                 failureStrategy.routeFlowFiles(session, flowFiles);
                 context.yield();
             }
+        } catch (final KafkaException e) {
+            getLogger().error("Failed to obtain Kafka publisher; will yield Processor", e);
+            session.transfer(flowFiles);
+            context.yield();
         }
     }
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
@@ -20,6 +20,7 @@ package org.apache.nifi.processors.kafka.pubsub;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
 import org.apache.kafka.common.errors.ProducerFencedException;
@@ -509,6 +510,10 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
                 failureStrategy.routeFlowFiles(session, flowFiles);
                 context.yield();
             }
+        } catch (final KafkaException e) {
+            getLogger().error("Failed to obtain Kafka publisher; will yield Processor", e);
+            session.transfer(flowFiles);
+            context.yield();
         }
     }
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
@@ -511,7 +511,7 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
                 context.yield();
             }
         } catch (final KafkaException e) {
-            getLogger().error("Failed to obtain Kafka publisher; will yield Processor", e);
+            getLogger().error("Failed to obtain Kafka Producer", e);
             session.transfer(flowFiles);
             context.yield();
         }


### PR DESCRIPTION
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [-] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [-] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [-] Documentation formatting appears as expected in rendered files
