### PR TITLE
NIFI-12276 Addressed Dependency Check Findings for support branch

### DIFF
--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -455,6 +455,18 @@ limitations under the License.
                 <artifactId>guava</artifactId>
                 <version>32.1.2-jre</version>
             </dependency>
+
+            <!-- Override Commons Compiler 3.1.9 from calcite-core -->
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>3.1.10</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-commons/nifi-property-protection-azure/pom.xml
+++ b/nifi-commons/nifi-property-protection-azure/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.16</version>
+                <version>1.2.17</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/nifi-commons/nifi-property-protection-gcp/pom.xml
+++ b/nifi-commons/nifi-property-protection-gcp/pom.xml
@@ -22,7 +22,7 @@
     </parent>
     <artifactId>nifi-property-protection-gcp</artifactId>
     <properties>
-        <gcp.sdk.version>26.17.0</gcp.sdk.version>
+        <gcp.sdk.version>26.25.0</gcp.sdk.version>
         <guava.version>32.1.2-jre</guava.version>
     </properties>
     <dependencyManagement>

--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -259,4 +259,269 @@
         <packageUrl regex="true">^pkg:maven/io\.netty/netty.*?@.*$</packageUrl>
         <cve>CVE-2022-41915</cve>
     </suppress>
+    <suppress>
+        <notes>CVE-2023-34462 applies to Netty servers using SniHandler not Netty 4.1 shaded for Couchbase and HBase 2</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*$</packageUrl>
+        <cve>CVE-2023-34462</cve>
+    </suppress>
+    <suppress>
+        <notes>The Square Wire framework is not the same as the Wire secure communication application</notes>
+        <packageUrl regex="true">^pkg:maven/com\.squareup\.wire/.*$</packageUrl>
+        <cpe>cpe:/a:wire:wire</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-44487 applies to Solr Server not Solr client libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.solr/solr\-solrj@.*$</packageUrl>
+        <cve>CVE-2023-44487</cve>
+    </suppress>
+    <suppress>
+        <notes>Quartz maintainers dispute CVE-2023-39017 because it requires code injection from external users</notes>
+        <packageUrl regex="true">^pkg:maven/org\.quartz\-scheduler/quartz@.*$</packageUrl>
+        <cve>CVE-2023-39017</cve>
+    </suppress>
+    <suppress>
+        <notes>Avro project vulnerabilities do not apply to Parquet Avro</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.parquet/parquet\-avro@.*$</packageUrl>
+        <cpe>cpe:/a:avro_project:avro</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-4759 is resolved in 6.7.0 which is already upgraded in nifi-registry</notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jgit/.*$</packageUrl>
+        <cve>CVE-2023-4759</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-4586 is resolved in Netty 4.1.100 which is already upgraded</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*$</packageUrl>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-35887 applies to MINA SSHD not MINA core libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.mina/mina\-core@.*$</packageUrl>
+        <cve>CVE-2023-35887</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2016-5397 applies to Apache Thrift Go not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+        <cve>CVE-2016-5397</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-0210 applies to Apache Thrift Go server not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+        <cve>CVE-2019-0210</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2018-11798 applies Apache Thrift Node.js not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+        <cve>CVE-2018-11798</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-11939 applies to Thrift Servers in Go not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-11939</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3552 applies to Thrift Servers in CPP not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3552</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3553 applies to Thrift Servers in CPP not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3553</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3558 applies to Thrift Servers in Python not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3558</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3564 applies to Thrift Servers in Go not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3564</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3565 applies to Thrift Servers in CPP not Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3565</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2021-24028 applies to Facebook Thrift CPP</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2021-24028</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-11938 applies to Facebook Thrift Servers</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-11938</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-3559 applies to Facebook Thrift Servers</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libfb303@.*$</packageUrl>
+        <cve>CVE-2019-3559</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-36479 was resolved in Jetty 10.0.16</notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-servlets@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-36479</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>The jetty-servlet-api is versioned according to the Java Servlet API version not the Jetty version</notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-servlet\-api@.*$</packageUrl>
+        <cpe>cpe:/a:eclipse:jetty</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-31419 applies to Elasticsearch Server not client libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.elasticsearch/elasticsearch@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-31419</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-37475 applies to Hamba Avro in Go not Apache Avro for Java</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.avro/.*$</packageUrl>
+        <cve>CVE-2023-37475</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-45860 is resolved in Hazelcast 5.3.5</notes>
+        <packageUrl regex="true">^pkg:maven/com\.hazelcast/hazelcast@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-45860</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-36414 applies to Azure Identity for .NET not Java</notes>
+        <packageUrl regex="true">^pkg:maven/com\.azure/azure\-identity@.*$</packageUrl>
+        <cve>CVE-2023-36414</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-36415 applies to Azure Identity for Python not Java</notes>
+        <packageUrl regex="true">^pkg:maven/com\.azure/azure\-identity@.*$</packageUrl>
+        <cve>CVE-2023-36415</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-13949 applies to Thrift and not to Hive</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.hive.*$</packageUrl>
+        <cve>CVE-2020-13949</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-44487 applies to netty-codec-http2 as a Server</notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*$</packageUrl>
+        <cve>CVE-2023-44487</cve>
+    </suppress>
+    <suppress>
+        <notes>Parquet MR vulnerabilities do not apply to other Parquet libraries</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.parquet/parquet\-(?!mr).*$</packageUrl>
+        <cpe>cpe:/a:apache:parquet-mr</cpe>
+    </suppress>
+    <suppress>
+        <notes>Apache Hadoop vulnerabilities do not apply to Parquet Hadoop Bundle library</notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.parquet/parquet\-hadoop\-bundle@.*$</packageUrl>
+        <cpe>cpe:/a:apache:hadoop</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2017-7525 applies to Jackson 2 not Jackson 1</notes>
+        <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson\-mapper\-asl@.*$</packageUrl>
+        <vulnerabilityName>CVE-2017-7525</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-11358 applies to bundled copies of jQuery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2019-11358</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-11022 applies to bundled copies of jQuery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2020-11022</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-11023 applies to bundled copies of jQuery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2020-11023</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-23064 applies to bundled copies of jQuery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2020-23064</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2011-4969 applies to bundled copies of jQUery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2011-4969</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2012-6708 applies to bundled copies of jQUery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2012-6708</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2015-9251 applies to bundled copies of jQUery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2015-9251</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-7656 applies to bundled copies of jQUery not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <cve>CVE-2020-7656</cve>
+    </suppress>
+    <suppress>
+        <notes>jQuery vulnerability warning for historical versions</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <vulnerabilityName>jQuery 1.x and 2.x are End-of-Life and no longer receiving security updates</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-28458 applies to bundled copies of jQuery datatables not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery\.datatables@.*$</packageUrl>
+        <cve>CVE-2020-28458</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2021-23445 applies to bundled copies of jQuery datatables not used in the project</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery\.datatables@.*$</packageUrl>
+        <cve>CVE-2021-23445</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-44487 references gRPC for Go</notes>
+        <packageUrl regex="true">^pkg:maven/io\.grpc/grpc.*$</packageUrl>
+        <cve>CVE-2023-44487</cve>
+    </suppress>
+    <suppress>
+        <notes>Guava temporary directory file creation is not used</notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <cve>CVE-2023-2976</cve>
+    </suppress>
+    <suppress>
+        <notes>Guava temporary directory file creation is not used</notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <cve>CVE-2020-8908</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2021-44521 applies to Apache Cassandra Server</notes>
+        <packageUrl regex="true">^pkg:maven/com\.datastax\.cassandra/cassandra\-driver\-extras@.*$</packageUrl>
+        <cve>CVE-2021-44521</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-17516 applies to Apache Cassandra Server</notes>
+        <packageUrl regex="true">^pkg:maven/com\.datastax\.cassandra/cassandra\-driver\-extras@.*$</packageUrl>
+        <cve>CVE-2020-17516</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-2684 applies to Apache Cassandra Server</notes>
+        <packageUrl regex="true">^pkg:maven/com\.datastax\.cassandra/cassandra\-driver\-extras@.*$</packageUrl>
+        <cve>CVE-2019-2684</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2020-13946 applies to Apache Cassandra Server</notes>
+        <packageUrl regex="true">^pkg:maven/com\.datastax\.cassandra/cassandra\-driver\-extras@.*$</packageUrl>
+        <cve>CVE-2020-13946</cve>
+    </suppress>
+    <suppress>
+        <notes>CVE-2019-10172 applies to Jackson 1 XmlMapper not JSON mapper used in Ranger plugins</notes>
+        <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson\-mapper\-asl@.*$</packageUrl>
+        <cve>CVE-2019-10172</cve>
+    </suppress>
+    <suppress>
+        <notes>Bundled versions of jQuery DataTables are not used</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery\.datatables@.*$</packageUrl>
+        <vulnerabilityName>prototype pollution</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>Bundled versions of jQuery DataTables are not used</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery\.datatables@.*$</packageUrl>
+        <vulnerabilityName>possible XSS</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
@@ -59,18 +59,6 @@
                 <artifactId>hadoop-client-runtime</artifactId>
                 <version>${hadoop.version}</version>
             </dependency>
