### PR TITLE
NIFI-12419: Applying a copy of the nifi-web-frontend rat config in the parent module when the new ui profile is not activated

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/pom.xml
@@ -12,7 +12,9 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
---><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.nifi</groupId>
@@ -48,6 +50,35 @@
             <modules>
                 <module>nifi-web-frontend</module>
             </modules>
+        </profile>
+        <profile>
+            <id>apply-nifi-web-frontend-rat-config</id>
+            <activation>
+                <property>
+                    <name>!include-new-ui</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>nifi-web-frontend/src/main/nifi/coverage/**/*</exclude>
+                                <exclude>nifi-web-frontend/src/main/nifi/node_modules/**/*</exclude>
+                                <exclude>nifi-web-frontend/src/main/nifi/src/assets/fonts/**/*</exclude>
+                                <exclude>nifi-web-frontend/src/main/nifi/.editorconfig</exclude>
+                                <exclude>nifi-web-frontend/src/main/nifi/README.md</exclude>
+                                <exclude>nifi-web-frontend/src/main/nifi/proxy.config.mjs</exclude>
+                                <exclude>nifi-web-frontend/src/main/nifi/.prettierrc</exclude>
+                                <exclude>nifi-web-frontend/src/main/nifi/src/.eslintrc</exclude>
+                                <exclude>nifi-web-frontend/target/**/*</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 


### PR DESCRIPTION
NIFI-12419:
- Applying a copy of the nifi-web-frontend rat config in the parent module when the new ui profile is not activated. Previously, if the new ui profile was not activated, the rat check would fail.