### PR TITLE
NIFI-12298 add swagger annotations for createExtensionBundleVersion form fields

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketBundleResource.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketBundleResource.java
@@ -19,6 +19,8 @@ package org.apache.nifi.registry.web.api;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
@@ -90,6 +92,22 @@ public class BucketBundleResource extends ApplicationResource {
                     @Extension(name = "access-policy", properties = {
                             @ExtensionProperty(name = "action", value = "write"),
                             @ExtensionProperty(name = "resource", value = "/buckets/{bucketId}") })
+            }
+    )
+    @ApiImplicitParams(
+            value = {
+                    @ApiImplicitParam(
+                            name = "file",
+                            value = "The binary content of the bundle file being uploaded.",
+                            required = true,
+                            type = "file",
+                            paramType = "formData"),
+                    @ApiImplicitParam(
+                            name = "sha256",
+                            value = "Optional sha256 of the provided bundle",
+                            required = false,
+                            type = "string",
+                            paramType = "formData")
             }
     )
     @ApiResponses({


### PR DESCRIPTION

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12298](https://issues.apache.org/jira/browse/NIFI-12298)

The current swagger annotations for the 
createExtensionBundleVersion function in BucketBundleResource results in the form parameters for 'file' and 'sha256' being left out of the generated swagger api defenition for the /buckets/{bucketId}/bundles/{bundleType} endpoint.
 
By adding a 
ApiImplicitParams annotation for both these fields, swagger will correctly interpret these and add them as fields to the endpoint.
 
When generating swagger clients, this change is required to correctly support the necessary input arguments.

Swagger defenition of endpoint BEFORE changes:

```json
"/buckets/{bucketId}/bundles/{bundleType}" : {
      "post" : {
        "tags" : [ "Swagger Resource" ],
        "summary" : "Create extension bundle version",
        "description" : "Creates a version of an extension bundle by uploading a binary artifact. If an extension bundle already exists in the given bucket with the same group id and artifact id as that of the bundle being uploaded, then it will be added as a new version to the existing bundle. If an extension bundle does not already exist in the given bucket with the same group id and artifact id, then a new extension bundle will be created and this version will be added to the new bundle. Client's may optionally supply a SHA-256 in hex format through the multi-part form field 'sha256'. If supplied, then this value will be compared against the SHA-256 computed by the server, and the bundle will be rejected if the values do not match. If not supplied, the bundle will be accepted, but will be marked to indicate that the client did not supply a SHA-256 during creation. \n\nNOTE: This endpoint is subject to change as NiFi Registry and its REST API evolve.",
        "operationId" : "createExtensionBundleVersion",
        "consumes" : [ "multipart/form-data" ],
        "produces" : [ "application/json" ],
        "parameters" : [ {
          "name" : "bucketId",
          "in" : "path",
          "description" : "The bucket identifier",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "bundleType",
          "in" : "path",
          "description" : "The type of the bundle",
          "required" : true,
          "type" : "string",
          "enum" : [ "nifi-nar", "minifi-cpp" ]
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/BundleVersion"
            }
          },
          "400" : {
            "description" : "NiFi Registry was unable to complete the request because it was invalid. The request should not be retried without modification."
          },
          "401" : {
            "description" : "Client could not be authenticated."
          },
          "403" : {
            "description" : "Client is not authorized to make this request."
          },
          "404" : {
            "description" : "The specified resource could not be found."
          },
          "409" : {
            "description" : "NiFi Registry was unable to complete the request because it assumes a server state that is not valid."
          }
        },
        "security" : [ {
          "Authorization" : [ ]
        } ],
        "x-access-policy" : {
          "resource" : "/buckets/{bucketId}",
          "action" : "write"
        }
      }
```


Swagger definition of endpoint AFTER changes:

```json
"/buckets/{bucketId}/bundles/{bundleType}" : {
      "post" : {
        "tags" : [ "Swagger Resource" ],
        "summary" : "Create extension bundle version",
        "description" : "Creates a version of an extension bundle by uploading a binary artifact. If an extension bundle already exists in the given bucket with the same group id and artifact id as that of the bundle being uploaded, then it will be added as a new version to the existing bundle. If an extension bundle does not already exist in the given bucket with the same group id and artifact id, then a new extension bundle will be created and this version will be added to the new bundle. Client's may optionally supply a SHA-256 in hex format through the multi-part form field 'sha256'. If supplied, then this value will be compared against the SHA-256 computed by the server, and the bundle will be rejected if the values do not match. If not supplied, the bundle will be accepted, but will be marked to indicate that the client did not supply a SHA-256 during creation. \n\nNOTE: This endpoint is subject to change as NiFi Registry and its REST API evolve.",
        "operationId" : "createExtensionBundleVersion",
        "consumes" : [ "multipart/form-data" ],
        "produces" : [ "application/json" ],
        "parameters" : [ {
          "name" : "bucketId",
          "in" : "path",
          "description" : "The bucket identifier",
          "required" : true,
          "type" : "string"
        }, {
          "name" : "bundleType",
          "in" : "path",
          "description" : "The type of the bundle",
          "required" : true,
          "type" : "string",
          "enum" : [ "nifi-nar", "minifi-cpp" ]
        }, {
          "name" : "file",
          "in" : "formData",
          "description" : "The binary content of the bundle file being uploaded.",
          "required" : true,
          "type" : "file"
        }, {
          "name" : "sha256",
          "in" : "formData",
          "description" : "Optional sha256 of the provided bundle",
          "required" : false,
          "type" : "string"
        } ],
        "responses" : {
          "200" : {
            "description" : "successful operation",
            "schema" : {
              "$ref" : "#/definitions/BundleVersion"
            }
          },
          "400" : {
            "description" : "NiFi Registry was unable to complete the request because it was invalid. The request should not be retried without modification."
          },
          "401" : {
            "description" : "Client could not be authenticated."
          },
          "403" : {
            "description" : "Client is not authorized to make this request."
          },
          "404" : {
            "description" : "The specified resource could not be found."
          },
          "409" : {
            "description" : "NiFi Registry was unable to complete the request because it assumes a server state that is not valid."
          }
        },
        "security" : [ {
          "Authorization" : [ ]
        } ],
        "x-access-policy" : {
          "resource" : "/buckets/{bucketId}",
          "action" : "write"
        }
      }
```


# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

~~- [ ] Documentation formatting appears as expected in rendered files~~
