### PR TITLE
NIFI-12321 Avoid Exceptions when removing Python Processors

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -26,6 +26,7 @@ on:
       - 'nifi-api/**'
       - 'nifi-framework-api/**'
       - 'nifi-nar-bundles/nifi-framework-bundle/**'
+      - 'nifi-nar-bundles/nifi-py4j-bundle/**'
       - 'nifi-stateless/**'
   pull_request:
     paths:
@@ -34,6 +35,7 @@ on:
       - 'nifi-api/**'
       - 'nifi-framework-api/**'
       - 'nifi-nar-bundles/nifi-framework-bundle/**'
+      - 'nifi-nar-bundles/nifi-py4j-bundle/**'
       - 'nifi-stateless/**'
 
 env:


### PR DESCRIPTION
# Summary

[NIFI-12321](https://issues.apache.org/jira/browse/NIFI-12321) Updates the `StandardPythonBridge.onProcessorRemoved()` method to avoid throwing exceptions when called with a Processor Type and Version that is not registered.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
