### PR TITLE
NIFI-12373 Add LICENSE and NOTICE for nifi-standard-shared-nar

### DIFF
--- a/nifi-nar-bundles/nifi-standard-shared-bundle/nifi-standard-shared-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-nar-bundles/nifi-standard-shared-bundle/nifi-standard-shared-nar/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,234 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+APACHE NIFI SUBCOMPONENTS:
+
+The Apache NiFi project contains subcomponents with separate copyright
+notices and license terms. Your use of the source code for the these
+subcomponents is subject to the terms and conditions of the following
+licenses.
+
+The binary distribution of this product bundles the following libraries under an MIT style license:
+
+    - Bouncy Castle Provider
+    - Checker Framework
+
+    Copyright (c) 2000-2023 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.

--- a/nifi-nar-bundles/nifi-standard-shared-bundle/nifi-standard-shared-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-standard-shared-bundle/nifi-standard-shared-nar/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,422 @@
+nifi-standard-shared-nar
+Copyright 2014-2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+===========================================
+Apache Software License v2
+===========================================
+
+The following binary components are provided under the Apache Software License v2
+
+  (ASLv2) Apache Commons Codec
+    The following NOTICE information applies:
+
+    Apache Commons Codec
+    Copyright 2002-2023 The Apache Software Foundation
+
+    src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
+    contains test data from http://aspell.net/test/orig/batch0.tab.
+    Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
+
+    ===============================================================================
+
+    The content of package org.apache.commons.codec.language.bm has been translated
+    from the original php source code available at http://stevemorse.org/phoneticinfo.htm
+    with permission from the original authors.
+    Original source copyright:
+    Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
+
+  (ASLv2) Apache Commons Compress
+    The following NOTICE information applies:
+
+    Apache Commons Compress
+    Copyright 2002-2023 The Apache Software Foundation
+
+    The files in the package org.apache.commons.compress.archivers.sevenz
+    were derived from the LZMA SDK, version 9.20 (C/ and CPP/7zip/),
+    which has been placed in the public domain:
+
+    "LZMA SDK is placed in the public domain." (http://www.7-zip.org/sdk.html)
+
+  (ASLv2) Apache Commons IO
+    The following NOTICE information applies:
+
+    Apache Commons IO
+    Copyright 2002-2023 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Lang
+    The following NOTICE information applies:
+
+    Apache Commons Lang
+    Copyright 2001-2023 The Apache Software Foundation
+
+    This product includes software from the Spring Framework,
+    under the Apache License 2.0 (see: StringUtils.containsWhitespace())
+
+  (ASLv2) Apache Commons Net
+    The following NOTICE information applies:
+
+    Apache Commons Net
+    Copyright 2001-2023 The Apache Software Foundation
+
+  (ASLv2) Apache Commons Text
+    The following NOTICE information applies:
+
+    Apache Commons Text
+    Copyright 2001-2023 The Apache Software Foundation
+
+  (ASLv2) Jackson JSON
+    The following NOTICE information applies:
+
+    Jackson is a high-performance, Free/Open Source JSON processing library.
+    It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+    been in development since 2007.
+    It is currently developed by a community of developers.
+
+    ## Copyright
+
+    Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+    ## Licensing
+
+    Jackson 2.x core and extension components are licensed under Apache License 2.0
+    To find the details that apply to this artifact see the accompanying LICENSE file.
+
+    ## Credits
+
+    A list of contributors may be found from CREDITS(-2.x) file, which is included
+    in some artifacts (usually source distributions); but is always available
+    from the source code management (SCM) system project uses.
+
+    ## FastDoubleParser
+
+    jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+    That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+    under the following copyright.
+
+    Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+    See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+    and the licenses and copyrights that apply to that code.
+
+  (ASLv2) Caffeine
+    The following NOTICE information applies:
+
+    Caffeine (caching library)
+    Copyright Ben Manes
+
+  (ASLv2) Error Prone Annotations
+    The following NOTICE information applies:
+
+    Error Prone Annotations
+    Copyright 2015 The Error Prone Authors
+
+  (ASLv2) JetBrains java-annotations
+    The following NOTICE information applies:
+
+    JetBrains java-annotations
+    Copyright 2000-2023 JetBrains s.r.o
+
+  (ASLv2) Kotlin Standard Libraries
+    The following NOTICE information applies:
+
+    Kotlin Standard Libraries
+    Copyright 2010-2023 JetBrains s.r.o
+
+  (ASLv2) OkHttp
+    The following NOTICE information applies:
+
+    OkHttp
+    Copyright 2014 Square Inc
+
+  (ASLv2) Okio
+    The following NOTICE information applies:
+
+    Okio
+    Copyright 2013 Square Inc
+
+  (ASLv2) The Netty Project
+    The following NOTICE information applies:
+
+                                  The Netty Project
+                                  =================
+
+      Please visit the Netty web site for more information:
+
+        * https://netty.io/
+
+      Copyright 2014 The Netty Project
+
+      The Netty Project licenses this file to you under the Apache License,
+      version 2.0 (the "License"); you may not use this file except in compliance
+      with the License. You may obtain a copy of the License at:
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+      WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+      License for the specific language governing permissions and limitations
+      under the License.
+
+      Also, please refer to each LICENSE.<component>.txt file, which is located in
+      the 'license' directory of the distribution file, for the license terms of the
+      components that this product depends on.
+
+      -------------------------------------------------------------------------------
+      This product contains the extensions to Java Collections Framework which has
+      been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
+
+        * LICENSE:
+          * license/LICENSE.jsr166y.txt (Public Domain)
+        * HOMEPAGE:
+          * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
+          * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
+
+      This product contains a modified version of Robert Harder's Public Domain
+      Base64 Encoder and Decoder, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.base64.txt (Public Domain)
+        * HOMEPAGE:
+          * http://iharder.sourceforge.net/current/java/base64/
+
+      This product contains a modified portion of 'Webbit', an event based
+      WebSocket and HTTP server, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.webbit.txt (BSD License)
+        * HOMEPAGE:
+          * https://github.com/joewalnes/webbit
+
+      This product contains a modified portion of 'SLF4J', a simple logging
+      facade for Java, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.slf4j.txt (MIT License)
+        * HOMEPAGE:
+          * https://www.slf4j.org/
+
+      This product contains a modified portion of 'Apache Harmony', an open source
+      Java SE, which can be obtained at:
+
+        * NOTICE:
+          * license/NOTICE.harmony.txt
+        * LICENSE:
+          * license/LICENSE.harmony.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://archive.apache.org/dist/harmony/
+
+      This product contains a modified portion of 'jbzip2', a Java bzip2 compression
+      and decompression library written by Matthew J. Francis. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jbzip2.txt (MIT License)
+        * HOMEPAGE:
+          * https://code.google.com/p/jbzip2/
+
+      This product contains a modified portion of 'libdivsufsort', a C API library to construct
+      the suffix array and the Burrows-Wheeler transformed string for any input string of
+      a constant-size alphabet written by Yuta Mori. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.libdivsufsort.txt (MIT License)
+        * HOMEPAGE:
+          * https://github.com/y-256/libdivsufsort
+
+      This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
+       which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jctools.txt (ASL2 License)
+        * HOMEPAGE:
+          * https://github.com/JCTools/JCTools
+
+      This product optionally depends on 'JZlib', a re-implementation of zlib in
+      pure Java, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jzlib.txt (BSD style License)
+        * HOMEPAGE:
+          * http://www.jcraft.com/jzlib/
+
+      This product optionally depends on 'Compress-LZF', a Java library for encoding and
+      decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/ning/compress
+
+      This product optionally depends on 'lz4', a LZ4 Java compression
+      and decompression library written by Adrien Grand. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.lz4.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/jpountz/lz4-java
+
+      This product optionally depends on 'lzma-java', a LZMA Java compression
+      and decompression library, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.lzma-java.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/jponge/lzma-java
+
+      This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+      and decompression library, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.zstd-jni.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/luben/zstd-jni
+
+      This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
+      and decompression library written by William Kinney. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jfastlz.txt (MIT License)
+        * HOMEPAGE:
+          * https://code.google.com/p/jfastlz/
+
+      This product contains a modified portion of and optionally depends on 'Protocol Buffers', Google's data
+      interchange format, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.protobuf.txt (New BSD License)
+        * HOMEPAGE:
+          * https://github.com/google/protobuf
+
+      This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
+      a temporary self-signed X.509 certificate when the JVM does not provide the
+      equivalent functionality.  It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.bouncycastle.txt (MIT License)
+        * HOMEPAGE:
+          * https://www.bouncycastle.org/
+
+      This product optionally depends on 'Snappy', a compression library produced
+      by Google Inc, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.snappy.txt (New BSD License)
+        * HOMEPAGE:
+          * https://github.com/google/snappy
+
+      This product optionally depends on 'JBoss Marshalling', an alternative Java
+      serialization API, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/jboss-remoting/jboss-marshalling
+
+      This product optionally depends on 'Caliper', Google's micro-
+      benchmarking framework, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.caliper.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/google/caliper
+
+      This product optionally depends on 'Apache Commons Logging', a logging
+      framework, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.commons-logging.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://commons.apache.org/logging/
+
+      This product optionally depends on 'Apache Log4J', a logging framework, which
+      can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.log4j.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://logging.apache.org/log4j/
+
+      This product optionally depends on 'Aalto XML', an ultra-high performance
+      non-blocking XML processor, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://wiki.fasterxml.com/AaltoHome
+
+      This product contains a modified version of 'HPACK', a Java implementation of
+      the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.hpack.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/twitter/hpack
+
+      This product contains a modified version of 'HPACK', a Java implementation of
+      the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.hyper-hpack.txt (MIT License)
+        * HOMEPAGE:
+          * https://github.com/python-hyper/hpack/
+
+      This product contains a modified version of 'HPACK', a Java implementation of
+      the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.nghttp2-hpack.txt (MIT License)
+        * HOMEPAGE:
+          * https://github.com/nghttp2/nghttp2/
+
+      This product contains a modified portion of 'Apache Commons Lang', a Java library
+      provides utilities for the java.lang API, which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.commons-lang.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://commons.apache.org/proper/commons-lang/
+
+
+      This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+
+        * LICENSE:
+          * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/takari/maven-wrapper
+
+      This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+      This private header is also used by Apple's open source
+       mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+
+       * LICENSE:
+          * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+        * HOMEPAGE:
+          * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+
+      This product optionally depends on 'Brotli4j', Brotli compression and
+      decompression for Java., which can be obtained at:
+
+        * LICENSE:
+          * license/LICENSE.brotli4j.txt (Apache License 2.0)
+        * HOMEPAGE:
+          * https://github.com/hyperxpro/Brotli4j
+
+===========================================
+MIT License
+===========================================
+
+  (MIT) Bouncy Castle Provider
+    The following NOTICE information applies:
+
+    Bouncy Castle Provider
+    Copyright 2000-2023 The Legion of the Bouncy Castle Inc (https://www.bouncycastle.org)
+
+  (MIT) Checker Qual
+    The following NOTICE information applies:
+
+    Copyright (c) Copyright 2004-present by the Checker Framework developers
+    All rights reserved.
+    https://www.checkerframework.org/


### PR DESCRIPTION
# Summary

[NIFI-12373](https://issues.apache.org/jira/browse/NIFI-12373) Adds `LICENSE` and `NOTICE` files to `nifi-standard-shared-nar` which were not present in the initial version.

These files follow the recommendations from the [Assembling LICENSE and NOTICE files](https://infra.apache.org/licensing-howto.html) on Apache Infrastructure documentation.

The `LICENSE` includes the standard Apache Software License Version 2 and the MIT License for the Bouncy Castle and Checker Framework libraries.

The `NOTICE` enumerates all dependencies. Most of the dependencies are licensed under ASLv2 and do not have explicit notices, but are listed for completeness.

This addition should be applied to both the main and support branches.

The current contents of the `nifi-standard-shared-nar` is as follows:

```
annotations-13.0.jar
bcpkix-jdk18on-1.76.jar
bcprov-jdk18on-1.76.jar
bcutil-jdk18on-1.76.jar
caffeine-3.1.8.jar
checker-qual-3.37.0.jar
commons-codec-1.16.0.jar
commons-compress-1.24.0.jar
commons-io-2.15.0.jar
commons-lang3-3.13.0.jar
commons-net-3.10.0.jar
commons-text-1.11.0.jar
error_prone_annotations-2.21.1.jar
jackson-annotations-2.15.3.jar
jackson-core-2.15.3.jar
jackson-databind-2.15.3.jar
kotlin-stdlib-1.9.10.jar
kotlin-stdlib-common-1.9.10.jar
kotlin-stdlib-jdk7-1.9.10.jar
kotlin-stdlib-jdk8-1.9.10.jar
netty-buffer-4.1.100.Final.jar
netty-codec-4.1.100.Final.jar
netty-common-4.1.100.Final.jar
netty-handler-4.1.100.Final.jar
netty-resolver-4.1.100.Final.jar
netty-transport-4.1.100.Final.jar
netty-transport-native-unix-common-4.1.100.Final.jar
okhttp-4.12.0.jar
okio-3.6.0.jar
okio-jvm-3.6.0.jar
```

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
