### PR TITLE
NIFI-12411: Update PublishAMQP to read AMQP headers value from FlowFile attributes and `amq$headers` string

### DIFF
--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPPublisher.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPPublisher.java
@@ -28,7 +28,7 @@ import com.rabbitmq.client.ReturnListener;
 
 /**
  * Generic publisher of messages to AMQP-based messaging system. It is based on
- * RabbitMQ client API (https://www.rabbitmq.com/api-guide.html)
+ * RabbitMQ client API (<a href="https://www.rabbitmq.com/api-guide.html">Java Client API Guide</a>)
  */
 final class AMQPPublisher extends AMQPWorker {
 
@@ -63,7 +63,7 @@ final class AMQPPublisher extends AMQPWorker {
         exchange = exchange == null ? "" : exchange.trim();
 
         if (processorLog.isDebugEnabled()) {
-            if (exchange.length() == 0) {
+            if (exchange.isEmpty()) {
                 processorLog.debug("The 'exchangeName' is not specified. Messages will be sent to default exchange");
             }
             processorLog.debug("Successfully connected AMQPPublisher to {} and '{}' exchange with '{}' as a routing key.", this.connectionString, exchange, routingKey);

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -24,7 +24,6 @@ import com.rabbitmq.client.impl.DefaultExceptionHandler;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -49,7 +48,7 @@ import org.apache.nifi.ssl.SSLContextService;
 
 /**
  * Base processor that uses RabbitMQ client API
- * (https://www.rabbitmq.com/api-guide.html) to rendezvous with AMQP-based
+ * (<a href="https://www.rabbitmq.com/api-guide.html">Java Client API Guide</a>) to rendezvous with AMQP-based
  * messaging systems version 0.9.1
  *
  * @param <T> the type of {@link AMQPWorker}. Please see {@link AMQPPublisher}
@@ -57,6 +56,20 @@ import org.apache.nifi.ssl.SSLContextService;
  */
 abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProcessor {
 
+    public static final String AMQP_APPID_ATTRIBUTE = "amqp$appId";
+    public static final String AMQP_CONTENT_ENCODING_ATTRIBUTE = "amqp$contentEncoding";
+    public static final String AMQP_CONTENT_TYPE_ATTRIBUTE = "amqp$contentType";
+    public static final String AMQP_HEADERS_ATTRIBUTE = "amqp$headers";
+    public static final String AMQP_DELIVERY_MODE_ATTRIBUTE = "amqp$deliveryMode";
+    public static final String AMQP_PRIORITY_ATTRIBUTE = "amqp$priority";
+    public static final String AMQP_CORRELATION_ID_ATTRIBUTE = "amqp$correlationId";
+    public static final String AMQP_REPLY_TO_ATTRIBUTE = "amqp$replyTo";
+    public static final String AMQP_EXPIRATION_ATTRIBUTE = "amqp$expiration";
+    public static final String AMQP_MESSAGE_ID_ATTRIBUTE = "amqp$messageId";
+    public static final String AMQP_TIMESTAMP_ATTRIBUTE = "amqp$timestamp";
+    public static final String AMQP_TYPE_ATTRIBUTE = "amqp$type";
+    public static final String AMQP_USER_ID_ATTRIBUTE = "amqp$userId";
+    public static final String AMQP_CLUSTER_ID_ATTRIBUTE = "amqp$clusterId";
     public static final PropertyDescriptor BROKERS = new PropertyDescriptor.Builder()
             .name("Brokers")
             .description("A comma-separated list of known AMQP Brokers in the format <host>:<port> (e.g., localhost:5672). If this is " +
@@ -129,17 +142,15 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
     private static final List<PropertyDescriptor> propertyDescriptors;
 
     static {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(BROKERS);
-        properties.add(HOST);
-        properties.add(PORT);
-        properties.add(V_HOST);
-        properties.add(USER);
-        properties.add(PASSWORD);
-        properties.add(AMQP_VERSION);
-        properties.add(SSL_CONTEXT_SERVICE);
-        properties.add(USE_CERT_AUTHENTICATION);
-        propertyDescriptors = Collections.unmodifiableList(properties);
+        propertyDescriptors = List.of(
+                BROKERS,
+                HOST, PORT,
+                V_HOST,
+                USER,
+                PASSWORD,
+                AMQP_VERSION,
+                SSL_CONTEXT_SERVICE,
+                USE_CERT_AUTHENTICATION);
     }
 
     protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -263,7 +263,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
         try {
             updater.accept(attributeValue);
         } catch (final Exception e) {
-            getLogger().warn("Failed to update AMQP Message Property {}", attributeKey, e);
+            getLogger().warn("Failed to update AMQP Message Property [{}]", attributeKey, e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -19,6 +19,7 @@ package org.apache.nifi.amqp.processors;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Connection;
+import java.util.EnumSet;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.ReadsAttribute;
@@ -27,6 +28,7 @@ import org.apache.nifi.annotation.behavior.SystemResource;
 import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.DescribedValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
@@ -42,7 +44,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -58,23 +59,22 @@ import java.util.regex.Pattern;
     + "that happens you will see a log in both app-log and bulletin stating to that effect, and the FlowFile will be routed to the 'failure' relationship.")
 @SystemResourceConsideration(resource = SystemResource.MEMORY)
 @ReadsAttributes({
-    @ReadsAttribute(attribute = "amqp$appId", description = "The App ID field to set on the AMQP Message"),
-    @ReadsAttribute(attribute = "amqp$contentEncoding", description = "The Content Encoding to set on the AMQP Message"),
-    @ReadsAttribute(attribute = "amqp$contentType", description = "The Content Type to set on the AMQP Message"),
-    @ReadsAttribute(attribute = "amqp$headers", description = "The headers to set on the AMQP Message"),
-    @ReadsAttribute(attribute = "amqp$deliveryMode", description = "The numeric indicator for the Message's Delivery Mode"),
-    @ReadsAttribute(attribute = "amqp$priority", description = "The Message priority"),
-    @ReadsAttribute(attribute = "amqp$correlationId", description = "The Message's Correlation ID"),
-    @ReadsAttribute(attribute = "amqp$replyTo", description = "The value of the Message's Reply-To field"),
-    @ReadsAttribute(attribute = "amqp$expiration", description = "The Message Expiration"),
-    @ReadsAttribute(attribute = "amqp$messageId", description = "The unique ID of the Message"),
-    @ReadsAttribute(attribute = "amqp$timestamp", description = "The timestamp of the Message, as the number of milliseconds since epoch"),
-    @ReadsAttribute(attribute = "amqp$type", description = "The type of message"),
-    @ReadsAttribute(attribute = "amqp$userId", description = "The ID of the user"),
-    @ReadsAttribute(attribute = "amqp$clusterId", description = "The ID of the AMQP Cluster"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_APPID_ATTRIBUTE, description = "The App ID field to set on the AMQP Message"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_CONTENT_ENCODING_ATTRIBUTE, description = "The Content Encoding to set on the AMQP Message"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_CONTENT_TYPE_ATTRIBUTE, description = "The Content Type to set on the AMQP Message"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, description = "The headers to set on the AMQP Message"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_DELIVERY_MODE_ATTRIBUTE, description = "The numeric indicator for the Message's Delivery Mode"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_PRIORITY_ATTRIBUTE, description = "The Message priority"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_CORRELATION_ID_ATTRIBUTE, description = "The Message's Correlation ID"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_REPLY_TO_ATTRIBUTE, description = "The value of the Message's Reply-To field"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_EXPIRATION_ATTRIBUTE, description = "The Message Expiration"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_MESSAGE_ID_ATTRIBUTE, description = "The unique ID of the Message"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_TIMESTAMP_ATTRIBUTE, description = "The timestamp of the Message, as the number of milliseconds since epoch"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_TYPE_ATTRIBUTE, description = "The type of message"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_USER_ID_ATTRIBUTE, description = "The ID of the user"),
+    @ReadsAttribute(attribute = AbstractAMQPProcessor.AMQP_CLUSTER_ID_ATTRIBUTE, description = "The ID of the AMQP Cluster"),
 })
 public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
-    private static final String ATTRIBUTES_PREFIX = "amqp$";
 
     public static final PropertyDescriptor EXCHANGE = new PropertyDescriptor.Builder()
             .name("Exchange Name")
@@ -85,9 +85,9 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .addValidator(Validator.VALID)
             .build();
-
     public static final PropertyDescriptor ROUTING_KEY = new PropertyDescriptor.Builder()
             .name("Routing Key")
+            .displayName("Routing Key")
             .description("The name of the Routing Key that will be used by AMQP to route messages from the exchange to a destination queue(s). "
                     + "Usually provided by the administrator (e.g., 'myKey')In the event when messages are sent to a default exchange this property "
                     + "corresponds to a destination queue name, otherwise a binding from the Exchange to a Queue via Routing Key must be set "
@@ -96,13 +96,44 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
-
+    public static final PropertyDescriptor HEADERS_SOURCE = new PropertyDescriptor.Builder()
+            .name("Headers Source")
+            .displayName("Headers Source")
+            .description(
+                    "The source of the headers which will be put in the published message. They can come either from the processor property as a string or they can be " +
+                            "picked from flow file attributes based on Regex expression.")
+            .required(true)
+            .allowableValues(InputHeaderSource.getAllowedValues())
+            .defaultValue(InputHeaderSource.STRING)
+            .build();
+    public static final PropertyDescriptor HEADERS_SOURCE_PRECEDENCE = new PropertyDescriptor.Builder()
+            .name("Headers Source Precedence")
+            .displayName("Headers Source Precedence")
+            .description(
+                    "In case of key duplication in header sources, this defines which value to take.")
+            .required(true)
+            .dependsOn(HEADERS_SOURCE, InputHeaderSource.BOTH)
+            .allowableValues(InputHeaderSource.STRING, InputHeaderSource.ATTRIBUTES)
+            .defaultValue(InputHeaderSource.STRING)
+            .build();
+    public static final PropertyDescriptor HEADERS_ATTRIBUTES_REGEX = new PropertyDescriptor.Builder()
+            .name("Attributes To Headers Regular Expression")
+            .displayName("Attributes To Headers Regular Expression")
+            .description("Regular expression that will be evaluated against the flow file attributes to select "
+                    + "the matching attributes and put as AMQP headers.")
+            .required(true)
+            .dependsOn(HEADERS_SOURCE, InputHeaderSource.ATTRIBUTES, InputHeaderSource.BOTH)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .addValidator(StandardValidators.createRegexValidator(0, Integer.MAX_VALUE, true))
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
     public static final PropertyDescriptor HEADER_SEPARATOR = new PropertyDescriptor.Builder()
             .name("header.separator")
             .displayName("Header Separator")
             .description("The character that is used to split key-value for headers. The value must only one character. "
                     + "Otherwise you will get an error message")
             .defaultValue(",")
+            .dependsOn(HEADERS_SOURCE, InputHeaderSource.STRING, InputHeaderSource.BOTH)
             .addValidator(StandardValidators.SINGLE_CHAR_VALIDATOR)
             .required(false)
             .build();
@@ -125,26 +156,25 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
         List<PropertyDescriptor> properties = new ArrayList<>();
         properties.add(EXCHANGE);
         properties.add(ROUTING_KEY);
+        properties.add(HEADERS_SOURCE);
+        properties.add(HEADERS_SOURCE_PRECEDENCE);
+        properties.add(HEADERS_ATTRIBUTES_REGEX);
         properties.add(HEADER_SEPARATOR);
         properties.addAll(getCommonPropertyDescriptors());
         propertyDescriptors = Collections.unmodifiableList(properties);
-
-        Set<Relationship> rels = new HashSet<>();
-        rels.add(REL_SUCCESS);
-        rels.add(REL_FAILURE);
-        relationships = Collections.unmodifiableSet(rels);
+        relationships = Set.of(REL_SUCCESS, REL_FAILURE);
     }
-
 
     /**
      * Will construct AMQP message by extracting its body from the incoming {@link FlowFile}. AMQP Properties will be extracted from the
      * {@link FlowFile} and converted to {@link BasicProperties} to be sent along with the message. Upon success the incoming {@link FlowFile} is
      * transferred to 'success' {@link Relationship} and upon failure FlowFile is penalized and transferred to the 'failure' {@link Relationship}
      * <br>
-     *
-     * NOTE: Attributes extracted from {@link FlowFile} are considered
-     * candidates for AMQP properties if their names are prefixed with
-     * {@link PublishAMQP#ATTRIBUTES_PREFIX} (e.g., amqp$contentType=text/xml)
+     * <p>
+     * NOTE: Attributes extracted from {@link FlowFile} are considered candidates for AMQP properties if their names are prefixed with
+     * "amq$" (e.g., amqp$contentType=text/xml). For "amqp$headers" it depends on the value of
+     * {@link PublishAMQP#HEADERS_SOURCE}, if the value is {@link InputHeaderSource#ATTRIBUTES} then message headers are created from this attribute value,
+     * otherwise this attribute will be ignored.
      */
     @Override
     protected void processResource(final Connection connection, final AMQPPublisher publisher, ProcessContext context, ProcessSession session) throws ProcessException {
@@ -158,10 +188,21 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
             throw new IllegalArgumentException("Failed to determine 'routing key' with provided value '"
                 + context.getProperty(ROUTING_KEY) + "' after evaluating it as expression against incoming FlowFile.");
         }
+        String selectedHeaderSource = context.getProperty(HEADERS_SOURCE).getValue();
+        String headerSourcePrecedence = null;
+        Character headerSeparator = null;
+        Pattern pattern = null;
+        if (context.getProperty(HEADERS_ATTRIBUTES_REGEX).isSet()) {
+            pattern = Pattern.compile(context.getProperty(HEADERS_ATTRIBUTES_REGEX).evaluateAttributeExpressions().getValue());
+        }
+        if (context.getProperty(HEADERS_SOURCE_PRECEDENCE).isSet()) {
+            headerSourcePrecedence = context.getProperty(HEADERS_SOURCE_PRECEDENCE).getValue();
+        }
+        if (context.getProperty(HEADER_SEPARATOR).isSet()) {
+            headerSeparator = context.getProperty(HEADER_SEPARATOR).getValue().charAt(0);
+        }
 
-        final Character separator = context.getProperty(HEADER_SEPARATOR).toString().charAt(0);
-
-        final BasicProperties amqpProperties = extractAmqpPropertiesFromFlowFile(flowFile, separator);
+        final BasicProperties amqpProperties = extractAmqpPropertiesFromFlowFile(flowFile, selectedHeaderSource, headerSourcePrecedence, headerSeparator, pattern);
 
         final String exchange = context.getProperty(EXCHANGE).evaluateAttributeExpressions(flowFile).getValue();
         final byte[] messageContent = extractMessage(flowFile, session);
@@ -206,8 +247,15 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
     }
 
 
-    private void updateBuilderFromAttribute(final FlowFile flowFile, final String attribute, final Consumer<String> updater) {
-        final String attributeValue = flowFile.getAttribute(ATTRIBUTES_PREFIX + attribute);
+    /**
+     * Reads an attribute from flowFile and pass it to the consumer function
+     *
+     * @param flowFile        FlowFile for reading the attribute
+     * @param attributeKey    Name of the attribute
+     * @param updater         Consumer function which will use the attribute value
+     */
+    private void readAmqpAttribute(final FlowFile flowFile, final String attributeKey, final Consumer<String> updater) {
+        final String attributeValue = flowFile.getAttribute(attributeKey);
         if (attributeValue == null) {
             return;
         }
@@ -215,35 +263,76 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
         try {
             updater.accept(attributeValue);
         } catch (final Exception e) {
-            getLogger().warn("Failed to update AMQP Message Property {}", attribute, e);
+            getLogger().warn("Failed to update AMQP Message Property {}", attributeKey, e);
         }
     }
 
     /**
      * Extracts AMQP properties from the {@link FlowFile} attributes. Attributes
      * extracted from {@link FlowFile} are considered candidates for AMQP
-     * properties if their names are prefixed with
-     * {@link PublishAMQP#ATTRIBUTES_PREFIX} (e.g., amqp$contentType=text/xml).
+     * properties if their names are prefixed with "amq$" (e.g., amqp$contentType=text/xml).
      */
-    private BasicProperties extractAmqpPropertiesFromFlowFile(FlowFile flowFile, Character headerSeparator) {
+    private BasicProperties extractAmqpPropertiesFromFlowFile(FlowFile flowFile, String selectedHeaderSource, String headerSourcePrecedence, Character separator, Pattern pattern) {
         final AMQP.BasicProperties.Builder builder = new AMQP.BasicProperties.Builder();
 
-        updateBuilderFromAttribute(flowFile, "contentType", builder::contentType);
-        updateBuilderFromAttribute(flowFile, "contentEncoding", builder::contentEncoding);
-        updateBuilderFromAttribute(flowFile, "deliveryMode", mode -> builder.deliveryMode(Integer.parseInt(mode)));
-        updateBuilderFromAttribute(flowFile, "priority", pri -> builder.priority(Integer.parseInt(pri)));
-        updateBuilderFromAttribute(flowFile, "correlationId", builder::correlationId);
-        updateBuilderFromAttribute(flowFile, "replyTo", builder::replyTo);
-        updateBuilderFromAttribute(flowFile, "expiration", builder::expiration);
-        updateBuilderFromAttribute(flowFile, "messageId", builder::messageId);
-        updateBuilderFromAttribute(flowFile, "timestamp", ts -> builder.timestamp(new Date(Long.parseLong(ts))));
-        updateBuilderFromAttribute(flowFile, "type", builder::type);
-        updateBuilderFromAttribute(flowFile, "userId", builder::userId);
-        updateBuilderFromAttribute(flowFile, "appId", builder::appId);
-        updateBuilderFromAttribute(flowFile, "clusterId", builder::clusterId);
-        updateBuilderFromAttribute(flowFile, "headers", headers -> builder.headers(validateAMQPHeaderProperty(headers, headerSeparator)));
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_CONTENT_TYPE_ATTRIBUTE, builder::contentType);
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_CONTENT_ENCODING_ATTRIBUTE, builder::contentEncoding);
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_DELIVERY_MODE_ATTRIBUTE, mode -> builder.deliveryMode(Integer.parseInt(mode)));
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_PRIORITY_ATTRIBUTE, pri -> builder.priority(Integer.parseInt(pri)));
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_CORRELATION_ID_ATTRIBUTE, builder::correlationId);
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_REPLY_TO_ATTRIBUTE, builder::replyTo);
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_EXPIRATION_ATTRIBUTE, builder::expiration);
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_MESSAGE_ID_ATTRIBUTE, builder::messageId);
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_TIMESTAMP_ATTRIBUTE, ts -> builder.timestamp(new Date(Long.parseLong(ts))));
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_TYPE_ATTRIBUTE, builder::type);
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_USER_ID_ATTRIBUTE, builder::userId);
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_APPID_ATTRIBUTE, builder::appId);
+        readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_CLUSTER_ID_ATTRIBUTE, builder::clusterId);
+
+        Map<String, Object> headers = prepareAMQPHeaders(flowFile, selectedHeaderSource, headerSourcePrecedence, separator, pattern);
+        builder.headers(headers);
 
         return builder.build();
