### PR TITLE
NIFI-12462 Upgrade Logback from 1.3.13 to 1.3.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <aspectj.version>1.9.20.1</aspectj.version>
         <jersey.bom.version>2.41</jersey.bom.version>
         <log4j2.version>2.20.0</log4j2.version>
-        <logback.version>1.3.13</logback.version>
+        <logback.version>1.3.14</logback.version>
         <mockito.version>5.7.0</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.2</snakeyaml.version>


### PR DESCRIPTION
# Summary

[NIFI-12462](https://issues.apache.org/jira/browse/NIFI-12462) Upgrades Logback from 1.3.13 to [1.3.14](https://logback.qos.ch/news.html#1.3.14).

As described in the Logback release notes, Logback 1.3.14 resolves CVE-2023-6481, related to potential denial of service attacks on socket-based appenders. NiFi and project components do not use socket-based appenders in the default configuration.

Logback 1.3.14 is compatible with Java 8 and higher, so this upgrade should be applied to both main and support branches.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
