### PR TITLE
NIFI-12393 Upgrade OWASP Check from 8.4.2 to 8.4.3 and Address Findings

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -26,6 +26,91 @@
     <packaging>pom</packaging>
     <description>Apache NiFi reporting module for aggregating code coverage information</description>
 
+    <properties>
+        <ant.version>1.10.14</ant.version>
+        <calcite.avatica.version>1.6.0</calcite.avatica.version>
+        <avatica.version>1.23.0</avatica.version>
+    </properties>
+
+    <!-- Managed Dependency Versions for referenced modules required based on different parent bundle project -->
+    <dependencyManagement>
+        <dependencies>
+            <!-- Apache Derby referenced in Hive and tests -->
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbynet</artifactId>
+                <version>${derby.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbytools</artifactId>
+                <version>${derby.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyclient</artifactId>
+                <version>${derby.version}</version>
+            </dependency>
+            <!-- Apache Ant referenced in Groovy and Hive -->
+            <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>${ant.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant-antlr</artifactId>
+                <version>${ant.version}</version>
+            </dependency>
+            <!-- Calcite Avatica referenced in Hive -->
+            <dependency>
+                <groupId>org.apache.calcite</groupId>
+                <artifactId>calcite-avatica</artifactId>
+                <version>${calcite.avatica.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.calcite.avatica</groupId>
+                <artifactId>avatica</artifactId>
+                <version>${avatica.version}</version>
+            </dependency>
+            <!-- Commons Compiler 3.1.9 from calcite-core -->
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>3.1.10</version>
+            </dependency>
+            <!-- XML Security from spring-security-saml2-service-provider -->
+            <dependency>
+                <groupId>org.apache.santuario</groupId>
+                <artifactId>xmlsec</artifactId>
+                <version>2.3.4</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.woodstox</groupId>
+                        <artifactId>woodstox-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- Reactor Netty client 1.0.34 from Azure Identity -->
+            <dependency>
+                <groupId>io.projectreactor.netty</groupId>
+                <artifactId>reactor-netty-http</artifactId>
+                <version>1.0.39</version>
+            </dependency>
+            <!-- core-io from Couchbase -->
+            <dependency>
+                <groupId>com.couchbase.client</groupId>
+                <artifactId>core-io</artifactId>
+                <version>1.7.24</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Command and Control modules -->
         <dependency>

--- a/nifi-commons/nifi-property-protection-azure/pom.xml
+++ b/nifi-commons/nifi-property-protection-azure/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.17</version>
+                <version>1.2.18</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -439,4 +439,9 @@
         <packageUrl regex="true">^pkg:javascript/jquery\.datatables@.*$</packageUrl>
         <vulnerabilityName>possible XSS</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes>Picocli misidentified as LINE library from Android so CVE-2015-0897 does not apply</notes>
+        <packageUrl regex="true">^pkg:maven/info\.picocli/picocli@.*$</packageUrl>
+        <cve>CVE-2015-0897</cve>
+    </suppress>
 </suppressions>

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -27,8 +27,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <azure.sdk.bom.version>1.2.17</azure.sdk.bom.version>
-        <msal4j.version>1.13.10</msal4j.version>
+        <azure.sdk.bom.version>1.2.18</azure.sdk.bom.version>
+        <msal4j.version>1.14.0</msal4j.version>
         <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>
 
@@ -67,6 +67,12 @@
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.33</version>
+            </dependency>
+            <!-- Override Reactor Netty client 1.0.34 from Azure Identity -->
+            <dependency>
+                <groupId>io.projectreactor.netty</groupId>
+                <artifactId>reactor-netty-http</artifactId>
+                <version>1.0.39</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-box-bundle/nifi-box-services-api/pom.xml
+++ b/nifi-nar-bundles/nifi-box-bundle/nifi-box-services-api/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.box</groupId>
             <artifactId>box-java-sdk</artifactId>
-            <version>4.4.0</version>
+            <version>4.6.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>

--- a/nifi-nar-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-box-bundle/pom.xml
@@ -34,15 +34,4 @@
         <module>nifi-box-services-api</module>
         <module>nifi-box-services-nar</module>
     </modules>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override jose4j 0.9.0 from box-java-sdk -->
-            <dependency>
-                <groupId>org.bitbucket.b_c</groupId>
-                <artifactId>jose4j</artifactId>
-                <version>0.9.3</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/nifi-nar-bundles/nifi-groovyx-bundle/nifi-groovyx-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-groovyx-bundle/nifi-groovyx-nar/pom.xml
@@ -24,9 +24,6 @@
 
     <artifactId>nifi-groovyx-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <ant.version>1.10.14</ant.version>
-    </properties>
 
     <dependencies>
         <dependency>
@@ -59,18 +56,6 @@
                     <artifactId>ant-junit</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <!-- Override ant from groovy-ant -->
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
-            <version>${ant.version}</version>
-        </dependency>
-        <dependency>
-            <!-- Override ant from groovy-ant -->
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-antlr</artifactId>
-            <version>${ant.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-groovyx-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-groovyx-bundle/pom.xml
@@ -26,6 +26,10 @@
     <packaging>pom</packaging>
     <description>NiFi Groovy Extended Processor</description>
 
+    <properties>
+        <ant.version>1.10.14</ant.version>
+    </properties>
+
     <modules>
         <module>nifi-groovyx-processors</module>
         <module>nifi-groovyx-nar</module>
@@ -43,6 +47,18 @@
                 <version>${nifi.groovy.version}</version>
                 <type>pom</type>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <!-- Override ant from groovy-ant -->
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>${ant.version}</version>
+            </dependency>
+            <dependency>
+                <!-- Override ant from groovy-ant -->
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant-antlr</artifactId>
+                <version>${ant.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/pom.xml
@@ -198,6 +198,11 @@
             <version>${derby.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>${derby.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hive.hcatalog</groupId>
             <artifactId>hive-hcatalog-server-extensions</artifactId>
             <version>${hive.version}</version>

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -91,7 +91,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.10.13</version>
+                <version>1.10.14</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.parquet</groupId>

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/pom.xml
@@ -132,7 +132,7 @@
                     <artifactId>bcprov-jdk15on</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.apache.groovy</groupId>
+                    <groupId>org.codehaus.groovy</groupId>
                     <artifactId>groovy-all</artifactId>
                 </exclusion>
                 <exclusion>

--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-nar/pom.xml
@@ -24,9 +24,6 @@
 
     <artifactId>nifi-scripting-nar</artifactId>
     <packaging>nar</packaging>
-    <properties>
-        <ant.version>1.10.14</ant.version>
-    </properties>
 
     <dependencies>
         <dependency>
@@ -76,18 +73,6 @@
                     <artifactId>ant-junit</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <!-- Override ant from groovy-ant -->
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
-            <version>${ant.version}</version>
-        </dependency>
-        <dependency>
-            <!-- Override ant from groovy-ant -->
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-antlr</artifactId>
-            <version>${ant.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-scripting-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-scripting-bundle/pom.xml
@@ -26,6 +26,10 @@
     <artifactId>nifi-scripting-bundle</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <ant.version>1.10.14</ant.version>
+    </properties>
+
     <modules>
         <module>nifi-scripting-processors</module>
         <module>nifi-scripting-nar</module>
@@ -72,6 +76,18 @@
                 <version>${nifi.groovy.version}</version>
                 <type>pom</type>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <!-- Override ant from groovy-ant -->
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>${ant.version}</version>
+            </dependency>
+            <dependency>
+                <!-- Override ant from groovy-ant -->
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant-antlr</artifactId>
+                <version>${ant.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -665,6 +665,11 @@
                 <version>${okio.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-fakefilesystem</artifactId>
+                <version>${okio.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-bom</artifactId>
                 <version>${kotlin.version}</version>
@@ -1281,7 +1286,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>8.4.2</version>
+                        <version>8.4.3</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>


### PR DESCRIPTION
# Summary

[NIFI-12393](https://issues.apache.org/jira/browse/NIFI-12393) Upgrades the OWASP Dependency Check Maven Plugin from 8.4.2 to 8.4.3 and addresses several vulnerability findings.

Dependency upgrades and changes include the following:

- Upgraded Azure SDK BOM from 1.2.17 to 1.2.18
- Upgraded Reactor Netty HTTP from 1.0.34 to 1.0.39 for Azure Identity
- Upgraded MSAL4J from 1.13.10 to 1.14.0
- Upgraded Box Java SDK from 4.4.0 to 4.6.1
- Relocated Apache Ant managed versions to bundle parent modules
- Added okio-fakefilesystem to managed dependencies
- Suppressed vulnerability for Picocli misidentified as LINE library
- Added managed dependencies to nifi-code-coverage to avoid false positives due to different parent modules

Remaining dependency check findings apply primarily to Hadoop 3.3.6 and Hive 3.1.3 shaded dependencies.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
