### PR TITLE
NIFI-12368 Clear versionedComponentId on top-level components of popu…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/SnippetUtils.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/SnippetUtils.java
@@ -404,7 +404,7 @@ public final class SnippetUtils {
     public FlowSnippetDTO copy(final FlowSnippetDTO snippetContents, final ProcessGroup group, final String idGenerationSeed, boolean isCopy) {
         final FlowSnippetDTO snippetCopy = copyContentsForGroup(snippetContents, group.getIdentifier(), null, null, idGenerationSeed, isCopy);
         resolveNameConflicts(snippetCopy, group);
-        removeTopLevelVersionedIds(snippetContents);
+        removeTopLevelVersionedIds(snippetCopy);
         return snippetCopy;
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/SnippetUtils.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/SnippetUtils.java
@@ -404,7 +404,24 @@ public final class SnippetUtils {
     public FlowSnippetDTO copy(final FlowSnippetDTO snippetContents, final ProcessGroup group, final String idGenerationSeed, boolean isCopy) {
         final FlowSnippetDTO snippetCopy = copyContentsForGroup(snippetContents, group.getIdentifier(), null, null, idGenerationSeed, isCopy);
         resolveNameConflicts(snippetCopy, group);
+        removeTopLevelVersionedIds(snippetContents);
         return snippetCopy;
+    }
+
+    private void removeTopLevelVersionedIds(final FlowSnippetDTO snippetContents) {
+        removeVersionedIds(snippetContents.getProcessors());
+        removeVersionedIds(snippetContents.getLabels());
+        removeVersionedIds(snippetContents.getConnections());
+        removeVersionedIds(snippetContents.getInputPorts());
+        removeVersionedIds(snippetContents.getOutputPorts());
+        removeVersionedIds(snippetContents.getRemoteProcessGroups());
+        removeVersionedIds(snippetContents.getFunnels());
+    }
+
+    private <T extends ComponentDTO> void removeVersionedIds(final Collection<T> components) {
+        if (components != null) {
+            components.forEach(c -> c.setVersionedComponentId(null));
+        }
     }
 
     private void resolveNameConflicts(final FlowSnippetDTO snippetContents, final ProcessGroup group) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/util/SnippetUtilsTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/util/SnippetUtilsTest.java
@@ -257,8 +257,8 @@ public class SnippetUtilsTest {
         assertNotNull(copiedLabels);
         final LabelDTO copiedLabel = copiedLabels.iterator().next();
         assertNotNull(copiedLabel);
-        assertNotNull(copiedLabel.getVersionedComponentId());
+        assertNull(copiedLabel.getVersionedComponentId());
 
-        assertNull(labelDTO.getVersionedComponentId());
+        assertNotNull(labelDTO.getVersionedComponentId());
     }
 }


### PR DESCRIPTION
…lated Snippet

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12368](https://issues.apache.org/jira/browse/NIFI-12368)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
