### PR TITLE
NIFI-12277: Added SSLContextService to Slack Processors

### DIFF
--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-nar/pom.xml
@@ -35,5 +35,11 @@
             <artifactId>nifi-slack-processors</artifactId>
             <version>1.24.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-services-api-nar</artifactId>
+            <version>1.24.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-ssl-context-service-api</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PutSlackTest.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PutSlackTest.java
@@ -185,13 +185,14 @@ public class PutSlackTest {
     public void testGetPropertyDescriptors() {
         PutSlack processor = new PutSlack();
         List<PropertyDescriptor> pd = processor.getSupportedPropertyDescriptors();
-        assertEquals(6, pd.size(), "size should be eq");
+        assertEquals(7, pd.size(), "size should be eq");
         assertTrue(pd.contains(PutSlack.WEBHOOK_TEXT));
         assertTrue(pd.contains(PutSlack.WEBHOOK_URL));
         assertTrue(pd.contains(PutSlack.CHANNEL));
         assertTrue(pd.contains(PutSlack.USERNAME));
         assertTrue(pd.contains(PutSlack.ICON_URL));
         assertTrue(pd.contains(PutSlack.ICON_EMOJI));
+        assertTrue(pd.contains(PutSlack.SSL_CONTEXT_SERVICE));
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12277](https://issues.apache.org/jira/browse/NIFI-12277)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
