### PR TITLE
NIFI-12297 Standardize File Path resolution in Persistence Providers

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/FileSystemFlowPersistenceProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/FileSystemFlowPersistenceProvider.java
@@ -33,7 +33,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A FlowPersistenceProvider that uses the local filesystem for storage.
@@ -45,6 +50,8 @@ public class FileSystemFlowPersistenceProvider implements FlowPersistenceProvide
     static final String FLOW_STORAGE_DIR_PROP = "Flow Storage Directory";
 
     static final String SNAPSHOT_EXTENSION = ".snapshot";
+
+    private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
 
     private File flowStorageDir;
 
@@ -63,7 +70,7 @@ public class FileSystemFlowPersistenceProvider implements FlowPersistenceProvide
         try {
             flowStorageDir = new File(flowStorageDirValue);
             FileUtils.ensureDirectoryExistAndCanReadAndWrite(flowStorageDir);
-            LOGGER.info("Configured FileSystemFlowPersistenceProvider with Flow Storage Directory {}", new Object[] {flowStorageDir.getAbsolutePath()});
+            LOGGER.info("Configured FileSystemFlowPersistenceProvider with Flow Storage Directory {}", flowStorageDir.getAbsolutePath());
         } catch (IOException e) {
             throw new ProviderCreationException(e);
         }
@@ -71,14 +78,14 @@ public class FileSystemFlowPersistenceProvider implements FlowPersistenceProvide
 
     @Override
     public synchronized void saveFlowContent(final FlowSnapshotContext context, final byte[] content) throws FlowPersistenceException {
-        final File bucketDir = new File(flowStorageDir, context.getBucketId());
+        final File bucketDir = getChildLocation(flowStorageDir, getNormalizedIdPath(context.getBucketId()));
         try {
             FileUtils.ensureDirectoryExistAndCanReadAndWrite(bucketDir);
         } catch (IOException e) {
             throw new FlowPersistenceException("Error accessing bucket directory at " + bucketDir.getAbsolutePath(), e);
         }
 
-        final File flowDir = new File(bucketDir, context.getFlowId());
+        final File flowDir = getChildLocation(bucketDir, getNormalizedIdPath(context.getFlowId()));
         try {
             FileUtils.ensureDirectoryExistAndCanReadAndWrite(flowDir);
         } catch (IOException e) {
@@ -86,27 +93,28 @@ public class FileSystemFlowPersistenceProvider implements FlowPersistenceProvide
         }
 
         final String versionString = String.valueOf(context.getVersion());
-        final File versionDir = new File(flowDir, versionString);
+        final File versionDir = getChildLocation(flowDir, Paths.get(versionString));
         try {
             FileUtils.ensureDirectoryExistAndCanReadAndWrite(versionDir);
         } catch (IOException e) {
             throw new FlowPersistenceException("Error accessing version directory at " + versionDir.getAbsolutePath(), e);
         }
 
-        final File versionFile = new File(versionDir, versionString + SNAPSHOT_EXTENSION);
+        final String versionExtension = versionString + SNAPSHOT_EXTENSION;
+        final File versionFile = getChildLocation(versionDir, Paths.get(versionExtension));
         if (versionFile.exists()) {
             throw new FlowPersistenceException("Unable to save, a snapshot already exists with version " + versionString);
         }
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Saving snapshot with filename {}", new Object[] {versionFile.getAbsolutePath()});
+            LOGGER.debug("Saving snapshot with filename {}", versionFile.getAbsolutePath());
         }
 
         try (final OutputStream out = new FileOutputStream(versionFile)) {
             out.write(content);
             out.flush();
         } catch (Exception e) {
-            throw new FlowPersistenceException("Unable to write snapshot to disk due to " + e.getMessage(), e);
+            throw new FlowPersistenceException("Unable to write snapshot to disk", e);
         }
     }
 
