### PR TITLE
NIFI-12306 ConsumeAzureEventHub logs partition ownership changes at i…

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
@@ -512,11 +512,12 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
         if (throwable instanceof AmqpException) {
             final AmqpException amqpException = (AmqpException) throwable;
             if (amqpException.getErrorCondition() == AmqpErrorCondition.LINK_STOLEN) {
-                getLogger().info("Partition was stolen by another consumer instance from the consumer group. Namespace [{}] Event Hub [{}] Consumer Group [{}] Partition [{}]",
+                getLogger().info("Partition was stolen by another consumer instance from the consumer group. Namespace [{}] Event Hub [{}] Consumer Group [{}] Partition [{}]. {}",
                         partitionContext.getFullyQualifiedNamespace(),
                         partitionContext.getEventHubName(),
                         partitionContext.getConsumerGroup(),
-                        partitionContext.getPartitionId());
+                        partitionContext.getPartitionId(),
+                        amqpException.getMessage());
                 return;
             }
         }


### PR DESCRIPTION
…nfo level

# Summary

[NIFI-12306](https://issues.apache.org/jira/browse/NIFI-12306)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
