### PR TITLE
NIFI-12328 Update OpenPGP Test Key Generator Settings

### DIFF
--- a/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-test-utils/src/main/java/org/apache/nifi/pgp/util/PGPSecretKeyGenerator.java
+++ b/nifi-nar-bundles/nifi-pgp-bundle/nifi-pgp-test-utils/src/main/java/org/apache/nifi/pgp/util/PGPSecretKeyGenerator.java
@@ -47,15 +47,13 @@ public class PGPSecretKeyGenerator {
 
     private static final String DSA_KEY_ALGORITHM = "DSA";
 
-    private static final int DSA_KEY_SIZE = 1024;
+    private static final int DSA_KEY_SIZE = 2048;
 
     private static final String ELGAMAL_KEY_ALGORITHM = "ELGAMAL";
 
     private static final String KEY_IDENTITY = PGPSecretKey.class.getSimpleName();
 
     private static final int KEY_ENCRYPTION_ALGORITHM = PGPEncryptedData.AES_256;
-
-    private static final int HASH_ALGORITHM = HashAlgorithmTags.SHA1;
 
     /**
      * Generate Secret Keyring containing DSA and ElGamal Key Pairs
@@ -122,10 +120,11 @@ public class PGPSecretKeyGenerator {
     }
 
     private static PGPContentSignerBuilder getContentSignerBuilder(final int algorithm) {
-        return new JcaPGPContentSignerBuilder(algorithm, HASH_ALGORITHM);
+        return new JcaPGPContentSignerBuilder(algorithm, HashAlgorithmTags.SHA256);
     }
 
     private static PGPDigestCalculator getDigestCalculator() throws PGPException {
-        return new JcaPGPDigestCalculatorProviderBuilder().build().get(HASH_ALGORITHM);
+        // RFC 4880 Section 5.5.3 requires SHA-1 for Secret-Key hash calculation
+        return new JcaPGPDigestCalculatorProviderBuilder().build().get(HashAlgorithmTags.SHA1);
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-12328](https://issues.apache.org/jira/browse/NIFI-12328) Updates DSA key size and content signer algorithm values used for testing OpenPGP components with generated key pairs.

Changes include updating the DSA key size from 1024 to 2048 and updating the content signer algorithm from SHA-1 to SHA-256. These changes align with current recommendations and also compatibility with OpenPGP standards.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
