### PR TITLE
NIFI-12375 Remove maxFileSize from non-applicable policies in Logback

### DIFF
--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
@@ -54,8 +54,6 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.minifi.bootstrap.config.log.dir}/${org.apache.nifi.minifi.bootstrap.config.log.bootstrap.file.name}_%d.${org.apache.nifi.minifi.bootstrap.config.log.bootstrap.file.extension}.gz</fileNamePattern>
-            <!-- Control the maximum size of each log file before rolling over -->
-            <maxFileSize>10MB</maxFileSize>
             <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>10</maxHistory>
             <!-- Control the total size of all log archive files for this appender -->

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -56,8 +56,6 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-user_%d.log</fileNamePattern>
-            <!-- Control the maximum size of each log file before rolling over -->
-            <maxFileSize>100MB</maxFileSize>
             <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>30</maxHistory>
             <!-- Control the total size of all log archive files for this appender -->
@@ -74,8 +72,6 @@
         <file>${org.apache.nifi.bootstrap.config.log.dir}/nifi-request.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-request_%d.log</fileNamePattern>
-            <!-- Control the maximum size of each log file before rolling over -->
-            <maxFileSize>100MB</maxFileSize>
             <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>30</maxHistory>
             <!-- Control the total size of all log archive files for this appender -->
@@ -98,8 +94,6 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.bootstrap.config.log.dir}/nifi-bootstrap_%d.log</fileNamePattern>
-            <!-- Control the maximum size of each log file before rolling over -->
-            <maxFileSize>100MB</maxFileSize>
             <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>30</maxHistory>
             <!-- Control the total size of all log archive files for this appender -->

--- a/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/logback.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/logback.xml
@@ -53,8 +53,6 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.registry.bootstrap.config.log.dir}/nifi-registry-bootstrap_%d.log</fileNamePattern>
-            <!-- Control the maximum size of each log file before rolling over -->
-            <maxFileSize>100MB</maxFileSize>
             <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>30</maxHistory>
             <!-- Control the total size of all log archive files for this appender -->
@@ -77,8 +75,6 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.registry.bootstrap.config.log.dir}/nifi-registry-event_%d.log</fileNamePattern>
-            <!-- Control the maximum size of each log file before rolling over -->
-            <maxFileSize>100MB</maxFileSize>
             <!-- Control the maximum number of log archive files kept and asynchronously delete older files -->
             <maxHistory>30</maxHistory>
             <!-- Control the total size of all log archive files for this appender -->


### PR DESCRIPTION
# Summary

[NIFI-12375](https://issues.apache.org/jira/browse/NIFI-12375) Removes the `maxFileSize` settings from several `TimeBasedRollingPolicy` definitions in default logback.xml files. This settings does not impact behavior, but causes warnings on application shutdown because it does not apply to TimeBasedRollingPolicy configurations.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