@@ -114,7 +122,7 @@ public class FileSystemFlowPersistenceProvider implements FlowPersistenceProvide
     public synchronized byte[] getFlowContent(final String bucketId, final String flowId, final int version) throws FlowPersistenceException {
         final File snapshotFile = getSnapshotFile(bucketId, flowId, version);
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Retrieving snapshot with filename {}", new Object[] {snapshotFile.getAbsolutePath()});
+            LOGGER.debug("Retrieving snapshot with filename {}", snapshotFile.getAbsolutePath());
         }
 
         if (!snapshotFile.exists()) {
@@ -130,9 +138,12 @@ public class FileSystemFlowPersistenceProvider implements FlowPersistenceProvide
 
     @Override
     public synchronized void deleteAllFlowContent(final String bucketId, final String flowId) throws FlowPersistenceException {
-        final File flowDir = new File(flowStorageDir, bucketId + "/" + flowId);
+        final Path bucketIdPath = getNormalizedIdPath(bucketId);
+        final Path flowIdPath = getNormalizedIdPath(flowId);
+        final Path bucketFlowPath = bucketIdPath.resolve(flowIdPath);
+        final File flowDir = getChildLocation(flowStorageDir, bucketFlowPath);
         if (!flowDir.exists()) {
-            LOGGER.debug("Snapshot directory does not exist at {}", new Object[] {flowDir.getAbsolutePath()});
+            LOGGER.debug("Snapshot directory does not exist at {}", flowDir.getAbsolutePath());
             return;
         }
 
@@ -150,12 +161,12 @@ public class FileSystemFlowPersistenceProvider implements FlowPersistenceProvide
         }
 
         // delete the directory for the bucket if there is nothing left
-        final File bucketDir = new File(flowStorageDir, bucketId);
+        final File bucketDir = getChildLocation(flowStorageDir, getNormalizedIdPath(bucketId));
         final File[] bucketFiles = bucketDir.listFiles();
-        if (bucketFiles.length == 0) {
+        if (bucketFiles == null || bucketFiles.length == 0) {
             final boolean deletedBucket = bucketDir.delete();
             if (!deletedBucket) {
-                LOGGER.error("Unable to delete bucket directory: " + flowDir.getAbsolutePath());
+                LOGGER.error("Unable to delete bucket directory: {}", flowDir.getAbsolutePath());
             }
         }
     }
@@ -164,7 +175,7 @@ public class FileSystemFlowPersistenceProvider implements FlowPersistenceProvide
     public synchronized void deleteFlowContent(final String bucketId, final String flowId, final int version) throws FlowPersistenceException {
         final File snapshotFile = getSnapshotFile(bucketId, flowId, version);
         if (!snapshotFile.exists()) {
-            LOGGER.debug("Snapshot file does not exist at {}", new Object[] {snapshotFile.getAbsolutePath()});
+            LOGGER.debug("Snapshot file does not exist at {}", snapshotFile.getAbsolutePath());
             return;
         }
 
@@ -174,13 +185,40 @@ public class FileSystemFlowPersistenceProvider implements FlowPersistenceProvide
         }
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Deleted snapshot at {}", new Object[] {snapshotFile.getAbsolutePath()});
+            LOGGER.debug("Deleted snapshot at {}", snapshotFile.getAbsolutePath());
         }
     }
 
     protected File getSnapshotFile(final String bucketId, final String flowId, final int version) {
-        final String snapshotFilename = bucketId + "/" + flowId + "/" + version + "/" + version + SNAPSHOT_EXTENSION;
-        return new File(flowStorageDir, snapshotFilename);
+        final String versionExtension = version + SNAPSHOT_EXTENSION;
+        final Path snapshotLocation = Paths.get(getNormalizedId(bucketId), getNormalizedId(flowId), Integer.toString(version), versionExtension);
+        return getChildLocation(flowStorageDir, snapshotLocation);
     }
 
