### PR TITLE
NIFI-12310 Validate Python Component Type for Processes

### DIFF
--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/StandardPythonBridge.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/StandardPythonBridge.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -299,23 +298,5 @@ public class StandardPythonBridge implements PythonBridge {
     }
 
     private record ExtensionId(String type, String version) {
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final ExtensionId that = (ExtensionId) o;
-            return Objects.equals(type, that.type) && Objects.equals(version, that.version);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(type, version);
-        }
     }
 }

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/StandardPythonBridge.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/StandardPythonBridge.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -50,7 +51,6 @@ public class StandardPythonBridge implements PythonBridge {
     private PythonProcess controllerProcess;
     private final Map<ExtensionId, Integer> processorCountByType = new ConcurrentHashMap<>();
     private final Map<ExtensionId, List<PythonProcess>> processesByProcessorType = new ConcurrentHashMap<>();
-
 
     @Override
     public void initialize(final PythonBridgeInitializationContext context) {
@@ -78,7 +78,6 @@ public class StandardPythonBridge implements PythonBridge {
         }
     }
 
-
     @Override
     public void discoverExtensions() {
         ensureStarted();
@@ -93,9 +92,10 @@ public class StandardPythonBridge implements PythonBridge {
     public PythonProcessorBridge createProcessor(final String identifier, final String type, final String version, final boolean preferIsolatedProcess) {
         ensureStarted();
 
-        logger.debug("Creating Python Processor of type {}", type);
+        final ExtensionId extensionId = getExtensionId(type, version);
+        logger.debug("Creating Python Processor Type [{}] Version [{}]", extensionId.type(), extensionId.version());
 
-        final PythonProcess pythonProcess = getProcessForNextComponent(type, identifier, version, preferIsolatedProcess);
+        final PythonProcess pythonProcess = getProcessForNextComponent(extensionId, identifier, preferIsolatedProcess);
         final String workDirPath = processConfig.getPythonWorkingDirectory().getAbsolutePath();
 
         final PythonController controller = pythonProcess.getController();
@@ -122,14 +122,13 @@ public class StandardPythonBridge implements PythonBridge {
             .build();
 
         pythonProcess.addProcessor(identifier, preferIsolatedProcess);
-        final ExtensionId extensionId = new ExtensionId(type, version);
         processorCountByType.merge(extensionId, 1, Integer::sum);
         return processorBridge;
     }
 
     @Override
     public synchronized void onProcessorRemoved(final String identifier, final String type, final String version) {
-        final ExtensionId extensionId = new ExtensionId(type, version);
+        final ExtensionId extensionId = getExtensionId(type, version);
         final List<PythonProcess> processes = processesByProcessorType.get(extensionId);
         if (processes == null) {
             return;
@@ -137,7 +136,7 @@ public class StandardPythonBridge implements PythonBridge {
 
         // Find the Python Process that has the Processor, if any, and remove it.
         // If there are no additional Processors in the Python Process, remove it from our list and shut down the process.
-        final Iterator<PythonProcess> processItr = processes.iterator(); // Use iter so we can call remove()
+        final Iterator<PythonProcess> processItr = processes.iterator(); // Use iterator so we can call remove()
         while (processItr.hasNext()) {
             final PythonProcess process = processItr.next();
             final boolean removed = process.removeProcessor(identifier);
@@ -159,8 +158,7 @@ public class StandardPythonBridge implements PythonBridge {
         return count;
     }
 
-    private synchronized PythonProcess getProcessForNextComponent(final String type, final String componentId, final String version, final boolean preferIsolatedProcess) {
-        final ExtensionId extensionId = new ExtensionId(type, version);
+    private synchronized PythonProcess getProcessForNextComponent(final ExtensionId extensionId, final String componentId, final boolean preferIsolatedProcess) {
         final int processorsOfThisType = processorCountByType.getOrDefault(extensionId, 0);
         final int processIndex = processorsOfThisType % processConfig.getMaxPythonProcessesPerType();
 
@@ -172,7 +170,7 @@ public class StandardPythonBridge implements PythonBridge {
         final List<PythonProcess> processesForType = processesByProcessorType.computeIfAbsent(extensionId, key -> new ArrayList<>());
         for (final PythonProcess pythonProcess : processesForType) {
             if (!preferIsolatedProcess || !pythonProcess.containsIsolatedProcessor()) {
-                logger.debug("Using {} to create Processor of type {}", pythonProcess, type);
+                logger.debug("Using {} to create Processor of type {}", pythonProcess, extensionId.type());
                 return pythonProcess;
             }
         }
@@ -187,12 +185,12 @@ public class StandardPythonBridge implements PythonBridge {
                 }
 
                 logger.info("In order to create Python Processor of type {}, launching a new Python Process because there are currently {} Python Processors of this type and {} Python Processes",
-                    type, processorsOfThisType, processesByProcessorType.size());
+                    extensionId.type(), processorsOfThisType, processesByProcessorType.size());
 
                 final File extensionsWorkDir = new File(processConfig.getPythonWorkingDirectory(), "extensions");
-                final File componentTypeHome = new File(extensionsWorkDir, type);
-                final File envHome = new File(componentTypeHome, version);
-                final PythonProcess pythonProcess = new PythonProcess(processConfig, serviceTypeLookup, envHome, type, componentId);
+                final File componentTypeHome = new File(extensionsWorkDir, extensionId.type());
+                final File envHome = new File(componentTypeHome, extensionId.version());
+                final PythonProcess pythonProcess = new PythonProcess(processConfig, serviceTypeLookup, envHome, extensionId.type(), componentId);
                 pythonProcess.start();
 
                 final List<String> extensionsDirs = processConfig.getPythonExtensionsDirectories().stream()
@@ -206,13 +204,14 @@ public class StandardPythonBridge implements PythonBridge {
 
                 return pythonProcess;
             } catch (final IOException ioe) {
-                throw new RuntimeException("Failed launch Python Process in order to create new Processor of type " + type, ioe);
+                final String message = String.format("Failed to launch Process for Python Processor [%s] Version [%s]", extensionId.type(), extensionId.version());
+                throw new RuntimeException(message, ioe);
             }
         } else {
             final PythonProcess pythonProcess = processesForType.get(processIndex);
             logger.warn("Using existing process {} to create Processor of type {} because configuration indicates that no more than {} processes " +
                 "should be created for any Processor Type. This may result in slower performance for Processors of this type",
-                pythonProcess, type, processConfig.getMaxPythonProcessesPerType());
+                pythonProcess, extensionId.type(), processConfig.getMaxPythonProcessesPerType());
 
             return pythonProcess;
         }
@@ -229,7 +228,7 @@ public class StandardPythonBridge implements PythonBridge {
         final Map<String, Integer> counts = new HashMap<>(processesByProcessorType.size());
 
         for (final Map.Entry<ExtensionId, List<PythonProcess>> entry : processesByProcessorType.entrySet()) {
-            counts.put(entry.getKey().getType() + " version " + entry.getKey().getVersion(), entry.getValue().size());
+            counts.put(entry.getKey().type() + " version " + entry.getKey().version(), entry.getValue().size());
         }
 
         return counts;
@@ -245,7 +244,7 @@ public class StandardPythonBridge implements PythonBridge {
 
             for (final PythonProcess process : processes) {
                 final Map<String, Integer> counts = process.getJavaObjectBindingCounts();
-                final BoundObjectCounts boundObjectCounts = new StandardBoundObjectCounts(process.toString(), extensionId.getType(), extensionId.getVersion(), counts);
+                final BoundObjectCounts boundObjectCounts = new StandardBoundObjectCounts(process.toString(), extensionId.type(), extensionId.version(), counts);
                 list.add(boundObjectCounts);
             }
         }
@@ -288,23 +287,18 @@ public class StandardPythonBridge implements PythonBridge {
         return "StandardPythonBridge";
     }
 
+    private ExtensionId getExtensionId(final String type, final String version) {
+        final List<PythonProcessorDetails> processorTypes = controllerProcess.getController().getProcessorTypes();
+        final Optional<PythonProcessorDetails> processorTypeFound = processorTypes.stream()
+                .filter(details -> details.getProcessorType().equals(type))
+                .filter(details -> details.getProcessorVersion().equals(version))
+                .findFirst();
 
-    private static class ExtensionId {
-        private final String type;
-        private final String version;
+        return processorTypeFound.map(details -> new ExtensionId(details.getProcessorType(), details.getProcessorVersion()))
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Processor Type [%s] Version [%s] not found", type, version)));
+    }
 
-        public ExtensionId(final String type, final String version) {
-            this.type = type;
-            this.version = version;
-        }
-
-        public String getType() {
-            return type;
-        }
-
-        public String getVersion() {
-            return version;
-        }
+    private record ExtensionId(String type, String version) {
 
         @Override
         public boolean equals(final Object o) {


### PR DESCRIPTION
# Summary

[NIFI-12310](https://issues.apache.org/jira/browse/NIFI-12310) Updates the `StandardPythonBridge` to validate the request Component Type and Version against available Python Processors when starting new Python processes.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
