### PR TITLE
NIFI-12392 Correct Component Documentation NAR Unpacking

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/test/java/org/apache/nifi/nar/NarUnpackerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/test/java/org/apache/nifi/nar/NarUnpackerTest.java
@@ -16,13 +16,17 @@
  */
 package org.apache.nifi.nar;
 
+import org.apache.nifi.bundle.BundleCoordinate;
 import org.apache.nifi.util.NiFiProperties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,16 +40,42 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import java.util.stream.Stream;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NarUnpackerTest {
 
     private static final String PROPERTIES_PATH = "/NarUnpacker/conf/nifi.properties";
+
+    private static final String GROUP_ID = "org.apache.nifi";
+
+    private static final String ARTIFACT_ID = "nifi-nar";
+
+    private static final String VERSION = "1.0.0";
+
+    private static final String DOCS_DIR = "docs";
+
+    private static final String COMPONENT_JAR = String.format("component-%s.jar", VERSION);
+
+    private static final String PROCESSOR = "org.apache.nifi.processors.UnpackNar";
+
+    private static final String PROCESSOR_PATH = "META-INF/services/org.apache.nifi.processor.Processor";
+
+    private static final String COMPONENT_DOCS_PATH = String.format("docs/%s/", PROCESSOR);
+
+    private static final String ADDITIONAL_DETAILS_HTML = "additionalDetails.html";
+
+    private static final String ADDITIONAL_DETAILS_PATH = String.format("docs/%s/%s", PROCESSOR, ADDITIONAL_DETAILS_HTML);
+
+    private static final String HTML = "<html></html>";
 
     @BeforeAll
     public static void copyResources() throws IOException {
@@ -172,6 +202,66 @@ public class NarUnpackerTest {
         final ExtensionMapping extensionMapping = NarUnpacker.unpackNars(properties, SystemBundle.create(properties), NarUnpackMode.UNPACK_INDIVIDUAL_JARS);
 
         assertNull(extensionMapping);
+    }
+
+    @Test
+    public void testMapExtensionNoDependencies(@TempDir final Path tempDir) throws IOException {
+        final File unpackedNarDir = tempDir.resolve(ARTIFACT_ID).toFile();
+        final File docsDir = tempDir.resolve(DOCS_DIR).toFile();
+
+        final BundleCoordinate bundleCoordinate = new BundleCoordinate(GROUP_ID, ARTIFACT_ID, VERSION);
+        final ExtensionMapping extensionMapping = new ExtensionMapping();
+
+        NarUnpacker.mapExtension(unpackedNarDir, bundleCoordinate, docsDir, extensionMapping);
+
+        assertNull(docsDir.listFiles());
+    }
+
+    @Test
+    public void testMapExtensionAdditionalDetails(@TempDir final Path tempDir) throws IOException {
+        final File unpackedNarDir = tempDir.resolve(ARTIFACT_ID).toFile();
+        final File docsDir = tempDir.resolve(DOCS_DIR).toFile();
+
+        final BundleCoordinate bundleCoordinate = new BundleCoordinate(GROUP_ID, ARTIFACT_ID, VERSION);
+        final ExtensionMapping extensionMapping = new ExtensionMapping();
+        extensionMapping.addProcessor(bundleCoordinate, PROCESSOR);
+
+        final Path unpackedNarDependenciesDir = unpackedNarDir.toPath().resolve(NarUnpacker.BUNDLED_DEPENDENCIES_DIRECTORY);
+        assertTrue(unpackedNarDependenciesDir.toFile().mkdirs());
+
+        final File componentJar = unpackedNarDependenciesDir.resolve(COMPONENT_JAR).toFile();
+        writeComponentJar(componentJar);
+
+        NarUnpacker.mapExtension(unpackedNarDir, bundleCoordinate, docsDir, extensionMapping);
+
+        final File[] documentationFiles = docsDir.listFiles();
+        assertNotNull(documentationFiles, "Documentation Files not found");
+
+        final Path expectedRelativePath = Paths.get(GROUP_ID, ARTIFACT_ID, VERSION, PROCESSOR, ADDITIONAL_DETAILS_HTML);
+        final Path documentationFilePath = docsDir.toPath().resolve(expectedRelativePath);
+        assertTrue(Files.exists(documentationFilePath), "Documentation File not found");
+
+        final byte[] documentationBytes = Files.readAllBytes(documentationFilePath);
+        assertArrayEquals(HTML.getBytes(StandardCharsets.UTF_8), documentationBytes);
+    }
+
+    private void writeComponentJar(final File componentJar) throws IOException {
+        try (JarOutputStream jarOutputStream = new JarOutputStream(new FileOutputStream(componentJar))) {
+            final JarEntry processorJarEntry = new JarEntry(PROCESSOR_PATH);
+            jarOutputStream.putNextEntry(processorJarEntry);
+            jarOutputStream.write(PROCESSOR.getBytes(StandardCharsets.UTF_8));
+            jarOutputStream.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
+            jarOutputStream.closeEntry();
+
+            final JarEntry docDirectoryEntry = new JarEntry(COMPONENT_DOCS_PATH);
+            jarOutputStream.putNextEntry(docDirectoryEntry);
+            jarOutputStream.closeEntry();
+
+            final JarEntry docJarEntry = new JarEntry(ADDITIONAL_DETAILS_PATH);
+            jarOutputStream.putNextEntry(docJarEntry);
+            jarOutputStream.write(HTML.getBytes(StandardCharsets.UTF_8));
+            jarOutputStream.closeEntry();
+        }
     }
 
     private NiFiProperties loadSpecifiedProperties(final Map<String, String> others) {


### PR DESCRIPTION
# Summary

[NIFI-12392](https://issues.apache.org/jira/browse/NIFI-12392) Corrects NAR unpacking for additional component documentation contained in bundled JAR files. This change resolves a problem introduced in changes for [NIFI-12294](https://issues.apache.org/jira/browse/NIFI-12294), which resulted in additional details links not being rendered for applicable components.

The resolution corrects the filtering process used to find additional documentation for enumerated components contained in bundled JAR files within a given NAR. The filtering method depends on the presence of a `docs` path followed by the complete class name of the component being evaluated.

Additional changes include new unit tests for the `NarUnpacker` to confirm the presence of additional details documentation extracted to the expected location.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
