### PR TITLE
NIFI-12297 Standardize File Path resolution in Persistence Providers

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/extension/FileSystemBundlePersistenceProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/extension/FileSystemBundlePersistenceProvider.java
@@ -39,6 +39,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -71,8 +73,7 @@ public class FileSystemBundlePersistenceProvider implements BundlePersistencePro
         try {
             bundleStorageDir = new File(bundleStorageDirValue);
             FileUtils.ensureDirectoryExistAndCanReadAndWrite(bundleStorageDir);
-            LOGGER.info("Configured BundlePersistenceProvider with Extension Bundle Storage Directory {}",
-                    new Object[] {bundleStorageDir.getAbsolutePath()});
+            LOGGER.info("Configured BundlePersistenceProvider with Extension Bundle Storage Directory {}", bundleStorageDir.getAbsolutePath());
         } catch (IOException e) {
             throw new ProviderCreationException(e);
         }
@@ -107,7 +108,7 @@ public class FileSystemBundlePersistenceProvider implements BundlePersistencePro
         }
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Writing extension bundle to {}", new Object[]{bundleFile.getAbsolutePath()});
+            LOGGER.debug("Writing extension bundle to {}", bundleFile.getAbsolutePath());
         }
 
         try (final OutputStream out = new FileOutputStream(bundleFile)) {
@@ -124,7 +125,7 @@ public class FileSystemBundlePersistenceProvider implements BundlePersistencePro
 
         final File bundleFile = getBundleFile(versionCoordinate);
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Reading extension bundle from {}", new Object[]{bundleFile.getAbsolutePath()});
+            LOGGER.debug("Reading extension bundle from {}", bundleFile.getAbsolutePath());
         }
 
         try (final InputStream in = new FileInputStream(bundleFile);
@@ -142,7 +143,7 @@ public class FileSystemBundlePersistenceProvider implements BundlePersistencePro
     public synchronized void deleteBundleVersion(final BundleVersionCoordinate versionCoordinate) throws BundlePersistenceException {
         final File bundleFile = getBundleFile(versionCoordinate);
         if (!bundleFile.exists()) {
-            LOGGER.warn("Extension bundle content does not exist at {}", new Object[] {bundleFile.getAbsolutePath()});
+            LOGGER.warn("Extension bundle content does not exist at {}", bundleFile.getAbsolutePath());
             return;
         }
 
@@ -152,7 +153,7 @@ public class FileSystemBundlePersistenceProvider implements BundlePersistencePro
         }
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Deleted extension bundle content at {}", new Object[] {bundleFile.getAbsolutePath()});
+            LOGGER.debug("Deleted extension bundle content at {}", bundleFile.getAbsolutePath());
         }
     }
 
@@ -160,7 +161,7 @@ public class FileSystemBundlePersistenceProvider implements BundlePersistencePro
     public synchronized void deleteAllBundleVersions(final BundleCoordinate bundleCoordinate) throws BundlePersistenceException {
         final File bundleDir = getBundleDirectory(bundleStorageDir, bundleCoordinate);
         if (!bundleDir.exists()) {
-            LOGGER.warn("Extension bundle directory does not exist at {}", new Object[] {bundleDir.getAbsolutePath()});
+            LOGGER.warn("Extension bundle directory does not exist at {}", bundleDir.getAbsolutePath());
             return;
         }
 
@@ -207,7 +208,8 @@ public class FileSystemBundlePersistenceProvider implements BundlePersistencePro
         final String groupId = bundleCoordinate.getGroupId();
         final String artifactId = bundleCoordinate.getArtifactId();
 
-        return new File(bundleStorageDir, sanitize(bucketId) + "/" + sanitize(groupId) + "/" + sanitize(artifactId));
+        final Path artifactPath = getArtifactPath(bucketId, groupId, artifactId);
+        return getChildLocation(bundleStorageDir, artifactPath);
     }
 
     static File getBundleVersionDirectory(final File bundleStorageDir, final BundleVersionCoordinate versionCoordinate) {
@@ -216,7 +218,9 @@ public class FileSystemBundlePersistenceProvider implements BundlePersistencePro
         final String artifactId = versionCoordinate.getArtifactId();
         final String version = versionCoordinate.getVersion();
 
-        return new File(bundleStorageDir, sanitize(bucketId) + "/" + sanitize(groupId) + "/" + sanitize(artifactId) + "/" + sanitize(version));
+        final Path artifactPath = getArtifactPath(bucketId, groupId, artifactId);
+        final Path versionPath = Paths.get(sanitize(version)).normalize();
+        return getChildLocation(bundleStorageDir, artifactPath.resolve(versionPath));
     }
 
     static File getBundleFile(final File parentDir, final BundleVersionCoordinate versionCoordinate) {
@@ -227,7 +231,11 @@ public class FileSystemBundlePersistenceProvider implements BundlePersistencePro
 
         final String bundleFileExtension = getBundleFileExtension(bundleType);
         final String bundleFilename = sanitize(artifactId) + "-" + sanitize(version) + bundleFileExtension;
-        return new File(parentDir, bundleFilename);
+        return getChildLocation(parentDir, Paths.get(bundleFilename));
+    }
+
+    static Path getArtifactPath(final String bucketId, final String groupId, final String artifactId) {
+        return Paths.get(sanitize(bucketId), sanitize(groupId), sanitize(artifactId)).normalize();
     }
 
     static String sanitize(final String input) {
@@ -246,4 +254,12 @@ public class FileSystemBundlePersistenceProvider implements BundlePersistencePro
         }
     }
 
+    private static File getChildLocation(final File parentDir, final Path childLocation) {
+        final Path parentPath = parentDir.toPath().normalize();
+        final Path childPath = parentPath.resolve(childLocation.normalize());
+        if (childPath.startsWith(parentPath)) {
+            return childPath.toFile();
+        }
+        throw new IllegalArgumentException(String.format("Child location not valid [%s]", childLocation));
+    }
 }


### PR DESCRIPTION
# Summary

[NIFI-12297](https://issues.apache.org/jira/browse/NIFI-12297) Standardizes file path resolution in the NiFi Registry File System Bundle and Flow Persistence Providers, as well as the file-backed client for system tests. These changes replace string concatenation and related strategies with a standard approach using Java NIO Paths. Using Paths ensures consistent directory separator handling and path normalization.

Additional changes include updating related unit tests to reuse shared identifier values.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
