### PR TITLE
NIFI-12303 Removed deprecated Consumer Hostname property from Consume…

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
@@ -148,14 +148,6 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             .defaultValue("$Default")
             .required(true)
             .build();
-    static final PropertyDescriptor CONSUMER_HOSTNAME = new PropertyDescriptor.Builder()
-            .name("event-hub-consumer-hostname")
-            .displayName("Consumer Hostname")
-            .description("DEPRECATED: This property is no longer used.")
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
-            .required(false)
-            .build();
 
     static final PropertyDescriptor RECORD_READER = new PropertyDescriptor.Builder()
             .name("record-reader")
@@ -291,7 +283,6 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
                 POLICY_PRIMARY_KEY,
                 USE_MANAGED_IDENTITY,
                 CONSUMER_GROUP,
-                CONSUMER_HOSTNAME,
                 RECORD_READER,
                 RECORD_WRITER,
                 INITIAL_OFFSET,


### PR DESCRIPTION
…AzureEventHub

# Summary

[NIFI-12303](https://issues.apache.org/jira/browse/NIFI-12303)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