-            <!-- Override ZooKeeper from accumulo-core -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <!-- Override commons-configuration2:2.5 from accumulo-core -->
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/nifi-nar-bundles/nifi-asana-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-asana-bundle/pom.xml
@@ -72,6 +72,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- Override grpc-context from Asana -->
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-context</artifactId>
+                <version>1.59.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-atlas-bundle/pom.xml
@@ -117,6 +117,12 @@
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
+            <!-- Override Jettison from Atlas -->
+            <dependency>
+                <groupId>org.codehaus.jettison</groupId>
+                <artifactId>jettison</artifactId>
+                <version>1.5.4</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <microsoft.azure-storage.version>8.6.6</microsoft.azure-storage.version>
-        <azure.sdk.bom.version>1.2.16</azure.sdk.bom.version>
+        <azure.sdk.bom.version>1.2.17</azure.sdk.bom.version>
         <msal4j.version>1.13.10</msal4j.version>
         <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>

--- a/nifi-nar-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-box-bundle/pom.xml
@@ -33,4 +33,15 @@
         <module>nifi-box-services-api</module>
         <module>nifi-box-services-nar</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override jose4j 0.9.0 from box-java-sdk -->
+            <dependency>
+                <groupId>org.bitbucket.b_c</groupId>
+                <artifactId>jose4j</artifactId>
+                <version>0.9.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -462,11 +462,6 @@
                 <version>4.2.19</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-framework</artifactId>
                 <version>${curator.version}</version>