+    }
+
+    /**
+     * Extract AMQP headers from incoming {@link FlowFile} based on selected headers source value.
+     *
+     * @param flowFile used to extract headers
+     * @return {@link Map}
+     */
+    private Map<String, Object> prepareAMQPHeaders(FlowFile flowFile, String selectedHeaderSource, String headerSourcePrecedence, Character headerSeparator, Pattern pattern) {
+        final Map<String, Object> headers = new HashMap<>();
+        if (InputHeaderSource.ATTRIBUTES.getValue().equals(selectedHeaderSource)) {
+                headers.putAll(attributesToHeaders(flowFile.getAttributes(), pattern));
+        } else if (InputHeaderSource.STRING.getValue().equals(selectedHeaderSource)) {
+            readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, value -> headers.putAll(validateAMQPHeaderProperty(value, headerSeparator)));
+        } else {
+            // When precedence matches, put values in the last so it can override keys from other source
+            if (InputHeaderSource.ATTRIBUTES.getValue().equals(headerSourcePrecedence)) {
+                readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, value -> headers.putAll(validateAMQPHeaderProperty(value, headerSeparator)));
+                headers.putAll(attributesToHeaders(flowFile.getAttributes(), pattern));
+            } else {
+                headers.putAll(attributesToHeaders(flowFile.getAttributes(), pattern));
+                readAmqpAttribute(flowFile, AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, value -> headers.putAll(validateAMQPHeaderProperty(value, headerSeparator)));
+            }
+        }
+        return headers;
+    }
+
+    /**
+     * Matches the pattern to keys of input attributes and output the amqp headers map
+     * @param attributes flowFile attributes to scan for match
+     * @return Map with entries matching the pattern
+     */
+    private Map<String, String> attributesToHeaders(Map<String, String> attributes, Pattern pattern) {
+        final Map<String, String> headers = new HashMap<>();
+        for (Map.Entry<String, String> attributeEntry : attributes.entrySet()) {
+            if (pattern.matcher(attributeEntry.getKey()).matches()) {
+                headers.put(attributeEntry.getKey(), attributeEntry.getValue());
+            }
+        }
+        return headers;
     }
 
     /**
@@ -267,5 +356,44 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
             }
         }
         return headers;
+    }
+    public enum InputHeaderSource implements DescribedValue {
+
+        ATTRIBUTES("headersFromAttributes", "Attributes Matching Regex",
+            "Select attributes based on regex pattern to put in rabbitmq headers. Key of the attribute will be used as header key"),
+        STRING("headersFromString", "Attribute 'amp$headers' Value",
+            "Prepare headers from 'amp$headers' attribute string"),
+        BOTH("headersFromBoth", "Regex Match And 'amp$headers' Value",
+            "Take headers from both sources: 'amp$headers' attribute and attributes matching Regex. In case of key duplication precedence property will define which value to take.");
+
+        private final String value;
+        private final String displayName;
+        private final String description;
+
+        InputHeaderSource(String value, String displayName, String description) {
+
+            this.value = value;
+            this.displayName = displayName;
+            this.description = description;
+        }
+
+        public static EnumSet<InputHeaderSource> getAllowedValues() {
+            return EnumSet.of(STRING, ATTRIBUTES, BOTH);
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
     }
 }

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.PublishAMQP/additionalDetails.html
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/resources/docs/org.apache.nifi.amqp.processors.PublishAMQP/additionalDetails.html
@@ -34,8 +34,8 @@
     This processor does two things. It constructs AMQP Message by extracting FlowFile contents (both body and attributes). 
     Once message is constructed it is sent to an AMQP Exchange.
     AMQP Properties will be extracted from the FlowFile and converted to <i>com.rabbitmq.client.AMQP.BasicProperties</i> to be sent
-    along with the message. Upon success the incoming FlowFile is transfered to <i>success</i> Relationship and upon failure FlowFile is
-    penalized and transfered to the <i>failure</i> Relationship. 
+    along with the message. Upon success the incoming FlowFile is transferred to <i>success</i> Relationship and upon failure FlowFile is
+    penalized and transferred to the <i>failure</i> Relationship.
 </p>
 <h2>Where did my message go?</h2>
 <p>
@@ -51,9 +51,21 @@
     properties if their names are prefixed with <i>amqp$</i> (e.g., amqp$contentType=text/xml). To enrich message with additional AMQP properties 
     you may use <b>UpdateAttribute</b> processor between the source processor and PublishAMQP processor.
     The following is the list of available standard AMQP properties: <i>("amqp$contentType", "amqp$contentEncoding",
-            "amqp$headers", "amqp$deliveryMode", "amqp$priority", "amqp$correlationId", "amqp$replyTo",
+            "amqp$headers" (if 'Headers Source' is set to 'Attribute "amqp$headers" Value') , "amqp$deliveryMode", "amqp$priority", "amqp$correlationId", "amqp$replyTo",
             "amqp$expiration", "amqp$messageId", "amqp$timestamp", "amqp$type", "amqp$userId", "amqp$appId",
             "amqp$clusterId")</i>
+</p>
+<h3>AMQP Message Headers Source</h3>
+<p>
+    The headers attached to AMQP message by the processor depends on the "Headers Source" property value.
+    <ol>
+    <li><b>Attribute "amqp$headers" Value</b> - The processor will read single attribute "amqp$headers" and split it based on "Header Separator" and then read headers
+    in <i>key=value</i> format.
+    </li>
+    <li><b>Attributes Matching Regex</b> - The processor will pick flow file attributes by matching the regex provided in "Attributes To Headers Regular Expression".
+    The name of the attribute is used as key of header
+    </li>
+    </ol>
 </p>
 <h2>Configuration Details</h2>
 <p>

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.MessageProperties;
+import org.apache.nifi.amqp.processors.ConsumeAMQP.OutputHeaderFormat;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.exception.ProcessException;
@@ -160,8 +161,8 @@ public class ConsumeAMQPTest {
             runner.run();
             final MockFlowFile successFF = runner.getFlowFilesForRelationship(ConsumeAMQP.REL_SUCCESS).get(0);
             assertNotNull(successFF);
-            successFF.assertAttributeEquals("amqp$routingKey", "key1");
-            successFF.assertAttributeEquals("amqp$exchange", "myExchange");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_ROUTING_KEY_ATTRIBUTE, "key1");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_EXCHANGE_ATTRIBUTE, "myExchange");
         }
     }
 
@@ -187,13 +188,13 @@ public class ConsumeAMQPTest {
 
             ConsumeAMQP proc = new LocalConsumeAMQP(connection);
             TestRunner runner = initTestRunner(proc);
-            runner.setProperty(ConsumeAMQP.HEADER_FORMAT, ConsumeAMQP.HEADERS_FORMAT_JSON_STRING);
+            runner.setProperty(ConsumeAMQP.HEADER_FORMAT, OutputHeaderFormat.JSON_STRING);
             runner.run();
             final MockFlowFile successFF = runner.getFlowFilesForRelationship(ConsumeAMQP.REL_SUCCESS).get(0);
             assertNotNull(successFF);
-            successFF.assertAttributeEquals("amqp$routingKey", "key1");
-            successFF.assertAttributeEquals("amqp$exchange", "myExchange");
-            String headers = successFF.getAttribute("amqp$headers");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_ROUTING_KEY_ATTRIBUTE, "key1");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_EXCHANGE_ATTRIBUTE, "myExchange");
+            String headers = successFF.getAttribute(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE);
             JsonNode jsonNode = objectMapper.readTree(headers);
             assertEquals(expectedJson, jsonNode);
         }
@@ -222,14 +223,14 @@ public class ConsumeAMQPTest {
 
             ConsumeAMQP proc = new LocalConsumeAMQP(connection);
             TestRunner runner = initTestRunner(proc);
-            runner.setProperty(ConsumeAMQP.HEADER_FORMAT, ConsumeAMQP.HEADERS_FORMAT_ATTRIBUTES);
+            runner.setProperty(ConsumeAMQP.HEADER_FORMAT, OutputHeaderFormat.ATTRIBUTES);
             runner.setProperty(ConsumeAMQP.HEADER_KEY_PREFIX, headerPrefix);
             runner.run();
             final MockFlowFile successFF = runner.getFlowFilesForRelationship(ConsumeAMQP.REL_SUCCESS).get(0);
             assertNotNull(successFF);
-            successFF.assertAttributeEquals("amqp$routingKey", "key1");
-            successFF.assertAttributeEquals("amqp$exchange", "myExchange");
-            successFF.assertAttributeNotExists("amqp$headers");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_ROUTING_KEY_ATTRIBUTE, "key1");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_EXCHANGE_ATTRIBUTE, "myExchange");
+            successFF.assertAttributeNotExists(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE);
             expectedHeadersMap.forEach((key, value) -> {
                 successFF.assertAttributeEquals(headerPrefix + "." + key, value.toString());
             } );
@@ -260,9 +261,9 @@ public class ConsumeAMQPTest {
             runner.run();
             final MockFlowFile successFF = runner.getFlowFilesForRelationship(ConsumeAMQP.REL_SUCCESS).get(0);
             assertNotNull(successFF);
-            successFF.assertAttributeEquals("amqp$routingKey", "key1");
-            successFF.assertAttributeEquals("amqp$exchange", "myExchange");
-            String headers = successFF.getAttribute("amqp$headers");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_ROUTING_KEY_ATTRIBUTE, "key1");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_EXCHANGE_ATTRIBUTE, "myExchange");
+            String headers = successFF.getAttribute(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE);
             assertEquals(EXPECTED_RESULT, headers);
         }
     }
@@ -297,9 +298,9 @@ public class ConsumeAMQPTest {
             runner.run();
             final MockFlowFile successFF = runner.getFlowFilesForRelationship(ConsumeAMQP.REL_SUCCESS).get(0);
             assertNotNull(successFF);
-            successFF.assertAttributeEquals("amqp$routingKey", "key1");
-            successFF.assertAttributeEquals("amqp$exchange", "myExchange");
-            successFF.assertAttributeEquals("amqp$headers", "key1=(bar,bar)");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_ROUTING_KEY_ATTRIBUTE, "key1");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_EXCHANGE_ATTRIBUTE, "myExchange");
+            successFF.assertAttributeEquals(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, "key1=(bar,bar)");
 
         }
     }
@@ -329,9 +330,9 @@ public class ConsumeAMQPTest {
             runner.run();
             final MockFlowFile successFF = runner.getFlowFilesForRelationship(ConsumeAMQP.REL_SUCCESS).get(0);
             assertNotNull(successFF);
-            successFF.assertAttributeEquals("amqp$routingKey", "key1");
-            successFF.assertAttributeEquals("amqp$exchange", "myExchange");
-            String headers = successFF.getAttribute("amqp$headers");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_ROUTING_KEY_ATTRIBUTE, "key1");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_EXCHANGE_ATTRIBUTE, "myExchange");
+            String headers = successFF.getAttribute(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE);
             assertEquals(EXPECTED_RESULT, headers);
         }
     }
@@ -362,9 +363,9 @@ public class ConsumeAMQPTest {
             runner.run();
             final MockFlowFile successFF = runner.getFlowFilesForRelationship(ConsumeAMQP.REL_SUCCESS).get(0);
             assertNotNull(successFF);
-            successFF.assertAttributeEquals("amqp$routingKey", "key1");
-            successFF.assertAttributeEquals("amqp$exchange", "myExchange");
-            String headers = successFF.getAttribute("amqp$headers");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_ROUTING_KEY_ATTRIBUTE, "key1");
+            successFF.assertAttributeEquals(ConsumeAMQP.AMQP_EXCHANGE_ATTRIBUTE, "myExchange");
+            String headers = successFF.getAttribute(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE);
             assertEquals(EXPECTED_RESULT, headers);
         }
     }

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
@@ -19,6 +19,7 @@ package org.apache.nifi.amqp.processors;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.GetResponse;
+import org.apache.nifi.amqp.processors.PublishAMQP.InputHeaderSource;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
@@ -45,28 +46,27 @@ public class PublishAMQPTest {
         final TestRunner runner = TestRunners.newTestRunner(pubProc);
         setConnectionProperties(runner);
 
-        final Map<String, String> expectedHeaders = new HashMap<String, String>() {{
-            put("foo", "bar");
-            put("foo2", "bar2");
-            put("foo3", null);
-        }};
+        final Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("foo", "bar");
+        expectedHeaders.put("foo2", "bar2");
+        expectedHeaders.put("foo3", null);
 
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("foo", "bar");
-        attributes.put("amqp$contentType", "foo/bar");
-        attributes.put("amqp$contentEncoding", "foobar123");
-        attributes.put("amqp$headers", "foo=bar,foo2=bar2,foo3");
-        attributes.put("amqp$deliveryMode", "1");
-        attributes.put("amqp$priority", "2");
-        attributes.put("amqp$correlationId", "correlationId123");
-        attributes.put("amqp$replyTo", "replyTo123");
-        attributes.put("amqp$expiration", "expiration123");
-        attributes.put("amqp$messageId", "messageId123");
-        attributes.put("amqp$timestamp", "123456789");
-        attributes.put("amqp$type", "type123");
-        attributes.put("amqp$userId", "userId123");
-        attributes.put("amqp$appId", "appId123");
-        attributes.put("amqp$clusterId", "clusterId123");
+        attributes.put(AbstractAMQPProcessor.AMQP_CONTENT_TYPE_ATTRIBUTE, "foo/bar");
+        attributes.put(AbstractAMQPProcessor.AMQP_CONTENT_ENCODING_ATTRIBUTE, "foobar123");
+        attributes.put(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, "foo=bar,foo2=bar2,foo3");
+        attributes.put(AbstractAMQPProcessor.AMQP_DELIVERY_MODE_ATTRIBUTE, "1");
+        attributes.put(AbstractAMQPProcessor.AMQP_PRIORITY_ATTRIBUTE, "2");
+        attributes.put(AbstractAMQPProcessor.AMQP_CORRELATION_ID_ATTRIBUTE, "correlationId123");
+        attributes.put(AbstractAMQPProcessor.AMQP_REPLY_TO_ATTRIBUTE, "replyTo123");
+        attributes.put(AbstractAMQPProcessor.AMQP_EXPIRATION_ATTRIBUTE, "expiration123");
+        attributes.put(AbstractAMQPProcessor.AMQP_MESSAGE_ID_ATTRIBUTE, "messageId123");
+        attributes.put(AbstractAMQPProcessor.AMQP_TIMESTAMP_ATTRIBUTE, "123456789");
+        attributes.put(AbstractAMQPProcessor.AMQP_TYPE_ATTRIBUTE, "type123");
+        attributes.put(AbstractAMQPProcessor.AMQP_USER_ID_ATTRIBUTE, "userId123");
+        attributes.put(AbstractAMQPProcessor.AMQP_APPID_ATTRIBUTE, "appId123");
+        attributes.put(AbstractAMQPProcessor.AMQP_CLUSTER_ID_ATTRIBUTE, "clusterId123");
 
         runner.enqueue("Hello Joe".getBytes(), attributes);
 
@@ -107,14 +107,13 @@ public class PublishAMQPTest {
         setConnectionProperties(runner);
         runner.setProperty(PublishAMQP.HEADER_SEPARATOR, "|");
 
-        final Map<String, String> expectedHeaders = new HashMap<String, String>() {{
-            put("foo", "(bar,bar)");
-            put("foo2", "bar2");
-            put("foo3", null);
-        }};
+        final Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("foo", "(bar,bar)");
+        expectedHeaders.put("foo2", "bar2");
+        expectedHeaders.put("foo3", null);
 
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("amqp$headers", "foo=(bar,bar)|foo2=bar2|foo3");
+        attributes.put(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, "foo=(bar,bar)|foo2=bar2|foo3");
 
         runner.enqueue("Hello Joe".getBytes(), attributes);
 
@@ -135,7 +134,7 @@ public class PublishAMQPTest {
     }
 
     @Test
-    public void validateWithNotValidHeaderSeparatorParameter()  {
+    public void validateWithNotValidHeaderSeparatorParameter() {
         final PublishAMQP pubProc = new LocalPublishAMQP();
         final TestRunner runner = TestRunners.newTestRunner(pubProc);
         runner.setProperty(PublishAMQP.HEADER_SEPARATOR, "|,");
@@ -149,14 +148,14 @@ public class PublishAMQPTest {
         setConnectionProperties(runner);
         runner.setProperty(PublishAMQP.HEADER_SEPARATOR, "|");
 
-        final Map<String, String> expectedHeaders = new HashMap<String, String>() {{
-            put("foo", "(bar,bar)");
-            put("foo2", "bar2");
-            put("foo3", null);
-        }};
+        final Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("foo", "(bar,bar)");
+        expectedHeaders.put("foo2", "bar2");
+        expectedHeaders.put("foo3", null);
+
 
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("amqp$headers", "foo=(bar,bar)|foo2=bar2|foo3|foo4=malformed=|foo5=mal=formed");
+        attributes.put(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, "foo=(bar,bar)|foo2=bar2|foo3|foo4=malformed=|foo5=mal=formed");
 
         runner.enqueue("Hello Joe".getBytes(), attributes);
 
@@ -191,6 +190,157 @@ public class PublishAMQPTest {
         assertNotNull(runner.getFlowFilesForRelationship(PublishAMQP.REL_FAILURE).get(0));
     }
 
+    @Test
+    public void validateSuccessWithHeaderFromAttributeRegexToSuccess() throws Exception {
+        final PublishAMQP pubProc = new LocalPublishAMQP();
+        final TestRunner runner = TestRunners.newTestRunner(pubProc);
+        setConnectionProperties(runner);
+        runner.setProperty(PublishAMQP.HEADERS_SOURCE, InputHeaderSource.ATTRIBUTES);
+        runner.setProperty(PublishAMQP.HEADERS_ATTRIBUTES_REGEX, "test.*|tmp\\..*|foo2|foo3");
+
+        final Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("test1", "value1");
+        expectedHeaders.put("test2", "value2");
+        expectedHeaders.put("foo2", "");
+        expectedHeaders.put("foo3", null);
+        expectedHeaders.put("tmp.test1", "tmp1");
+        expectedHeaders.put("tmp.test2.key", "tmp2");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, "foo=(bar,bar)|foo2=bar2|foo3");
+        attributes.put("test1", "value1");
+        attributes.put("test2", "value2");
+        attributes.put("foo4", "value4");
+        attributes.put("foo2", "");
+        attributes.put("foo3", null);
+        attributes.put("tmp.test1", "tmp1");
+        attributes.put("tmp.test2.key", "tmp2");
+
+        runner.enqueue("Hello Joe".getBytes(), attributes);
+
+        runner.run();
+
+        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
+        assertNotNull(successFF);
+
+        final Channel channel = ((LocalPublishAMQP) pubProc).getConnection().createChannel();
+        final GetResponse msg1 = channel.basicGet("queue1", true);
+        assertNotNull(msg1);
+
+        final Map<String, Object> headerMap = msg1.getProps().getHeaders();
+
+        assertEquals(expectedHeaders, headerMap);
+
+        assertNotNull(channel.basicGet("queue2", true));
+    }
+
+    @Test
+    public void validateWithNotValidRegexForAttributeMatch() {
+        final PublishAMQP pubProc = new LocalPublishAMQP();
+        final TestRunner runner = TestRunners.newTestRunner(pubProc);
+        setConnectionProperties(runner);
+        runner.setProperty(PublishAMQP.HEADERS_SOURCE, InputHeaderSource.ATTRIBUTES);
+        runner.setProperty(PublishAMQP.HEADERS_ATTRIBUTES_REGEX, "*");
+        runner.assertNotValid();
+    }
+
+    @Test
+    public void validateSuccessWithHeaderFromBothSourcesToSuccess() throws Exception {
+        final PublishAMQP pubProc = new LocalPublishAMQP();
+        final TestRunner runner = TestRunners.newTestRunner(pubProc);
+        setConnectionProperties(runner);
+        runner.setProperty(PublishAMQP.HEADERS_SOURCE, InputHeaderSource.BOTH);
+        // header keys from `amq$headers will be put in output if present in both sources
+        runner.setProperty(PublishAMQP.HEADERS_SOURCE_PRECEDENCE, InputHeaderSource.STRING);
+        runner.setProperty(PublishAMQP.HEADERS_ATTRIBUTES_REGEX, "test.*|tmp\\..*|foo2|foo3");
+        runner.setProperty(PublishAMQP.HEADER_SEPARATOR, "|");
+        final Map<String, String> expectedHeaders = new HashMap<>();
+            expectedHeaders.put("test1", "value1");
+            expectedHeaders.put("test2", "value2");
+            expectedHeaders.put("foo2", "string"); // value should be from `amq$headers` since precedence is set from string
+            expectedHeaders.put("foo3", null);
+            expectedHeaders.put("tmp.test1", "tmp1");
+            expectedHeaders.put("tmp.test2.key", "tmp2");
+            expectedHeaders.put("foo", "(bar,bar)");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, "foo=(bar,bar)|foo2=string");
+        attributes.put("test1", "value1");
+        attributes.put("test2", "value2");
+        attributes.put("foo4", "value4");
+        attributes.put("foo2", "attribute");
+        attributes.put("foo3", null);
+        // attributes where key matches Regex for headers
+        attributes.put("tmp.test1", "tmp1");
+        attributes.put("tmp.test2.key", "tmp2");
+
+        runner.enqueue("Hello Joe".getBytes(), attributes);
+
+        runner.run();
+
+        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
+        assertNotNull(successFF);
+
+        final Channel channel = ((LocalPublishAMQP) pubProc).getConnection().createChannel();
+        final GetResponse msg1 = channel.basicGet("queue1", true);
+        assertNotNull(msg1);
+
+        final Map<String, Object> headerMap = msg1.getProps().getHeaders();
+
+        assertEquals(expectedHeaders, headerMap);
+
+        assertNotNull(channel.basicGet("queue2", true));
+    }
+
+    @Test
+    public void validateSuccessAttributesPrecedenceWithHeaderFromBothSourcesToSuccess() throws Exception {
+        final PublishAMQP pubProc = new LocalPublishAMQP();
+        final TestRunner runner = TestRunners.newTestRunner(pubProc);
+        setConnectionProperties(runner);
+        runner.setProperty(PublishAMQP.HEADERS_SOURCE, InputHeaderSource.BOTH);
+        // header keys from `amq$headers will be put in output if present in both sources
+        runner.setProperty(PublishAMQP.HEADERS_SOURCE_PRECEDENCE, InputHeaderSource.ATTRIBUTES);
+        runner.setProperty(PublishAMQP.HEADERS_ATTRIBUTES_REGEX, "test.*|tmp\\..*|foo2|foo3");
+        runner.setProperty(PublishAMQP.HEADER_SEPARATOR, "|");
+        final Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("test1", "value1");
+        expectedHeaders.put("test2", "value2");
+        expectedHeaders.put("foo2", "attribute"); // value should be from attribute since precedence is set from attribute
+        expectedHeaders.put("foo3", null);
+        expectedHeaders.put("tmp.test1", "tmp1");
+        expectedHeaders.put("tmp.test2.key", "tmp2");
+        expectedHeaders.put("foo", "(bar,bar)");
+
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(AbstractAMQPProcessor.AMQP_HEADERS_ATTRIBUTE, "foo=(bar,bar)|foo2=string");
+        attributes.put("test1", "value1");
+        attributes.put("test2", "value2");
+        attributes.put("foo4", "value4");
+        attributes.put("foo2", "attribute");
+        attributes.put("foo3", null);
+        // attributes where key matches Regex for headers
+        attributes.put("tmp.test1", "tmp1");
+        attributes.put("tmp.test2.key", "tmp2");
+
+        runner.enqueue("Hello Joe".getBytes(), attributes);
+
+        runner.run();
+
+        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
+        assertNotNull(successFF);
+
+        final Channel channel = ((LocalPublishAMQP) pubProc).getConnection().createChannel();
+        final GetResponse msg1 = channel.basicGet("queue1", true);
+        assertNotNull(msg1);
+
+        final Map<String, Object> headerMap = msg1.getProps().getHeaders();
+
+        assertEquals(expectedHeaders, headerMap);
+
+        assertNotNull(channel.basicGet("queue2", true));
+    }
+
     private void setConnectionProperties(TestRunner runner) {
         runner.setProperty(PublishAMQP.BROKERS, "injvm:5672");
         runner.setProperty(PublishAMQP.USER, "user");
@@ -200,7 +350,7 @@ public class PublishAMQPTest {
     }
 
     public static class LocalPublishAMQP extends PublishAMQP {
-        private TestConnection connection;
+        private final TestConnection connection;
 
         public LocalPublishAMQP() {
             final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Arrays.asList("queue1", "queue2"));


### PR DESCRIPTION

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12411](https://issues.apache.org/jira/browse/NIFI-12411)

Processor can now also create message headers using attributes matching the given Regex property. The name of the attribute is used as header key. In addition to that it can read values from two sources i.e. attributes matching Regex and the headers present in `amq$headers` string. In case of key duplication in both sources, the precedence property decide which value will be used.

AMQP attributes keys are now set as constants strings and reused where needed.

Added `onScheduled` to PublishAMQP and ConsumeAMQP to read all properties which don't change during running state.

Test cases added for `PublishAMQP` headers source changes.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
