### PR TITLE
NIFI-12331: Added PublishSlack Processor

### DIFF
--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
@@ -27,6 +27,23 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.slack.api</groupId>
+            <artifactId>bolt-socket-mode</artifactId>
+            <version>1.32.1</version>
+        </dependency>
+        <!-- Required by bolt-socket-mode but the library itself doesn't have the dependency. -->
+        <dependency>
+            <groupId>org.glassfish.tyrus.bundles</groupId>
+            <artifactId>tyrus-standalone-client</artifactId>
+            <version>1.20</version>
+        </dependency>
+
+        <dependency>
             <groupId>javax.json</groupId>
             <artifactId>javax.json-api</artifactId>
             <version>1.1.4</version>
@@ -48,10 +65,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
@@ -34,13 +34,13 @@
         <dependency>
             <groupId>com.slack.api</groupId>
             <artifactId>bolt-socket-mode</artifactId>
-            <version>1.32.1</version>
+            <version>1.36.1</version>
         </dependency>
         <!-- Required by bolt-socket-mode but the library itself doesn't have the dependency. -->
         <dependency>
             <groupId>org.glassfish.tyrus.bundles</groupId>
             <artifactId>tyrus-standalone-client</artifactId>
-            <version>1.20</version>
+            <version>1.21</version>
         </dependency>
 
         <dependency>

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PostSlack.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PostSlack.java
@@ -36,6 +36,7 @@ import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
@@ -85,6 +86,14 @@ import java.util.stream.Collectors;
                 " The property name will not be used by the processor.",
         expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
 @WritesAttribute(attribute="slack.file.url", description = "The Slack URL of the uploaded file. It will be added if 'Upload FlowFile' has been set to 'Yes'.")
