### PR TITLE
NIFI-12420: Add Sawmill transformation processors

### DIFF
--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
@@ -90,6 +90,9 @@
     <!-- Suppress non-error messages due to known warning about redundant path annotation (NIFI-574) -->
     <logger name="com.sun.jersey.spi.inject.Errors" level="ERROR"/>
 
+    <!-- Suppress non-error messages due to Sawmill ProcessorFactoriesLoader emitting a large amount of WARNS. -->
+    <logger name="io.logz.sawmill.ProcessorFactoriesLoader" level="ERROR"/>
+
     <!--
         Logger for capturing Bootstrap logs and MiNiFi's standard error and standard out.
     -->

--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -906,6 +906,12 @@ language governing permissions and limitations under the License. -->
             <version>2.0.0-SNAPSHOT</version>
             <type>nar</type>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-sawmill-nar</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
         <!-- AspectJ library needed by the Java Agent used for native library loading (see bootstrap.conf) -->
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -207,6 +207,9 @@
     <!-- Suppress non-error messages due to Jetty AnnotationParser emitting a large amount of WARNS. Issue described in NIFI-5479. -->
     <logger name="org.eclipse.jetty.annotations.AnnotationParser" level="ERROR"/>
 
+    <!-- Suppress non-error messages due to Sawmill ProcessorFactoriesLoader emitting a large amount of WARNS. -->
+    <logger name="io.logz.sawmill.ProcessorFactoriesLoader" level="ERROR"/>
+
     <!-- Suppress non-error messages from SSHJ which was emitting large amounts of INFO logs by default -->
     <logger name="net.schmizz.sshj" level="WARN" />
     <logger name="com.hierynomus.sshj" level="WARN" />

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-nar/pom.xml
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-nar/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-sawmill-bundle</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-sawmill-nar</artifactId>
+    <packaging>nar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-sawmill-processors</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-shared-nar</artifactId>
+            <type>nar</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-nar/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-nar/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,36 @@
+nifi-sawmill-nar
+Copyright 2014-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+******************
+Apache Software License v2
+******************
+
+The following binary components are provided under the Apache Software License v2
+
+  (ASLv2) Sawmill
+
+  (ASLv2) Jackson JSON processor
+    The following NOTICE information applies:
+      # Jackson JSON processor
+
+      Jackson is a high-performance, Free/Open Source JSON processing library.
+      It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+      been in development since 2007.
+      It is currently developed by a community of developers, as well as supported
+      commercially by FasterXML.com.
+
+      ## Licensing
+
+      Jackson core and extension components may licensed under different licenses.
+      To find the details that apply to this artifact see the accompanying LICENSE file.
+      For more information, including possible other licensing options, contact
+      FasterXML.com (http://fasterxml.com).
+
+      ## Credits
+
+      A list of contributors may be found from CREDITS file, which is included
+      in some artifacts (usually source distributions); but is always available
+      from the source code management (SCM) system project uses.

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-sawmill-bundle</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-sawmill-processors</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.logz.sawmill</groupId>
+            <artifactId>sawmill-core</artifactId>
+            <exclusions>
+                <!-- Override Guava version -->
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>32.1.2-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock-record-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-services</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-schema-registry-service-api</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes combine.children="append">
+                        <exclude>src/test/resources/*.json</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/main/java/org/apache/nifi/processors/sawmill/BaseSawmillProcessor.java
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/main/java/org/apache/nifi/processors/sawmill/BaseSawmillProcessor.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.sawmill;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.logz.sawmill.GeoIpConfiguration;
+import io.logz.sawmill.Pipeline;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.resource.ResourceCardinality;
+import org.apache.nifi.components.resource.ResourceReference;
+import org.apache.nifi.components.resource.ResourceType;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+public abstract class BaseSawmillProcessor extends AbstractProcessor {
+
+    public static final PropertyDescriptor SAWMILL_TRANSFORM = new PropertyDescriptor.Builder()
+            .name("Sawmill Transformation")
+            .description("Sawmill Transformation for transform of JSON data. Any NiFi Expression Language present will be evaluated first to get the final transform to be applied. " +
+                    "The Sawmill Tutorial provides an overview of supported expressions: https://github.com/logzio/sawmill/wiki")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .identifiesExternalResource(ResourceCardinality.SINGLE, ResourceType.TEXT, ResourceType.FILE)
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor TRANSFORM_CACHE_SIZE = new PropertyDescriptor.Builder()
+            .name("Transform Cache Size")
+            .description("Compiling a Sawmill Transform can be fairly expensive. Ideally, this will be done only once. However, if Expression Language is used in the transform, we may need "
+                    + "a new Transform for each FlowFile. This value controls how many of those Transforms we cache in memory in order to avoid having to compile the Transform each time.")
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .defaultValue("1")
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor GEO_DATABASE_FILE = new PropertyDescriptor.Builder()
+            .name("MaxMind Database File")
+            .description("Path to Maxmind IP Enrichment Database File")
+            .required(false)
+            .identifiesExternalResource(ResourceCardinality.SINGLE, ResourceType.FILE)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .dynamicallyModifiesClasspath(true)
+            .build();
+
+    protected static final ObjectMapper jsonObjectMapper = new ObjectMapper();
+    protected volatile Cache<String, Pipeline> transformCache;
+
+    protected volatile AtomicReference<Pipeline.Factory> pipelineFactory = new AtomicReference<>();
+
+    protected void onScheduled(final ProcessContext context) {
+        if (context.getProperty(GEO_DATABASE_FILE).isSet()) {
+            final String geoIpDbPath = context.getProperty(GEO_DATABASE_FILE).asResource().asFile().getName();
+            GeoIpConfiguration geoIpConfiguration = new GeoIpConfiguration(geoIpDbPath);
+
+            try {
+                Pipeline.Factory createdFactory = new Pipeline.Factory(geoIpConfiguration);
+                pipelineFactory.compareAndSet(null, createdFactory);
+            } catch (Throwable t) {
+                getLogger().warn("Error finding or reading GeoIP database was specified. GeoIP-related pipeline steps will fail");
+                pipelineFactory.compareAndSet(null, new Pipeline.Factory());
+            }
+        } else {
+            getLogger().info("No GeoIP database was specified. GeoIP-related pipeline steps will fail");
+            pipelineFactory.compareAndSet(null, new Pipeline.Factory());
+        }
+
+        int maxTransformsToCache = context.getProperty(TRANSFORM_CACHE_SIZE).asInteger();
+        transformCache = Caffeine.newBuilder()
+                .maximumSize(maxTransformsToCache)
+                .build();
+        // Precompile the transform if it hasn't been done already (and if there is no PipelineDefinition Language present)
+        final PropertyValue transformProperty = context.getProperty(SAWMILL_TRANSFORM);
+        if (!transformProperty.isExpressionLanguagePresent()) {
+            try {
+                final String transform = readTransform(transformProperty);
+                transformCache.put(transform, getSawmillPipelineDefinition(transform));
+            } catch (final IOException | RuntimeException e) {
+                throw new ProcessException("Sawmill Transform compilation failed", e);
+            }
+        }
+    }
+
+    @Override
+    public void onPropertyModified(PropertyDescriptor descriptor, String oldValue, String newValue) {
+        super.onPropertyModified(descriptor, oldValue, newValue);
+        if (descriptor.equals(GEO_DATABASE_FILE)) {
+            pipelineFactory.set(null);
+        }
+    }
+
+    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
+        final List<ValidationResult> results = new ArrayList<>(super.customValidate(validationContext));
+        final String transform = validationContext.getProperty(SAWMILL_TRANSFORM).getValue();
+
+        try {
+            final boolean elPresent = validationContext.isExpressionLanguagePresent(transform);
+
+            if (elPresent) {
+                final String invalidExpressionMsg = validationContext.newExpressionLanguageCompiler().validateExpression(transform, true);
+                if (invalidExpressionMsg != null) {
+                    results.add(new ValidationResult.Builder().valid(false)
+                            .subject(SAWMILL_TRANSFORM.getDisplayName())
+                            .explanation("Invalid Expression Language: " + invalidExpressionMsg)
+                            .build());
+                }
+            } else {
+                // For validation we want to be able to ensure the spec is syntactically correct and not try to resolve variables since they may not exist yet
+                try {
+                    final Pipeline.Factory testFactory;
+                    if (validationContext.getProperty(GEO_DATABASE_FILE).isSet()) {
+                        final String geoIpDbPath = validationContext.getProperty(GEO_DATABASE_FILE).asResource().asFile().getName();
+                        GeoIpConfiguration geoIpConfiguration = new GeoIpConfiguration(geoIpDbPath);
+                        // Try to instantiate a factory with a GeoIP database location
+                        testFactory = new Pipeline.Factory(geoIpConfiguration);
+                    } else {
+                        // Try to instantiate a factory
+                        testFactory = new Pipeline.Factory();
+                    }
+                    final String content = readTransform(validationContext.getProperty(SAWMILL_TRANSFORM));
+                    testFactory.create(content);
+                } catch (Throwable t) {
+                    results.add(new ValidationResult.Builder().valid(false)
+                            .subject(SAWMILL_TRANSFORM.getDisplayName())
+                            .explanation(t.getCause() != null ? t.getCause().getMessage() :  t.getMessage())
+                            .build());
+                }
+            }
+        } catch (final Exception e) {
+            getLogger().info("Processor is not valid - ", e);
+            String message = "Specification not valid for the selected transformation.";
+            results.add(new ValidationResult.Builder().valid(false)
+                    .explanation(message)
+                    .build());
+        }
+        return results;
+    }
+
+    protected Pipeline getSawmillPipelineDefinition(String transform) {
+        return pipelineFactory.get().create(transform);
+    }
+
+    protected String readTransform(final PropertyValue propertyValue, final FlowFile flowFile) throws IOException {
+        final String transform;
+
+        if (propertyValue.isExpressionLanguagePresent()) {
+            transform = propertyValue.evaluateAttributeExpressions(flowFile).getValue();
+        } else {
+            transform = readTransform(propertyValue);
+        }
+
+        return transform;
+    }
+
+    protected String readTransform(final PropertyValue propertyValue) throws IOException {
+        final ResourceReference resourceReference = propertyValue.asResource();
+        if (resourceReference == null) {
+            return propertyValue.getValue();
+        }
+        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(resourceReference.read()))) {
+            return reader.lines().collect(Collectors.joining());
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/main/java/org/apache/nifi/processors/sawmill/SawmillTransformJSON.java
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/main/java/org/apache/nifi/processors/sawmill/SawmillTransformJSON.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.sawmill;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import io.logz.sawmill.Doc;
+import io.logz.sawmill.ExecutionResult;
+import io.logz.sawmill.Pipeline;
+import io.logz.sawmill.PipelineExecutor;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.SideEffectFree;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.SystemResource;
+import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnShutdown;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.util.StopWatch;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@SideEffectFree
+@SupportsBatching
+@Tags({"json", "sawmill", "transform", "grok", "tag"})
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+@SystemResourceConsideration(resource = SystemResource.MEMORY)
+@WritesAttribute(attribute = "mime.type", description = "Always set to application/json")
+@CapabilityDescription("Applies a Sawmill transformation to the FlowFile JSON payload. A new FlowFile is created "
+        + "with transformed content and is routed to the 'success' relationship. If the transform "
+        + "fails, the original FlowFile is routed to the 'failure' relationship. Note that the input is expected to be a top-level "
+        + "JSON object not an array. If the input is an array use SawmillTransformRecord instead, and the transformation will be "
+        + "applied to each object. It is not currently possible to apply a Sawmill transformation to an entire top-level array.")
+public class SawmillTransformJSON extends BaseSawmillProcessor {
+
+    public static final PropertyDescriptor PRETTY_PRINT = new PropertyDescriptor.Builder()
+            .name("sawmill-transform-pretty_print")
+            .displayName("Pretty Print")
+            .description("Apply pretty-print formatting to the output of the Sawmill transform")
+            .required(true)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .build();
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("The FlowFile with transformed content will be routed to this relationship")
+            .build();
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("If a FlowFile fails processing for any reason (for example, the FlowFile is not valid JSON), it will be routed to this relationship")
+            .build();
+
+    private static final List<PropertyDescriptor> descriptors;
+    private static final Set<Relationship> relationships;
+
+    static {
+        descriptors = Collections.unmodifiableList(
+                Arrays.asList(
+                        SAWMILL_TRANSFORM,
+                        GEO_DATABASE_FILE,
+                        PRETTY_PRINT,
+                        TRANSFORM_CACHE_SIZE
+                )
+        );
+
+        relationships = Collections.unmodifiableSet(new LinkedHashSet<>(
+                Arrays.asList(
+                        REL_SUCCESS,
+                        REL_FAILURE
+                )
+        ));
+    }
+
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    @Override
+    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return descriptors;
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
+        return super.customValidate(validationContext);
+    }
+
+    private ValidationResult validateSawmill(PropertyDescriptor property, PropertyValue value) {
+        final ValidationResult.Builder builder = new ValidationResult.Builder().subject(property.getDisplayName());
+        try {
+            final String transform = readTransform(value);
+            getSawmillPipelineDefinition(transform);
+            builder.valid(true);
+        } catch (final IOException | RuntimeException e) {
+            final String explanation = String.format("%s not valid: %s", property.getDisplayName(), e.getMessage());
+            builder.valid(false).explanation(explanation);
+        }
+        return builder.build();
+    }
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        super.onScheduled(context);
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        final FlowFile original = session.get();
+        if (original == null) {
+            return;
+        }
+        final StopWatch stopWatch = new StopWatch(true);
+
+        final PropertyValue transformProperty = context.getProperty(SAWMILL_TRANSFORM);
+        FlowFile transformed;
+
+        try (final PipelineExecutor pipelineExecutor = new PipelineExecutor()) {
+            final String transform = readTransform(transformProperty, original);
+            final Pipeline sawmillPipelineDefinition = transformCache.get(transform, currString -> getSawmillPipelineDefinition(transform));
+
+            final boolean prettyPrint = context.getProperty(PRETTY_PRINT).asBoolean();
+
+            transformed = session.write(original, (inputStream, outputStream) -> {
+                Map<String, Object> jsonNode = jsonObjectMapper.readValue(inputStream, new TypeReference<Map<String, Object>>() {
+                });
+                final ObjectWriter writer = prettyPrint ? jsonObjectMapper.writerWithDefaultPrettyPrinter() : jsonObjectMapper.writer();
+                final JsonGenerator jsonGenerator = writer.createGenerator(outputStream);
+
+                Doc doc = new Doc(jsonNode);
+                ExecutionResult executionResult = pipelineExecutor.execute(sawmillPipelineDefinition, doc);
+                if (executionResult.isSucceeded()) {
+                    jsonGenerator.writeObject(doc.getSource());
+                } else {
+                    getLogger().warn("Sawmill Transform failed or resulted in no data: Error = {}",
+                            executionResult.getError().orElse(new ExecutionResult.Error("unknown", "unknown", Optional.empty())));
+                }
+
+                jsonGenerator.flush();
+            });
+
+            transformed = session.putAttribute(transformed, CoreAttributes.MIME_TYPE.key(), "application/json");
+            session.transfer(transformed, REL_SUCCESS);
+            session.getProvenanceReporter().modifyContent(transformed, "Modified With " + transform, stopWatch.getElapsed(TimeUnit.MILLISECONDS));
+            stopWatch.stop();
+            getLogger().debug("Sawmill Transform completed {}", original);
+        } catch (final Exception e) {
+            getLogger().error("Sawmill Transform failed {}", original, e);
+            session.transfer(original, REL_FAILURE);
+        }
+    }
+
+    @OnStopped
+    @OnShutdown
+    public void onStopped() {
+        if (transformCache != null) {
+            transformCache.cleanUp();
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/main/java/org/apache/nifi/processors/sawmill/SawmillTransformRecord.java
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/main/java/org/apache/nifi/processors/sawmill/SawmillTransformRecord.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.sawmill;
+
+import io.logz.sawmill.Doc;
+import io.logz.sawmill.ExecutionResult;
+import io.logz.sawmill.Pipeline;
+import io.logz.sawmill.PipelineExecutor;
+import org.apache.nifi.annotation.behavior.SideEffectFree;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.serialization.RecordReader;
+import org.apache.nifi.serialization.RecordReaderFactory;
+import org.apache.nifi.serialization.RecordSetWriter;
+import org.apache.nifi.serialization.RecordSetWriterFactory;
+import org.apache.nifi.serialization.WriteResult;
+import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.serialization.record.util.DataTypeUtils;
+import org.apache.nifi.util.StopWatch;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@SideEffectFree
+@SupportsBatching
+@Tags({"record", "sawmill", "transform", "grok", "tag"})
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+@WritesAttributes({
+        @WritesAttribute(attribute = "record.count", description = "The number of records in an outgoing FlowFile"),
+        @WritesAttribute(attribute = "mime.type", description = "The MIME Type that the configured Record Writer indicates is appropriate"),
+})
+@CapabilityDescription("Applies a Sawmill transformation to each record in the FlowFile payload. A new FlowFile is created "
+        + "with transformed content and is routed to the 'success' relationship. If the transform "
+        + "fails, the original FlowFile is routed to the 'failure' relationship.")
+@RequiresInstanceClassLoading
+@SeeAlso({SawmillTransformJSON.class})
+public class SawmillTransformRecord extends BaseSawmillProcessor {
+
+    static final PropertyDescriptor RECORD_READER = new PropertyDescriptor.Builder()
+            .name("Record Reader")
+            .description("Specifies the Controller Service to use for parsing incoming data and determining the data's schema.")
+            .identifiesControllerService(RecordReaderFactory.class)
+            .required(true)
+            .build();
+
+    static final PropertyDescriptor RECORD_WRITER = new PropertyDescriptor.Builder()
+            .name("Record Writer")
+            .description("Specifies the Controller Service to use for writing out the records")
+            .identifiesControllerService(RecordSetWriterFactory.class)
+            .required(true)
+            .build();
+
+    static final PropertyDescriptor TRANSFORM_CACHE_SIZE = new PropertyDescriptor.Builder()
+            .name("Transform Cache Size")
+            .description("Compiling a Sawmill Transform can be fairly expensive. Ideally, this will be done only once. However, if the Expression Language is used in the transform, we may need "
+                    + "a new Transform for each FlowFile. This value controls how many of those Transforms we cache in memory in order to avoid having to compile the Transform each time.")
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .defaultValue("1")
+            .required(true)
+            .build();
+
+    static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("The FlowFile with transformed content will be routed to this relationship")
+            .build();
+
+    static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("If a FlowFile fails processing for any reason (for example, the FlowFile records cannot be parsed), it will be routed to this relationship")
+            .build();
+
+    static final Relationship REL_ORIGINAL = new Relationship.Builder()
+            .name("original")
+            .description("The original FlowFile that was transformed. If the FlowFile fails processing, nothing will be sent to this relationship")
+            .build();
+
+    private final static List<PropertyDescriptor> properties;
+    private final static Set<Relationship> relationships;
+
+    /*
+     * It is a cache for transform objects. It keep values indexed by jolt specification string.
+     * For some cases the key could be empty. It means that it represents default transform (e.g. for custom transform
+     * when there is no sawmill-record-spec specified).
+     */
+    static {
+        final List<PropertyDescriptor> _properties = new ArrayList<>();
+        _properties.add(RECORD_READER);
+        _properties.add(RECORD_WRITER);
+        _properties.add(SAWMILL_TRANSFORM);
+        _properties.add(GEO_DATABASE_FILE);
+        _properties.add(TRANSFORM_CACHE_SIZE);
+        properties = Collections.unmodifiableList(_properties);
+
+        final Set<Relationship> _relationships = new HashSet<>();
+        _relationships.add(REL_SUCCESS);
+        _relationships.add(REL_FAILURE);
+        _relationships.add(REL_ORIGINAL);
+        relationships = Collections.unmodifiableSet(_relationships);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
+        return super.customValidate(validationContext);
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, ProcessSession session) throws ProcessException {
+        final FlowFile original = session.get();
+        if (original == null) {
+            return;
+        }
+
+        final ComponentLog logger = getLogger();
+        final StopWatch stopWatch = new StopWatch(true);
+
+        final RecordReaderFactory readerFactory = context.getProperty(RECORD_READER).asControllerService(RecordReaderFactory.class);
+        final RecordSetWriterFactory writerFactory = context.getProperty(RECORD_WRITER).asControllerService(RecordSetWriterFactory.class);
+
+        final RecordSchema schema;
+        FlowFile transformed = null;
+
+        try (final InputStream in = session.read(original);
+             final RecordReader reader = readerFactory.createRecordReader(original, in, getLogger());
+             final PipelineExecutor pipelineExecutor = new PipelineExecutor()) {
+            schema = writerFactory.getSchema(original.getAttributes(), reader.getSchema());
+
+            final Map<String, String> attributes = new HashMap<>();
+            final WriteResult writeResult;
+            transformed = session.create(original);
+
+            // We want to transform the first record before creating the Record Writer. We do this because the Record will likely end up with a different structure
+            // and therefore a difference Schema after being transformed. As a result, we want to transform the Record and then provide the transformed schema to the
+            // Record Writer so that if the Record Writer chooses to inherit the Record Schema from the Record itself, it will inherit the transformed schema, not the
+            // schema determined by the Record Reader.
+            final Record firstRecord = reader.nextRecord();
+            if (firstRecord == null) {
+                try (final OutputStream out = session.write(transformed);
+                     final RecordSetWriter writer = writerFactory.createWriter(getLogger(), schema, out, transformed)) {
+
+                    writer.beginRecordSet();
+                    writeResult = writer.finishRecordSet();
+
+                    attributes.put("record.count", String.valueOf(writeResult.getRecordCount()));
+                    attributes.put(CoreAttributes.MIME_TYPE.key(), writer.getMimeType());
+                    attributes.putAll(writeResult.getAttributes());
+                }
+
+                transformed = session.putAllAttributes(transformed, attributes);
+                logger.info("{} had no Records to transform", original);
+            } else {
+                final PropertyValue transformProperty = context.getProperty(SAWMILL_TRANSFORM);
+                final String transform = readTransform(transformProperty, original);
+                final Pipeline sawmillPipelineDefinition = transformCache.get(transform, currString -> getSawmillPipelineDefinition(transform));
+                final List<Record> transformedFirstRecords = transform(firstRecord, pipelineExecutor, sawmillPipelineDefinition);
+
+                final RecordSchema newSchema;
+                final Record transformedFirstRecord;
+                if (transformedFirstRecords.isEmpty()) {
+                    logger.debug("Transformation produced no output, if this is not expected it indicates an error with the transformation");
+                    newSchema = firstRecord.getSchema();
+                    transformedFirstRecord = null;
+                } else {
+                    transformedFirstRecord = transformedFirstRecords.get(0);
+                    if (transformedFirstRecord == null) {
+                        throw new ProcessException("Error transforming the first record");
+                    }
+                    newSchema = transformedFirstRecord.getSchema();
+                }
+
+                final RecordSchema writeSchema = writerFactory.getSchema(original.getAttributes(), newSchema);
+
+                // TODO: Is it possible that two Records with the same input schema could have different schemas after transformation?
+                // If so, then we need to avoid this pattern of writing all Records from the input FlowFile to the same output FlowFile
+                // and instead use a Map<RecordSchema, RecordSetWriter>. This way, even if many different output schemas are possible,
+                // the output FlowFiles will each only contain records that have the same schema.
+                try (final OutputStream out = session.write(transformed);
+                     final RecordSetWriter writer = writerFactory.createWriter(getLogger(), writeSchema, out, transformed)) {
+
+                    writer.beginRecordSet();
+
+                    if (transformedFirstRecord != null) {
+                        writer.write(transformedFirstRecord);
+                    }
+                    Record record;
+                    // If multiple output records were generated, write them out
+                    for (int i = 1; i < transformedFirstRecords.size(); i++) {
+                        record = transformedFirstRecords.get(i);
+                        if (record == null) {
+                            throw new ProcessException("Error transforming the first record");
+                        }
+                        writer.write(record);
+                    }
+
+                    while ((record = reader.nextRecord()) != null) {
+                        final List<Record> transformedRecords = transform(record, pipelineExecutor, sawmillPipelineDefinition);
+                        for (Record transformedRecord : transformedRecords) {
+                            writer.write(transformedRecord);
+                        }
+                    }
+
+                    writeResult = writer.finishRecordSet();
+
+                    try {
+                        writer.close();
+                    } catch (final IOException ioe) {
+                        getLogger().warn("Failed to close Writer for {}", transformed);
+                    }
+
+                    attributes.put("record.count", String.valueOf(writeResult.getRecordCount()));
+                    attributes.put(CoreAttributes.MIME_TYPE.key(), writer.getMimeType());
+                    attributes.putAll(writeResult.getAttributes());
+                }
+
+                transformed = session.putAllAttributes(transformed, attributes);
+                session.getProvenanceReporter().modifyContent(transformed, "Modified With Sawmill", stopWatch.getElapsed(TimeUnit.MILLISECONDS));
+                logger.debug("Transform completed {}", original);
+            }
+        } catch (final Exception e) {
+            logger.error("Transform failed for {}", original, e);
+            session.transfer(original, REL_FAILURE);
+            if (transformed != null) {
+                session.remove(transformed);
+            }
+            return;
+        }
+        if (transformed != null) {
+            session.transfer(transformed, REL_SUCCESS);
+        }
+        session.transfer(original, REL_ORIGINAL);
+    }
+
+    private List<Record> transform(final Record record, final PipelineExecutor pipelineExecutor, final Pipeline sawmillPipelineDefinition) {
+        Map<String, Object> recordMap = (Map<String, Object>) DataTypeUtils.convertRecordFieldtoObject(record, RecordFieldType.RECORD.getRecordDataType(record.getSchema()));
+        Doc doc = new Doc(recordMap);
+        ExecutionResult executionResult = pipelineExecutor.execute(sawmillPipelineDefinition, doc);
+        final Map<String, Object> transformedObject;
+        if (executionResult.isSucceeded()) {
+            transformedObject = doc.getSource();
+        } else {
+            getLogger().warn("Sawmill Transform failed or resulted in no data: Error = {}",
+                    executionResult.getError().orElse(new ExecutionResult.Error("unknown", "unknown", Optional.empty())));
+            transformedObject = null;
+        }
+
+        // JOLT expects arrays to be of type List where our Record code uses Object[].
+        // Make another pass of the transformed objects to change List to Object[].
+        final Object normalizedRecordValues = normalizeRecordObjects(transformedObject);
+        final List<Record> recordList = new ArrayList<>();
+
+        if (normalizedRecordValues == null) {
+            return recordList;
+        }
+
+        // If the top-level object is an array, return a list of the records inside. Otherwise return a singleton list with the single transformed record
+        if (normalizedRecordValues instanceof Object[]) {
+            for (Object o : (Object[]) normalizedRecordValues) {
+                if (o != null) {
+                    recordList.add(DataTypeUtils.toRecord(o, "r"));
+                }
+            }
+        } else {
+            recordList.add(DataTypeUtils.toRecord(normalizedRecordValues, "r"));
+        }
+        return recordList;
+    }
+
+    @OnScheduled
+    public void setup(final ProcessContext context) {
+        super.onScheduled(context);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static Object normalizeRecordObjects(final Object o) {
+        if (o instanceof Map) {
+            Map<String, Object> m = ((Map<String, Object>) o);
+            m.forEach((k, v) -> m.put(k, normalizeRecordObjects(v)));
+            return m;
+        } else if (o instanceof List) {
+            final List<Object> objectList = (List<Object>) o;
+            final Object[] objectArray = new Object[objectList.size()];
+            for (int i = 0; i < objectArray.length; i++) {
+                objectArray[i] = normalizeRecordObjects(objectList.get(i));
+            }
+            return objectArray;
+        } else if (o instanceof Collection) {
+            Collection<?> c = (Collection<?>) o;
+            final List<Object> objectList = new ArrayList<>();
+            for (Object obj : c) {
+                objectList.add(normalizeRecordObjects(obj));
+            }
+            return objectList;
+        } else {
+            return o;
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.processors.sawmill.SawmillTransformJSON
+org.apache.nifi.processors.sawmill.SawmillTransformRecord

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/java/org/apache/nifi/processors/sawmill/TestSawmillTransformJSON.java
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/java/org/apache/nifi/processors/sawmill/TestSawmillTransformJSON.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.sawmill;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.nifi.stream.io.StreamUtils;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestSawmillTransformJSON {
+
+    private TestRunner runner = TestRunners.newTestRunner(new SawmillTransformJSON());
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setup() {
+        runner = TestRunners.newTestRunner(new SawmillTransformJSON());
+    }
+
+    @Test
+    public void testBadInput() {
+        final String inputFlowFile = "I am not JSON";
+        final String transform = getResource("simpleTransform.json");
+        runner.setProperty(SawmillTransformJSON.SAWMILL_TRANSFORM, transform);
+        runner.setProperty(SawmillTransformJSON.PRETTY_PRINT, Boolean.TRUE.toString());
+        runner.enqueue(inputFlowFile);
+
+        runner.run();
+
+        runner.assertTransferCount(SawmillTransformJSON.REL_SUCCESS, 0);
+        runner.assertTransferCount(SawmillTransformJSON.REL_FAILURE, 1);
+    }
+
+    @Test
+    public void testInvalidSawmillTransform() {
+        final TestRunner runner = TestRunners.newTestRunner(new SawmillTransformJSON());
+        final String invalidTransform = "invalid";
+        runner.setProperty(SawmillTransformJSON.SAWMILL_TRANSFORM, invalidTransform);
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void testTransformFilePath() {
+        final URL transformUrl = Objects.requireNonNull(getClass().getResource("/simpleTransform.json"));
+        final String transformPath = transformUrl.getPath();
+
+        runner.setProperty(SawmillTransformJSON.SAWMILL_TRANSFORM, transformPath);
+        runner.setProperty(SawmillTransformJSON.PRETTY_PRINT, Boolean.TRUE.toString());
+
+        final String json = getResource("input.json");
+        runner.enqueue(json);
+
+        assertRunSuccess();
+    }
+
+    @Test
+    public void testSimpleSawmill() {
+        runTransform("input.json", "simpleTransform.json", "simpleOutput.json");
+    }
+
+    @Test
+    public void testExpressionLanguageTransform() {
+        final String inputFlowFile = getResource("input.json");
+        final String transform = getResource("expressionLanguageTransform.json");
+        runner.setProperty(SawmillTransformJSON.SAWMILL_TRANSFORM, transform);
+        runner.assertValid();
+        runner.setProperty(SawmillTransformJSON.PRETTY_PRINT, Boolean.TRUE.toString());
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put("hashing.key", "ThisIsMyHashingKey");
+        runner.enqueue(inputFlowFile, attrs);
+
+        final MockFlowFile flowFile = assertRunSuccess();
+        final String expectedOutput = getResource("expressionLanguageOutput.json");
+        assertContentEquals(flowFile, expectedOutput);
+    }
+
+    @Test
+    public void testSawmillNoOutput() throws IOException {
+        final String input = "{\"a\":1}";
+        final String transform = "{\"steps\": [{\"drop\": {\"config\": {}}}]}";
+        runner.setProperty(SawmillTransformJSON.SAWMILL_TRANSFORM, transform);
+        runner.setProperty(SawmillTransformJSON.PRETTY_PRINT, Boolean.TRUE.toString());
+        runner.enqueue(input);
+
+        final MockFlowFile flowFile = assertRunSuccess();
+        flowFile.assertContentEquals(new byte[0]);
+    }
+
+    // This test verifies transformCache cleanup does not throw an exception
+    @Test
+    public void testShutdown() {
+        runner.stop();
+    }
+
+    private void runTransform(final String inputFileName, final String transformFileName, final String outputFileName) {
+        setTransformEnqueueJson(transformFileName, inputFileName);
+
+        final MockFlowFile flowFile = assertRunSuccess();
+
+        final String expectedOutput = getResource(outputFileName);
+        assertContentEquals(flowFile, expectedOutput);
+    }
+
+    private void assertContentEquals(final MockFlowFile flowFile, final String expectedJson) {
+        try {
+            final JsonNode flowFileNode = objectMapper.readTree(flowFile.getContent());
+            final JsonNode expectedNode = objectMapper.readTree(expectedJson);
+            assertEquals(expectedNode, flowFileNode);
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void setTransformEnqueueJson(final String transformFileName, final String jsonFileName) {
+        final String transform = getResource(transformFileName);
+        final String json = getResource(jsonFileName);
+        runner.setProperty(SawmillTransformJSON.SAWMILL_TRANSFORM, transform);
+        runner.setProperty(SawmillTransformJSON.PRETTY_PRINT, Boolean.TRUE.toString());
+        runner.enqueue(json);
+    }
+
+    private MockFlowFile assertRunSuccess() {
+        runner.run();
+        runner.assertTransferCount(SawmillTransformJSON.REL_SUCCESS, 1);
+        runner.assertTransferCount(SawmillTransformJSON.REL_FAILURE, 0);
+        return runner.getFlowFilesForRelationship(SawmillTransformJSON.REL_SUCCESS).iterator().next();
+    }
+
+    private String getResource(final String fileName) {
+        final String path = String.format("/%s", fileName);
+        try (
+                final InputStream inputStream = Objects.requireNonNull(getClass().getResourceAsStream(path), "Resource not found");
+                final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+                ) {
+            StreamUtils.copy(inputStream, outputStream);
+            return outputStream.toString();
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/java/org/apache/nifi/processors/sawmill/TestSawmillTransformRecord.java
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/java/org/apache/nifi/processors/sawmill/TestSawmillTransformRecord.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.sawmill;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.json.JsonRecordSetWriter;
+import org.apache.nifi.json.JsonTreeReader;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.schema.access.SchemaAccessUtils;
+import org.apache.nifi.schema.inference.SchemaInferenceUtil;
+import org.apache.nifi.stream.io.StreamUtils;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestSawmillTransformRecord {
+    private final TestRunner runner = TestRunners.newTestRunner(new SawmillTransformRecord());
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private JsonRecordSetWriter writer;
+
+
+    @BeforeEach
+    public void setup() throws IOException {
+        JsonTreeReader parser = new JsonTreeReader();
+        try {
+            runner.addControllerService("parser", parser);
+            runner.setProperty(parser, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaInferenceUtil.INFER_SCHEMA);
+
+        } catch (InitializationException e) {
+            throw new IOException(e);
+        }
+        runner.enableControllerService(parser);
+        runner.setProperty(SawmillTransformRecord.RECORD_READER, "parser");
+        writer = new JsonRecordSetWriter();
+        try {
+            runner.addControllerService("writer", writer);
+        } catch (InitializationException e) {
+            throw new IOException(e);
+        }
+        runner.setProperty(writer, "Schema Write Strategy", "full-schema-attribute");
+        runner.setProperty(SawmillTransformRecord.RECORD_WRITER, "writer");
+        // Each test must set the Schema Access strategy and Schema, and enable the writer CS
+    }
+
+    @Test
+    public void testBadInput() {
+        final String inputFlowFile = "I am not JSON";
+        final String transform = getResource("simpleTransform.json");
+        runner.setProperty(writer, "Pretty Print JSON", "true");
+        runner.enableControllerService(writer);
+
+        runner.setProperty(SawmillTransformRecord.SAWMILL_TRANSFORM, transform);
+        runner.enqueue(inputFlowFile);
+
+        runner.run();
+
+        runner.assertTransferCount(SawmillTransformRecord.REL_SUCCESS, 0);
+        runner.assertTransferCount(SawmillTransformRecord.REL_FAILURE, 1);
+    }
+
+    @Test
+    public void testInvalidSawmillTransform() {
+        final TestRunner runner = TestRunners.newTestRunner(new SawmillTransformRecord());
+        final String invalidTransform = "invalid";
+        runner.setProperty(SawmillTransformRecord.SAWMILL_TRANSFORM, invalidTransform);
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void testTransformFilePath() {
+        final URL transformUrl = Objects.requireNonNull(getClass().getResource("/simpleTransform.json"));
+        final String transformPath = transformUrl.getPath();
+
+        runner.setProperty(writer, "Pretty Print JSON", "true");
+        runner.enableControllerService(writer);
+
+        runner.setProperty(SawmillTransformRecord.SAWMILL_TRANSFORM, transformPath);
+
+        final String json = getResource("input.json");
+        runner.enqueue(json);
+
+        assertRunSuccess();
+    }
+
+    @Test
+    public void testSimpleSawmill() {
+        final String inputFlowFile = getResource("input.json");
+        final String transform = getResource("simpleTransform.json");
+        final String expectedOutput = "[" + getResource("simpleOutput.json") + "]";
+        runner.setProperty(SawmillTransformRecord.SAWMILL_TRANSFORM, transform);
+        runner.setProperty(writer, "Pretty Print JSON", "true");
+        runner.enableControllerService(writer);
+
+        runner.assertValid();
+        runner.enqueue(inputFlowFile);
+        runner.run();
+        runner.assertTransferCount(SawmillTransformRecord.REL_SUCCESS, 1);
+        runner.assertTransferCount(SawmillTransformRecord.REL_ORIGINAL, 1);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(SawmillTransformRecord.REL_SUCCESS).get(0);
+        transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
+        transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
+        assertContentEquals(transformed, expectedOutput);
+    }
+
+    @Test
+    public void testExpressionLanguageTransform() {
+        final String inputFlowFile = getResource("input.json");
+        final String transform = getResource("expressionLanguageTransform.json");
+        runner.setProperty(SawmillTransformRecord.SAWMILL_TRANSFORM, transform);
+        runner.setProperty(writer, "Pretty Print JSON", "true");
+        runner.enableControllerService(writer);
+        runner.assertValid();
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put("hashing.key", "ThisIsMyHashingKey");
+        runner.enqueue(inputFlowFile, attrs);
+
+        final MockFlowFile flowFile = assertRunSuccess();
+        // Output will be as array
+        final String expectedOutput = "[" + getResource("expressionLanguageOutput.json") + "]";
+        assertContentEquals(flowFile, expectedOutput);
+    }
+
+    @Test
+    public void testSawmillNoOutput() {
+        final String input = "{\"a\":1}";
+        final String transform = "{\"steps\": [{\"drop\": {\"config\": {}}}]}";
+
+        runner.setProperty(writer, "Pretty Print JSON", "true");
+        runner.enableControllerService(writer);
+        runner.setProperty(SawmillTransformRecord.SAWMILL_TRANSFORM, transform);
+        runner.enqueue(input);
+
+        final MockFlowFile flowFile = assertRunSuccess();
+        flowFile.assertContentEquals("[ ]");
+    }
+
+    // This test verifies transformCache cleanup does not throw an exception
+    @Test
+    public void testShutdown() {
+        runner.stop();
+    }
+
+
+    private void assertContentEquals(final MockFlowFile flowFile, final String expectedJson) {
+        try {
+            final JsonNode flowFileNode = objectMapper.readTree(flowFile.getContent());
+            final JsonNode expectedNode = objectMapper.readTree(expectedJson);
+            assertEquals(expectedNode, flowFileNode);
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private MockFlowFile assertRunSuccess() {
+        runner.run();
+        runner.assertTransferCount(SawmillTransformRecord.REL_SUCCESS, 1);
+        runner.assertTransferCount(SawmillTransformRecord.REL_FAILURE, 0);
+        return runner.getFlowFilesForRelationship(SawmillTransformRecord.REL_SUCCESS).iterator().next();
+    }
+
+    private String getResource(final String fileName) {
+        final String path = String.format("/%s", fileName);
+        try (
+                final InputStream inputStream = Objects.requireNonNull(getClass().getResourceAsStream(path), "Resource not found");
+                final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        ) {
+            StreamUtils.copy(inputStream, outputStream);
+            return outputStream.toString();
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/expressionLanguageOutput.json
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/expressionLanguageOutput.json
@@ -1,0 +1,5 @@
+{
+  "FieldFrom1": "testing steps",
+  "FieldFrom2": "testing multiple renames",
+  "checksum": "hello"
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/expressionLanguageTransform.json
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/expressionLanguageTransform.json
@@ -1,0 +1,15 @@
+{
+  "steps": [
+    {
+      "anonymize": {
+        "config": {
+          "fields": [
+            "checksum2"
+          ],
+          "algorithm": "MD5",
+          "key": "${hashing.key}"
+        }
+      }
+    }
+  ]
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/input.json
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/input.json
@@ -1,0 +1,5 @@
+{
+  "FieldFrom1": "testing steps",
+  "FieldFrom2": "testing multiple renames",
+  "checksum": "hello"
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/inputWithNull.json
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/inputWithNull.json
@@ -1,0 +1,13 @@
+{
+  "rating": {
+    "primary": {
+      "value": 3
+    },
+    "series": {
+      "value": [5,4]
+    },
+    "quality": {
+      "value": null
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/simpleOutput.json
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/simpleOutput.json
@@ -1,0 +1,1 @@
+{"checksum":"5d41402abc4b2a76b9719d911017c592","FieldTo2":"testing multiple renames","FieldTo1":"testing steps"}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/simpleOutputWithNull.json
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/simpleOutputWithNull.json
@@ -1,0 +1,8 @@
+{
+  "SecondaryRatings" : {
+    "quality" : {
+      "Value" : 3,
+      "RatingRange" : null
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/simpleOutputWithoutNull.json
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/simpleOutputWithoutNull.json
@@ -1,0 +1,7 @@
+{
+  "SecondaryRatings" : {
+    "quality" : {
+      "Value" : 3
+    }
+  }
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/simpleTransform.json
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/nifi-sawmill-processors/src/test/resources/simpleTransform.json
@@ -1,0 +1,25 @@
+{
+  "steps": [
+    {
+      "anonymize": {
+        "config": {
+          "fields": [
+            "checksum"
+          ],
+          "algorithm": "MD5",
+          "key": "ThisIsMyHashingKey"
+        }
+      }
+    },
+    {
+      "rename": {
+        "config": {
+          "renames": {
+            "FieldFrom1": "FieldTo1",
+            "FieldFrom2": "FieldTo2"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/nifi-nar-bundles/nifi-sawmill-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-sawmill-bundle/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>nifi-standard-shared-bom</artifactId>
+        <groupId>org.apache.nifi</groupId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../nifi-standard-shared-bundle/nifi-standard-shared-bom</relativePath>
+    </parent>
+
+    <groupId>org.apache.nifi</groupId>
+    <artifactId>nifi-sawmill-bundle</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>nifi-sawmill-processors</module>
+        <module>nifi-sawmill-nar</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-record</artifactId>
+                <version>2.0.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-record-serialization-service-api</artifactId>
+                <version>2.0.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>io.logz.sawmill</groupId>
+                <artifactId>sawmill-core</artifactId>
+                <version>2.0.23</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.nifi</groupId>
+                <artifactId>nifi-mock-record-utils</artifactId>
+                <version>2.0.0-SNAPSHOT</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/nifi-nar-bundles/pom.xml
+++ b/nifi-nar-bundles/pom.xml
@@ -116,6 +116,7 @@
         <module>nifi-compress-bundle</module>
         <module>nifi-opentelemetry-bundle</module>
         <module>nifi-apicurio-bundle</module>
+        <module>nifi-sawmill-bundle</module>
     </modules>
 
     <build>


### PR DESCRIPTION
# Summary

[NIFI-12420](https://issues.apache.org/jira/browse/NIFI-12420) This PR offers the SawmillTransformJSON and SawmillTransformRecord processors, using the Sawmill library to transform input.

Couple of questions for the reviewer(s):
- The NAR is 9.3 MB, should this be a profile disabled by default?
- The SawmillTransformJSON processor is faster for JSON input/output, but is it useful enough to include?
- There is a Guava override to eliminate vulnerabilities, seems to work fine but would like to confirm?

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
