### PR TITLE
NIFI-12313 - Update PutDatabaseRecord.java add property use database table column datatype

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -345,6 +345,14 @@ public class PutDatabaseRecord extends AbstractProcessor {
             .expressionLanguageSupported(FLOWFILE_ATTRIBUTES)
             .build();
 
+    static final PropertyDescriptor USE_DATABASE_TABLE_COLUMN_DATATYPE = new Builder()
+            .name("put-db-record-use-database-table-column-datatype")
+            .displayName("Use database table column data types")
+            .description("Enabling this option will cause all column values to be formatted using database table column data types.")
+            .allowableValues("true", "false")
+            .defaultValue("true")
+            .build();
+
     static final PropertyDescriptor DB_TYPE;
 
     protected static final Map<String, DatabaseAdapter> dbAdapters;
@@ -399,6 +407,7 @@ public class PutDatabaseRecord extends AbstractProcessor {
         pds.add(RollbackOnFailure.ROLLBACK_ON_FAILURE);
         pds.add(TABLE_SCHEMA_CACHE_SIZE);
         pds.add(MAX_BATCH_SIZE);
+        pds.add(USE_DATABASE_TABLE_COLUMN_DATATYPE);
 
         propDescriptors = Collections.unmodifiableList(pds);
     }
@@ -739,8 +748,10 @@ public class PutDatabaseRecord extends AbstractProcessor {
                             }
                         }
 
+                        final boolean use_database_table_column_datatype = context.getProperty(USE_DATABASE_TABLE_COLUMN_DATATYPE).asBoolean();
+
                         // Convert (if necessary) from field data type to column data type
-                        if (fieldSqlType != sqlType) {
+                        if ((fieldSqlType != sqlType) && use_database_table_column_datatype) {
                             try {
                                 DataType targetDataType = DataTypeUtils.getDataTypeFromSQLTypeValue(sqlType);
                                 // If sqlType is unsupported, fall back to the fieldSqlType instead

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -347,7 +347,7 @@ public class PutDatabaseRecord extends AbstractProcessor {
 
     static final PropertyDescriptor USE_DATABASE_TABLE_COLUMN_DATATYPE = new Builder()
             .name("put-db-record-use-database-table-column-datatype")
-            .displayName("Use database table column data types")
+            .displayName("Use Database Table Column Data Types")
             .description("Enabling this option will cause all column values to be formatted using database table column data types.")
             .allowableValues("true", "false")
             .defaultValue("true")
@@ -748,10 +748,10 @@ public class PutDatabaseRecord extends AbstractProcessor {
                             }
                         }
 
-                        final boolean use_database_table_column_datatype = context.getProperty(USE_DATABASE_TABLE_COLUMN_DATATYPE).asBoolean();
+                        final boolean useDatabaseTableColumnDatatype = context.getProperty(USE_DATABASE_TABLE_COLUMN_DATATYPE).asBoolean();
 
                         // Convert (if necessary) from field data type to column data type
-                        if ((fieldSqlType != sqlType) && use_database_table_column_datatype) {
+                        if ((fieldSqlType != sqlType) && useDatabaseTableColumnDatatype) {
                             try {
                                 DataType targetDataType = DataTypeUtils.getDataTypeFromSQLTypeValue(sqlType);
                                 // If sqlType is unsupported, fall back to the fieldSqlType instead

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -613,6 +613,7 @@ public class PutDatabaseRecord extends AbstractProcessor {
         final String updateKeys = context.getProperty(UPDATE_KEYS).evaluateAttributeExpressions(flowFile).getValue();
         final int maxBatchSize = context.getProperty(MAX_BATCH_SIZE).evaluateAttributeExpressions(flowFile).asInteger();
         final int timeoutMillis = context.getProperty(QUERY_TIMEOUT).evaluateAttributeExpressions().asTimePeriod(TimeUnit.MILLISECONDS).intValue();
+        final boolean useDatabaseTableColumnDatatype = context.getProperty(USE_DATABASE_TABLE_COLUMN_DATATYPE).asBoolean();
 
         // Ensure the table name has been set, the generated SQL statements (and TableSchema cache) will need it
         if (StringUtils.isEmpty(tableName)) {
@@ -747,8 +748,6 @@ public class PutDatabaseRecord extends AbstractProcessor {
                                 sqlType = -156;
                             }
                         }
-
-                        final boolean useDatabaseTableColumnDatatype = context.getProperty(USE_DATABASE_TABLE_COLUMN_DATATYPE).asBoolean();
 
                         // Convert (if necessary) from field data type to column data type
                         if ((fieldSqlType != sqlType) && useDatabaseTableColumnDatatype) {


### PR DESCRIPTION
NIFI-12313 - Update PutDatabaseRecord.java add property use database table column table column datatype

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

We have encountered an issue when migrating from version 1.12.1 to version 1.23.2, which is related to the change associated with this issue: "[NIFI-8223](https://issues.apache.org/jira/browse/NIFI-8223) - PutDatabaseRecord should use table column datatype instead of field datatype." 

This issue introduced a change in the data transformation logic in the PutDatabaseRecord processor, which converts a field (e.g., of type string) to the data type of its corresponding database column.

This is causing problems because our field in the database is of type datetime2 and our string is "2023-10-19 14:14:59.999314" However, the processor is converting it to "2023-10-19 14:14:59" without microseconds, despite setting the format in the csvreader.

To address this, we have made an adjustment in the PutDatabaseRecord processor so that users at the processor level can choose whether to apply the transformation to the database column type or maintain the Nifi format.

[NIFI-12313](https://issues.apache.org/jira/browse/NIFI-12313)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
