### PR TITLE
NIFI-12446 Refactor FilterAttribute to align with code conventions

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFilterAttribute.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFilterAttribute.java
@@ -90,7 +90,7 @@ class TestFilterAttribute {
 
             @BeforeEach
             void setUp() {
-                runner.setProperty(FilterAttribute.FILTER_MODE, FilterAttribute.FILTER_MODE_VALUE_REMOVE);
+                runner.setProperty(FilterAttribute.FILTER_MODE, FilterAttribute.FilterMode.REMOVE.getValue());
             }
 
             @Test
@@ -199,8 +199,8 @@ class TestFilterAttribute {
         }
 
         private void runTestWith(Map<String, String> attributes, String attributeSet, Set<String> expectedAttributes) {
-            runner.setProperty(FilterAttribute.MATCHING_STRATEGY, FilterAttribute.MATCHING_STRATEGY_VALUE_ENUMERATION);
-            runner.setProperty(FilterAttribute.ATTRIBUTE_SET, attributeSet);
+            runner.setProperty(FilterAttribute.MATCHING_STRATEGY, FilterAttribute.MatchingStrategy.ENUMERATION.getValue());
+            runner.setProperty(FilterAttribute.ATTRIBUTE_ENUMERATION, attributeSet);
 
             final MockFlowFile input = runner.enqueue(exampleContent, attributes);
             final Map<String, String> inputAttributes = input.getAttributes();
@@ -268,7 +268,7 @@ class TestFilterAttribute {
 
             @BeforeEach
             void setUp() {
-                runner.setProperty(FilterAttribute.FILTER_MODE, FilterAttribute.FILTER_MODE_VALUE_REMOVE);
+                runner.setProperty(FilterAttribute.FILTER_MODE, FilterAttribute.FilterMode.REMOVE.getValue());
             }
 
             @Test
@@ -321,8 +321,8 @@ class TestFilterAttribute {
         }
 
         private void runTestWith(Map<String, String> attributes, String regexPattern, Set<String> expectedAttributes) {
-            runner.setProperty(FilterAttribute.MATCHING_STRATEGY, FilterAttribute.MATCHING_STRATEGY_VALUE_REGEX);
-            runner.setProperty(FilterAttribute.ATTRIBUTE_REGEX, regexPattern);
+            runner.setProperty(FilterAttribute.MATCHING_STRATEGY, FilterAttribute.MatchingStrategy.PATTERN.getValue());
+            runner.setProperty(FilterAttribute.ATTRIBUTE_PATTERN, regexPattern);
 
             final MockFlowFile input = runner.enqueue(exampleContent, attributes);
             final Map<String, String> inputAttributes = input.getAttributes();
@@ -357,7 +357,7 @@ class TestFilterAttribute {
                     "bar", "" + i
             ));
         }
-        runner.setProperty(FilterAttribute.ATTRIBUTE_SET, "foo");
+        runner.setProperty(FilterAttribute.ATTRIBUTE_ENUMERATION, "foo");
 
         runner.run(flowFileCount);
         runner.assertAllFlowFilesTransferred(FilterAttribute.REL_SUCCESS, flowFileCount);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Refactors the recently added `FilterAttribute` processor to align with common code practices followed by other processors, before it's included in a first release version.

[NIFI-12446](https://issues.apache.org/jira/browse/NIFI-12446)

Note: This targets the `support/nifi-1.x` branch. The `main` will be receive a PR once the changes have finalized and this PR is merged.  

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-12446`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-12446`

### Pull Request Formatting

- [x] Pull Request based on current revision of the ~~`main`~~`support/nifi-1.x` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] ~~JDK 21~~JDK 1.8

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
