### PR TITLE
NIFI-12293 Standardize HTTP error response messages

### DIFF
--- a/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/configuration/ListenerHandleResult.java
+++ b/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/configuration/ListenerHandleResult.java
@@ -49,7 +49,7 @@ public class ListenerHandleResult {
         if (failureCause == null) {
             return getDescriptor() + " successfully handled the configuration change";
         } else {
-            return getDescriptor() + " FAILED to handle the configuration change due to: '" + failureCause.getMessage() + "'";
+            return getDescriptor() + " FAILED to handle the configuration change";
         }
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/filter/ExceptionFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/filter/ExceptionFilter.java
@@ -17,8 +17,6 @@
 package org.apache.nifi.web.filter;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -44,20 +42,12 @@ public class ExceptionFilter implements Filter {
 
         try {
             filterChain.doFilter(req, resp);
-        } catch (RequestRejectedException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("An exception was caught performing the HTTP request security filter check and the stacktrace has been suppressed from the response");
-            }
+        } catch (final RequestRejectedException e) {
+            logger.warn("Client request rejected", e);
 
-            HttpServletResponse filteredResponse = (HttpServletResponse) resp;
+            final HttpServletResponse filteredResponse = (HttpServletResponse) resp;
             filteredResponse.setStatus(500);
-            filteredResponse.getWriter().write(e.getMessage());
-
-            StringWriter sw = new StringWriter();
-            sw.write("Exception caught by ExceptionFilter:\n");
-            PrintWriter pw = new PrintWriter(sw);
-            e.printStackTrace(pw);
-            logger.error(sw.toString());
+            filteredResponse.getWriter().write("Client request rejected");
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
@@ -138,14 +138,14 @@ public abstract class NiFiAuthenticationFilter extends GenericFilterBean {
         // use the type of authentication exception to determine the response code
         if (ae instanceof InvalidAuthenticationException) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            out.println(ae.getMessage());
+            out.println("Authentication credentials invalid");
         } else if (ae instanceof UntrustedProxyException) {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-            out.println(ae.getMessage());
+            out.println("Authentication Proxy Server not trusted");
         } else if (ae instanceof AuthenticationServiceException) {
             log.error("Authentication Service Failed: {}", ae.getMessage(), ae);
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            out.println(String.format("Unable to authenticate: %s", ae.getMessage()));
+            out.println("Authentication service processing failed");
         } else {
             log.error("Authentication Exception: {}", ae.getMessage(), ae);
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);


### PR DESCRIPTION
# Summary

[NIFI-12293](https://issues.apache.org/jira/browse/NIFI-12293) Updates exception handling in several web application filters to write standard messages based on the type of exception being processed.

Changes include adjusting applicable filters to write standard messages to the HTTP response stream. Existing log methods continue to include the full message and stack trace details.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