--- a/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
@@ -26,7 +26,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.22.0</google.libraries.version>
+        <google.libraries.version>26.25.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-nar-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/pom.xml
+++ b/nifi-nar-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/pom.xml
@@ -26,36 +26,26 @@
     <packaging>jar</packaging>
 
     <dependencies>
-        <!-- Internal dependencies -->
-
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-hazelcast-services-api</artifactId>
             <version>1.24.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
             <version>1.24.0-SNAPSHOT</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-distributed-cache-client-service-api</artifactId>
         </dependency>
-
-        <!-- External dependencies -->
-
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>5.3.2</version>
+            <version>5.3.5</version>
         </dependency>
-
-        <!-- Test dependencies -->
-
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/pom.xml
@@ -133,6 +133,27 @@
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
                 </exclusion>
+                <!-- Exclude HBase -->
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-mapreduce</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-hadoop2-compat</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-hadoop-compat</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -68,6 +68,17 @@
                 <artifactId>avatica</artifactId>
                 <version>${avatica.version}</version>
             </dependency>
+            <!-- Override Commons Compiler 3.1.9 from calcite-core -->
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>3.1.10</version>
+            </dependency>
             <!-- Override commons-beanutils -->
             <dependency>
                 <groupId>commons-beanutils</groupId>
@@ -79,18 +90,6 @@
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derby</artifactId>
                 <version>10.14.2.0</version>
-            </dependency>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <!-- Override ant -->
             <dependency>
@@ -114,6 +113,18 @@
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.33</version>
+            </dependency>
+            <!-- Override Jettison from Hive -->
+            <dependency>
+                <groupId>org.codehaus.jettison</groupId>
+                <artifactId>jettison</artifactId>
+                <version>1.5.4</version>
+            </dependency>
+            <!-- Override Groovy from hive-exec -->
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>2.4.21</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/pom.xml
@@ -187,6 +187,14 @@
                     <artifactId>hbase-client</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-mapreduce</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-hadoop2-compat</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>co.cask.tephra</groupId>
                     <artifactId>tephra-api</artifactId>
                 </exclusion>

--- a/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
@@ -64,18 +64,6 @@
                 <artifactId>derby</artifactId>
                 <version>10.14.2.0</version>
             </dependency>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <!-- Override ant -->
             <dependency>
                 <groupId>org.apache.ant</groupId>
@@ -115,6 +103,12 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>32.1.2-jre</version>
+            </dependency>
+            <!-- Override Groovy from hive-exec -->
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>2.4.21</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-ranger-bundle/pom.xml
@@ -37,12 +37,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-            </dependency>
             <!-- Override commons-beanutils -->
             <dependency>
                 <groupId>commons-beanutils</groupId>