+@DeprecationNotice(
+    alternatives = {PublishSlack.class},
+    reason = "This Processor is more difficult to configure than necessary, and exposes intricate nuances of the Slack API that need not be exposed. " +
+             "Additionally, it lacks some capabilities, such as responding to messages in threads. It interacts directly with the Slack API instead of " +
+             "making use of the Slack-provided SDK, which makes the Processor much more brittle. Additionally, it does not make clear the differences " +
+             "between PutSlack and PostSlack. Each provides slightly different capabilities. " +
+             "PublishSlack combines the capabilities of both Processors in a simpler configuration that makes use of Slack's standard REST API."
+)
 public class PostSlack extends AbstractProcessor {
 
     private static final String SLACK_POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage";

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PublishSlack.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PublishSlack.java
@@ -1,0 +1,489 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.slack;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.methods.request.files.FilesUploadV2Request;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.slack.api.methods.response.files.FilesUploadV2Response;
+import com.slack.api.model.File;
+import com.slack.api.model.File.ShareDetail;
+import com.slack.api.model.File.Shares;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.configuration.DefaultSettings;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.DataUnit;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.slack.util.ChannelMapper;
+import org.apache.nifi.processors.slack.util.RateLimit;
+import org.apache.nifi.stream.io.StreamUtils;
+import org.apache.nifi.util.FormatUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@InputRequirement(Requirement.INPUT_REQUIRED)
+@CapabilityDescription("Posts a message to the specified Slack channel. The content of the message can be either a user-defined message that makes use of Expression Language or " +
+    "the contents of the FlowFile can be sent as the message. If sending a user-defined message, the contents of the FlowFile may also be optionally uploaded as " +
+    "a file attachment.")
+@Tags({"slack", "conversation", "chat.postMessage", "social media", "team", "text", "unstructured", "write", "upload", "send", "publish"})
+@WritesAttributes({
+    @WritesAttribute(attribute = "slack.channel.id", description = "The ID of the Slack Channel from which the messages were retrieved"),
+    @WritesAttribute(attribute = "slack.ts", description = "The timestamp of the slack messages that was sent; this is used by Slack as a unique identifier")
+})
+@DefaultSettings(yieldDuration = "3 sec")
+public class PublishSlack extends AbstractProcessor {
+
+    static final AllowableValue PUBLISH_STRATEGY_CONTENT_AS_MESSAGE = new AllowableValue("Send FlowFile Content as Message", "Send FlowFile Content as Message",
+        "The contents of the FlowFile will be sent as the message text.");
+    static final AllowableValue PUBLISH_STRATEGY_USE_PROPERTY = new AllowableValue("Use 'Message Text' Property", "Use 'Message Text' Property",
+        "The value of the Message Text Property will be sent as the message text.");
+
+    static final PropertyDescriptor ACCESS_TOKEN = new PropertyDescriptor.Builder()
+        .name("Access Token")
+        .description("OAuth Access Token used for authenticating/authorizing the Slack request sent by NiFi. This may be either a User Token or a Bot Token. " +
+                     "The token must be granted the chat:write scope. Additionally, in order to upload FlowFile contents as an attachment, it must be granted files:write.")
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .required(true)
+        .sensitive(true)
+        .build();
+
+    static PropertyDescriptor CHANNEL = new PropertyDescriptor.Builder()
+        .name("Channel")
+        .description("The name or identifier of the channel to send the message to. If using a channel name, it must be prefixed with the # character. " +
+                     "For example, #general. This is valid only for public channels. Otherwise, the unique identifier of the channel to publish to must be " +
+                     "provided.")
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .required(true)
+        .build();
+
+    static PropertyDescriptor PUBLISH_STRATEGY = new PropertyDescriptor.Builder()
+        .name("Publish Strategy")
+        .description("Specifies how the Processor will send the message or file to Slack.")
+        .required(true)
+        .allowableValues(PUBLISH_STRATEGY_CONTENT_AS_MESSAGE, PUBLISH_STRATEGY_USE_PROPERTY)
+        .defaultValue(PUBLISH_STRATEGY_CONTENT_AS_MESSAGE.getValue())
+        .build();
+
+    static PropertyDescriptor CHARACTER_SET = new PropertyDescriptor.Builder()
+        .name("Character Set")
+        .description("Specifies the name of the Character Set used to encode the FlowFile contents.")
+        .required(true)
+        .defaultValue("UTF-8")
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .dependsOn(PUBLISH_STRATEGY, PUBLISH_STRATEGY_CONTENT_AS_MESSAGE)
+        .build();
+
+    static PropertyDescriptor MESSAGE_TEXT = new PropertyDescriptor.Builder()
+        .name("Message Text")
+        .description("The text of the message to send to Slack.")
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .required(true)
+        .addValidator(Validator.VALID)
+        .dependsOn(PUBLISH_STRATEGY, PUBLISH_STRATEGY_USE_PROPERTY)
+        .build();
+
+    static PropertyDescriptor SEND_CONTENT_AS_ATTACHMENT = new PropertyDescriptor.Builder()
+        .name("Include FlowFile Content as Attachment")
+        .description("Specifies whether or not the contents of the FlowFile should be uploaded as an attachment to the Slack message.")
+        .allowableValues("true", "false")
+        .required(true)
+        .dependsOn(PUBLISH_STRATEGY, PUBLISH_STRATEGY_USE_PROPERTY)
+        .defaultValue("false")
+        .build();
+
+    static PropertyDescriptor MAX_FILE_SIZE = new PropertyDescriptor.Builder()
+        .name("Max FlowFile Size")
+        .description("The maximum size of a FlowFile that can be sent to Slack. If any FlowFile exceeds this size, it will be routed to failure. " +
+                     "This plays an important role because the entire contents of the file must be loaded into NiFi's heap in order to send the data " +
+                     "to Slack.")
+        .required(true)
+        .dependsOn(SEND_CONTENT_AS_ATTACHMENT, "true")
+        .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
+        .defaultValue("1 MB")
+        .build();
+
+    static PropertyDescriptor THREAD_TS = new PropertyDescriptor.Builder()
+        .name("Thread Timestamp")
+        .description("The Timestamp identifier for the thread that this message is to be a part of. If not specified, the message will be a top-level message instead of " +
+                     "being in a thread.")
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .required(false)
+        .build();
+
+    private static final List<PropertyDescriptor> properties = Collections.unmodifiableList(Arrays.asList(ACCESS_TOKEN,
+        CHANNEL,
+        PUBLISH_STRATEGY,
+        MESSAGE_TEXT,
+        CHARACTER_SET,
+        SEND_CONTENT_AS_ATTACHMENT,
+        MAX_FILE_SIZE,
+        THREAD_TS));
+
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+        .name("success")
+        .description("FlowFiles are routed to success after being successfully sent to Slack")
+        .build();
+
+    public static final Relationship REL_RATE_LIMITED = new Relationship.Builder()
+        .name("rate limited")
+        .description("FlowFiles are routed to 'rate limited' if the Rate Limit has been exceeded")
+        .build();
+
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+        .name("failure")
+        .description("FlowFiles are routed to 'failure' if unable to be sent to Slack for any other reason")
+        .build();
+
+    private static final Set<Relationship> relationships = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+        REL_SUCCESS,
+        REL_RATE_LIMITED,
+        REL_FAILURE)));
+
+    private final RateLimit rateLimit = new RateLimit(getLogger());
+
+    private volatile ChannelMapper channelMapper;
+    private volatile App slackApp;
+    private volatile MethodsClient client;
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    @OnScheduled
+    public void setup(final ProcessContext context) {
+        slackApp = createSlackApp(context);
+        client = slackApp.client();
+
+        channelMapper = new ChannelMapper(client);
+    }
+
+    @OnStopped
+    public void shutdown() {
+        if (slackApp != null) {
+            slackApp.stop();
+        }
+    }
+
+    private App createSlackApp(final ProcessContext context) {
+        final String botToken = context.getProperty(ACCESS_TOKEN).getValue();
+        final AppConfig appConfig = AppConfig.builder()
+            .singleTeamBotToken(botToken)
+            .build();
+
+        return new App(appConfig);
+    }
+
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        if (rateLimit.isLimitReached()) {
+            getLogger().debug("Will not publish to Slack because rate limit has been reached");
+            context.yield();
+            return;
+        }
+
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        final String channelId = getChannelId(flowFile, session, context);
+        if (channelId == null) {
+            // error will have already been logged
+            return;
+        }
+
+        // Get the message text
+        final String publishStrategy = context.getProperty(PUBLISH_STRATEGY).getValue();
+        if (PUBLISH_STRATEGY_CONTENT_AS_MESSAGE.getValue().equalsIgnoreCase(publishStrategy)) {
+            publishContentAsMessage(flowFile, channelId, context, session);
+        } else if (context.getProperty(SEND_CONTENT_AS_ATTACHMENT).asBoolean()) {
+            publishAsFile(flowFile, channelId, context, session);
+        } else {
+            final String messageText = context.getProperty(MESSAGE_TEXT).evaluateAttributeExpressions(flowFile).getValue();
+            publishAsMessage(flowFile, channelId, messageText, context, session);
+        }
+    }
+
+    private String getChannelId(final FlowFile flowFile, final ProcessSession session, final ProcessContext context) {
+        final String channelNameOrId = context.getProperty(CHANNEL).evaluateAttributeExpressions(flowFile).getValue();
+        if (channelNameOrId.isEmpty()) {
+            getLogger().error("No Channel ID was given for {}; routing to failure", flowFile);
+            session.transfer(flowFile, REL_FAILURE);
+            return null;
+        }
+
+        if (!channelNameOrId.startsWith("#")) {
+            return channelNameOrId;
+        }
+
+        // Resolve Channel name to an ID
+        try {
+            final String channelId = channelMapper.lookupChannelId(channelNameOrId);
+            if (channelId == null) {
+                getLogger().error("Could not find Channel with name {} for {}; routing to failure", channelNameOrId, flowFile);
+                session.transfer(flowFile, REL_FAILURE);
+                return null;
+            }
+
+            return channelId;
+        } catch (final Exception e) {
+            final Relationship relationship = handleClientException(channelNameOrId, flowFile, session, context, e);
+            getLogger().error("Failed to resolve Slack Channel ID for {}; transferring to {}", flowFile, relationship, e);
+            return null;
+        }
+    }
+
+    private void publishContentAsMessage(FlowFile flowFile, final String channelId, final ProcessContext context, final ProcessSession session) {
+        // Slack limits the message size to 100,000 characters. We don't have a way to know based on the size of the FlowFile how many characters it will contain,
+        // but we can be rather certain that if the size exceeds 500,000 bytes, it will also exceed 100,000 characters. As a result, we pre-emptively route to
+        // 'too large' in order to avoid buffering the contents into memory.
+        if (flowFile.getSize() > 500_000) {
+            getLogger().error("Cannot send contents of FlowFile {} to Slack because its length exceeds 500,000 bytes; routing to 'failure'");
+            session.transfer(flowFile, REL_FAILURE);
+            return;
+        }
+
+        final String charsetName = context.getProperty(CHARACTER_SET).evaluateAttributeExpressions(flowFile).getValue();
+
+        final byte[] buffer = new byte[(int) flowFile.getSize()];
+        final String messageText;
+        try (final InputStream in = session.read(flowFile)) {
+            StreamUtils.fillBuffer(in, buffer, true);
+            messageText = new String(buffer, charsetName);
+        } catch (final IOException ioe) {
+            getLogger().error("Failed to send contents of FlowFile {} to Slack; routing to failure", ioe);
+            session.transfer(flowFile, REL_FAILURE);
+            return;
+        }
+
+        if (messageText.length() > 100_000) {
+            getLogger().error("Cannot send contents of FlowFile {} to Slack because its length exceeds 100,000 characters; routing to 'failure'");
+            session.transfer(flowFile, REL_FAILURE);
+            return;
+        }
+
+        publishAsMessage(flowFile, channelId, messageText, context, session);
+    }
+
+    private void publishAsMessage(FlowFile flowFile, final String channelId, final String messageText, final ProcessContext context, final ProcessSession session) {
+        final String threadTs = context.getProperty(THREAD_TS).evaluateAttributeExpressions(flowFile).getValue();
+
+        final ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+            .channel(channelId)
+            .text(messageText)
+            .threadTs(threadTs)
+            .build();
+
+        final ChatPostMessageResponse postMessageResponse;
+        try {
+            postMessageResponse = client.chatPostMessage(request);
+        } catch (final Exception e) {
+            final Relationship relationship = handleClientException(channelId, flowFile, session, context, e);
+            getLogger().error("Failed to send message to Slack for {}; transferring to {}", flowFile, e, relationship);
+            return;
+        }
+
+        if (!postMessageResponse.isOk()) {
+            final String errorMessage = getErrorMessage(postMessageResponse.getError(), postMessageResponse.getNeeded(),
+                postMessageResponse.getProvided(), postMessageResponse.getWarning());
+
+            getLogger().error("Could not send message to Slack for {} - received error: {}", flowFile, errorMessage);
+            session.transfer(flowFile, REL_FAILURE);
+            return;
+        }
+
+        final String ts = postMessageResponse.getTs();
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("slack.ts", ts);
+        attributes.put("slack.channel.id", channelId);
+        flowFile = session.putAllAttributes(flowFile, attributes);
+        session.getProvenanceReporter().send(flowFile, "https://slack.com/api/chat.postMessage");
+        session.transfer(flowFile, REL_SUCCESS);
+    }
+
+
+    private void publishAsFile(FlowFile flowFile, final String channelId, final ProcessContext context, final ProcessSession session) {
+        final String filename = flowFile.getAttribute(CoreAttributes.FILENAME.key());
+        final long maxSize = context.getProperty(MAX_FILE_SIZE).asDataSize(DataUnit.B).longValue();
+        if (flowFile.getSize() > maxSize) {
+            getLogger().warn("{} exceeds max allowable file size. Max File Size = {}; FlowFile size = {}; routing to 'failure'",
+                flowFile, FormatUtils.formatDataSize(maxSize), FormatUtils.formatDataSize(flowFile.getSize()));
+            session.transfer(flowFile, REL_FAILURE);
+            return;
+        }
+
+        final FilesUploadV2Response uploadResponse;
+        try {
+            final byte[] buffer = new byte[(int) flowFile.getSize()];
+            try (final InputStream in = session.read(flowFile)) {
+                StreamUtils.fillBuffer(in, buffer, true);
+            }
+
+            final String message = context.getProperty(MESSAGE_TEXT).evaluateAttributeExpressions(flowFile).getValue();
+            final String threadTs = context.getProperty(THREAD_TS).evaluateAttributeExpressions(flowFile).getValue();
+
+            final FilesUploadV2Request uploadRequest = FilesUploadV2Request.builder()
+                .filename(filename)
+                .title(filename)
+                .initialComment(message)
+                .channel(channelId)
+                .threadTs(threadTs)
+                .fileData(buffer)
+                .build();
+
+            uploadResponse = client.filesUploadV2(uploadRequest);
+        } catch (final Exception e) {
+            final Relationship relationship = handleClientException(channelId, flowFile, session, context, e);
+            getLogger().error("Could not upload contents of {} to Slack; routing to {}", flowFile, e, relationship);
+            return;
+        }
+
+        if (!uploadResponse.isOk()) {
+            final String errorMessage = getErrorMessage(uploadResponse.getError(), uploadResponse.getNeeded(),
+                uploadResponse.getProvided(), uploadResponse.getWarning());
+
+            getLogger().error("Could not upload contents of {} to Slack - received error: {}", flowFile, errorMessage);
+            session.transfer(flowFile, REL_FAILURE);
+            return;
+        }
+
+        // Get timestamp that the file was shared so that we can add as an attribute.
+        final File file = uploadResponse.getFile();
+        final Shares shares = file.getShares();
+        String ts = null;
+        if (shares != null) {
+            ts = getTs(shares.getPrivateChannels());
+            if (ts == null) {
+                ts = getTs(shares.getPublicChannels());
+            }
+        }
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("slack.channel.id", channelId);
+        if (ts != null) {
+            attributes.put("slack.ts", ts);
+        }
+        flowFile = session.putAllAttributes(flowFile, attributes);
+        session.getProvenanceReporter().send(flowFile, "https://slack.com/api/files.upload");
+        session.transfer(flowFile, REL_SUCCESS);
+    }
+
+    private Relationship handleClientException(final String channel, final FlowFile flowFile, final ProcessSession session, final ProcessContext context, final Exception cause) {
+        final boolean rateLimited = yieldOnRateLimit(cause, channel, context);
+        final Relationship relationship = rateLimited ? REL_RATE_LIMITED : REL_FAILURE;
+        session.transfer(flowFile, relationship);
+        return relationship;
+    }
+
+    private boolean yieldOnRateLimit(final Throwable t, final String channelId, final ProcessContext context) {
+        final boolean rateLimited = isRateLimited(t);
+        if (rateLimited) {
+            getLogger().warn("Slack indicated that the Rate Limit has been exceeded when attempting to publish messages to channel {}", channelId);
+        } else {
+            getLogger().error("Failed to retrieve messages for channel {}", channelId, t);
+        }
+
+        final int retryAfterSeconds = getRetryAfterSeconds(t);
+        rateLimit.retryAfter(Duration.ofSeconds(retryAfterSeconds));
+        context.yield();
+        return rateLimited;
+    }
+
+    public static String getErrorMessage(final String error, final String needed, final String provided, final String warning) {
+        final String mainMessage = error == null ? warning : error;
+
+        if (needed != null && provided != null) {
+            return mainMessage + ": Permission needed: " + needed + "; Permission granted to this bot: " + provided;
+        }
+
+        return mainMessage;
+    }
+
+    public static boolean isRateLimited(final Throwable cause) {
+        return cause instanceof SlackApiException && 429 == ((SlackApiException) cause).getResponse().code();
+    }
+
+    public static int getRetryAfterSeconds(final Throwable cause) {
+        if (!(cause instanceof SlackApiException)) {
+            return 1;
+        }
+
+        final SlackApiException slackApiException = (SlackApiException) cause;
+        return Integer.parseInt( slackApiException.getResponse().header("Retry-After", "10") );
+    }
+
+
+    private String getTs(final Map<String, List<ShareDetail>> shareDetails) {
+        if (shareDetails == null) {
+            return null;
+        }
+
+        for (final List<ShareDetail> detailList : shareDetails.values()) {
+            for (final ShareDetail detail : detailList) {
+                final String ts = detail.getTs();
+                if (ts != null) {
+                    return ts;
+                }
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PublishSlack.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PublishSlack.java
@@ -335,7 +335,7 @@ public class PublishSlack extends AbstractProcessor {
             postMessageResponse = client.chatPostMessage(request);
         } catch (final Exception e) {
             final Relationship relationship = handleClientException(channelId, flowFile, session, context, e);
-            getLogger().error("Failed to send message to Slack for {}; transferring to {}", flowFile, e, relationship);
+            getLogger().error("Failed to send message to Slack for {}; transferring to {}", flowFile, relationship, e);
             return;
         }
 
@@ -390,7 +390,7 @@ public class PublishSlack extends AbstractProcessor {
             uploadResponse = client.filesUploadV2(uploadRequest);
         } catch (final Exception e) {
             final Relationship relationship = handleClientException(channelId, flowFile, session, context, e);
-            getLogger().error("Could not upload contents of {} to Slack; routing to {}", flowFile, e, relationship);
+            getLogger().error("Could not upload contents of {} to Slack; routing to {}", flowFile, relationship, e);
             return;
         }
 

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PutSlack.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PutSlack.java
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.slack;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -68,6 +69,13 @@ import java.util.TreeSet;
 @DynamicProperty(name = "A JSON object to add to Slack's \"attachments\" JSON payload.", value = "JSON-formatted string to add to Slack's payload JSON appended to the \"attachments\" JSON array.",
         expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES,
         description = "Converts the contents of each value specified by the Dynamic Property's value to JSON and appends it to the payload being sent to Slack.")
+@DeprecationNotice(
+    alternatives = {PublishSlack.class},
+    reason = "This Processor makes use of a Webhook URL, rather than Slack's REST API. As a result, the Processor is more difficult to configure than necessary and " +
+             "requires special permissions for the Slack Application / Bot. These permissions must be granted for every channel that the application is to respond to, " +
+             "which makes setup and maintenance difficult. Additionally, it does not make clear the differences between PutSlack and PostSlack. Each provides slightly " +
+             "different capabilities. PublishSlack combines the capabilities of both Processors in a simpler configuration that makes use of Slack's standard REST API."
+)
 public class PutSlack extends AbstractProcessor {
 
     public static final PropertyDescriptor WEBHOOK_URL = new PropertyDescriptor

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/util/ChannelMapper.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/util/ChannelMapper.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.slack.util;
+
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.conversations.ConversationsListRequest;
+import com.slack.api.methods.response.conversations.ConversationsListResponse;
+import org.apache.nifi.processors.slack.PublishSlack;
+import org.apache.nifi.util.StringUtils;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ChannelMapper {
+
+    private final Map<String, String> mappedChannels = new ConcurrentHashMap<>();
+    private final MethodsClient client;
+
+    public ChannelMapper(final MethodsClient client) {
+        this.client = client;
+    }
+
+    public String lookupChannelId(String channelName) throws SlackApiException, IOException {
+        if (channelName == null) {
+            return null;
+        }
+
+        channelName = channelName.trim();
+        if (channelName.startsWith("#")) {
+            if (channelName.length() == 1) {
+                return null;
+            }
+
+            channelName = channelName.substring(1);
+        }
+
+        final String channelId = mappedChannels.get(channelName);
+        if (channelId == null) {
+            lookupChannels(channelName);
+        }
+
+        return mappedChannels.get(channelName);
+    }
+
+    private void lookupChannels(final String desiredChannelName) throws SlackApiException, IOException {
+        String cursor = null;
+        while (true) {
+            final ConversationsListRequest request = ConversationsListRequest.builder()
+                .cursor(cursor)
+                .limit(1000)
+                .build();
+
+            final ConversationsListResponse response = client.conversationsList(request);
+            if (response.isOk()) {
+                response.getChannels().forEach(channel -> mappedChannels.put(channel.getName(), channel.getId()));
+                cursor = response.getResponseMetadata().getNextCursor();
+                if (StringUtils.isEmpty(cursor)) {
+                    return;
+                }
+                if (mappedChannels.containsKey(desiredChannelName)) {
+                    return;
+                }
+
+                continue;
+            }
+
+            final String errorMessage = PublishSlack.getErrorMessage(response.getError(), response.getNeeded(), response.getProvided(), response.getWarning());
+            throw new RuntimeException("Failed to determine Channel IDs: " + errorMessage);
+        }
+
+    }
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/util/RateLimit.java
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/util/RateLimit.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.slack.util;
+
+import org.apache.nifi.logging.ComponentLog;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class RateLimit {
+    private final AtomicLong nextRequestTime = new AtomicLong(0L);
+    private final ComponentLog logger;
+
+    public RateLimit(final ComponentLog logger) {
+        this.logger = logger;
+    }
+
+    public void retryAfter(final Duration duration) {
+        final long timeOfNextRequest = System.currentTimeMillis() + duration.toMillis();
+        nextRequestTime.getAndUpdate(currentTime -> Math.max(currentTime, timeOfNextRequest));
+    }
+
+    public boolean isLimitReached() {
+        final long nextTime = nextRequestTime.get();
+        if (nextTime > 0 && System.currentTimeMillis() < nextTime) {
+            logger.debug("Will not interact with Slack until {} due to Slack's Rate Limit", new Date(nextTime));
+            return true;
+        } else if (nextTime > 0) {
+            // Set nextRequestTime to 0 so that we no longer bother to make system calls to System.currentTimeMillis()
+            nextRequestTime.compareAndSet(nextTime, 0);
+        }
+
+        return false;
+    }
+
+}

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -12,5 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 org.apache.nifi.processors.slack.PutSlack
 org.apache.nifi.processors.slack.PostSlack
+org.apache.nifi.processors.slack.PublishSlack

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/resources/docs/org.apache.nifi.processors.slack.PublishSlack/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/resources/docs/org.apache.nifi.processors.slack.PublishSlack/additionalDetails.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<head>
+    <meta charset="utf-8"/>
+    <title>PublishSlack</title>
+    <link rel="stylesheet" href="../../../../../css/component-usage.css" type="text/css"/>
+</head>
+
+<body>
+<h2>Description:</h2>
+
+<p>
+    PublishSlack allows for the ability to send messages to Slack using Slack's <code>chat.postMessage</code> API.
+    This Processor should be preferred over the deprecated PutSlack and PostSlack Processors, as it aims to incorporate
+    the capabilities of both of those Processors, improve the maintainability, and ease the configuration for the user.
+</p>
+
+
+<h2>Slack Setup</h2>
+<p>
+    In order use this Processor, it requires that a Slack App be created and installed in your Slack workspace.
+    An OAuth User or Bot Token must be created for the App.
+    The token must have the <code>chat:write</code> Token Scope.
+    Please see <a href="https://api.slack.com/start/quickstart">Slack's documentation</a> for the
+    latest information on how to create an Application and install it into your workspace.
+</p>
+
+<p>
+    Depending on the Processor's configuration, you may also require additional Scopes.
+    For example, if configured to upload the contents of the FlowFile as a message attachment, the <code>files:write</code>
+    User Token Scope or Bot Token Scope must be granted.
+    Additionally, the Channels to consume from may be listed either as a Channel ID or (for public Channels) a Channel Name.
+    However, if a name, such as <code>#general</code> is used, the token must be provided the <code>channels:read</code> scope
+    in order to determine the Channel ID for you.
+</p>
+
+<p>
+    Rather than requiring the <code>channels:read</code> Scope, you may alternatively supply only Channel IDs for the
+    "Channel" property. To determine the ID of a Channel, navigate to the desired Channel in Slack. Click the name of
+    the Channel at the top of the screen. This provides a popup that provides information about the Channel. Scroll to
+    the bottom of the popup, and you will be shown the Channel ID with the ability to click a button to Copy the ID
+    to your clipboard.
+</p>
+
+<p>
+    At the time of this writing, the following steps may be used to create a Slack App with the necessary scope of
+    <code>chat:write</code> scope. However, these instructions are subject to change at any time, so it is
+    best to read through <a href="https://api.slack.com/start/quickstart">Slack's Quickstart Guide</a>.
+</p>
+<ul>
+    <li>
+        Create a Slack App. Click <a href="https://api.slack.com/apps">here</a> to get started. From here,
+        click the "Create New App" button and choose "From scratch." Give your App a name and choose the workspace
+        that you want to use for developing the app.
+    </li>
+    <li>
+        Creating your app will take you to the configuration page for your application.
+        For example, <code>https://api.slack.com/apps/&lt;APP_IDENTIFIER&gt;</code>. From here, click on
+        "OAuth & Permissions" in the left-hand menu. Scroll down to the "Scopes" section and click the
+        "Add an OAuth Scope" button under 'Bot Token Scopes'. Choose the <code>chat:write</code> scope.
+    </li>
+    <li>
+        Scroll back to the top, and under the "OAuth Tokens for Your Workspace" section, click the
+        "Install to Workspace" button. This will prompt you to allow the application to be added to your workspace,
+        if you have the appropriate permissions. Otherwise, it will generate a notification for a Workspace Owner
+        to approve the installation. Additionally, it will generate a "Bot User OAuth Token".
+    </li>
+    <li>
+        Copy the value of the "Bot User OAuth Token." This will be used as the value for the ConsumeSlack Processor's
+        <code>Access Token</code> property.
+    </li>
+    <li>
+        The Bot must then be enabled for each Channel that you would like to consume messages from. In order to do that,
+        in the Slack application, go to the Channel that you would like to consume from and press <code>/</code>.
+        Choose the <code>Add apps to this channel</code> option, and add the Application that you created as a Bot to
+        the channel.
+    </li>
+</ul>
+
+
+</body>
+</html>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
