### PR TITLE
NIFI-12398 Upgrade Derby from 10.16.1.1 to 10.17.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <org.bouncycastle.version>1.77</org.bouncycastle.version>
         <testcontainers.version>1.19.1</testcontainers.version>
         <org.slf4j.version>2.0.9</org.slf4j.version>
-        <derby.version>10.16.1.1</derby.version>
+        <derby.version>10.17.1.0</derby.version>
         <ranger.version>2.4.0</ranger.version>
         <jetty.version>10.0.18</jetty.version>
         <jackson.bom.version>2.15.3</jackson.bom.version>


### PR DESCRIPTION
# Summary

[NIFI-12398](https://issues.apache.org/jira/browse/NIFI-12398) Upgrades Apache Derby dependencies from 10.16.1.1 to [10.17.1.0](https://db.apache.org/derby/releases/release-10_17_1_0.cgi).

Derby 10.17.1.0 requires Java 21, so this upgrade applies only to the main branch. Most of the dependencies on Apache Derby are related to tests.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
