### PR TITLE
NIFI-12331: add new unified PublishSlack Processor

### DIFF
--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PublishSlack.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PublishSlack.java
@@ -1,0 +1,516 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.SlackFilesUploadV2Exception;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.request.conversations.ConversationsListRequest;
+import com.slack.api.methods.request.files.FilesUploadV2Request;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.slack.api.methods.response.conversations.ConversationsListResponse;
+import com.slack.api.methods.response.files.FilesUploadV2Response;
+import com.slack.api.model.Conversation;
+import com.slack.api.model.File;
+import org.apache.nifi.annotation.behavior.DynamicProperty;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.expression.AttributeExpression;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.slack.consume.ConsumeSlackUtil;
+import org.apache.nifi.processors.slack.publish.ContentMessageStrategy;
+import org.apache.nifi.processors.slack.publish.MessageOnlyStrategy;
+import org.apache.nifi.processors.slack.publish.PublishConfig;
+import org.apache.nifi.processors.slack.publish.PublishSlackClient;
+import org.apache.nifi.processors.slack.publish.PublishStrategy;
+import org.apache.nifi.processors.slack.publish.UploadAttachmentStrategy;
+import org.apache.nifi.processors.slack.publish.UploadLinkStrategy;
+import org.apache.nifi.processors.slack.publish.UploadOnlyStrategy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.apache.nifi.util.StringUtils.isEmpty;
+
+
+@Tags({"slack", "publish", "notify", "upload", "message"})
+@CapabilityDescription("Uploads the FlowFile content (e.g. an image) as a file, and/or Sends a message on Slack. The FlowFile content can be used as the message text or attached to the message.")
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+@DynamicProperty(name = "<Arbitrary name>", value = "JSON snippet specifying a Slack message \"attachment\"",
+        description = "The property value will be converted to JSON and will be added to the array of attachments in the JSON payload being sent to Slack." +
+                " The property name will not be used by the processor.",
+        expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+@WritesAttribute(attribute="slack.file.url", description = "The Slack URL of the uploaded file. It will be added if 'Upload FlowFile' has been set to 'Yes'.")
+public class PublishSlack extends AbstractProcessor {
+
+    private static final String UPLOAD_ONLY = "upload-only";
+    private static final String MESSAGE_ONLY = "message-only";
+    private static final String CONTENT_MESSAGE = "content-message";
+    private static final String UPLOAD_ATTACH = "upload-attach";
+    private static final String UPLOAD_LINK = "upload-link";
+
+    public static final PropertyDescriptor BOT_TOKEN = new PropertyDescriptor.Builder()
+            .name("Bot Token")
+            .description("The Bot Token that is registered to your Slack application")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .required(true)
+            .sensitive(true)
+            .build();
+
+    public static final AllowableValue STRATEGY_UPLOAD_ONLY = new AllowableValue(
+            UPLOAD_ONLY,
+            "Upload File Content Only",
+            "Only upload the FlowFile content - it will be a visible Slack message if 'Upload Channel' is specified."
+    );
+
+    public static final AllowableValue STRATEGY_MESSAGE_ONLY = new AllowableValue(
+            MESSAGE_ONLY,
+            "Post Message Only",
+            "Post a simple Slack message with optional 'Text' and/or dynamic Properties as attachments."
+    );
+
+    public static final AllowableValue STRATEGY_CONTENT_MESSAGE = new AllowableValue(
+            CONTENT_MESSAGE,
+            "Post File Content as Message Text",
+            "Post the FlowFile content as a Slack message with optional dynamic Properties as attachments."
+    );
+
+    public static final AllowableValue STRATEGY_UPLOAD_ATTACH = new AllowableValue(
+            UPLOAD_ATTACH,
+            "Upload File Content as Attachment to Message",
+            "Upload the FlowFile content and add a link to the uploaded file as an attachment to the posted Slack message. The message will include optional dynamic Properties as attachments."
+    );
+
+    public static final AllowableValue STRATEGY_UPLOAD_LINK = new AllowableValue(
+            UPLOAD_LINK,
+            "Upload File Content as Embedded Link",
+            "Upload the FlowFile content and append a link to the uploaded file in the posted Slack message. The message will include optional dynamic Properties as attachments."
+    );
+
+    public static final PropertyDescriptor PUBLISH_STRATEGY = new PropertyDescriptor.Builder()
+            .name("publish-strategy")
+            .displayName("Publish Strategy")
+            .description("Determines how the FlowFile is sent to Slack and how it appears.")
+            .allowableValues(STRATEGY_UPLOAD_ONLY, STRATEGY_MESSAGE_ONLY, STRATEGY_CONTENT_MESSAGE, STRATEGY_UPLOAD_ATTACH, STRATEGY_UPLOAD_LINK)
+            .required(true)
+            .defaultValue(UPLOAD_ATTACH)
+            .build();
+
+    public static final PropertyDescriptor CHANNEL = new PropertyDescriptor.Builder()
+            .name("channel")
+            .displayName("Channel")
+            .description("Slack channel, private group, or IM channel to post the message to.")
+            .dependsOn(PUBLISH_STRATEGY, MESSAGE_ONLY, CONTENT_MESSAGE, UPLOAD_ATTACH, UPLOAD_LINK)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor UPLOAD_CHANNEL = new PropertyDescriptor.Builder()
+            .name("upload-channel")
+            .displayName("Upload Channel")
+            .description("Slack channel, private group, or IM channel to upload the file to.")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor THREAD_TS = new PropertyDescriptor.Builder()
+            .name("Thread Timestamp")
+            .description("The timestamp of the parent message, also known as a thread_ts, or Thread Timestamp. If not specified, the message will be send to the channel " +
+                    "as an independent message. If this value is populated, the message will be sent as a reply to the message whose timestamp is equal to the given value.")
+            .required(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor TEXT = new PropertyDescriptor.Builder()
+            .name("text")
+            .displayName("Text")
+            .description("Text of the Slack message to send. Only required if no attachment has been specified and 'Upload File' has been set to 'No'.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor INITIAL_COMMENT = new PropertyDescriptor.Builder()
+            .name("upload-text")
+            .displayName("Upload Text")
+            .description("Text of the Slack message to include with a public upload. Only used if 'Publish Mode' has been set to 'Upload Only' and 'Upload Channel' is specified.")
+            .dependsOn(PUBLISH_STRATEGY, UPLOAD_ONLY)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor FILE_TITLE = new PropertyDescriptor.Builder()
+            .name("file-title")
+            .displayName("File Title")
+            .description("Title of the file displayed in the Slack message." +
+                    " The property value will only be used if 'Upload FlowFile' has been set to 'Yes'.")
+            .dependsOn(PUBLISH_STRATEGY, UPLOAD_ONLY, UPLOAD_ATTACH, UPLOAD_LINK)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor FILE_NAME = new PropertyDescriptor.Builder()
+            .name("file-name")
+            .displayName("File Name")
+            .description("Name of the file to be uploaded." +
+                    " The property value will only be used if 'Upload FlowFile' has been set to 'Yes'." +
+                    " If the property evaluated to null or empty string, then the file name will be set to 'file' in the Slack message.")
+            .dependsOn(PUBLISH_STRATEGY, UPLOAD_ONLY, UPLOAD_ATTACH, UPLOAD_LINK)
+            .defaultValue("${" + CoreAttributes.FILENAME.key() + "}")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor ICON_URL = new PropertyDescriptor
+            .Builder()
+            .name("icon-url")
+            .displayName("Icon URL")
+            .description("Icon URL to be used for the message")
+            .required(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.URL_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor ICON_EMOJI = new PropertyDescriptor
+            .Builder()
+            .name("icon-emoji")
+            .displayName("Icon Emoji")
+            .description("Icon Emoji to be used for the message. Must begin and end with a colon, e.g. :ghost:")
+            .required(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(new EmojiValidator())
+            .build();
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("FlowFiles are routed to success after being successfully sent to Slack")
+            .build();
+
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("FlowFiles are routed to failure if unable to be sent to Slack")
+            .build();
+
+    public static final Set<Relationship> relationships = Set.of(REL_SUCCESS, REL_FAILURE);
+
+    public static final List<PropertyDescriptor> properties = List.of(
+            BOT_TOKEN,
+            CHANNEL,
+            UPLOAD_CHANNEL,
+            THREAD_TS,
+            PUBLISH_STRATEGY,
+            TEXT,
+            INITIAL_COMMENT,
+            FILE_TITLE,
+            FILE_NAME,
+            ICON_URL,
+            ICON_EMOJI);
+
+    private final SortedSet<PropertyDescriptor> attachmentProperties = Collections.synchronizedSortedSet(new TreeSet<>());
+
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(String propertyDescriptorName) {
+        return new PropertyDescriptor.Builder()
+                .name(propertyDescriptorName)
+                .description("Slack Attachment JSON snippet that will be added to the message. The property value will be used unless 'Publish Mode' has been set to 'Upload Only'" +
+                        " and no 'Upload Channel' is provided. If the property evaluated to null or empty string, or contains invalid JSON, then it will not be added to the Slack message.")
+                .required(false)
+                .addValidator(StandardValidators.createAttributeExpressionLanguageValidator(AttributeExpression.ResultType.STRING, true))
+                .addValidator(StandardValidators.ATTRIBUTE_KEY_PROPERTY_NAME_VALIDATOR)
+                .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+                .dynamic(true)
+                .build();
+    }
+
+    @Override
+    public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
+        List<ValidationResult> validationResults = new ArrayList<>();
+
+        PublishStrategy strategy;
+        try {
+            strategy = strategyFor(validationContext.getProperty(PUBLISH_STRATEGY).getValue());
+        } catch (RuntimeException e) {
+            validationResults.add(new ValidationResult.Builder()
+                    .subject(PUBLISH_STRATEGY.getDisplayName())
+                    .valid(false)
+                    .explanation("unrecognized 'Publish Strategy' - must be one of the defined strategies.")
+                    .build());
+            return validationResults;
+        }
+        boolean channelSpecified = validationContext.getProperty(CHANNEL).isSet();
+        boolean textSpecified = validationContext.getProperty(TEXT).isSet();
+        boolean attachmentSpecified = validationContext.getProperties().keySet()
+                .stream()
+                .anyMatch(PropertyDescriptor::isDynamic);
+        boolean uploadFileYes = strategy.willUploadFile();
+        boolean flowFileAsContentYes = strategy.willSendContent() && !strategy.willUploadFile();
+
+        if (!channelSpecified && strategy.willPostMessage()) {
+            validationResults.add(new ValidationResult.Builder()
+                    .subject(CHANNEL.getDisplayName())
+                    .valid(false)
+                    .explanation("it is required unless 'Publish Strategy' is set to 'Upload File Content Only'.")
+                    .build());
+        }
+        if (!textSpecified && !attachmentSpecified && !uploadFileYes && !flowFileAsContentYes) {
+            validationResults.add(new ValidationResult.Builder()
+                    .subject(TEXT.getDisplayName())
+                    .valid(false)
+                    .explanation("it is required if no attachment has been specified, and 'Publish Strategy' has been set to 'Post Message Only'.")
+                    .build());
+        }
+
+        return validationResults;
+    }
+
+    protected PublishSlackClient initializeClient(final MethodsClient client) {
+        return new PublishSlack.DelegatingSlackClient(client);
+    }
+
+    @OnScheduled
+    public void onScheduled(ProcessContext context) {
+        attachmentProperties.clear();
+        attachmentProperties.addAll(
+                context.getProperties().keySet().stream().filter(PropertyDescriptor::isDynamic).toList());
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        final String botToken = context.getProperty(BOT_TOKEN).getValue();
+        final AppConfig appConfig = AppConfig.builder().singleTeamBotToken(botToken).build();
+
+        // The Bolt App's MethodsClient uses a thread pool...perhaps we should use the SlackHttpClient, instead?
+        final PublishSlackClient slackClient = initializeClient(new App(appConfig).getClient());
+
+        try {
+            final PublishConfig config = parseOptions(botToken, context, session, flowFile, slackClient);
+            final PublishStrategy strategy = strategyFor(config.getMode());
+            if (strategy.willPostMessage() && isEmpty(config.getChannel())) {
+                throw new RuntimeException("The channel must be specified when posting a message.");
+            }
+            if (strategy.willSendContent()) {
+                try (InputStream stream = session.read(flowFile)) {
+                    byte[] fileData = stream.readAllBytes();
+                    strategy.setFileContent(config, fileData);
+                }
+                if (strategy.willUploadFile()) {
+                    File upload = uploadFlowfile(strategy, config);
+                    strategy.setUploadFile(config, upload);
+                }
+            }
+            if (strategy.willPostMessage()) {
+                strategy.addMessageAttachments(getLogger(), config, attachmentProperties);
+                postMessage(strategy, config);
+            }
+
+            session.transfer(flowFile, REL_SUCCESS);
+
+        } catch (IOException | SlackApiException | RuntimeException e) {
+            getLogger().error("Failed to send message to Slack.", e);
+            flowFile = session.penalize(flowFile);
+            session.transfer(flowFile, REL_FAILURE);
+            context.yield();
+        }
+    }
+
+    private void postMessage(PublishStrategy strategy, PublishConfig config) throws IOException, SlackApiException {
+        ChatPostMessageRequest request = strategy.buildPostMessageRequest(config);
+        ChatPostMessageResponse response = config.getSlackClient().chatPostMessage(request);
+        if (response.getWarning() != null) {
+            getLogger().warn("Slack warning message: " + response.getWarning());
+        }
+        if (response.isOk()) {
+            getLogger().debug("Slack response: ok, channel = " + response.getChannel() + ", ts = " + response.getTs());
+        } else {
+            String error = response.getError();
+            getLogger().debug("Slack response: error = " + error);
+            throw new RuntimeException("Slack error response: " + error);
+        }
+    }
+
+    private File uploadFlowfile(PublishStrategy strategy, PublishConfig config) throws IOException, SlackApiException {
+        FilesUploadV2Request request = strategy.buildFilesUploadV2Request(getLogger(), config);
+        FilesUploadV2Response response = config.getSlackClient().filesUploadV2(request);
+        if (response.getWarning() != null) {
+            getLogger().warn("Slack warning message: " + response.getWarning());
+        }
+        if (!response.isOk()) {
+            String error = response.getError();
+            throw new RuntimeException("Slack error response: " + error);
+        }
+        return response.getFile();
+    }
+
+    public static String lookupChannelId(PublishSlackClient slackClient, String channel) throws SlackApiException, IOException {
+        ConversationsListResponse response;
+        String cursor = null;
+        do {
+            final ConversationsListRequest request = ConversationsListRequest.builder()
+                    .cursor(cursor)
+                    .excludeArchived(true)
+                    .limit(500)
+                    .build();
+
+            response = slackClient.conversationsList(request);
+            if (response.isOk()) {
+                for (Conversation convo : response.getChannels()) {
+                    if (channel.equals(convo.getName()) || channel.equals(convo.getId())) {
+                        return convo.getId();
+                    }
+                }
+                cursor = response.getResponseMetadata().getNextCursor();
+            }
+        } while (!isEmpty(cursor));
+
+        final String errorMessage = ConsumeSlackUtil.getErrorMessage(response.getError(), response.getNeeded(), response.getProvided(), response.getWarning());
+        throw new RuntimeException("Failed to determine Channel ID: " + errorMessage);
+    }
+
+    protected PublishStrategy strategyFor(String publishStrategy) {
+        if (UPLOAD_ONLY.equals(publishStrategy)) {
+            return new UploadOnlyStrategy();
+        }
+        if (MESSAGE_ONLY.equals(publishStrategy)) {
+            return new MessageOnlyStrategy();
+        }
+        if (CONTENT_MESSAGE.equals(publishStrategy)) {
+            return new ContentMessageStrategy();
+        }
+        if (UPLOAD_ATTACH.equals(publishStrategy)) {
+            return new UploadAttachmentStrategy();
+        }
+        if (UPLOAD_LINK.equals(publishStrategy)) {
+            return new UploadLinkStrategy();
+        }
+        throw new RuntimeException("Did not recognize the 'Publish Strategy': " + publishStrategy);
+    }
+
+    protected PublishConfig parseOptions(String botToken, ProcessContext context, ProcessSession session, FlowFile flowFile, PublishSlackClient slackClient) {
+        final PublishConfig config = new PublishConfig();
+        config.setContext(context);
+        config.setSession(session);
+        config.setFlowFile(flowFile);
+        config.setSlackClient(slackClient);
+        config.setMode(context.getProperty(PUBLISH_STRATEGY).getValue());
+        config.setBotToken(botToken);
+        config.setChannel(context.getProperty(CHANNEL).evaluateAttributeExpressions(flowFile).getValue());
+        config.setUploadChannel(context.getProperty(UPLOAD_CHANNEL).evaluateAttributeExpressions(flowFile).getValue());
+        config.setThreadTs(context.getProperty(THREAD_TS).evaluateAttributeExpressions(flowFile).getValue());
+        config.setText(context.getProperty(TEXT).evaluateAttributeExpressions(flowFile).getValue());
+        config.setInitComment(context.getProperty(INITIAL_COMMENT).evaluateAttributeExpressions(flowFile).getValue());
+        config.setIconUrl(context.getProperty(ICON_URL).evaluateAttributeExpressions(flowFile).getValue());
+        config.setIconEmoji(context.getProperty(ICON_EMOJI).evaluateAttributeExpressions(flowFile).getValue());
+        config.setFileName(context.getProperty(FILE_NAME).evaluateAttributeExpressions(flowFile).getValue());
+        config.setFileTitle(context.getProperty(FILE_TITLE).evaluateAttributeExpressions(flowFile).getValue());
+        return config;
+    }
+
+    public static String linkify(final String url, final String linkText) {
+        if (isEmpty(url)) {
+            return linkText;
+        }
+        if (isEmpty(linkText)) {
+            return "<" + url + ">";
+        }
+        return "<" + url + "|" + linkText + ">";
+    }
+
+    public static String nullify(final String value) {
+        return isEmpty(value) ? null : value;
+    }
+
+    protected static class EmojiValidator implements Validator {
+        @Override
+        public ValidationResult validate(final String subject, final String input, final ValidationContext context) {
+            if (input.startsWith(":") && input.endsWith(":") && input.length() > 2) {
+                return new ValidationResult.Builder().subject(subject).input(input).valid(true).build();
+            }
+
+            return new ValidationResult.Builder().input(input).subject(subject).valid(false)
+                    .explanation("Must begin and end with a colon")
+                    .build();
+        }
+    }
+
+
+    protected static class DelegatingSlackClient implements PublishSlackClient {
+        private final MethodsClient delegate;
+
+        public DelegatingSlackClient(final MethodsClient delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ConversationsListResponse conversationsList(ConversationsListRequest request) throws SlackApiException, IOException {
+            return delegate.conversationsList(request);
+        }
+
+        @Override
+        public FilesUploadV2Response filesUploadV2(FilesUploadV2Request request) throws SlackFilesUploadV2Exception, SlackApiException, IOException {
+            return delegate.filesUploadV2(request);
+        }
+
+        @Override
+        public ChatPostMessageResponse chatPostMessage(ChatPostMessageRequest request) throws SlackApiException, IOException {
+            return delegate.chatPostMessage(request);
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/AbstractStrategy.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/AbstractStrategy.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack.publish;
+
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.request.files.FilesUploadV2Request;
+import com.slack.api.model.File;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.ProcessSession;
+
+import java.io.IOException;
+import java.util.Set;
+
+public abstract class AbstractStrategy implements PublishStrategy {
+
+    private final PostMessageComponent postMessageComponent = new PostMessageComponent();
+    private final UploadComponent uploadComponent = new UploadComponent();
+
+    @Override
+    public boolean willSendContent() {
+        return false;
+    }
+
+    @Override
+    public boolean willUploadFile() {
+        return false;
+    }
+
+    @Override
+    public boolean willPostMessage() {
+        return false;
+    }
+
+    @Override
+    public void setFileContent(PublishConfig config, byte[] fileContent) {
+        config.setFileContent(fileContent);
+    }
+
+    @Override
+    public void setUploadFile(PublishConfig config, File uploadFile) {
+        config.setUpload(uploadFile);
+        ProcessSession session = config.getSession();
+        FlowFile flowFile = config.getFlowFile();
+        if (session != null && flowFile != null && uploadFile.getUrlPrivate() != null) {
+            session.putAttribute(flowFile, "slack.file.url", uploadFile.getUrlPrivate());
+            session.getProvenanceReporter().send(flowFile, uploadFile.getUrlPrivate());
+        }
+    }
+
+    protected String getMessageText(PublishConfig config) {
+        return config.getText();
+    }
+
+    protected String getUploadChannel(PublishConfig config) {
+        return config.getUploadChannel();
+    }
+
+    protected String getInitialComment(PublishConfig config) {
+        return config.getInitComment();
+    }
+
+    @Override
+    public FilesUploadV2Request buildFilesUploadV2Request(ComponentLog logger, PublishConfig config) throws SlackApiException, IOException {
+        return uploadComponent.buildFilesUploadV2Request(logger, getUploadChannel(config), getInitialComment(config), config);
+    }
+
+    @Override
+    public void addMessageAttachments(ComponentLog logger, PublishConfig config, Set<PropertyDescriptor> properties) {
+        postMessageComponent.addMessageAttachments(logger, config, properties);
+    }
+
+    @Override
+    public ChatPostMessageRequest buildPostMessageRequest(PublishConfig config) {
+        return postMessageComponent.buildPostMessageRequest(getMessageText(config), config);
+    }
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/ContentMessageStrategy.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/ContentMessageStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack.publish;
+
+public class ContentMessageStrategy extends AbstractStrategy {
+
+    private String messageText = null;
+
+    @Override
+    public boolean willSendContent() {
+        return true;
+    }
+
+    @Override
+    public boolean willPostMessage() {
+        return true;
+    }
+
+    @Override
+    protected String getMessageText(PublishConfig config) {
+        byte[] content = config.getFileContent();
+        if (messageText == null && content != null) {
+            messageText = new String(content);
+        }
+        return messageText;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/MessageOnlyStrategy.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/MessageOnlyStrategy.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack.publish;
+
+public class MessageOnlyStrategy extends AbstractStrategy {
+
+    @Override
+    public boolean willPostMessage() {
+        return true;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/PostMessageComponent.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/PostMessageComponent.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack.publish;
+
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.model.Attachment;
+import org.apache.http.entity.ContentType;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.ProcessContext;
+
+import javax.json.Json;
+import javax.json.stream.JsonParsingException;
+import java.io.StringReader;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.nifi.processors.slack.PublishSlack.nullify;
+import static org.apache.nifi.util.StringUtils.isEmpty;
+
+public class PostMessageComponent {
+
+    public void addMessageAttachments(ComponentLog logger, PublishConfig config, Set<PropertyDescriptor> properties) {
+        // Build Attachments for the posted message and add them to the config's list
+        ProcessContext context = config.getContext();
+        FlowFile flowFile = config.getFlowFile();
+        List<Attachment> attachments = config.getAttachments();
+        for (PropertyDescriptor attachmentProperty : properties) {
+            String propertyValue = context.getProperty(attachmentProperty).evaluateAttributeExpressions(flowFile).getValue();
+            if (propertyValue != null && !propertyValue.isEmpty()) {
+                try {
+                    Attachment.AttachmentBuilder builder = Attachment.builder()
+                            .text(Json.createReader(new StringReader(propertyValue)).readObject().toString())
+                            .fallback(propertyValue)    // client logs warnings if fallback isn't set
+                            .mimetype(ContentType.APPLICATION_JSON.toString());
+                    attachments.add(builder.build());
+                } catch (JsonParsingException e) {
+                    logger.warn(attachmentProperty.getName() + " property contains invalid JSON, has been skipped.");
+                }
+            } else {
+                logger.warn(attachmentProperty.getName() + " property has no value, has been skipped.");
+            }
+        }
+    }
+
+    public ChatPostMessageRequest buildPostMessageRequest(String message, PublishConfig config) {
+        List<Attachment> attachments = config.getAttachments();
+        if (isEmpty(message) && attachments.isEmpty()) {
+            throw new RuntimeException("The text of the message must be specified if no attachment has been specified and 'Upload File' has been set to 'No'.");
+        }
+        ChatPostMessageRequest.ChatPostMessageRequestBuilder builder = ChatPostMessageRequest.builder()
+                .token(config.getBotToken())
+                .channel(config.getChannel())
+                .threadTs(nullify(config.getThreadTs()))
+                .text(nullify(message))
+                .iconUrl(nullify(config.getIconUrl()))
+                .iconEmoji(nullify(config.getIconEmoji()))
+                .attachments(attachments.isEmpty() ? null : attachments);
+        return builder.build();
+    }
+
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/PublishConfig.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/PublishConfig.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack.publish;
+
+import com.slack.api.model.Attachment;
+import com.slack.api.model.File;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PublishConfig {
+    public ProcessContext getContext() {
+        return context;
+    }
+
+    public void setContext(ProcessContext context) {
+        this.context = context;
+    }
+
+    public ProcessSession getSession() {
+        return session;
+    }
+
+    public void setSession(ProcessSession session) {
+        this.session = session;
+    }
+
+    public FlowFile getFlowFile() {
+        return flowFile;
+    }
+
+    public void setFlowFile(FlowFile flowFile) {
+        this.flowFile = flowFile;
+    }
+
+    public PublishSlackClient getSlackClient() {
+        return slackClient;
+    }
+
+    public void setSlackClient(PublishSlackClient slackClient) {
+        this.slackClient = slackClient;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+
+    public String getBotToken() {
+        return botToken;
+    }
+
+    public void setBotToken(String botToken) {
+        this.botToken = botToken;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public String getUploadChannel() {
+        return uploadChannel;
+    }
+
+    public void setUploadChannel(String uploadChannel) {
+        this.uploadChannel = uploadChannel;
+    }
+
+    public String getThreadTs() {
+        return threadTs;
+    }
+
+    public void setThreadTs(String threadTs) {
+        this.threadTs = threadTs;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getInitComment() {
+        return initComment;
+    }
+
+    public void setInitComment(String initComment) {
+        this.initComment = initComment;
+    }
+
+    public String getIconUrl() {
+        return iconUrl;
+    }
+
+    public void setIconUrl(String iconUrl) {
+        this.iconUrl = iconUrl;
+    }
+
+    public String getIconEmoji() {
+        return iconEmoji;
+    }
+
+    public void setIconEmoji(String iconEmoji) {
+        this.iconEmoji = iconEmoji;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getFileTitle() {
+        return fileTitle;
+    }
+
+    public void setFileTitle(String fileTitle) {
+        this.fileTitle = fileTitle;
+    }
+
+    public byte[] getFileContent() {
+        return fileContent;
+    }
+
+    public void setFileContent(byte[] fileContent) {
+        this.fileContent = fileContent;
+    }
+
+    public File getUpload() {
+        return upload;
+    }
+
+    public void setUpload(File upload) {
+        this.upload = upload;
+    }
+
+    public List<Attachment> getAttachments() {
+        return attachments;
+    }
+
+    private ProcessContext context;
+    private ProcessSession session;
+    private FlowFile flowFile;
+    private PublishSlackClient slackClient;
+    private String mode;
+    private String botToken;
+    private String channel;
+    private String uploadChannel;
+    private String threadTs;
+    private String text;
+    private String initComment;
+    private String iconUrl;
+    private String iconEmoji;
+    private String fileName;
+    private String fileTitle;
+    private byte[] fileContent = null;
+    private File upload = null;
+    private final List<Attachment> attachments = new ArrayList<>();
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/PublishSlackClient.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/PublishSlackClient.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack.publish;
+
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.SlackFilesUploadV2Exception;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.request.conversations.ConversationsListRequest;
+import com.slack.api.methods.request.files.FilesUploadV2Request;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.slack.api.methods.response.conversations.ConversationsListResponse;
+import com.slack.api.methods.response.files.FilesUploadV2Response;
+
+import java.io.IOException;
+
+
+/**
+ * A simple wrapper around the Slack Client with the methods that we use so that they can be easily mocked for testing
+ */
+public interface PublishSlackClient {
+
+    ConversationsListResponse conversationsList(ConversationsListRequest request)
+            throws SlackApiException, IOException;
+
+    FilesUploadV2Response filesUploadV2(FilesUploadV2Request request)
+            throws SlackFilesUploadV2Exception, SlackApiException, IOException;
+
+    ChatPostMessageResponse chatPostMessage(ChatPostMessageRequest request)
+            throws SlackApiException, IOException;
+
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/PublishStrategy.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/PublishStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack.publish;
+
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.request.files.FilesUploadV2Request;
+import com.slack.api.model.File;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.logging.ComponentLog;
+
+import java.io.IOException;
+import java.util.Set;
+
+public interface PublishStrategy {
+    boolean willSendContent();
+    boolean willUploadFile();
+    boolean willPostMessage();
+    void setFileContent(PublishConfig config, byte[] fileData);
+    void setUploadFile(PublishConfig config, File uploadFile);
+
+    FilesUploadV2Request buildFilesUploadV2Request(ComponentLog logger, PublishConfig config) throws SlackApiException, IOException;
+
+    void addMessageAttachments(ComponentLog logger, PublishConfig config, Set<PropertyDescriptor> properties);
+
+    ChatPostMessageRequest buildPostMessageRequest(PublishConfig config);
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/UploadAttachmentStrategy.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/UploadAttachmentStrategy.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack.publish;
+
+import com.slack.api.model.Attachment;
+import com.slack.api.model.File;
+
+import java.util.List;
+
+import static org.apache.nifi.processors.slack.PublishSlack.linkify;
+
+public class UploadAttachmentStrategy extends AbstractStrategy {
+
+    @Override
+    public boolean willSendContent() {
+        return true;
+    }
+
+    @Override
+    public boolean willUploadFile() {
+        return true;
+    }
+
+    @Override
+    public boolean willPostMessage() {
+        return true;
+    }
+
+    @Override
+    public void setUploadFile(PublishConfig config, File uploadFile) {
+        super.setUploadFile(config, uploadFile);
+        Attachment fileAttachment = Attachment.builder()
+                .text(linkify(uploadFile.getPermalink(), uploadFile.getTitle()))
+                .fallback(uploadFile.getTitle())
+                .filename(uploadFile.getName())
+                .url(uploadFile.getPermalink())
+                .size(uploadFile.getSize())
+                .files(List.of(uploadFile))
+                .build();
+        config.getAttachments().add(fileAttachment);
+    }
+
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/UploadComponent.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/UploadComponent.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack.publish;
+
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.files.FilesUploadV2Request;
+import org.apache.nifi.logging.ComponentLog;
+
+import java.io.IOException;
+
+import static org.apache.nifi.processors.slack.PublishSlack.lookupChannelId;
+import static org.apache.nifi.processors.slack.PublishSlack.nullify;
+import static org.apache.nifi.util.StringUtils.isEmpty;
+
+public class UploadComponent {
+
+    public FilesUploadV2Request buildFilesUploadV2Request(
+            ComponentLog logger,
+            String channel,
+            String initialComment,
+            PublishConfig config) throws SlackApiException, IOException {
+        String channelId = isEmpty(channel) ? null : lookupChannelId(config.getSlackClient(), channel);
+        String fileName = config.getFileName();
+        if (fileName == null || fileName.isEmpty()) {
+            fileName = "file";
+            logger.warn("File name not specified, has been set to {}.", fileName);
+        }
+        final String title = config.getFileTitle();
+        FilesUploadV2Request.FilesUploadV2RequestBuilder builder = FilesUploadV2Request.builder()
+                .token(config.getBotToken())
+                .channel(channelId)
+                .threadTs(isEmpty(channelId) ? null : nullify(config.getThreadTs()))
+                .filename(fileName)
+                .title(isEmpty(title) ? fileName : title)
+                .fileData(config.getFileContent())
+                .initialComment(nullify(initialComment));
+        return builder.build();
+    }
+
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/UploadLinkStrategy.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/UploadLinkStrategy.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack.publish;
+
+import com.slack.api.model.File;
+
+import static org.apache.nifi.processors.slack.PublishSlack.linkify;
+import static org.apache.nifi.util.StringUtils.isEmpty;
+
+public class UploadLinkStrategy extends AbstractStrategy {
+
+    @Override
+    public boolean willSendContent() {
+        return true;
+    }
+
+    @Override
+    public boolean willUploadFile() {
+        return true;
+    }
+
+    @Override
+    public boolean willPostMessage() {
+        return true;
+    }
+
+    @Override
+    protected String getMessageText(PublishConfig config) {
+        String text = config.getText();
+        File upload = config.getUpload();
+        String link = upload == null ? null : upload.getPermalink();
+        String title = upload == null ? null : upload.getTitle();
+        String linked = linkify(link, title);
+        if (isEmpty(text)) {
+            return linked;
+        }
+        if (isEmpty(linked)) {
+            return text;
+        }
+        return text + "\n" + linked;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/UploadOnlyStrategy.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/publish/UploadOnlyStrategy.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack.publish;
+
+import static org.apache.nifi.util.StringUtils.isEmpty;
+
+public class UploadOnlyStrategy extends AbstractStrategy {
+
+    @Override
+    public boolean willSendContent() {
+        return true;
+    }
+
+    @Override
+    public boolean willUploadFile() {
+        return true;
+    }
+
+    @Override
+    protected String getUploadChannel(PublishConfig config) {
+        if (isEmpty(config.getUploadChannel())) {
+            // fallback to CHANNEL in case the user set the wrong Property
+            return config.getChannel();
+        }
+        return config.getUploadChannel();
+    }
+
+    @Override
+    protected String getInitialComment(PublishConfig config) {
+        if (isEmpty(config.getInitComment())) {
+            // fallback to TEXT in case the user set the wrong Property
+            return config.getText();
+        }
+        return config.getInitComment();
+    }
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/MockPublishSlackClient.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/MockPublishSlackClient.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack;
+
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.request.conversations.ConversationsListRequest;
+import com.slack.api.methods.request.files.FilesUploadV2Request;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.slack.api.methods.response.conversations.ConversationsListResponse;
+import com.slack.api.methods.response.files.FilesUploadV2Response;
+import com.slack.api.model.Conversation;
+import com.slack.api.model.File;
+import com.slack.api.model.ResponseMetadata;
+import okhttp3.Response;
+import org.apache.nifi.processors.slack.publish.PublishSlackClient;
+
+import java.io.IOException;
+import java.util.List;
+
+public class MockPublishSlackClient implements PublishSlackClient {
+
+    public static final String VALID_TOKEN = "bot-access-token";
+    public static final String INVALID_TOKEN = "invalid-token";
+    public static final String VALID_CHANNEL = "my-channel";
+    public static final String VALID_CHANNEL_ID = "C0000000000";
+    public static final String INVALID_CHANNEL = "wrong-channel";
+    public static final String ERROR_CHANNEL = "error-channel";
+    public static final String WARNING_CHANNEL = "warning-channel";
+    public static final String VALID_TEXT = "my-text";
+    public static final String INTERNATIONAL_TEXT = "Iñtërnâtiônàližætiøn";
+    public static final String EMPTY_TEXT = "${dummy}";
+    public static final String ERROR_TEXT = "slack-error";
+    public static final String INTERNAL_ERROR_TEXT = "internal_error";
+    public static final String TOKEN_REVOKED_TEXT = "token_revoked";
+    public static final String NOT_IN_CHANNEL_TEXT = "not_in_channel";
+    public static final String WARNING_TEXT = "Warning - Token Expiration in 5 days!";
+    public static final String IO_EXCEPT_TEXT = "io-exception";
+    public static final String SLACK_EXCEPT_TEXT = "slack-exception";
+    public static final String FLOWFILE_CONTENT = "FlowFile Content - Hello, world!";
+    public static final String BASE_PERMA_LINK = "https://files.slack.com/foo/bar/";
+    public static final String BASE_URL_PRIVATE = "https://private.slack.com/super/secret/";
+    public static final int UPLOAD_FILE_SIZE = 28248282;
+
+    private static final ChatPostMessageResponse CHAT_INVALID_TOKEN_RESPONSE;
+    private static final ChatPostMessageResponse CHAT_INVALID_CHANNEL_RESPONSE;
+    private static final ConversationsListResponse CONVERSATIONS_NORMAL_RESPONSE;
+    private ChatPostMessageRequest lastChatRequest = null;
+    private ChatPostMessageResponse lastChatResponse = null;
+    private ConversationsListRequest lastConvoRequest = null;
+    private ConversationsListResponse lastConvoResponse = null;
+    private FilesUploadV2Request lastFileRequest = null;
+    private FilesUploadV2Response lastFileResponse = null;
+
+    static {
+        CHAT_INVALID_TOKEN_RESPONSE = new ChatPostMessageResponse();
+        CHAT_INVALID_TOKEN_RESPONSE.setOk(false);
+        CHAT_INVALID_TOKEN_RESPONSE.setError(TOKEN_REVOKED_TEXT);
+        CHAT_INVALID_CHANNEL_RESPONSE = new ChatPostMessageResponse();
+        CHAT_INVALID_CHANNEL_RESPONSE.setOk(false);
+        CHAT_INVALID_CHANNEL_RESPONSE.setError(NOT_IN_CHANNEL_TEXT);
+        CONVERSATIONS_NORMAL_RESPONSE = new ConversationsListResponse();
+        CONVERSATIONS_NORMAL_RESPONSE.setOk(true);
+        Conversation channel = Conversation.builder()
+                .isChannel(true)
+                .id(VALID_CHANNEL_ID)
+                .name(VALID_CHANNEL)
+                .build();
+        CONVERSATIONS_NORMAL_RESPONSE.setChannels(List.of(channel));
+        CONVERSATIONS_NORMAL_RESPONSE.setResponseMetadata(new ResponseMetadata());
+    }
+
+    @Override
+    public ConversationsListResponse conversationsList(ConversationsListRequest request) throws IOException, SlackApiException {
+        lastConvoRequest = request;
+        // check request token and cursor to see if we should throw an exception, etc
+        lastConvoResponse = CONVERSATIONS_NORMAL_RESPONSE;
+        return lastConvoResponse;
+    }
+
+    @Override
+    public FilesUploadV2Response filesUploadV2(FilesUploadV2Request request) throws IOException, SlackApiException {
+        lastFileRequest = request;
+        if (IO_EXCEPT_TEXT.equals(request.getInitialComment())) {
+            throw new IOException(IO_EXCEPT_TEXT);
+        }
+        if (SLACK_EXCEPT_TEXT.equals(request.getInitialComment())) {
+            throw new SlackApiException(new Response.Builder().build(), SLACK_EXCEPT_TEXT);
+        }
+        if (request.getChannel() != null && !VALID_CHANNEL_ID.equals(request.getChannel())) {
+            lastFileResponse = new FilesUploadV2Response();
+            lastFileResponse.setOk(false);
+            lastFileResponse.setError(NOT_IN_CHANNEL_TEXT);
+            return lastFileResponse;
+        }
+        // return an error response in some cases?
+        File file = File.builder()
+                .name(request.getFilename())
+                .title(request.getTitle())
+                .permalink(BASE_PERMA_LINK + request.getFilename())
+                .urlPrivate(BASE_URL_PRIVATE + request.getFilename())
+                .size(UPLOAD_FILE_SIZE)
+                .build();
+        lastFileResponse = new FilesUploadV2Response();
+        lastFileResponse.setFile(file);
+        lastFileResponse.setOk(true);
+        return lastFileResponse;
+    }
+
+    @Override
+    public ChatPostMessageResponse chatPostMessage(ChatPostMessageRequest request) throws IOException, SlackApiException {
+        lastChatRequest = request;
+        if (IO_EXCEPT_TEXT.equals(request.getText())) {
+            throw new IOException(IO_EXCEPT_TEXT);
+        }
+        if (SLACK_EXCEPT_TEXT.equals(request.getText())) {
+            throw new SlackApiException(new Response.Builder().build(), SLACK_EXCEPT_TEXT);
+        }
+        if (INVALID_TOKEN.equals(request.getToken())) {
+            return lastChatResponse = CHAT_INVALID_TOKEN_RESPONSE;
+        }
+        if (INVALID_CHANNEL.equals(request.getChannel())) {
+            return lastChatResponse = CHAT_INVALID_CHANNEL_RESPONSE;
+        }
+        if (ERROR_CHANNEL.equals(request.getChannel())) {
+            lastChatResponse = new ChatPostMessageResponse();
+            lastChatResponse.setOk(false);
+            lastChatResponse.setError(request.getText());
+            return lastChatResponse;
+        }
+        if (WARNING_CHANNEL.equals(request.getChannel())) {
+            lastChatResponse = new ChatPostMessageResponse();
+            lastChatResponse.setOk(true);
+            lastChatResponse.setWarning(request.getText());
+            return lastChatResponse;
+        }
+        lastChatResponse = new ChatPostMessageResponse();
+        lastChatResponse.setOk(true);
+        return lastChatResponse;
+    }
+
+    public ChatPostMessageRequest getLastChatPostMessageRequest() {
+        return lastChatRequest;
+    }
+
+    public ChatPostMessageResponse getLastChatPostMessageResponse() {
+        return lastChatResponse;
+    }
+
+    public ConversationsListRequest getLastConversationsListRequest() {
+        return lastConvoRequest;
+    }
+
+    public ConversationsListResponse getLastConversationsListResponse() {
+        return lastConvoResponse;
+    }
+
+    public FilesUploadV2Request getLastFilesUploadRequest() {
+        return lastFileRequest;
+    }
+
+    public FilesUploadV2Response getLastFilesUploadResponse() {
+        return lastFileResponse;
+    }
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PublishSlackConfigValidationTest.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PublishSlackConfigValidationTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack;
+
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PublishSlackConfigValidationTest {
+
+    private TestRunner testRunner;
+
+    @BeforeEach
+    public void setup() {
+        testRunner = TestRunners.newTestRunner(PublishSlack.class);
+    }
+
+    @Test
+    public void validationShouldPassIfTheConfigIsFine() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.THREAD_TS, "thread-timestamp");
+        testRunner.setProperty(PublishSlack.TEXT, "my-text");
+        testRunner.setProperty(PublishSlack.ICON_URL, "http://slack.com/emojis/happy.gif");
+        testRunner.setProperty(PublishSlack.ICON_EMOJI, ":happy:");
+
+        testRunner.assertValid();
+    }
+
+    @Test
+    public void validationShouldPassIfMinimalConfigForMessageOnly() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.TEXT, "my-text");
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+
+        testRunner.assertValid();
+    }
+
+    @Test
+    public void validationShouldFailIfAccessTokenIsNotGiven() {
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.TEXT, "my-text");
+
+        testRunner.assertNotValid();
+    }
+
+    @Test
+    public void validationShouldFailIfAccessTokenIsEmptyString() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.TEXT, "my-text");
+
+        testRunner.assertNotValid();
+    }
+
+    @Test
+    public void validationShouldFailIfChannelIsNotGiven() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.TEXT, "my-text");
+
+        testRunner.assertNotValid();
+    }
+
+    @Test
+    public void validationShouldFailIfChannelIsEmptyString() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "");
+        testRunner.setProperty(PublishSlack.TEXT, "my-text");
+
+        testRunner.assertNotValid();
+    }
+
+    @Test
+    public void validationShouldFailIfThreadTsIsEmptyString() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.THREAD_TS, "");
+        testRunner.setProperty(PublishSlack.TEXT, "my-text");
+
+        testRunner.assertNotValid();
+    }
+
+    @Test
+    public void validationShouldFailIfIconEmojiInvalid() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.ICON_EMOJI, "sadface");
+        testRunner.setProperty(PublishSlack.TEXT, "my-text");
+
+        testRunner.assertNotValid();
+    }
+
+    @Test
+    public void validationShouldFailIfIconUrlInvalid() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.ICON_URL, "not-url");
+        testRunner.setProperty(PublishSlack.TEXT, "my-text");
+
+        testRunner.assertNotValid();
+    }
+
+    @Test
+    public void validationShouldFailIfTextIsNotGivenAndNoAttachmentSpecifiedForMessageOnly() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+
+        testRunner.assertNotValid();
+    }
+
+    @Test
+    public void validationShouldPassWithoutTextForUploadOnly() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_UPLOAD_ONLY);
+
+        testRunner.assertValid();
+    }
+
+    @Test
+    public void validationShouldPassIfTextIsNotGivenButAttachmentSpecified() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty("attachment_01", "{\"my-attachment-key\": \"my-attachment-value\"}");
+
+        testRunner.assertValid();
+    }
+
+    @Test
+    public void validationShouldPassIfTextIsNotGivenButUploadAttachChosen() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        // UPLOAD_ATTACH is the default
+        // testRunner.setProperty(PublishSlack.PUBLISH_MODE, PublishSlack.STRATEGY_UPLOAD_ATTACH);
+
+        testRunner.assertValid();
+    }
+
+    @Test
+    public void validationShouldPassIfTextIsNotGivenButUploadLinkChosen() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_UPLOAD_LINK);
+
+        testRunner.assertValid();
+    }
+
+    @Test
+    public void validationShouldPassIfTextIsNotGivenButContentFlowfileChosen() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_CONTENT_MESSAGE);
+
+        testRunner.assertValid();
+    }
+
+    @Test
+    public void validationShouldPassIfChannelIsNotGivenButUploadOnlyChosen() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_UPLOAD_ONLY);
+
+        testRunner.assertValid();
+    }
+
+    @Test
+    public void validationShouldFailForUploadOnlyIfInitialCommentIsEmptyString() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, "my-access-token");
+        testRunner.setProperty(PublishSlack.CHANNEL, "my-channel");
+        testRunner.setProperty(PublishSlack.INITIAL_COMMENT, "");
+        testRunner.setProperty("attachment_01", "{\"my-attachment-key\": \"my-attachment-value\"}");
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_UPLOAD_ONLY);
+
+        testRunner.assertNotValid();
+    }
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PublishSlackFileMessageTest.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PublishSlackFileMessageTest.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack;
+
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.request.files.FilesUploadV2Request;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.File;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processors.slack.publish.PublishSlackClient;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.BASE_PERMA_LINK;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.BASE_URL_PRIVATE;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.EMPTY_TEXT;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.VALID_CHANNEL;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.VALID_CHANNEL_ID;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.VALID_TOKEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PublishSlackFileMessageTest {
+
+    public static final String THREAD_TS = "some-thread-ts";
+    public static final String TEXT = "my-text";
+    public static final String INITIAL_COMMENT = "my-initial-comment";
+    public static final String FILE_NAME = "my-file-name";
+    public static final String FILE_TITLE = "my-file-title";
+    public static final String FILE_DATA = "my-data";
+
+    private TestRunner testRunner;
+
+    private MockPublishSlackClient mockClient;
+
+    @BeforeEach
+    public void init() {
+        mockClient = new MockPublishSlackClient();
+        // Create an instance of the processor that mocks out the initialize() method to return a client we can use for testing
+        final PublishSlack processor = new PublishSlack() {
+            @Override
+            protected PublishSlackClient initializeClient(final MethodsClient client) {
+                return mockClient;
+            }
+        };
+        testRunner = TestRunners.newTestRunner(processor);
+    }
+
+    @Test
+    public void sendMessageWithBasicPropertiesSuccessfully() {
+        // default strategy is STRATEGY_UPLOAD_ATTACH, so we don't need to set it
+        // testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_UPLOAD_ATTACH);
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+
+        Map<String, String> flowFileAttributes = new HashMap<>();
+        flowFileAttributes.put(CoreAttributes.FILENAME.key(), FILE_NAME);
+
+        // in order not to make the assertion logic (even more) complicated, the file content is tested with character data instead of binary data
+        testRunner.enqueue(FILE_DATA, flowFileAttributes);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        FilesUploadV2Request uploadRequest = mockClient.getLastFilesUploadRequest();
+        assertEquals(VALID_TOKEN, uploadRequest.getToken());
+        assertNull(uploadRequest.getChannel());
+        assertNull(uploadRequest.getThreadTs());
+        assertNull(uploadRequest.getInitialComment());
+        assertEquals(FILE_NAME, uploadRequest.getFilename());
+        assertEquals(FILE_NAME, uploadRequest.getTitle());
+        assertEquals(FILE_DATA, new String(uploadRequest.getFileData()));
+
+        ChatPostMessageRequest postRequest = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, postRequest.getToken());
+        assertEquals(VALID_CHANNEL, postRequest.getChannel());
+        assertNull(postRequest.getText());
+        List<Attachment> attachments = postRequest.getAttachments();
+        assertNotNull(attachments);
+        assertEquals(1, attachments.size());
+        String expected = "<" + BASE_PERMA_LINK + FILE_NAME + "|" + FILE_NAME + ">";
+        assertEquals(expected, attachments.get(0).getText());
+        assertEquals(FILE_NAME, attachments.get(0).getFilename());
+        assertEquals(BASE_PERMA_LINK + FILE_NAME, attachments.get(0).getUrl());
+        List<File> files = attachments.get(0).getFiles();
+        assertNotNull(files);
+        assertEquals(1, files.size());
+        assertEquals(FILE_NAME, files.get(0).getName());
+        assertEquals(FILE_NAME, files.get(0).getTitle());
+        assertEquals(BASE_PERMA_LINK + FILE_NAME, files.get(0).getPermalink());
+        assertEquals(BASE_URL_PRIVATE + FILE_NAME, files.get(0).getUrlPrivate());
+
+        FlowFile flowFileOut = testRunner.getFlowFilesForRelationship(PutSlack.REL_SUCCESS).get(0);
+        assertEquals(BASE_URL_PRIVATE + FILE_NAME, flowFileOut.getAttribute("slack.file.url"));
+    }
+
+    @Test
+    public void sendMessageWithAllPropertiesSuccessfully() {
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_UPLOAD_LINK);
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.UPLOAD_CHANNEL, VALID_CHANNEL_ID);
+        testRunner.setProperty(PublishSlack.THREAD_TS, THREAD_TS);
+        testRunner.setProperty(PublishSlack.TEXT, TEXT);
+        testRunner.setProperty(PublishSlack.INITIAL_COMMENT, INITIAL_COMMENT);
+        testRunner.setProperty(PublishSlack.FILE_TITLE, FILE_TITLE);
+        testRunner.setProperty(PublishSlack.FILE_NAME, FILE_NAME);
+        testRunner.setProperty("attachment_01", "{\"my-attachment-key\": \"my-attachment-value\"}");
+
+        testRunner.enqueue(FILE_DATA);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        FilesUploadV2Request uploadRequest = mockClient.getLastFilesUploadRequest();
+        assertEquals(VALID_TOKEN, uploadRequest.getToken());
+        assertEquals(VALID_CHANNEL_ID, uploadRequest.getChannel());
+        assertEquals(THREAD_TS, uploadRequest.getThreadTs());
+        assertEquals(INITIAL_COMMENT, uploadRequest.getInitialComment());
+        assertEquals(FILE_NAME, uploadRequest.getFilename());
+        assertEquals(FILE_TITLE, uploadRequest.getTitle());
+        assertEquals(FILE_DATA, new String(uploadRequest.getFileData()));
+
+        ChatPostMessageRequest postRequest = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, postRequest.getToken());
+        assertEquals(VALID_CHANNEL, postRequest.getChannel());
+        String expected = TEXT + "\n<" + BASE_PERMA_LINK + FILE_NAME + "|" + FILE_TITLE + ">";
+        assertEquals(expected, postRequest.getText());
+        List<Attachment> attachments = postRequest.getAttachments();
+        assertNotNull(attachments);
+        assertEquals(1, attachments.size());
+        assertEquals("{\"my-attachment-key\":\"my-attachment-value\"}", attachments.get(0).getText());
+
+        FlowFile flowFileOut = testRunner.getFlowFilesForRelationship(PutSlack.REL_SUCCESS).get(0);
+        assertEquals(BASE_URL_PRIVATE + FILE_NAME, flowFileOut.getAttribute("slack.file.url"));
+    }
+
+    @Test
+    public void processShouldFailWhenChannelIsEmpty() {
+        // default strategy is STRATEGY_UPLOAD_ATTACH, so we don't need to set it
+        // testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_UPLOAD_ATTACH);
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, EMPTY_TEXT);
+
+        testRunner.enqueue(FILE_DATA);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_FAILURE);
+    }
+
+    @Test
+    public void fileNameShouldHaveFallbackValueWhenEmpty() {
+        final String defaultFileName = "file";
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_UPLOAD_LINK);
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.FILE_NAME, EMPTY_TEXT);
+
+        testRunner.enqueue(FILE_DATA);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        FilesUploadV2Request uploadRequest = mockClient.getLastFilesUploadRequest();
+        assertEquals(VALID_TOKEN, uploadRequest.getToken());
+        assertNull(uploadRequest.getChannel());
+        assertNull(uploadRequest.getThreadTs());
+        assertNull(uploadRequest.getInitialComment());
+        // fallback value for file name is 'file'
+        assertEquals(defaultFileName, uploadRequest.getFilename());
+        assertEquals(defaultFileName, uploadRequest.getTitle());
+        assertEquals(FILE_DATA, new String(uploadRequest.getFileData()));
+
+        ChatPostMessageRequest postRequest = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, postRequest.getToken());
+        assertEquals(VALID_CHANNEL, postRequest.getChannel());
+        String expected = "<" + BASE_PERMA_LINK + defaultFileName + "|" + defaultFileName + ">";
+        assertEquals(expected, postRequest.getText());
+        List<Attachment> attachments = postRequest.getAttachments();
+        assertNull(attachments);
+
+        FlowFile flowFileOut = testRunner.getFlowFilesForRelationship(PutSlack.REL_SUCCESS).get(0);
+        assertEquals(BASE_URL_PRIVATE + defaultFileName, flowFileOut.getAttribute("slack.file.url"));
+    }
+
+    @Test
+    public void uploadFieldsShouldHaveFallbackValuesWhenUploadOnly() {
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_UPLOAD_ONLY);
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL_ID);
+        testRunner.setProperty(PublishSlack.THREAD_TS, THREAD_TS);
+        testRunner.setProperty(PublishSlack.TEXT, TEXT);
+        testRunner.setProperty(PublishSlack.FILE_NAME, FILE_NAME);
+
+        testRunner.enqueue(FILE_DATA);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        FilesUploadV2Request uploadRequest = mockClient.getLastFilesUploadRequest();
+        assertEquals(VALID_TOKEN, uploadRequest.getToken());
+        // channel should be used as backup for upload channel
+        assertEquals(VALID_CHANNEL_ID, uploadRequest.getChannel());
+        assertEquals(THREAD_TS, uploadRequest.getThreadTs());
+        // text should be used as backup for initial comment
+        assertEquals(TEXT, uploadRequest.getInitialComment());
+        assertEquals(FILE_NAME, uploadRequest.getFilename());
+        assertEquals(FILE_NAME, uploadRequest.getTitle());
+        assertEquals(FILE_DATA, new String(uploadRequest.getFileData()));
+
+        ChatPostMessageRequest postRequest = mockClient.getLastChatPostMessageRequest();
+        assertNull(postRequest);
+
+        FlowFile flowFileOut = testRunner.getFlowFilesForRelationship(PutSlack.REL_SUCCESS).get(0);
+        assertEquals(BASE_URL_PRIVATE + FILE_NAME, flowFileOut.getAttribute("slack.file.url"));
+    }
+
+    @Test
+    public void channelNameShouldBeTranslatedToChannelIdForUploadOnly() {
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_UPLOAD_ONLY);
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.FILE_NAME, FILE_NAME);
+
+        testRunner.enqueue(FILE_DATA);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        FilesUploadV2Request uploadRequest = mockClient.getLastFilesUploadRequest();
+        assertEquals(VALID_TOKEN, uploadRequest.getToken());
+        // channel should be used as backup for upload channel and translated to Channel ID
+        assertEquals(VALID_CHANNEL_ID, uploadRequest.getChannel());
+        assertNull(uploadRequest.getThreadTs());
+        assertEquals(FILE_NAME, uploadRequest.getFilename());
+        assertEquals(FILE_NAME, uploadRequest.getTitle());
+        assertEquals(FILE_DATA, new String(uploadRequest.getFileData()));
+
+        ChatPostMessageRequest postRequest = mockClient.getLastChatPostMessageRequest();
+        assertNull(postRequest);
+
+        FlowFile flowFileOut = testRunner.getFlowFilesForRelationship(PutSlack.REL_SUCCESS).get(0);
+        assertEquals(BASE_URL_PRIVATE + FILE_NAME, flowFileOut.getAttribute("slack.file.url"));
+    }
+
+    @Test
+    public void sendInternationalMessageSuccessfully() {
+        final String internationalization = "Iñtërnâtiônàližætiøn";
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_UPLOAD_ONLY);
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.TEXT, internationalization);
+        testRunner.setProperty(PublishSlack.FILE_TITLE, internationalization);
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        FilesUploadV2Request uploadRequest = mockClient.getLastFilesUploadRequest();
+        assertEquals(VALID_TOKEN, uploadRequest.getToken());
+        // channel should be used as backup for upload channel and translated to Channel ID
+        assertEquals(VALID_CHANNEL_ID, uploadRequest.getChannel());
+        assertNull(uploadRequest.getThreadTs());
+        assertEquals(internationalization, uploadRequest.getInitialComment());
+        assertNotNull(uploadRequest.getFilename());
+        assertTrue(uploadRequest.getFilename().endsWith(".mockFlowFile"));    // 994266770762705.mockFlowFile ?
+        assertEquals(internationalization, uploadRequest.getTitle());
+        assertEquals(0, uploadRequest.getFileData().length);
+
+        ChatPostMessageRequest postRequest = mockClient.getLastChatPostMessageRequest();
+        assertNull(postRequest);
+
+        FlowFile flowFileOut = testRunner.getFlowFilesForRelationship(PutSlack.REL_SUCCESS).get(0);
+        assertEquals(BASE_URL_PRIVATE + uploadRequest.getFilename(), flowFileOut.getAttribute("slack.file.url"));
+    }
+
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PublishSlackTextMessageTest.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/PublishSlackTextMessageTest.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.slack;
+
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.slack.api.model.Attachment;
+import org.apache.nifi.processors.slack.publish.PublishSlackClient;
+import org.apache.nifi.util.LogMessage;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.EMPTY_TEXT;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.ERROR_CHANNEL;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.ERROR_TEXT;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.FLOWFILE_CONTENT;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.INTERNAL_ERROR_TEXT;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.INTERNATIONAL_TEXT;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.INVALID_CHANNEL;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.INVALID_TOKEN;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.NOT_IN_CHANNEL_TEXT;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.TOKEN_REVOKED_TEXT;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.VALID_CHANNEL;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.VALID_TEXT;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.VALID_TOKEN;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.WARNING_CHANNEL;
+import static org.apache.nifi.processors.slack.MockPublishSlackClient.WARNING_TEXT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PublishSlackTextMessageTest {
+
+    private TestRunner testRunner;
+
+    private MockPublishSlackClient mockClient;
+
+    @BeforeEach
+    public void init() {
+        mockClient = new MockPublishSlackClient();
+        // Create an instance of the processor that mocks out the initialize() method to return a client we can use for testing
+        final PublishSlack processor = new PublishSlack() {
+            @Override
+            protected PublishSlackClient initializeClient(final MethodsClient client) {
+                return mockClient;
+            }
+        };
+        testRunner = TestRunners.newTestRunner(processor);
+    }
+
+    @Test
+    public void sendTextOnlyMessageSuccessfully() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty(PublishSlack.TEXT, VALID_TEXT);
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, request.getToken());
+        assertEquals(VALID_CHANNEL, request.getChannel());
+        assertEquals(VALID_TEXT, request.getText());
+        assertNull(request.getAttachments());
+    }
+
+    @Test
+    public void sendFlowFileContentOnlyMessageSuccessfully() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_CONTENT_MESSAGE);
+
+        testRunner.enqueue(FLOWFILE_CONTENT);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, request.getToken());
+        assertEquals(VALID_CHANNEL, request.getChannel());
+        assertEquals(FLOWFILE_CONTENT, request.getText());
+        assertNull(request.getAttachments());
+    }
+
+    @Test
+    public void sendTextWithAttachmentMessageSuccessfully() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty(PublishSlack.TEXT, VALID_TEXT);
+        testRunner.setProperty("attachment_01", "{\"my-attachment-key\": \"my-attachment-value\"}");
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, request.getToken());
+        assertEquals(VALID_CHANNEL, request.getChannel());
+        assertEquals(VALID_TEXT, request.getText());
+        List<Attachment> attachments = request.getAttachments();
+        assertNotNull(attachments);
+        assertEquals(1, attachments.size());
+        assertEquals("{\"my-attachment-key\":\"my-attachment-value\"}", attachments.get(0).getText());
+    }
+
+    @Test
+    public void sendAttachmentOnlyMessageSuccessfully() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty("attachment_01", "{\"my-attachment-key\": \"my-attachment-value\"}");
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, request.getToken());
+        assertEquals(VALID_CHANNEL, request.getChannel());
+        assertNull(request.getText());
+        List<Attachment> attachments = request.getAttachments();
+        assertNotNull(attachments);
+        assertEquals(1, attachments.size());
+        assertEquals("{\"my-attachment-key\":\"my-attachment-value\"}", attachments.get(0).getText());
+    }
+
+    @Test
+    public void processShouldFailWhenInvalidToken() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, INVALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty(PublishSlack.TEXT, VALID_TEXT);
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_FAILURE);
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(INVALID_TOKEN, request.getToken());
+        assertEquals(VALID_CHANNEL, request.getChannel());
+        assertEquals(VALID_TEXT, request.getText());
+        ChatPostMessageResponse response = mockClient.getLastChatPostMessageResponse();
+        assertFalse(response.isOk());
+        assertEquals(TOKEN_REVOKED_TEXT, response.getError());
+    }
+
+    @Test
+    public void processShouldFailWhenInvalidChannel() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, INVALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty(PublishSlack.TEXT, VALID_TEXT);
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_FAILURE);
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, request.getToken());
+        assertEquals(INVALID_CHANNEL, request.getChannel());
+        assertEquals(VALID_TEXT, request.getText());
+        ChatPostMessageResponse response = mockClient.getLastChatPostMessageResponse();
+        assertFalse(response.isOk());
+        assertEquals(NOT_IN_CHANNEL_TEXT, response.getError());
+    }
+
+    @Test
+    public void processShouldFailWhenChannelIsEmpty() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, EMPTY_TEXT);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty(PublishSlack.TEXT, VALID_TEXT);
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_FAILURE);
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertNull(request);
+    }
+
+    @Test
+    public void processShouldFailWhenTextIsEmptyAndNoAttachmentSpecified() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty(PublishSlack.TEXT, EMPTY_TEXT);
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_FAILURE);
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertNull(request);
+    }
+
+    @Test
+    public void emptyAttachmentShouldBeSkipped() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty("attachment_01", EMPTY_TEXT);
+        testRunner.setProperty("attachment_02", "{\"my-attachment-key\": \"my-attachment-value\"}");
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, request.getToken());
+        assertEquals(VALID_CHANNEL, request.getChannel());
+        assertNull(request.getText());
+        List<Attachment> attachments = request.getAttachments();
+        assertNotNull(attachments);
+        assertEquals(1, attachments.size());
+        assertEquals("{\"my-attachment-key\":\"my-attachment-value\"}", attachments.get(0).getText());
+    }
+
+    @Test
+    public void invalidAttachmentShouldBeSkipped() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty("attachment_01", "{invalid-json}");
+        testRunner.setProperty("attachment_02", "{\"my-attachment-key\": \"my-attachment-value\"}");
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, request.getToken());
+        assertEquals(VALID_CHANNEL, request.getChannel());
+        assertNull(request.getText());
+        List<Attachment> attachments = request.getAttachments();
+        assertNotNull(attachments);
+        assertEquals(1, attachments.size());
+        assertEquals("{\"my-attachment-key\":\"my-attachment-value\"}", attachments.get(0).getText());
+    }
+
+    @Test
+    public void processShouldFailWhenHttpErrorCodeReturned() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, ERROR_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty(PublishSlack.TEXT, INTERNAL_ERROR_TEXT);
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_FAILURE);
+
+        List<LogMessage> logMessages = testRunner.getLogger().getErrorMessages();
+        assertEquals(1, logMessages.size());
+        assertNotNull(logMessages.get(0).getMsg());
+        assertTrue(logMessages.get(0).getMsg().contains("Failed to send message to Slack."));
+        logMessages = testRunner.getLogger().getDebugMessages();
+        assertEquals(1, logMessages.size());
+        assertNotNull(logMessages.get(0).getMsg());
+        assertTrue(logMessages.get(0).getMsg().contains(INTERNAL_ERROR_TEXT));
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, request.getToken());
+        assertEquals(ERROR_CHANNEL, request.getChannel());
+        assertEquals(INTERNAL_ERROR_TEXT, request.getText());
+        ChatPostMessageResponse response = mockClient.getLastChatPostMessageResponse();
+        assertFalse(response.isOk());
+        assertEquals(INTERNAL_ERROR_TEXT, response.getError());
+    }
+
+    @Test
+    public void processShouldFailWhenSlackReturnsError() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, ERROR_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty(PublishSlack.TEXT, ERROR_TEXT);
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_FAILURE);
+
+        List<LogMessage> logMessages = testRunner.getLogger().getErrorMessages();
+        assertEquals(1, logMessages.size());
+        assertNotNull(logMessages.get(0).getMsg());
+        assertTrue(logMessages.get(0).getMsg().contains("Failed to send message to Slack."));
+        logMessages = testRunner.getLogger().getDebugMessages();
+        assertEquals(1, logMessages.size());
+        assertNotNull(logMessages.get(0).getMsg());
+        assertTrue(logMessages.get(0).getMsg().contains(ERROR_TEXT));
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, request.getToken());
+        assertEquals(ERROR_CHANNEL, request.getChannel());
+        assertEquals(ERROR_TEXT, request.getText());
+        ChatPostMessageResponse response = mockClient.getLastChatPostMessageResponse();
+        assertFalse(response.isOk());
+        assertEquals(ERROR_TEXT, response.getError());
+    }
+
+    @Test
+    public void processShouldLogWarningAndNotFailWhenSlackReturnsWarning() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, WARNING_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty(PublishSlack.TEXT, WARNING_TEXT);
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        List<LogMessage> warnings = testRunner.getLogger().getWarnMessages();
+        assertEquals(1, warnings.size());
+        assertNotNull(warnings.get(0).getMsg());
+        assertTrue(warnings.get(0).getMsg().contains(WARNING_TEXT));
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, request.getToken());
+        assertEquals(WARNING_CHANNEL, request.getChannel());
+        assertEquals(WARNING_TEXT, request.getText());
+        ChatPostMessageResponse response = mockClient.getLastChatPostMessageResponse();
+        assertTrue(response.isOk());
+        assertEquals(WARNING_TEXT, response.getWarning());
+    }
+
+    @Test
+    public void sendInternationalMessageSuccessfully() {
+        testRunner.setProperty(PublishSlack.BOT_TOKEN, VALID_TOKEN);
+        testRunner.setProperty(PublishSlack.CHANNEL, VALID_CHANNEL);
+        testRunner.setProperty(PublishSlack.PUBLISH_STRATEGY, PublishSlack.STRATEGY_MESSAGE_ONLY);
+        testRunner.setProperty(PublishSlack.TEXT, INTERNATIONAL_TEXT);
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run(1);
+
+        testRunner.assertAllFlowFilesTransferred(PublishSlack.REL_SUCCESS);
+
+        ChatPostMessageRequest request = mockClient.getLastChatPostMessageRequest();
+        assertEquals(VALID_TOKEN, request.getToken());
+        assertEquals(VALID_CHANNEL, request.getChannel());
+        assertEquals(INTERNATIONAL_TEXT, request.getText());
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12331](https://issues.apache.org/jira/browse/NIFI-12331)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

No new libraries.

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
