### PR TITLE
NIFI-12349: Create Put processor for Apache Hudi

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -1418,6 +1418,23 @@ language governing permissions and limitations under the License. -->
             </dependencies>
         </profile>
         <profile>
+            <id>include-hudi</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>allProfiles</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-hudi-processors-nar</artifactId>
+                    <version>2.0.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>include-all</id>
             <properties>
               <allProfiles>true</allProfiles>

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors-nar/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-hudi-bundle</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-hudi-processors-nar</artifactId>
+    <packaging>nar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-hudi-processors</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-services-api-nar</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors-nar/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,221 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+APACHE NIFI SUBCOMPONENTS:
+
+The Apache NiFi project contains subcomponents with separate copyright
+notices and license terms. Your use of the source code for the these
+subcomponents is subject to the terms and conditions of the following
+licenses.
+
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Hudi.
+
+* Key generator related methods from HoodieSparkKeyGeneratorFactory.java
+* Test methods from HoodieTestUtils.java, TestHoodieJavaWriteClientInsert.java, TestHoodieSparkKeyGeneratorFactory.java
+
+Copyright: 2011-2023 The Apache Software Foundation
+Home page: https://hive.apache.org/
+License: https://www.apache.org/licenses/LICENSE-2.0

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors-nar/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,465 @@
+nifi-hudi-processors-nar
+Copyright 2014-2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+===========================================
+Apache Software License v2
+===========================================
+
+  (ASLv2) Apache Hudi
+    The following NOTICE information applies:
+      Apache Hudi
+      Copyright 2019-2020 The Apache Software Foundation
+
+      This product includes software developed at
+      The Apache Software Foundation (http://www.apache.org/).
+
+  (ASLv2) Apache Hadoop
+    The following NOTICE information applies:
+      The binary distribution of this product bundles binaries of
+      org.iq80.leveldb:leveldb-api (https://github.com/dain/leveldb), which has the
+      following notices:
+      * Copyright 2011 Dain Sundstrom <dain@iq80.com>
+      * Copyright 2011 FuseSource Corp. http://fusesource.com
+
+      The binary distribution of this product bundles binaries of
+      org.fusesource.hawtjni:hawtjni-runtime (https://github.com/fusesource/hawtjni),
+      which has the following notices:
+      * This product includes software developed by FuseSource Corp.
+        http://fusesource.com
+      * This product includes software developed at
+        Progress Software Corporation and/or its  subsidiaries or affiliates.
+      * This product includes software developed by IBM Corporation and others.
+
+  (ASLv2) Apache HBase
+    The following NOTICE information applies:
+      Apache HBase
+      Copyright 2007-2015 The Apache Software Foundation
+
+      --
+      This product incorporates portions of the 'Hadoop' project
+
+      Copyright 2007-2009 The Apache Software Foundation
+
+      Licensed under the Apache License v2.0
+      --
+      Our Orca logo we got here: http://www.vectorfree.com/jumping-orca
+      It is licensed Creative Commons Attribution 3.0.
+      See https://creativecommons.org/licenses/by/3.0/us/
+      We changed the logo by stripping the colored background, inverting
+      it and then rotating it some.
+
+      Later we found that vectorfree.com image is not properly licensed.
+      The original is owned by vectorportal.com. The original was
+      relicensed so we could use it as Creative Commons Attribution 3.0.
+      The license is bundled with the download available here:
+      http://www.vectorportal.com/subcategory/205/KILLER-WHALE-FREE-VECTOR.eps/ifile/9136/detailtest.asp
+      --
+      This product includes portions of the Bootstrap project v3.0.0
+
+      Copyright 2013 Twitter, Inc.
+
+      Licensed under the Apache License v2.0
+
+      This product uses the Glyphicons Halflings icon set.
+
+      http://glyphicons.com/
+
+      Copyright Jan Kovařík
+
+      Licensed under the Apache License v2.0 as a part of the Bootstrap project.
+
+      --
+      This product includes portions of the Guava project v14, specifically
+      'hbase-common/src/main/java/org/apache/hadoop/hbase/io/LimitInputStream.java'
+
+      Copyright (C) 2007 The Guava Authors
+
+      Licensed under the Apache License, Version 2.0
+
+  (ASLv2) Apache Hive
+    The following NOTICE information applies:
+      Apache Hive
+      Copyright 2008-2015 The Apache Software Foundation
+
+      This product includes software developed by The Apache Software
+      Foundation (http://www.apache.org/).
+
+      This product includes Jersey (https://jersey.java.net/)
+      Copyright (c) 2010-2014 Oracle and/or its affiliates.
+
+      This project includes software copyrighted by Microsoft Corporation and
+      licensed under the Apache License, Version 2.0.
+
+      This project includes software copyrighted by Dell SecureWorks and
+      licensed under the Apache License, Version 2.0.
+
+  (ASLv2) Apache Curator
+    The following NOTICE information applies:
+      Curator Framework
+      Copyright 2011-2014 The Apache Software Foundation
+
+      Curator Client
+      Copyright 2011-2014 The Apache Software Foundation
+
+      Curator Recipes
+      Copyright 2011-2014 The Apache Software Foundation
+
+  (ASLv2) Apache Kerby
+    The following NOTICE information applies:
+      Apache Kerby
+      Copyright 2003-2018 The Apache Software Foundation
+
+  (ASLv2) Apache Avro
+    The following NOTICE information applies:
+      Apache Avro
+      Copyright 2009-2017 The Apache Software Foundation
+
+  (ASLv2) Apache Parquet
+    The following NOTICE information applies:
+      Apache Parquet MR (Incubating)
+      Copyright 2014 The Apache Software Foundation
+
+      This product includes software developed at
+      The Apache Software Foundation (http://www.apache.org/).
+
+  (ASLv2) Apache ORC
+    The following NOTICE information applies:
+      Copyright 2013-2019 The Apache Software Foundation
+
+      This product includes software developed by The Apache Software
+      Foundation (http://www.apache.org/).
+
+      This product includes software developed by Hewlett-Packard:
+      (c) Copyright [2014-2015] Hewlett-Packard Development Company, L.P
+
+  (ASLv2) Apache ZooKeeper
+     The following NOTICE information applies:
+       Apache ZooKeeper
+       Copyright 2009-2012 The Apache Software Foundation
+
+  (ASLv2) Apache HttpComponents
+    The following NOTICE information applies:
+      Apache HttpClient
+      Copyright 1999-2015 The Apache Software Foundation
+
+      Apache HttpCore
+      Copyright 2005-2015 The Apache Software Foundation
+
+      Apache HttpMime
+      Copyright 1999-2013 The Apache Software Foundation
+
+      This project contains annotations derived from JCIP-ANNOTATIONS
+      Copyright (c) 2005 Brian Goetz and Tim Peierls. See https://www.jcip.net
+
+  (ASLv2) Audience Annotations
+    The following NOTICE information applies:
+      Apache Yetus
+      Copyright 2008-2018 The Apache Software Foundation
+
+  (ASLv2) Jetty
+    The following NOTICE information applies:
+       Jetty Web Container
+       Copyright 1995-2019 Mort Bay Consulting Pty Ltd.
+
+  (ASLv2) The Netty Project
+      The following NOTICE information applies:
+        The Netty Project
+        Copyright 2011 The Netty Project
+
+  (ASLv2) Prometheus Simple Client libraries
+    Copyright 2012-2019 The Prometheus Authors
+
+    (ASLv2) JCommander
+      The following NOTICE information applies:
+        JCommander Copyright Notices
+        Copyright 2010 Cedric Beust cedric@beust.com
+
+  (ASLv2) Jackson JSON processor
+    The following NOTICE information applies:
+      # Jackson JSON processor
+
+      Jackson is a high-performance, Free/Open Source JSON processing library.
+      It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+      been in development since 2007.
+      It is currently developed by a community of developers, as well as supported
+      commercially by FasterXML.com.
+
+      ## Licensing
+
+      Jackson core and extension components may licensed under different licenses.
+      To find the details that apply to this artifact see the accompanying LICENSE file.
+      For more information, including possible other licensing options, contact
+      FasterXML.com (http://fasterxml.com).
+
+      ## Credits
+
+      A list of contributors may be found from CREDITS file, which is included
+      in some artifacts (usually source distributions); but is always available
+      from the source code management (SCM) system project uses.
+
+  (ASLv2) Woodstox (com.fasterxml.woodstox:woodstox-core:bundle:5.4.0 - https://github.com/FasterXML/woodstox)
+      The following NOTICE information applies:
+        Woodstox Core 5.4.0
+        Copyright 2015, FasterXML, LLC
+
+  (ASLv2) Caffeine
+    The following NOTICE information applies:
+      Caffeine (caching library)
+      Copyright Ben Manes
+
+  (ASLv2) Kotlin Stdlib (org.jetbrains.kotlin:kotlin-stdlib:1.7.20 - https://kotlinlang.org/)
+        The following NOTICE information applies:
+          Kotlin Stdlib
+          Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors
+
+  (ASLv2) Kotlin Stdlib Common (org.jetbrains.kotlin:kotlin-stdlib-common:1.7.20 - https://kotlinlang.org/)
+          The following NOTICE information applies:
+            Kotlin Stdlib Common
+            Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors
+
+  (ASLv2) Kotlin Stdlib Jdk7 (org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.20 - https://kotlinlang.org/)
+            The following NOTICE information applies:
+              Kotlin Stdlib Jdk7
+              Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors
+
+  (ASLv2) Kotlin Stdlib Jdk8 (org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.20 - https://kotlinlang.org/)
+            The following NOTICE information applies:
+              Kotlin Stdlib Jdk8
+              Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors
+
+  (ASLv2) Dropwizard Metrics
+      The following NOTICE information applies:
+        Dropwizard Metrics
+        Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+
+  (ASLv2) Apache Commons IO
+    The following NOTICE information applies:
+      Apache Commons IO
+      Copyright 2002-2018 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Lang
+    The following NOTICE information applies:
+      Apache Commons Lang
+      Copyright 2001-2015 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Collections
+    The following NOTICE information applies:
+      Apache Commons Collections
+      Copyright 2001-2013 The Apache Software Foundation
+
+  (ASLv2) Apache Commons CLI
+    The following NOTICE information applies:
+      Apache Commons CLI
+      Copyright 2001-2017 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Codec
+    The following NOTICE information applies:
+      Apache Commons Codec
+      Copyright 2002-2014 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Daemon
+    The following NOTICE information applies:
+      Apache Commons Daemon
+      Copyright 2002-2013 The Apache Software Foundation
+
+  (ASLv2) Apache Commons BeanUtils
+    The following NOTICE information applies:
+      Apache Commons BeanUtils
+      Copyright 2000-2016 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Net
+    The following NOTICE information applies:
+      Apache Commons Net
+      Copyright 2001-2013 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Pool
+    The following NOTICE information applies:
+      Apache Commons Pool
+      Copyright 1999-2009 The Apache Software Foundation.
+
+  (ASLv2) Apache Commons CSV
+    The following NOTICE information applies:
+      Apache Commons CSV
+      Copyright 2005-2016 The Apache Software Foundation
+
+      This product includes software developed at
+      The Apache Software Foundation (http://www.apache.org/).
+
+  (ASLv2) Apache Commons Configuration
+    The following NOTICE information applies:
+      Apache Commons Configuration
+      Copyright 2001-2008 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Crypto
+    The following NOTICE information applies:
+      Apache Commons Crypto
+      Copyright 2016-2016 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Compress
+    The following NOTICE information applies:
+      Apache Commons Compress
+      Copyright 2002-2014 The Apache Software Foundation
+
+      The files in the package org.apache.commons.compress.archivers.sevenz
+      were derived from the LZMA SDK, version 9.20 (C/ and CPP/7zip/),
+      which has been placed in the public domain:
+
+      "LZMA SDK is placed in the public domain." (https://www.7-zip.org/sdk.html)
+
+  (ASLv2) Apache Commons Text
+    The following NOTICE information applies:
+      Apache Commons Text
+      Copyright 2001-2018 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Math
+    The following NOTICE information applies:
+      Apache Commons Math
+      Copyright 2001-2012 The Apache Software Foundation
+
+  (ASLv2) Snappy Java
+    The following NOTICE information applies:
+      This product includes software developed by Google
+       Snappy: https://code.google.com/p/snappy/ (New BSD License)
+
+      This product includes software developed by Apache
+       PureJavaCrc32C from apache-hadoop-common https://hadoop.apache.org/
+       (Apache 2.0 license)
+
+      This library containd statically linked libstdc++. This inclusion is allowed by
+      "GCC RUntime Library Exception"
+      https://gcc.gnu.org/onlinedocs/libstdc++/manual/license.html
+
+  (ASLv2) Guava
+    The following NOTICE information applies:
+      Guava
+      Copyright 2015 The Guava Authors
+
+  (ASLv2) Google GSON
+    The following NOTICE information applies:
+      Copyright 2008 Google Inc.
+
+  (ASLv2) Joda-Time
+    The following NOTICE information applies:
+      This product includes software developed by
+      Joda.org (http://www.joda.org/).
+
+  (ASLv2) JCIP Annotations Under Apache License
+    The following NOTICE information applies:
+      JCIP Annotations Under Apache License
+      Copyright 2013 Stephen Connolly.
+
+  (ASLv2) FindBugs JSR305
+    The following NOTICE information applies:
+      FindBugs JSR305
+      Copyright 2017 The FindBugs JSR305 Authors
+
+  (ASLv2) Nimbus JOSE+JWT (com.nimbusds:nimbus-jose-jwt - https://connect2id.com/products/nimbus-jose-jwt)
+    The following NOTICE information applies:
+      Nimbus JOSE+JWT
+      Copyright 2021, Connect2id Ltd.
+
+  (ASLv2) JetBrains/java-annotations
+    The following NOTICE information applies:
+      JetBrains/java-annotations
+      Copyright 2000-2016 JetBrains s.r.o.
+
+  (ASLv2) Objenesis
+      The following NOTICE information applies:
+        Objenesis
+        Copyright 2006-2013 Joe Walnes, Henri Tremblay, Leonardo Mesquita
+
+  (ASLv2) RocksDB JNI
+    The following NOTICE information applies:
+      Copyright (c) 2011-present, Facebook, Inc.
+
+************************
+The MIT License
+************************
+
+The following binary components are provided under the MIT License.  See project link for details.
+
+  (MIT License) Checker Qual
+    The following NOTICE information applies:
+      Copyright (c) Copyright 2004-present by the Checker Framework developers
+      All rights reserved.
+      https://www.checkerframework.org/
+
+************************
+BSD License
+************************
+
+  (BSD 3-Clause) JLine Bundle
+    The following NOTICE information applies:
+      Copyright (c) 2002-2007, Marc Prud'hommeaux. All rights reserved.
+      https://github.com/jline/jline1
+
+  (BSD 3-Clause) Kryo
+    The following NOTICE information applies:
+      Copyright (c) 2008-2023, Nathan Sweet All rights reserved.
+      https://github.com/EsotericSoftware/kryo
+
+  (BSD 3-Clause) MinLog
+    The following NOTICE information applies:
+      Copyright (c) 2008, Nathan Sweet
+      https://github.com/EsotericSoftware/MinLog
+
+  (BSD 3-Clause) ReflectASM
+    The following NOTICE information applies:
+      Copyright (c) 2008, Nathan Sweet
+      https://github.com/EsotericSoftware/ReflectASM
+
+  (BSD) Paranamer
+    The following NOTICE information applies:
+      Portions copyright (c) 2006-2018 Paul Hammant & ThoughtWorks Inc
+      Portions copyright (c) 2000-2007 INRIA, France Telecom
+      All rights reserved.
+      https://github.com/paul-hammant/paranamer
+
+************************
+Common Development and Distribution License 1.1
+************************
+
+The following binary components are provided under the Common Development and Distribution License 1.1. See project link for details.
+
+    (CDDL 1.1) (GPL2 w/ CPE) jersey-client (com.sun.jersey:jersey-client:jar:1.19.4 - https://jersey.java.net/jersey-client/)
+    (CDDL 1.1) (GPL2 w/ CPE) jersey-core (com.sun.jersey:jersey-core:jar:1.19.4 - https://jersey.java.net/jersey-core/)
+    (CDDL 1.1) (GPL2 w/ CPE) jersey-server (com.sun.jersey:jersey-server:jar:1.9 - https://jersey.java.net/jersey-server/)
+    (CDDL 1.1) (GPL2 w/ CPE) jersey-servlet (com.sun.jersey:jersey-servlet:jar:1.19.4 - https://jersey.java.net/jersey-servlet/)
+    (CDDL 1.1) (GPL2 w/ CPE) javax.annotation API (javax.annotation:javax.annotation-api:jar:1.3.2 - https://jcp.org/en/jsr/detail?id=250)
+    (CDDL 1.1) (GPL2 w/ CPE) JavaServer Pages (TM) TagLib Implementation (org.glassfish.web:javax.servlet.jsp.jstl:jar:2.3.2 - https://jstl.java.net)
+    (CDDL 1.1) (GPL2 w/ CPE) javax.ws.rs-api (javax.ws.rs:javax.ws.rs-api:jar:2.1.1 - https://jax-rs-spec.java.net)
+    (CDDL 1.0) JSR311 API (javax.ws.rs:jsr311-api:jar:1.1.1 - https://jsr311.dev.java.net)
+    (CDDL 1.1) (GPL2 w/ CPE) Java Architecture For XML Binding (javax.xml.bind:jaxb-api:jar:2.2.11 - https://jaxb.dev.java.net/)
+    (CDDL 1.1) (GPL2 w/ CPE) Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b12 - https://el-spec.java.net)
+    (CDDL 1.1) (GPL2 w/ CPE) javax.inject:1 as OSGi bundle (org.glassfish.hk2.external:jakarta.inject:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/external/jakarta.inject)
+
+************************
+Eclipse Distribution License 1.0
+************************
+
+The following binary components are provided under the Eclipse Distribution License 1.0.
+
+    (EDL 1.0) Jakarta Activation API (jakarta.activation:jakarta.activation-api:jar:1.2.2)
+    (EDL 1.0) Jakarta XML Binding API (jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3)
+
+*****************
+Public Domain
+*****************
+
+The following binary components are provided to the 'Public Domain'.  See project link for details.
+
+    (Public Domain) XZ for Java (org.tukaani:xz:jar:1.5 - https://tukaani.org/xz/java.html
+
+************************
+Go License
+************************
+
+The following binary components are provided under the Go License.  See project link for details.
+
+  (Go) RE2/J
+    The following NOTICE information applies:
+      Copyright (c) 2009 The Go Authors. All rights reserved.
+      https://github.com/google/re2j

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-hudi-bundle</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-hudi-processors</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- Internal dependencies -->
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-kerberos-user-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-security-kerberos-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-hadoop-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-avro-record-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- External dependencies -->
+        <dependency>
+            <groupId>org.apache.hudi</groupId>
+            <artifactId>hudi-java-client</artifactId>
+            <version>${hudi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo</artifactId>
+            <version>5.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-avro</artifactId>
+            <version>1.13.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock-record-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/main/java/org/apache/nifi/processors/hudi/AbstractHudiProcessor.java
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/main/java/org/apache/nifi/processors/hudi/AbstractHudiProcessor.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.hudi;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.components.ClassloaderIsolationKeyProvider;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.resource.ResourceCardinality;
+import org.apache.nifi.components.resource.ResourceReferences;
+import org.apache.nifi.components.resource.ResourceType;
+import org.apache.nifi.context.PropertyContext;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.kerberos.KerberosUserService;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.security.krb.KerberosLoginException;
+import org.apache.nifi.security.krb.KerberosUser;
+
+import java.io.IOException;
+import java.security.PrivilegedExceptionAction;
+import java.util.List;
+
+import static org.apache.nifi.hadoop.SecurityUtil.getUgiForKerberosUser;
+
+/**
+ * Base Hudi processor class.
+ */
+@RequiresInstanceClassLoading(cloneAncestorResources = true)
+public abstract class AbstractHudiProcessor extends AbstractProcessor implements ClassloaderIsolationKeyProvider {
+
+    static final PropertyDescriptor HUDI_CONFIGURATION_RESOURCES = new PropertyDescriptor.Builder()
+            .name("hudi-config-resources")
+            .displayName("Hudi Configuration Resources")
+            .description("A file, or comma separated list of files, which contain the Hudi configurations. Without this, default configuration will be used.")
+            .identifiesExternalResource(ResourceCardinality.MULTIPLE, ResourceType.FILE)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .build();
+
+    static final PropertyDescriptor HADOOP_CONFIGURATION_RESOURCES = new PropertyDescriptor.Builder()
+            .name("hadoop-config-resources")
+            .displayName("Hadoop Configuration Resources")
+            .description("A file, or comma separated list of files, which contain the Hadoop configuration (core-site.xml, etc.). Without this, default configuration will be used.")
+            .identifiesExternalResource(ResourceCardinality.MULTIPLE, ResourceType.FILE)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .build();
+
+    public static final PropertyDescriptor KERBEROS_USER_SERVICE = new PropertyDescriptor.Builder()
+            .name("kerberos-user-service")
+            .displayName("Kerberos User Service")
+            .description("Specifies the Kerberos User Controller Service that should be used for authenticating with Kerberos.")
+            .identifiesControllerService(KerberosUserService.class)
+            .build();
+
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("A FlowFile is routed to this relationship if the operation failed and retrying the operation will also fail, such as an invalid data or schema.")
+            .build();
+
+    private volatile KerberosUser kerberosUser;
+    private volatile UserGroupInformation ugi;
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        final KerberosUserService kerberosUserService = context.getProperty(KERBEROS_USER_SERVICE).asControllerService(KerberosUserService.class);
+
+        if (kerberosUserService != null) {
+            this.kerberosUser = kerberosUserService.createKerberosUser();
+            try {
+                this.ugi = getUgiForKerberosUser(getConfigurationFromFiles(getConfigLocations(context)), kerberosUser);
+            } catch (IOException e) {
+                throw new ProcessException("Kerberos Authentication failed", e);
+            }
+        }
+    }
+
+    @OnStopped
+    public void onStopped() {
+        if (kerberosUser != null) {
+            try {
+                kerberosUser.logout();
+            } catch (KerberosLoginException e) {
+                getLogger().error("Error logging out kerberos user", e);
+            } finally {
+                kerberosUser = null;
+                ugi = null;
+            }
+        }
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+        final FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        if (kerberosUser == null) {
+            doOnTrigger(context, session, flowFile);
+        } else {
+            try {
+                getUgi().doAs((PrivilegedExceptionAction<Void>) () -> {
+                    doOnTrigger(context, session, flowFile);
+                    return null;
+                });
+
+            } catch (Exception e) {
+                getLogger().error("Privileged action failed with kerberos user " + kerberosUser, e);
+                session.transfer(session.penalize(flowFile), REL_FAILURE);
+            }
+        }
+    }
+
+    @Override
+    public String getClassloaderIsolationKey(PropertyContext context) {
+        final KerberosUserService kerberosUserService = context.getProperty(KERBEROS_USER_SERVICE).asControllerService(KerberosUserService.class);
+        if (kerberosUserService != null) {
+            return kerberosUserService.getIdentifier();
+        }
+        return null;
+    }
+
+    private UserGroupInformation getUgi() {
+        try {
+            kerberosUser.checkTGTAndRelogin();
+        } catch (KerberosLoginException e) {
+            throw new ProcessException("Unable to re-login with kerberos credentials for " + kerberosUser.getPrincipal(), e);
+        }
+        return ugi;
+    }
+
+    protected List<String> getConfigLocations(PropertyContext context) {
+        final ResourceReferences configResources = context.getProperty(HADOOP_CONFIGURATION_RESOURCES).evaluateAttributeExpressions().asResources();
+        final List<String> locations = configResources.asLocations();
+        return locations;
+    }
+
+    /**
+     * Loads configuration files from the provided paths.
+     *
+     * @param configFilePaths list of config file paths separated with comma
+     * @return merged configuration
+     */
+    protected Configuration getConfigurationFromFiles(List<String> configFilePaths) {
+        final Configuration conf = new Configuration();
+        if (configFilePaths != null) {
+            for (final String configFile : configFilePaths) {
+                conf.addResource(new Path(configFile.trim()));
+            }
+        }
+        return conf;
+    }
+
+    protected abstract void doOnTrigger(ProcessContext context, ProcessSession session, FlowFile flowFile) throws ProcessException;
+}

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/main/java/org/apache/nifi/processors/hudi/HudiKeyGeneratorFactory.java
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/main/java/org/apache/nifi/processors/hudi/HudiKeyGeneratorFactory.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.hudi;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.exception.HoodieKeyGeneratorException;
+import org.apache.hudi.keygen.AutoRecordGenWrapperAvroKeyGenerator;
+import org.apache.hudi.keygen.BaseKeyGenerator;
+import org.apache.hudi.keygen.ComplexAvroKeyGenerator;
+import org.apache.hudi.keygen.CustomAvroKeyGenerator;
+import org.apache.hudi.keygen.GlobalAvroDeleteKeyGenerator;
+import org.apache.hudi.keygen.KeyGenUtils;
+import org.apache.hudi.keygen.KeyGenerator;
+import org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator;
+import org.apache.hudi.keygen.SimpleAvroKeyGenerator;
+import org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.keygen.constant.KeyGeneratorType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.apache.hudi.config.HoodieWriteConfig.KEYGENERATOR_CLASS_NAME;
+import static org.apache.hudi.config.HoodieWriteConfig.KEYGENERATOR_TYPE;
+import static org.apache.hudi.keygen.KeyGenUtils.inferKeyGeneratorType;
+
+/**
+ * Factory help to create {@link org.apache.hudi.keygen.KeyGenerator}.
+ */
+public class HudiKeyGeneratorFactory {
+    private static final Logger logger = LoggerFactory.getLogger(HudiKeyGeneratorFactory.class);
+
+    private static final Map<String, String> MAP_TO_COMMON_KEY_GENERATOR = new HashMap<>();
+
+    static {
+        MAP_TO_COMMON_KEY_GENERATOR.put("org.apache.hudi.keygen.ComplexKeyGenerator", "org.apache.hudi.keygen.ComplexAvroKeyGenerator");
+        MAP_TO_COMMON_KEY_GENERATOR.put("org.apache.hudi.keygen.CustomKeyGenerator", "org.apache.hudi.keygen.CustomAvroKeyGenerator");
+        MAP_TO_COMMON_KEY_GENERATOR.put("org.apache.hudi.keygen.GlobalDeleteKeyGenerator", "org.apache.hudi.keygen.GlobalAvroDeleteKeyGenerator");
+        MAP_TO_COMMON_KEY_GENERATOR.put("org.apache.hudi.keygen.NonpartitionedKeyGenerator", "org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator");
+        MAP_TO_COMMON_KEY_GENERATOR.put("org.apache.hudi.keygen.SimpleKeyGenerator", "org.apache.hudi.keygen.SimpleAvroKeyGenerator");
+        MAP_TO_COMMON_KEY_GENERATOR.put("org.apache.hudi.keygen.TimestampBasedKeyGenerator", "org.apache.hudi.keygen.TimestampBasedAvroKeyGenerator");
+    }
+
+    /**
+     * Convert SparkKeyGeneratorInterface implement to hoodie-common KeyGenerator.
+     */
+    public static String convertToCommonKeyGenerator(String keyGeneratorClassName) {
+        return MAP_TO_COMMON_KEY_GENERATOR.getOrDefault(keyGeneratorClassName, keyGeneratorClassName);
+    }
+
+    public static KeyGenerator createKeyGenerator(TypedProperties props) throws IOException {
+        final String keyGeneratorClass = getKeyGeneratorClassName(props);
+        final boolean autoRecordKeyGen = KeyGenUtils.enableAutoGenerateRecordKeys(props);
+        try {
+            final KeyGenerator keyGenerator = (KeyGenerator) ReflectionUtils.loadClass(keyGeneratorClass, props);
+            if (autoRecordKeyGen) {
+                return new AutoRecordGenWrapperAvroKeyGenerator(props, (BaseKeyGenerator) keyGenerator);
+            } else {
+                return keyGenerator;
+            }
+        } catch (Throwable e) {
+            throw new IOException("Could not load key generator class " + keyGeneratorClass, e);
+        }
+    }
+
+    private static String getKeyGeneratorClassName(TypedProperties props) {
+        String keyGeneratorClass = props.getString(KEYGENERATOR_CLASS_NAME.key(), null);
+
+        if (StringUtils.isNullOrEmpty(keyGeneratorClass)) {
+            final String keyGeneratorType = props.getString(KEYGENERATOR_TYPE.key(), null);
+            KeyGeneratorType keyGeneratorTypeEnum;
+            if (StringUtils.isNullOrEmpty(keyGeneratorType)) {
+                keyGeneratorTypeEnum = inferKeyGeneratorTypeFromWriteConfig(props);
+                logger.info("The value of {} is empty; inferred to be {}", KEYGENERATOR_TYPE.key(), keyGeneratorTypeEnum);
+            } else {
+                try {
+                    keyGeneratorTypeEnum = KeyGeneratorType.valueOf(keyGeneratorType.toUpperCase(Locale.ROOT));
+                } catch (IllegalArgumentException e) {
+                    throw new HoodieKeyGeneratorException("Unsupported keyGenerator Type " + keyGeneratorType);
+                }
+            }
+            keyGeneratorClass = getKeyGeneratorClassNameFromType(keyGeneratorTypeEnum);
+        }
+        return keyGeneratorClass;
+    }
+
+    /**
+     * Get a Key generator based on the provided type.
+     *
+     * @param type {@link KeyGeneratorType} enum.
+     * @return The key generator class name for the {@link KeyGeneratorType}.
+     */
+    private static String getKeyGeneratorClassNameFromType(KeyGeneratorType type) {
+        switch (type) {
+            case SIMPLE:
+                return SimpleAvroKeyGenerator.class.getName();
+            case COMPLEX:
+                return ComplexAvroKeyGenerator.class.getName();
+            case TIMESTAMP:
+                return TimestampBasedAvroKeyGenerator.class.getName();
+            case CUSTOM:
+                return CustomAvroKeyGenerator.class.getName();
+            case NON_PARTITION:
+                return NonpartitionedAvroKeyGenerator.class.getName();
+            case GLOBAL_DELETE:
+                return GlobalAvroDeleteKeyGenerator.class.getName();
+            default:
+                throw new HoodieKeyGeneratorException("Unsupported keyGenerator Type " + type);
+        }
+    }
+
+    /**
+     * Infers the key generator type based on the record key and partition fields.
+     * If neither of the record key and partition fields are set, the default type is returned.
+     *
+     * @param props Properties from the write config.
+     * @return Inferred key generator type.
+     */
+    public static KeyGeneratorType inferKeyGeneratorTypeFromWriteConfig(TypedProperties props) {
+        final String partitionFields = props.getString(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), null);
+        final String recordsKeyFields = props.getString(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), null);
+        return inferKeyGeneratorType(Option.ofNullable(recordsKeyFields), partitionFields);
+    }
+}

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/main/java/org/apache/nifi/processors/hudi/PutHudi.java
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/main/java/org/apache/nifi/processors/hudi/PutHudi.java
@@ -1,0 +1,330 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.hudi;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.client.HoodieJavaWriteClient;
+import org.apache.hudi.client.common.HoodieJavaEngineContext;
+import org.apache.hudi.common.config.DFSPropertiesConfiguration;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.engine.EngineType;
+import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.HoodieAvroRecord;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieIndexConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.HoodieIndex;
+import org.apache.hudi.keygen.KeyGenUtils;
+import org.apache.hudi.keygen.KeyGenerator;
+import org.apache.nifi.annotation.behavior.DynamicProperty;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.avro.AvroTypeUtil;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.resource.ResourceReference;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.hadoop.SecurityUtil;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.serialization.RecordReader;
+import org.apache.nifi.serialization.RecordReaderFactory;
+import org.apache.nifi.serialization.record.Record;
+
+import java.io.InputStream;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.config.DFSPropertiesConfiguration.DEFAULT_PATH;
+import static org.apache.hudi.common.table.HoodieTableConfig.KEY_GENERATOR_CLASS_NAME;
+import static org.apache.hudi.common.table.HoodieTableConfig.PARTITION_FIELDS;
+import static org.apache.hudi.common.table.HoodieTableConfig.RECORDKEY_FIELDS;
+import static org.apache.hudi.common.table.HoodieTableConfig.URL_ENCODE_PARTITIONING;
+import static org.apache.hudi.config.HoodieWriteConfig.KEYGENERATOR_CLASS_NAME;
+import static org.apache.hudi.keygen.KeyGenUtils.RECORD_KEY_GEN_INSTANT_TIME_CONFIG;
+import static org.apache.hudi.keygen.KeyGenUtils.RECORD_KEY_GEN_PARTITION_ID_CONFIG;
+import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;
+import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME;
+import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.RECORDKEY_FIELD_NAME;
+
+@Tags({"hudi", "put", "table", "store", "record"})
+@CapabilityDescription("This processor uses the Hudi Java Client to parse and load records into Hudi tables. " +
+        "The processor initialize a Hudi Write Client which can be configured through hudi config files and with user defined dynamic fields." +
+        "The target Hudi table should already exist and it must have matching schemas with the incoming records, " +
+        "which means the Record Reader schema must contain all the Hudi schema fields, every additional field which is not present in the Hudi schema will be ignored. " +
+        "To avoid 'small file problem' it is recommended pre-appending a MergeRecord processor.")
+@DynamicProperty(
+        name = "Hudi configuration property key.",
+        value = "Hudi configuration property value.",
+        expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES,
+        description = "Adds a Hudi configuration entry to the data writer client.")
+@WritesAttributes({
+        @WritesAttribute(attribute = "hudi.record.count", description = "The number of records in the FlowFile.")
+})
+public class PutHudi extends AbstractHudiProcessor {
+
+    public static final String HUDI_RECORD_COUNT = "hudi.record.count";
+
+    static final PropertyDescriptor RECORD_READER = new PropertyDescriptor.Builder()
+            .name("record-reader")
+            .displayName("Record Reader")
+            .description("Specifies the Controller Service to use for parsing incoming data and determining the data's schema.")
+            .identifiesControllerService(RecordReaderFactory.class)
+            .required(true)
+            .build();
+
+    static final PropertyDescriptor TABLE_PATH = new PropertyDescriptor.Builder()
+            .name("table-path")
+            .displayName("Table Path")
+            .description("Path to the Hudi table.")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .required(true)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .build();
+
+    static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("A FlowFile is routed to this relationship after the data ingestion was successful.")
+            .build();
+
+    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+            RECORD_READER,
+            TABLE_PATH,
+            HUDI_CONFIGURATION_RESOURCES,
+            HADOOP_CONFIGURATION_RESOURCES,
+            KERBEROS_USER_SERVICE
+    ));
+
+    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            REL_SUCCESS,
+            REL_FAILURE
+    )));
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTIES;
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return RELATIONSHIPS;
+    }
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        return new PropertyDescriptor.Builder()
+                .required(false)
+                .name(propertyDescriptorName)
+                .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+                .dynamic(true)
+                .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES).build();
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext context) {
+        final List<ValidationResult> problems = new ArrayList<>();
+
+        final boolean kerberosUserServiceIsSet = context.getProperty(KERBEROS_USER_SERVICE).isSet();
+        final boolean securityEnabled = SecurityUtil.isSecurityEnabled(getConfigurationFromFiles(getConfigLocations(context)));
+
+        if (securityEnabled && !kerberosUserServiceIsSet) {
+            problems.add(new ValidationResult.Builder()
+                    .subject(KERBEROS_USER_SERVICE.getDisplayName())
+                    .valid(false)
+                    .explanation("'hadoop.security.authentication' is set to 'kerberos' in the hadoop configuration files but no KerberosUserService is configured.")
+                    .build());
+        }
+
+        if (!securityEnabled && kerberosUserServiceIsSet) {
+            problems.add(new ValidationResult.Builder()
+                    .subject(KERBEROS_USER_SERVICE.getDisplayName())
+                    .valid(false)
+                    .explanation("KerberosUserService is configured but 'hadoop.security.authentication' is not set to 'kerberos' in the hadoop configuration files.")
+                    .build());
+        }
+
+        return problems;
+    }
+
+    @Override
+    public void doOnTrigger(ProcessContext context, ProcessSession session, FlowFile flowFile) throws ProcessException {
+        final long startNanos = System.nanoTime();
+        final Configuration hadoopConfig = getConfigurationFromFiles(getConfigLocations(context));
+        final ResourceReference hudiConfig = context.getProperty(HUDI_CONFIGURATION_RESOURCES).evaluateAttributeExpressions().asResource();
+        final RecordReaderFactory readerFactory = context.getProperty(RECORD_READER).asControllerService(RecordReaderFactory.class);
+        final String tablePath = context.getProperty(TABLE_PATH).getValue();
+        final Map<String, String> dynamicProperties = getDynamicProperties(context, flowFile);
+
+        final HoodieTableMetaClient tableClient = HoodieTableMetaClient.builder().setBasePath(tablePath).setConf(hadoopConfig).build();
+        final TypedProperties properties = getTypedProperties(hadoopConfig, hudiConfig, tableClient, dynamicProperties);
+
+        int recordCount;
+        try (final InputStream in = session.read(flowFile); final RecordReader reader = readerFactory.createRecordReader(flowFile, in, getLogger())) {
+            final TableSchemaResolver schemaResolver = new TableSchemaResolver(tableClient);
+            final Schema schema = schemaResolver.getTableAvroSchema();
+            final KeyGenerator keyGenerator = HudiKeyGeneratorFactory.createKeyGenerator(properties);
+            final HoodieJavaWriteClient<HoodieAvroPayload> client = createWriterClient(hadoopConfig, tablePath, schema, tableClient, properties);
+
+            List<HoodieRecord<HoodieAvroPayload>> writeRecords = new ArrayList<>();
+            Record record;
+            while ((record = reader.nextRecord()) != null) {
+                final GenericRecord genericRecord = AvroTypeUtil.createAvroRecord(record, schema);
+                writeRecords.add(new HoodieAvroRecord<>(keyGenerator.getKey(genericRecord), new HoodieAvroPayload(Option.of(genericRecord))));
+            }
+            recordCount = writeRecords.size();
+
+            final String newCommitTime = client.startCommit();
+            client.insert(writeRecords, newCommitTime);
+            client.close();
+        } catch (Exception e) {
+            getLogger().error("Exception occurred while writing hudi records.", e);
+            session.transfer(session.penalize(flowFile), REL_FAILURE);
+            return;
+        }
+
+        flowFile = session.putAttribute(flowFile, HUDI_RECORD_COUNT, String.valueOf(recordCount));
+        final long transferMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        session.getProvenanceReporter().send(flowFile, tablePath, transferMillis);
+        session.transfer(flowFile, REL_SUCCESS);
+    }
+
+    /**
+     * Initializing a java data writer client
+     *
+     * @param hadoopConfig hadoop configuration
+     * @param tablePath    path to the hudi table
+     * @param schema       table schema
+     * @param tableClient  table meta client
+     * @param properties   data writer properties
+     * @return data writer client
+     */
+    private HoodieJavaWriteClient<HoodieAvroPayload> createWriterClient(Configuration hadoopConfig, String tablePath, Schema schema, HoodieTableMetaClient tableClient, TypedProperties properties) {
+        final HoodieJavaEngineContext hoodieJavaEngineContext = new HoodieJavaEngineContext(hadoopConfig);
+        final HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder().withPath(tablePath)
+                .withEngineType(EngineType.JAVA)
+                .withSchema(schema.toString())
+                .forTable(tableClient.getTableConfig().getTableName())
+                .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.INMEMORY).build())
+                .withProps(properties)
+                .build();
+
+        return new HoodieJavaWriteClient<>(hoodieJavaEngineContext, writeConfig);
+    }
+
+    /**
+     * Constructs writer configuration from hadoop, hudi and user defined properties.
+     *
+     * @param hadoopConfig       hadoop configuration
+     * @param hudiConfig         hudi configuration
+     * @param tableClient        table meta client
+     * @param overrideProperties user defined configurations through dynamic properties
+     * @return constructed configuration
+     */
+    private TypedProperties getTypedProperties(Configuration hadoopConfig, ResourceReference hudiConfig, HoodieTableMetaClient tableClient, Map<String, String> overrideProperties) {
+        final DFSPropertiesConfiguration config = new DFSPropertiesConfiguration(hadoopConfig, DEFAULT_PATH);
+
+        if (hudiConfig != null) {
+            config.addPropsFromFile(new Path(hudiConfig.getLocation()));
+        }
+
+        TypedProperties properties = config.getProps();
+        addPropertiesFromTableConfig(properties, tableClient.getTableConfig().getProps());
+        properties.putAll(overrideProperties);
+
+        if (KeyGenUtils.enableAutoGenerateRecordKeys(properties)) {
+            properties.put(RECORD_KEY_GEN_PARTITION_ID_CONFIG, new SecureRandom().nextInt());
+            properties.put(RECORD_KEY_GEN_INSTANT_TIME_CONFIG, HoodieActiveTimeline.createNewInstantTime());
+        }
+
+        return properties;
+    }
+
+    /**
+     * Parse and set properties from table configuration to data writer configuration.
+     *
+     * @param writerProperties data writer configuration
+     * @param tableProperties  table configuration
+     */
+    private void addPropertiesFromTableConfig(TypedProperties writerProperties, TypedProperties tableProperties) {
+        if (tableProperties.containsKey(RECORDKEY_FIELDS.key())) {
+            writerProperties.put(RECORDKEY_FIELD_NAME.key(), tableProperties.get(RECORDKEY_FIELDS.key()));
+        }
+
+        if (tableProperties.containsKey(PARTITION_FIELDS.key())) {
+            writerProperties.put(PARTITIONPATH_FIELD_NAME.key(), tableProperties.get(PARTITION_FIELDS.key()));
+        }
+
+        if (tableProperties.containsKey(HIVE_STYLE_PARTITIONING_ENABLE.key())) {
+            writerProperties.put(HIVE_STYLE_PARTITIONING_ENABLE.key(), tableProperties.get(HIVE_STYLE_PARTITIONING_ENABLE.key()));
+        }
+
+        if (tableProperties.containsKey(URL_ENCODE_PARTITIONING.key())) {
+            writerProperties.put(URL_ENCODE_PARTITIONING.key(), tableProperties.get(URL_ENCODE_PARTITIONING.key()));
+        }
+
+        if (tableProperties.containsKey(KEY_GENERATOR_CLASS_NAME.key())) {
+            writerProperties.put(KEYGENERATOR_CLASS_NAME.key(),
+                    HudiKeyGeneratorFactory.convertToCommonKeyGenerator(String.valueOf(tableProperties.get(KEY_GENERATOR_CLASS_NAME.key()))));
+        }
+    }
+
+    /**
+     * Collects every non-blank dynamic property from the context.
+     *
+     * @param context  process context
+     * @param flowFile FlowFile to evaluate attribute expressions
+     * @return Map of dynamic properties
+     */
+    public static Map<String, String> getDynamicProperties(ProcessContext context, FlowFile flowFile) {
+        return context.getProperties().entrySet().stream()
+                // filter non-blank dynamic properties
+                .filter(e -> e.getKey().isDynamic()
+                        && StringUtils.isNotBlank(e.getValue())
+                        && StringUtils.isNotBlank(context.getProperty(e.getKey()).evaluateAttributeExpressions(flowFile).getValue())
+                )
+                // convert to Map keys and evaluated property values
+                .collect(Collectors.toMap(
+                        e -> e.getKey().getName(),
+                        e -> context.getProperty(e.getKey()).evaluateAttributeExpressions(flowFile).getValue()
+                ));
+    }
+
+}

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.nifi.processors.hudi.PutHudi

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/main/resources/docs/org/apache/nifi/processors/hudi/PutHudi/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/main/resources/docs/org/apache/nifi/processors/hudi/PutHudi/additionalDetails.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/html">
+<!--
+      Licensed to the Apache Software Foundation (ASF) under one or more
+      contributor license agreements.  See the NOTICE file distributed with
+      this work for additional information regarding copyright ownership.
+      The ASF licenses this file to You under the Apache License, Version 2.0
+      (the "License"); you may not use this file except in compliance with
+      the License.  You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+    -->
+    <head>
+        <meta charset="utf-8"/>
+        <title>PutHudi</title>
+        <link rel="stylesheet" href="../../../../../css/component-usage.css" type="text/css"/>
+    </head>
+
+    <body>
+
+        <h1>PutHudi</h1>
+
+        <h3>Description</h3>
+        <p>
+            Apache Hudi is a transactional data lake platform that brings database and data warehouse capabilities to the data lake.
+            The PutHudi processor is capable of pushing data into Hudi tables using the Hudi Java Client.
+        </p>
+
+        <h3>Key Generator</h3>
+        <p>
+            Every record is uniquely identified by a primary key, which is a pair of record key and partition path where the record belongs to.
+            To determine which key generator should be used the processor is going through the following decision order:
+            <ul>
+                <li>The processor tries to read the "hoodie.table.keygenerator.class" property from the target table's configuration and set it to the writer configuration</li>
+                <li>The processor checks the "hoodie.datasource.write.keygenerator.type" property in the writer's configuration</li>
+                <li>The processor tries to infer the key generator type from the "hoodie.datasource.write.partitionpath.field" and "hoodie.datasource.write.recordkey.field" properties</li>
+            </ul>
+
+        </p>
+
+        <h3>Configuration</h3>
+        <p>
+            Configuration files and entries can be provided in different ways to the processor. The configuration entry override hierarchy is the following:
+            <ul>
+                <li>Configuration provided thourgh the processors "Hudi Configuration Resources" property</li>
+                <li>Configuration entries mapped from the target table's configruation</li>
+                <ul>
+                    <li><code>"hoodie.table.recordkey.fields"                         ->  "hoodie.datasource.write.recordkey.field"</code></li>
+                    <li><code>"hoodie.table.partition.fields"                         ->  "hoodie.datasource.write.partitionpath.field"</code></li>
+                    <li><code>"hoodie.table.keygenerator.class"                       ->  "hoodie.datasource.write.keygenerator.class"</code></li>
+                    <li><code>"hoodie.datasource.write.hive_style_partitioning"       ->  "hoodie.datasource.write.hive_style_partitioning"</code></li>
+                    <li><code>"hoodie.datasource.write.partitionpath.urlencode"       ->  "hoodie.datasource.write.partitionpath.urlencode"</code></li>
+                </ul>
+                <li>Configuration entries provided through dynamic properties</li>
+            </ul>
+        </p>
+
+    </body>
+</html>

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/test/java/org/apache/nifi/processors/hudi/TestHudiKeyGeneratorFactory.java
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/test/java/org/apache/nifi/processors/hudi/TestHudiKeyGeneratorFactory.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.hudi;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieKeyGeneratorException;
+import org.apache.hudi.keygen.ComplexAvroKeyGenerator;
+import org.apache.hudi.keygen.CustomAvroKeyGenerator;
+import org.apache.hudi.keygen.KeyGenerator;
+import org.apache.hudi.keygen.NonpartitionedAvroKeyGenerator;
+import org.apache.hudi.keygen.SimpleAvroKeyGenerator;
+import org.apache.hudi.keygen.constant.KeyGeneratorOptions;
+import org.apache.hudi.keygen.constant.KeyGeneratorType;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.apache.hudi.config.HoodieWriteConfig.KEYGENERATOR_TYPE;
+import static org.apache.nifi.processors.hudi.HudiKeyGeneratorFactory.createKeyGenerator;
+import static org.apache.nifi.processors.hudi.HudiKeyGeneratorFactory.inferKeyGeneratorTypeFromWriteConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+public class TestHudiKeyGeneratorFactory {
+
+    @Test
+    public void testInferKeyGeneratorTypeFromWriteConfig() {
+        assertEquals(KeyGeneratorType.NON_PARTITION, inferKeyGeneratorTypeFromWriteConfig(new TypedProperties()));
+
+        TypedProperties props = getCommonProps();
+        assertEquals(KeyGeneratorType.SIMPLE, inferKeyGeneratorTypeFromWriteConfig(props));
+
+        props.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key,ts");
+        assertEquals(KeyGeneratorType.COMPLEX, inferKeyGeneratorTypeFromWriteConfig(props));
+
+        props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "");
+        assertEquals(KeyGeneratorType.NON_PARTITION, inferKeyGeneratorTypeFromWriteConfig(props));
+    }
+
+    @Test
+    public void testKeyGeneratorFactory() throws IOException {
+        TypedProperties props = getCommonProps();
+
+        // set KeyGenerator type only
+        props.put(KEYGENERATOR_TYPE.key(), KeyGeneratorType.CUSTOM.name());
+        props.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "field:simple");
+        KeyGenerator keyGenerator = createKeyGenerator(props);
+        assertEquals(CustomAvroKeyGenerator.class.getName(), keyGenerator.getClass().getName());
+
+        // set KeyGenerator class only
+        props = getCommonProps();
+        props.put(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), SimpleAvroKeyGenerator.class.getName());
+        KeyGenerator keyGenerator2 = createKeyGenerator(props);
+        assertEquals(SimpleAvroKeyGenerator.class.getName(), keyGenerator2.getClass().getName());
+
+        // set both class name and keyGenerator type
+        props.put(KEYGENERATOR_TYPE.key(), KeyGeneratorType.CUSTOM.name());
+        KeyGenerator keyGenerator3 = createKeyGenerator(props);
+        // KEYGENERATOR_TYPE_PROP was overwritten by KEYGENERATOR_CLASS_PROP
+        assertEquals(SimpleAvroKeyGenerator.class.getName(), keyGenerator3.getClass().getName());
+
+        // set wrong class name
+        final TypedProperties props2 = getCommonProps();
+        props2.put(HoodieWriteConfig.KEYGENERATOR_CLASS_NAME.key(), TestHudiKeyGeneratorFactory.class.getName());
+        assertThrows(IOException.class, () -> HudiKeyGeneratorFactory.createKeyGenerator(props2));
+
+        // set wrong keyGenerator type
+        final TypedProperties props3 = getCommonProps();
+        props3.put(KEYGENERATOR_TYPE.key(), "wrong_type");
+        assertThrows(HoodieKeyGeneratorException.class, () -> createKeyGenerator(props3));
+
+        // Infer key generator
+        TypedProperties props4 = getCommonProps();
+        assertEquals(SimpleAvroKeyGenerator.class.getName(), createKeyGenerator(props4).getClass().getName());
+
+        props4.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key,ts");
+        assertEquals(ComplexAvroKeyGenerator.class.getName(), createKeyGenerator(props4).getClass().getName());
+
+        props4.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "");
+        assertEquals(NonpartitionedAvroKeyGenerator.class.getName(), createKeyGenerator(props4).getClass().getName());
+    }
+
+    private TypedProperties getCommonProps() {
+        TypedProperties properties = new TypedProperties();
+        properties.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
+        properties.put(KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE.key(), "true");
+        properties.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "timestamp");
+        return properties;
+    }
+}

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/test/java/org/apache/nifi/processors/hudi/TestPutHudi.java
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/test/java/org/apache/nifi/processors/hudi/TestPutHudi.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.hudi;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.HoodieAvroPayload;
+import org.apache.hudi.common.model.HoodieTableType;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.BaseFileUtils;
+import org.apache.nifi.avro.AvroTypeUtil;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.record.MockRecordParser;
+import org.apache.nifi.serialization.record.RecordField;
+import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.apache.hudi.common.table.HoodieTableConfig.PARTITION_FIELDS;
+import static org.apache.hudi.common.table.HoodieTableConfig.RECORDKEY_FIELDS;
+import static org.apache.hudi.config.HoodieWriteConfig.KEYGENERATOR_CLASS_NAME;
+import static org.apache.hudi.keygen.constant.KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;
+import static org.apache.nifi.processors.hudi.PutHudi.HUDI_RECORD_COUNT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestPutHudi {
+
+    private static final String TABLE_NAME = "hudi_table";
+    private static final String DATABASE_NAME = "default";
+
+    @TempDir
+    private java.nio.file.Path tempDir;
+
+    private final Configuration hadoopConf = new Configuration();
+    private TestRunner runner;
+    private PutHudi processor;
+    private Schema inputSchema;
+    private String basePath;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        final String avroSchema = IOUtils.toString(Files.newInputStream(Paths.get("src/test/resources/user.avsc")), StandardCharsets.UTF_8);
+        inputSchema = new Schema.Parser().parse(avroSchema);
+        basePath = tempDir.resolve("hudi_tests" + System.currentTimeMillis()).toAbsolutePath().toUri().getPath();
+        processor = new PutHudi();
+    }
+
+    private void initRecordReader(List<TestUser> records) throws InitializationException {
+        final MockRecordParser readerFactory = new MockRecordParser();
+        final RecordSchema recordSchema = AvroTypeUtil.createSchema(inputSchema);
+
+        for (RecordField recordField : recordSchema.getFields()) {
+            readerFactory.addSchemaField(recordField.getFieldName(), recordField.getDataType().getFieldType(), recordField.isNullable());
+        }
+
+        for (TestUser testUser : records) {
+            readerFactory.addRecord(testUser.getId(), testUser.getName(), testUser.getDepartment());
+        }
+
+        runner.addControllerService("mock-reader-factory", readerFactory);
+        runner.enableControllerService(readerFactory);
+        runner.setProperty(PutHudi.RECORD_READER, "mock-reader-factory");
+    }
+
+    private HoodieTableMetaClient initMetaClient(Configuration hadoopConf, String basePath, HoodieTableType tableType,
+                                                 Properties properties, String schema) throws IOException {
+        final HoodieTableMetaClient.PropertyBuilder builder =
+                HoodieTableMetaClient.withPropertyBuilder()
+                        .setDatabaseName(DATABASE_NAME)
+                        .setTableName(TABLE_NAME)
+                        .setTableType(tableType)
+                        .setTableCreateSchema(schema)
+                        .setPayloadClass(HoodieAvroPayload.class);
+
+        final Properties processedProperties = builder.fromProperties(properties).build();
+        return HoodieTableMetaClient.initTableAndGetMetaClient(hadoopConf, basePath, processedProperties);
+    }
+
+    @Test
+    public void testHiveStylePartitionedTableWithSimpleKeyGenerator() throws Exception {
+        //init incoming records
+        final List<TestUser> records = new ArrayList<>();
+        records.add(new TestUser(0, "John", "Finance"));
+        records.add(new TestUser(1, "Jill", "Finance"));
+        records.add(new TestUser(2, "James", "Finance"));
+        records.add(new TestUser(3, "Joana", "Sales"));
+
+        //init table properties
+        final TypedProperties properties = new TypedProperties();
+        properties.put(KEYGENERATOR_CLASS_NAME.key(), "org.apache.hudi.keygen.SimpleAvroKeyGenerator");
+        properties.put(RECORDKEY_FIELDS.key(), "id");
+        properties.put(PARTITION_FIELDS.key(), "department");
+        properties.put(HIVE_STYLE_PARTITIONING_ENABLE.key(), "true");
+
+        //init table meta client
+        final HoodieTableMetaClient metaClient = initMetaClient(hadoopConf, basePath, HoodieTableType.COPY_ON_WRITE, new TypedProperties(properties), inputSchema.toString());
+        final BaseFileUtils fileUtils = BaseFileUtils.getInstance(metaClient);
+
+        runner = TestRunners.newTestRunner(processor);
+        initRecordReader(records);
+        runner.setProperty(PutHudi.TABLE_PATH, basePath);
+        runner.setValidateExpressionUsage(false);
+        runner.enqueue(new byte[0]);
+        runner.run();
+
+        runner.assertTransferCount(PutHudi.REL_SUCCESS, 1);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutHudi.REL_SUCCESS).get(0);
+
+        assertEquals("4", flowFile.getAttribute(HUDI_RECORD_COUNT));
+
+        // assert 'Finance' partition path and files
+        List<GenericRecord> fileRecords = fileUtils.readAvroRecords(hadoopConf, new Path(basePath + "/department=Finance"));
+        assertEquals(3, fileRecords.size());
+
+        for (GenericRecord genericRecord : fileRecords) {
+            assertEquals("Finance", genericRecord.get("department").toString());
+        }
+
+        // assert 'Sales' partition path and files
+        fileRecords = fileUtils.readAvroRecords(hadoopConf, new Path(basePath + "/department=Sales"));
+        assertEquals(1, fileRecords.size());
+        assertEquals("Sales", fileRecords.get(0).get("department").toString());
+    }
+
+    @Test
+    public void testUnpartitionedTable() throws Exception {
+        //init incoming records
+        final List<TestUser> records = new ArrayList<>();
+        records.add(new TestUser(0, "John", "Finance"));
+        records.add(new TestUser(1, "Jill", "Finance"));
+        records.add(new TestUser(2, "James", "Marketing"));
+        records.add(new TestUser(3, "Joana", "Sales"));
+
+        //init table meta client
+        final HoodieTableMetaClient metaClient = initMetaClient(hadoopConf, basePath, HoodieTableType.MERGE_ON_READ, new TypedProperties(), inputSchema.toString());
+        final BaseFileUtils fileUtils = BaseFileUtils.getInstance(metaClient);
+
+        runner = TestRunners.newTestRunner(processor);
+        initRecordReader(records);
+        runner.setProperty(PutHudi.TABLE_PATH, basePath);
+        runner.setValidateExpressionUsage(false);
+        runner.enqueue(new byte[0]);
+        runner.run();
+
+        runner.assertTransferCount(PutHudi.REL_SUCCESS, 1);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutHudi.REL_SUCCESS).get(0);
+
+        assertEquals("4", flowFile.getAttribute(HUDI_RECORD_COUNT));
+
+        //assert created files
+        final List<GenericRecord> fileRecords = fileUtils.readAvroRecords(hadoopConf, new Path(basePath));
+        assertEquals(4, fileRecords.size());
+
+        int index = 0;
+        for (GenericRecord genericRecord : fileRecords) {
+            assertEquals(records.get(index).getId(), genericRecord.get("id"));
+            assertEquals(records.get(index).getName(), genericRecord.get("name").toString());
+            assertEquals(records.get(index).getDepartment(), genericRecord.get("department").toString());
+            index++;
+        }
+    }
+
+    @Test
+    public void testPartitionedTableWithComplexKeyGeneratorAndDynamicFields() throws Exception {
+        //init incoming records
+        final List<TestUser> records = new ArrayList<>();
+        records.add(new TestUser(0, "John", "Finance"));
+        records.add(new TestUser(1, "James", "Finance"));
+        records.add(new TestUser(2, "James", "Finance"));
+
+        //init table meta client
+        final HoodieTableMetaClient metaClient = initMetaClient(hadoopConf, basePath, HoodieTableType.COPY_ON_WRITE, new TypedProperties(), inputSchema.toString());
+        final BaseFileUtils fileUtils = BaseFileUtils.getInstance(metaClient);
+
+        runner = TestRunners.newTestRunner(processor);
+        initRecordReader(records);
+        runner.setProperty(PutHudi.TABLE_PATH, basePath);
+        runner.setProperty("hoodie.datasource.write.partitionpath.field", "department,name");
+        runner.setProperty("hoodie.datasource.write.keygenerator.class", "org.apache.hudi.keygen.ComplexAvroKeyGenerator");
+        runner.setValidateExpressionUsage(false);
+        runner.enqueue(new byte[0]);
+        runner.run();
+
+        runner.assertTransferCount(PutHudi.REL_SUCCESS, 1);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutHudi.REL_SUCCESS).get(0);
+
+        assertEquals("3", flowFile.getAttribute(HUDI_RECORD_COUNT));
+
+        // assert '/Finance/James' partition path and files
+        List<GenericRecord> fileRecords = fileUtils.readAvroRecords(hadoopConf, new Path(basePath + "/Finance/James"));
+        assertEquals(2, fileRecords.size());
+
+        for (GenericRecord genericRecord : fileRecords) {
+            assertEquals("Finance", genericRecord.get("department").toString());
+            assertEquals("James", genericRecord.get("name").toString());
+        }
+
+        // assert '/Finance/John' partition path and files
+        fileRecords = fileUtils.readAvroRecords(hadoopConf, new Path(basePath + "/Finance/John"));
+        assertEquals(1, fileRecords.size());
+        assertEquals("Finance", fileRecords.get(0).get("department").toString());
+        assertEquals("John", fileRecords.get(0).get("name").toString());
+    }
+
+    private class TestUser {
+        private final long id;
+        private final String name;
+        private final String department;
+
+        public TestUser(long id, String name, String department) {
+            this.id = id;
+            this.name = name;
+            this.department = department;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getDepartment() {
+            return department;
+        }
+    }
+
+}

--- a/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/test/resources/user.avsc
+++ b/nifi-nar-bundles/nifi-hudi-bundle/nifi-hudi-processors/src/test/resources/user.avsc
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+ "namespace": "nifi",
+ "type": "record",
+ "name": "User",
+ "fields": [
+     {"name": "id",  "type": ["long", "null"]},
+     {"name": "name", "type": ["string", "null"]},
+     {"name": "department", "type": ["string", "null"]}
+ ]
+}

--- a/nifi-nar-bundles/nifi-hudi-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hudi-bundle/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-nar-bundles</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-hudi-bundle</artifactId>
+    <packaging>pom</packaging>
+
+    <properties>
+        <hudi.version>0.14.0</hudi.version>
+        <jetty.websocket.version>9.4.9.v20180320</jetty.websocket.version>
+    </properties>
+
+    <modules>
+        <module>nifi-hudi-processors</module>
+        <module>nifi-hudi-processors-nar</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override snapshot versions of javax.el -->
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.el</artifactId>
+                <version>3.0.1-b12</version>
+            </dependency>
+            <!-- Override nimbus-jose-jwt 9.8.1 from hadoop-auth -->
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>9.33</version>
+            </dependency>
+            <!-- Override Guava 27 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.1.2-jre</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>websocket-server</artifactId>
+                <version>${jetty.websocket.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>websocket-api</artifactId>
+                <version>${jetty.websocket.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>websocket-client</artifactId>
+                <version>${jetty.websocket.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/nifi-nar-bundles/pom.xml
+++ b/nifi-nar-bundles/pom.xml
@@ -116,6 +116,7 @@
         <module>nifi-compress-bundle</module>
         <module>nifi-opentelemetry-bundle</module>
         <module>nifi-apicurio-bundle</module>
+        <module>nifi-hudi-bundle</module>
     </modules>
 
     <build>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12349](https://issues.apache.org/jira/browse/NIFI-12349)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
