### PR TITLE
NIFI-12379 Refactor nifi-uuid5 using standard classes

### DIFF
--- a/nifi-commons/nifi-record-path/pom.xml
+++ b/nifi-commons/nifi-record-path/pom.xml
@@ -113,6 +113,10 @@
             <artifactId>caffeine</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>

--- a/nifi-commons/nifi-uuid5/pom.xml
+++ b/nifi-commons/nifi-uuid5/pom.xml
@@ -21,16 +21,4 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-uuid5</artifactId>
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <scope>compile</scope>
-        </dependency>
-    </dependencies>
 </project>

--- a/nifi-commons/nifi-uuid5/src/test/java/org/apache/nifi/uuid5/Uuid5UtilTest.java
+++ b/nifi-commons/nifi-uuid5/src/test/java/org/apache/nifi/uuid5/Uuid5UtilTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.uuid5;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class Uuid5UtilTest {
+    private static final String NAMESPACE = "11111111-1111-1111-1111-111111111111";
+
+    private static final String NAME = "identifier";
+
+    private static final String NAME_UUID_NULL_NAMESPACE = "485f3c34-2c6c-50a3-9904-63233467b96a";
+
+    private static final String NAME_UUID_NAMESPACE = "c9b54096-3890-53cc-b375-af7e7ec5e59f";
+
+    @Test
+    void testFromStringNullNamespace() {
+        final String uuid = Uuid5Util.fromString(NAME, null);
+
+        assertEquals(NAME_UUID_NULL_NAMESPACE, uuid);
+    }
+
+    @Test
+    void testFromStringNamespace() {
+        final String uuid = Uuid5Util.fromString(NAME, NAMESPACE);
+
+        assertEquals(NAME_UUID_NAMESPACE, uuid);
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-12379](https://issues.apache.org/jira/browse/NIFI-12379) Refactors the `Uuid5Util` class in `nifi-uuid5` using standard Java classes to remove dependencies on Apache Commons Lang3 and Apache Commons Codec. The Java [HexFormat](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/HexFormat.html) class provides hexadecimal encoding and the Java `MessageDigest` supports SHA-1.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
