### PR TITLE
NIFI-12405 Fixed the problem that CaptureChangeMySQL uses BinaryLogClient to cause too many sessions

### DIFF
--- a/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
+++ b/nifi-nar-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
@@ -464,8 +464,8 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
             .build();
 
     public static final PropertyDescriptor KEEP_ALIVE = new PropertyDescriptor.Builder()
-            .displayName("Keep Alive")
             .name("Keep Alive")
+            .displayName("Keep Alive")
             .description("Used to specify heartbeat messages or queries to be sent after a connection has been idle for a period of time to ensure that " +
                     "the connection remains active. This prevents the database server or middleware from closing the " +
                     "connection on a connection that has been inactive for a long time")
@@ -728,7 +728,7 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
 
             Long serverId = context.getProperty(SERVER_ID).evaluateAttributeExpressions().asLong();
 
-            Boolean keepAlive = context.getProperty(KEEP_ALIVE).evaluateAttributeExpressions().asBoolean();
+            Boolean keepAlive = context.getProperty(KEEP_ALIVE).asBoolean();
             Long keepAliveInterval = context.getProperty(KEEPALIVE_INTERVAL).evaluateAttributeExpressions().asLong();
             Long heartbeatInterval = context.getProperty(HEARTBEAT_INTERVAL).evaluateAttributeExpressions().asLong();
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12405](https://issues.apache.org/jira/browse/NIFI-12405)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-12405`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-12405`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
