### PR TITLE
NIFI-12383 Replication client should handle accept encoding with lowe…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/okhttp/OkHttpReplicationClient.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/okhttp/OkHttpReplicationClient.java
@@ -291,7 +291,11 @@ public class OkHttpReplicationClient implements HttpReplicationClient {
 
 
     private boolean isUseGzip(final Map<String, String> headers) {
-        final String rawAcceptEncoding = headers.get(HttpHeaders.ACCEPT_ENCODING);
+        String rawAcceptEncoding = headers.get(HttpHeaders.ACCEPT_ENCODING);
+
+        if (rawAcceptEncoding == null) {
+            rawAcceptEncoding = headers.get(HttpHeaders.ACCEPT_ENCODING.toLowerCase());
+        }
 
         if (rawAcceptEncoding == null) {
             return false;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/okhttp/OkHttpReplicationClientTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/okhttp/OkHttpReplicationClientTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.nifi.cluster.coordination.http.replication.okhttp;
 
+import org.apache.nifi.cluster.coordination.http.replication.PreparedRequest;
 import org.apache.nifi.security.util.TemporaryKeyStoreBuilder;
 import org.apache.nifi.security.util.TlsConfiguration;
 import org.apache.nifi.util.NiFiProperties;
@@ -98,6 +99,25 @@ public class OkHttpReplicationClientTest {
             assertEquals(2, headers.size());
             assertEquals("123", headers.get("Content-Length"));
         }
+    }
+
+    @Test
+    void testShouldReadCasInsensitiveAcceptEncoding() {
+        final Map<String, String> headers = new HashMap<>();
+        headers.put("accept-encoding", "gzip");
+        headers.put("Other-Header", "arbitrary value");
+
+        final NiFiProperties mockProperties = mockNiFiProperties();
+
+        final OkHttpReplicationClient client = new OkHttpReplicationClient(mockProperties);
+
+
+        PreparedRequest request = client.prepareRequest("POST", headers, "TEST");
+
+        assertEquals(3, request.getHeaders().size());
+        assertEquals("gzip", request.getHeaders().get("accept-encoding"));
+        assertEquals("gzip", request.getHeaders().get("Content-Encoding"));
+        assertEquals("arbitrary value", request.getHeaders().get("Other-Header"));
     }
 
     @Test


### PR DESCRIPTION
…rcase

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12383](https://issues.apache.org/jira/browse/NIFI-12383)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-12383) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-12383`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