+    private File getChildLocation(final File parentDir, final Path childLocation) {
+        final Path parentPath = parentDir.toPath().normalize();
+        final Path childPathNormalized = childLocation.normalize();
+        final Path childPath = parentPath.resolve(childPathNormalized);
+        if (childPath.startsWith(parentPath)) {
+            return childPath.toFile();
+        }
+        throw new IllegalArgumentException(String.format("Child location not valid [%s]", childLocation));
+    }
+
+    private Path getNormalizedIdPath(final String id) {
+        final String normalizedId = getNormalizedId(id);
+        return Paths.get(normalizedId).normalize();
+    }
+
+    private String getNormalizedId(final String input) {
+        final String sanitized = FileUtils.sanitizeFilename(input).trim().toLowerCase();
+        final Matcher matcher = NUMBER_PATTERN.matcher(sanitized);
+        if (matcher.matches()) {
+            final int normalized = Integer.parseInt(sanitized);
+            return Integer.toString(normalized);
+        } else {
+            final UUID normalized = UUID.fromString(input);
+            return normalized.toString();
+        }
+    }
 }

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/flow/registry/FileSystemFlowRegistryClient.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/flow/registry/FileSystemFlowRegistryClient.java
@@ -46,12 +46,25 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
+    private static final String TEST_FLOWS_BUCKET = "test-flows";
+
+    private static final Set<String> FLOW_IDS = Set.of(
+            "first-flow",
+            "flow-with-invalid-connection",
+            "port-moved-groups",
+            "Parent",
+            "Child"
+    );
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     {
@@ -77,14 +90,16 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
     @Override
     public boolean isStorageLocationApplicable(final FlowRegistryClientConfigurationContext context, final String storageLocation) {
         try {
-            final File file = new java.io.File(URI.create(storageLocation));
-            final Path path = file.toPath();
+            final Path rootPath = getRootDirectory(context).toPath().normalize();
+            final URI location = URI.create(storageLocation);
+            final Path storageLocationPath = Paths.get(location.getPath()).normalize();
 
-            final String configuredDirectory = context.getProperty(DIRECTORY).getValue();
-            final Path rootPath = Paths.get(configuredDirectory);
-
-            // If this doesn't throw an Exception, the given storageLocation is relative to the root path
-            rootPath.relativize(path);
+            if (storageLocationPath.startsWith(rootPath)) {
+                // If this doesn't throw an Exception, the given storageLocation is relative to the root path
+                Objects.requireNonNull(rootPath.relativize(storageLocationPath));
+            } else {
+                return false;
+            }
         } catch (final Exception e) {
             return false;
         }
@@ -100,8 +115,7 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
             throw new IOException("Cannot get listing of directory " + rootDir.getAbsolutePath());
         }
 
-        final Set<FlowRegistryBucket> buckets = Arrays.stream(children).map(this::toBucket).collect(Collectors.toSet());
-        return buckets;
+        return Arrays.stream(children).map(this::toBucket).collect(Collectors.toSet());
     }
 
     private FlowRegistryBucket toBucket(final File file) {
@@ -130,17 +144,14 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
     @Override
     public FlowRegistryBucket getBucket(final FlowRegistryClientConfigurationContext context, final String bucketId) {
         final File rootDir = getRootDirectory(context);
-        final File bucketDir = new File(rootDir, bucketId);
-        final FlowRegistryBucket bucket = toBucket(bucketDir);
-        return bucket;
+        final File bucketDir = getChildLocation(rootDir, getValidatedBucketPath(bucketId));
+        return toBucket(bucketDir);
     }
 
     @Override
     public RegisteredFlow registerFlow(final FlowRegistryClientConfigurationContext context, final RegisteredFlow flow) throws IOException {
-        final File rootDir = getRootDirectory(context);
         final String bucketId = flow.getBucketIdentifier();
-        final File bucketDir = new File(rootDir, bucketId);
-        final File flowDir = new File(bucketDir, flow.getIdentifier());
+        final File flowDir = getFlowDirectory(context, bucketId, flow.getIdentifier());
         Files.createDirectories(flowDir.toPath());
 
         return flow;
@@ -148,9 +159,7 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
 
     @Override
     public RegisteredFlow deregisterFlow(final FlowRegistryClientConfigurationContext context, final String bucketId, final String flowId) throws IOException {
-        final File rootDir = getRootDirectory(context);
-        final File bucketDir = new File(rootDir, bucketId);
-        final File flowDir = new File(bucketDir, flowId);
+        final File flowDir = getFlowDirectory(context, bucketId, flowId);
 
         final File[] versionDirs = flowDir.listFiles();
 
@@ -167,9 +176,7 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
 
     @Override
     public RegisteredFlow getFlow(final FlowRegistryClientConfigurationContext context, final String bucketId, final String flowId) {
-        final File rootDir = getRootDirectory(context);
-        final File bucketDir = new File(rootDir, bucketId);
-        final File flowDir = new File(bucketDir, flowId);
+        final File flowDir = getFlowDirectory(context, bucketId, flowId);
 
         final File[] versionDirs = flowDir.listFiles();
 
@@ -186,7 +193,7 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
     @Override
     public Set<RegisteredFlow> getFlows(final FlowRegistryClientConfigurationContext context, final String bucketId) throws IOException {
         final File rootDir = getRootDirectory(context);
-        final File bucketDir = new File(rootDir, bucketId);
+        final File bucketDir = getChildLocation(rootDir, getValidatedBucketPath(bucketId));
         final File[] flowDirs = bucketDir.listFiles();
         if (flowDirs == null) {
             throw new IOException("Could not get listing of directory " + bucketDir);
@@ -203,16 +210,12 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
 
     @Override
     public RegisteredFlowSnapshot getFlowContents(final FlowRegistryClientConfigurationContext context, final String bucketId, final String flowId, final int version) throws IOException {
-        final File rootDir = getRootDirectory(context);
-        final File bucketDir = new File(rootDir, bucketId);
-        final File flowDir = new File(bucketDir, flowId);
-        final File versionDir = new File(flowDir, String.valueOf(version));
-        final File snapshotFile = new File(versionDir, "snapshot.json");
-
+        final File flowDir = getFlowDirectory(context, bucketId, flowId);
         final Pattern intPattern = Pattern.compile("\\d+");
         final File[] versionFiles = flowDir.listFiles(file -> intPattern.matcher(file.getName()).matches());
 
         final JsonFactory factory = new JsonFactory(objectMapper);
+        final File snapshotFile = getSnapshotFile(context, bucketId, flowId, version);
         try (final JsonParser parser = factory.createParser(snapshotFile)) {
             final RegisteredFlowSnapshot snapshot = parser.readValueAs(RegisteredFlowSnapshot.class);
             populateBucket(snapshot, bucketId);
@@ -264,22 +267,19 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
 
     @Override
     public RegisteredFlowSnapshot registerFlowSnapshot(final FlowRegistryClientConfigurationContext context, final RegisteredFlowSnapshot flowSnapshot) throws IOException {
-        final File rootDir = getRootDirectory(context);
         final RegisteredFlowSnapshotMetadata metadata = flowSnapshot.getSnapshotMetadata();
         final String bucketId = metadata.getBucketIdentifier();
         final String flowId = metadata.getFlowIdentifier();
+        final File flowDir = getFlowDirectory(context, bucketId, flowId);
         final long version = metadata.getVersion();
-
-        final File bucketDir = new File(rootDir, bucketId);
-        final File flowDir = new File(bucketDir, flowId);
-        final File versionDir = new File(flowDir, String.valueOf(version));
+        final File versionDir = getChildLocation(flowDir, Paths.get(String.valueOf(version)));
 
         // Create the directory for the version, if it doesn't exist.
         if (!versionDir.exists()) {
             Files.createDirectories(versionDir.toPath());
         }
 
-        final File snapshotFile = new File(versionDir, "snapshot.json");
+        final File snapshotFile = getSnapshotFile(context, bucketId, flowId, version);
 
         final RegisteredFlowSnapshot fullyPopulated = fullyPopulate(flowSnapshot, flowDir);
         final JsonFactory factory = new JsonFactory(objectMapper);
@@ -329,7 +329,7 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
             flow.setPermissions(createAllowAllPermissions());
 
             final File[] flowVersionDirs = flowDir.listFiles();
-            final int versionCount = flowVersionDirs == null ? 0 : flowVersionDirs.length;;
+            final int versionCount = flowVersionDirs == null ? 0 : flowVersionDirs.length;
             flow.setVersionCount(versionCount);
 
             final RegisteredFlowVersionInfo versionInfo = new RegisteredFlowVersionInfo();
@@ -353,9 +353,7 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
 
     @Override
     public Set<RegisteredFlowSnapshotMetadata> getFlowVersions(final FlowRegistryClientConfigurationContext context, final String bucketId, final String flowId) throws IOException {
-        final File rootDir = getRootDirectory(context);
-        final File bucketDir = new File(rootDir, bucketId);
-        final File flowDir = new File(bucketDir, flowId);
+        final File flowDir = getFlowDirectory(context, bucketId, flowId);
         final File[] versionDirs = flowDir.listFiles();
         if (versionDirs == null) {
             throw new IOException("Could not list directories of " + flowDir);
@@ -379,9 +377,7 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
 
     @Override
     public int getLatestVersion(final FlowRegistryClientConfigurationContext context, final String bucketId, final String flowId) throws IOException {
-        final File rootDir = getRootDirectory(context);
-        final File bucketDir = new File(rootDir, bucketId);
-        final File flowDir = new File(bucketDir, flowId);
+        final File flowDir = getFlowDirectory(context, bucketId, flowId);
         final File[] versionDirs = flowDir.listFiles();
         if (versionDirs == null) {
             throw new IOException("Cannot list directories of " + flowDir);
@@ -392,5 +388,47 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
             .mapToInt(Integer::parseInt)
             .max();
         return greatestValue.orElse(-1);
+    }
+
+    private File getSnapshotFile(final FlowRegistryClientConfigurationContext context, final String bucketId, final String flowId, final long version) {
+        final File flowDirectory = getFlowDirectory(context, bucketId, flowId);
+        final File versionDirectory = getChildLocation(flowDirectory, Paths.get(String.valueOf(version)));
+        return new File(versionDirectory, "snapshot.json");
+    }
+
+    private File getFlowDirectory(final FlowRegistryClientConfigurationContext context, final String bucketId, final String flowId) {
+        final File rootDir = getRootDirectory(context);
+        final File bucketDir = getChildLocation(rootDir, getValidatedBucketPath(bucketId));
+        return getChildLocation(bucketDir, getFlowPath(flowId));
+    }
+
+    private File getChildLocation(final File parentDir, final Path childLocation) {
+        final Path parentPath = parentDir.toPath().normalize();
+        final Path childPath = parentPath.resolve(childLocation.normalize());
+        if (childPath.startsWith(parentPath)) {
+            return childPath.toFile();
+        }
+        throw new IllegalArgumentException(String.format("Child location not valid [%s]", childLocation));
+    }
+
+    private Path getFlowPath(final String flowId) {
+        final Optional<String> flowIdFound = FLOW_IDS.stream().filter(id -> id.equals(flowId)).findFirst();
+        if (flowIdFound.isPresent()) {
+            return Paths.get(flowIdFound.get());
+        }
+
+        try {
+            final UUID flowIdentifier = UUID.fromString(flowId);
+            return Paths.get(flowIdentifier.toString());
+        } catch (final RuntimeException e) {
+            throw new IllegalArgumentException(String.format("Flow ID [%s] not validated", flowId));
+        }
+    }
+
+    private Path getValidatedBucketPath(final String id) {
+        if (TEST_FLOWS_BUCKET.equals(id)) {
+            return Paths.get(TEST_FLOWS_BUCKET);
+        }
+        throw new IllegalArgumentException(String.format("Bucket [%s] not validated", id));
     }
 }

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/stateless/StatelessBasicsIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/stateless/StatelessBasicsIT.java
@@ -740,7 +740,7 @@ public class StatelessBasicsIT extends NiFiSystemIT {
         final FlowRegistryClientEntity registryClient = registerClient();
 
         // Register the first version of the flow
-        final VersionControlInformationEntity vci = getClientUtil().startVersionControl(statelessGroup, registryClient, "First Bucket", "testChangeFlowVersion");
+        final VersionControlInformationEntity vci = getClientUtil().startVersionControl(statelessGroup, registryClient, "test-flows", "first-flow");
         waitFor(() -> VersionControlInformationDTO.UP_TO_DATE.equals(getClientUtil().getVersionControlState(statelessGroup.getId())) );
 
         // Update the flow


### PR DESCRIPTION
# Summary

[NIFI-12297](https://issues.apache.org/jira/browse/NIFI-12297) Standardizes file path resolution in the NiFi Registry File System Bundle and Flow Persistence Providers, as well as the file-backed Registry client for system tests.

These changes replace string concatenation and related strategies with a standard approach using Java NIO Paths. Using Paths ensures consistent directory separator handling and path normalization.

Additional changes include updating related unit tests to reuse shared identifier values.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