@@ -95,6 +89,12 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>32.1.2-jre</version>
+            </dependency>
+            <!-- Override Jettison from Ranger -->
+            <dependency>
+                <groupId>org.codehaus.jettison</groupId>
+                <artifactId>jettison</artifactId>
+                <version>1.5.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-salesforce</artifactId>
-            <version>3.14.5</version>
+            <version>3.14.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/nifi-nar-bundles/nifi-spark-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-spark-bundle/pom.xml
@@ -65,18 +65,6 @@
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.33</version>
             </dependency>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
@@ -41,6 +41,17 @@
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
+            <!-- Override Commons Compiler 3.1.9 from calcite-core -->
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>3.1.10</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -293,6 +293,17 @@
                 <artifactId>json-schema-validator</artifactId>
                 <version>1.0.86</version>
             </dependency>
+            <!-- Override Commons Compiler 3.1.9 from calcite-core -->
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>3.1.10</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/nifi-hbase_2-client-service/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/nifi-hbase_2-client-service/pom.xml
@@ -184,6 +184,10 @@
                             <groupId>commons-logging</groupId>
                             <artifactId>commons-logging</artifactId>
                         </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.htrace</groupId>
+                            <artifactId>htrace-core4</artifactId>
+                        </exclusion>
                     </exclusions>
                 </dependency>
             </dependencies>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
@@ -61,18 +61,6 @@
                 <artifactId>commons-beanutils</artifactId>
                 <version>1.9.4</version>
             </dependency>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <!-- Override nimbus-jose-jwt 9.8.1 from hadoop-auth -->
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/pom.xml
@@ -48,12 +48,6 @@
                 <artifactId>jetty-webapp</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
-            <!-- Override zookeeper -->
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-            </dependency>
             <!-- Override SolrJ 8.6.3 from Ranger -->
             <dependency>
                 <groupId>org.apache.solr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
-        <com.amazonaws.version>1.12.550</com.amazonaws.version>
+        <com.amazonaws.version>1.12.573</com.amazonaws.version>
         <software.amazon.awssdk.version>2.20.148</software.amazon.awssdk.version>
         <gson.version>2.10.1</gson.version>
         <io.fabric8.kubernetes.client.version>6.8.1</io.fabric8.kubernetes.client.version>
@@ -140,7 +140,7 @@
         <ozone.version>1.2.1</ozone.version>
         <gcs.version>2.1.5</gcs.version>
         <aspectj.version>1.9.6</aspectj.version>
-        <jersey.bom.version>2.39.1</jersey.bom.version>
+        <jersey.bom.version>2.41</jersey.bom.version>
         <log4j2.version>2.20.0</log4j2.version>
         <mockito.version>4.11.0</mockito.version>
         <logback.version>1.3.11</logback.version>
@@ -691,6 +691,22 @@
                 <artifactId>caffeine</artifactId>
                 <version>${caffeine.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper-jute</artifactId>
+                <version>${zookeeper.version}</version>
+            </dependency>
+            <!-- Managed JUnit 4 version for transitive dependencies such as OkHttp MockWebServer -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1227,7 +1243,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>8.4.0</version>
+                        <version>8.4.2</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>


### PR DESCRIPTION
# Summary

[NIFI-12276](https://issues.apache.org/jira/browse/NIFI-12276) Addresses a number of OWASP Dependency Check findings. This pull request targets the version 1 support branch, applying the same basic set of changes already applied to the main branch. Dependency updates and changes include the following:

- Upgraded Janino Commons Compiler from 3.1.9 to 3.1.10
- Upgraded Azure SDK BOM from 1.2.16 to 1.2.17
- Upgraded GCP SDK BOM from 26.17.0 to 26.25.0
- Upgraded AWS SDK from 1.12.550 to 1.12.573
- Upgraded Hazelcast from 5.3.2 to 5.3.5
- Upgraded Jersey from 2.39.12 to 2.41
- Upgraded Camel Salesforce from 3.14.5 to 3.14.9
- Unified ZooKeeper versioning on 3.9.1
- Applied Groovy 2.4.21 to Hive 3 and Iceberg components
- Applied gRPC version 1.59.0 to Asana components
- Applied Jettison 1.5.4 to Atlas and Hive 3 components
- Managed JUnit 4 version to 4.13.2 for MockWebServer
- Excluded HBase libraries from Hive 3 following Iceberg approach
- Excluded Htrace from HBase components
- Upgraded OWASP Dependency Check from 8.4.0 to 8.4.2
- Removed non-applicable dependency check suppressions
- Added dependency check suppressions for non-applicable findings

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
