### PR TITLE
NIFI-12318: Fixed byte array generation in GenerateRecord

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateRecord.java
@@ -306,7 +306,7 @@ public class GenerateRecord extends AbstractProcessor {
             case BOOLEAN:
                 return FakerUtils.getFakeData("Bool.bool", faker);
             case BYTE:
-                return faker.number().numberBetween(Byte.MIN_VALUE, Byte.MAX_VALUE);
+                return (byte) faker.number().numberBetween(Byte.MIN_VALUE, Byte.MAX_VALUE);
             case CHAR:
                 return (char) faker.number().numberBetween(Character.MIN_VALUE, Character.MAX_VALUE);
             case DATE:

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestGenerateRecord/nested_no_nullable.avsc
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestGenerateRecord/nested_no_nullable.avsc
@@ -14,7 +14,7 @@
           "name": "ProviderType",
           "fields": [{
             "name": "Guid",
-            "type": "string"
+            "type": "bytes"
           }, {
             "name": "Name",
             "type": "string"

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestGenerateRecord/nested_nullable.avsc
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestGenerateRecord/nested_nullable.avsc
@@ -14,7 +14,7 @@
           "name": "ProviderType",
           "fields": [{
             "name": "Guid",
-            "type": ["null", "string"]
+            "type": ["null", "bytes"]
           }, {
             "name": "Name",
             "type": ["null", "string"]


### PR DESCRIPTION
# Summary

[NIFI-12318](https://issues.apache.org/jira/browse/NIFI-12318) GenerateRecords just needs to enforce `byte` type of the generated number(s).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
