### PR TITLE
NIFI-12418 Correct Provider Groups Missing in Refreshed Tokens

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtAuthenticationSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtAuthenticationSecurityConfiguration.java
@@ -36,7 +36,9 @@ import org.apache.nifi.web.security.jwt.key.StandardVerificationKeySelector;
 import org.apache.nifi.web.security.jwt.key.service.StandardVerificationKeyService;
 import org.apache.nifi.web.security.jwt.key.service.VerificationKeyService;
 import org.apache.nifi.web.security.jwt.provider.BearerTokenProvider;
+import org.apache.nifi.web.security.jwt.provider.IssuerProvider;
 import org.apache.nifi.web.security.jwt.provider.StandardBearerTokenProvider;
+import org.apache.nifi.web.security.jwt.provider.StandardIssuerProvider;
 import org.apache.nifi.web.security.jwt.provider.SupportedClaim;
 import org.apache.nifi.web.security.jwt.resolver.StandardBearerTokenResolver;
 import org.apache.nifi.web.security.jwt.revocation.JwtLogoutListener;
@@ -181,7 +183,12 @@ public class JwtAuthenticationSecurityConfiguration {
 
     @Bean
     public BearerTokenProvider bearerTokenProvider() {
-        return new StandardBearerTokenProvider(jwsSignerProvider());
+        return new StandardBearerTokenProvider(jwsSignerProvider(), issuerProvider());
+    }
+
+    @Bean
+    public IssuerProvider issuerProvider() {
+        return new StandardIssuerProvider(niFiProperties.getProperty(NiFiProperties.WEB_HTTPS_HOST), niFiProperties.getConfiguredHttpOrHttpsPort());
     }
 
     @Bean

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
@@ -364,14 +364,11 @@ public class SamlAuthenticationSecurityConfiguration {
     private Saml2AuthenticationSuccessHandler getAuthenticationSuccessHandler() {
         final long authenticationExpiration = (long) FormatUtils.getPreciseTimeDuration(properties.getSamlAuthenticationExpiration(), TimeUnit.MILLISECONDS);
         final Duration expiration = Duration.ofMillis(authenticationExpiration);
-        final String entityId = properties.getSamlServiceProviderEntityId();
-        final String issuer = entityId == null ? Saml2RegistrationProperty.REGISTRATION_ID.getProperty() : entityId;
         final Saml2AuthenticationSuccessHandler handler = new Saml2AuthenticationSuccessHandler(
                 bearerTokenProvider,
                 IdentityMappingUtil.getIdentityMappings(properties),
                 IdentityMappingUtil.getGroupMappings(properties),
-                expiration,
-                issuer
+                expiration
         );
 
         final String identityAttributeName = properties.getSamlIdentityAttributeName();

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/provider/IssuerProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/provider/IssuerProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.jwt.provider;
+
+import java.net.URI;
+
+/**
+ * JSON Web Token Issuer Provider abstracts determination of local address for issuer claims
+ */
+public interface IssuerProvider {
+    /**
+     * Get Issuer URI for issuer claims
+     *
+     * @return Issuer URI
+     */
+    URI getIssuer();
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.jwt.provider;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+
+/**
+ * Standard Issuer Provider with configurable host and port for HTTPS URI construction
+ */
+public class StandardIssuerProvider implements IssuerProvider {
+    private static final String URI_FORMAT = "https://%s:%d";
+
+    private final URI issuer;
+
+    /**
+     * Standard Issuer Provider constructor with optional host and required port properties
+     *
+     * @param host HTTPS Host address can be null or empty to default to InetAddress.getLocalHost() resolution
+     * @param port HTTPS port number
+     */
+    public StandardIssuerProvider(final String host, final int port) {
+        final String resolvedHost = getResolvedHost(host);
+        final String uri = URI_FORMAT.formatted(resolvedHost, port);
+        this.issuer = URI.create(uri);
+    }
+
+    /**
+     * Get Issuer URI for issuer claims
+     *
+     * @return Issuer URI
+     */
+    @Override
+    public URI getIssuer() {
+        return issuer;
+    }
+
+    private String getResolvedHost(final String host) {
+        final String resolvedHost;
+
+        if (host == null || host.isEmpty()) {
+            resolvedHost = getLocalHost();
+        } else {
+            resolvedHost = host;
+        }
+
+        return resolvedHost;
+    }
+
+    private String getLocalHost() {
+        try {
+            final InetAddress localHostAddress = InetAddress.getLocalHost();
+            return localHostAddress.getCanonicalHostName();
+        } catch (final UnknownHostException e) {
+            throw new IllegalStateException("Failed to resolve local host address", e);
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/web/authentication/OidcAuthenticationSuccessHandler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/web/authentication/OidcAuthenticationSuccessHandler.java
@@ -38,7 +38,6 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.net.URI;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -114,29 +113,23 @@ public class OidcAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuc
         final Set<String> groups = getGroups(oidcUser);
 
         final OAuth2AccessToken accessToken = getAccessToken(authenticationToken);
-        final String bearerToken = getBearerToken(identity, oidcUser, accessToken, groups);
+        final String bearerToken = getBearerToken(identity, accessToken, groups);
         applicationCookieService.addSessionCookie(resourceUri, response, ApplicationCookieName.AUTHORIZATION_BEARER, bearerToken);
     }
 
-    private String getBearerToken(final String identity, final OidcUser oidcUser, final OAuth2AccessToken accessToken, final Set<String> groups) {
-        final long sessionExpiration = getSessionExpiration(accessToken);
-        final String issuer = oidcUser.getIssuer().toString();
+    private String getBearerToken(final String identity, final OAuth2AccessToken accessToken, final Set<String> groups) {
+        final Instant sessionExpiration = getSessionExpiration(accessToken);
         final Set<? extends GrantedAuthority> authorities = groups.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
-        final LoginAuthenticationToken loginAuthenticationToken = new LoginAuthenticationToken(identity, identity, sessionExpiration, issuer, authorities);
+        final LoginAuthenticationToken loginAuthenticationToken = new LoginAuthenticationToken(identity, sessionExpiration, authorities);
         return bearerTokenProvider.getBearerToken(loginAuthenticationToken);
     }
 
-    private long getSessionExpiration(final OAuth2Token token) {
+    private Instant getSessionExpiration(final OAuth2Token token) {
         final Instant tokenExpiration = token.getExpiresAt();
         if (tokenExpiration == null) {
             throw new IllegalArgumentException("Token expiration claim not found");
         }
-        final Instant tokenIssued = token.getIssuedAt();
-        if (tokenIssued == null) {
-            throw new IllegalArgumentException("Token issued claim not found");
-        }
-        final Duration expiration = Duration.between(tokenIssued, tokenExpiration);
-        return expiration.toMillis();
+        return tokenExpiration;
     }
 
     private OAuth2AuthenticationToken getAuthenticationToken(final Authentication authentication) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/web/authentication/Saml2AuthenticationSuccessHandler.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/web/authentication/Saml2AuthenticationSuccessHandler.java
@@ -35,6 +35,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.net.URI;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -58,8 +59,6 @@ public class Saml2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSu
 
     private final Duration expiration;
 
-    private final String issuer;
-
     private Converter<Saml2AuthenticatedPrincipal, String> identityConverter = Saml2AuthenticatedPrincipal::getName;
 
     /**
@@ -69,20 +68,17 @@ public class Saml2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSu
      * @param userIdentityMappings User Identity Mappings
      * @param groupIdentityMappings Group Identity Mappings
      * @param expiration Expiration for generated tokens
-     * @param issuer Token Issuer
      */
     public Saml2AuthenticationSuccessHandler(
             final BearerTokenProvider bearerTokenProvider,
             final List<IdentityMapping> userIdentityMappings,
             final List<IdentityMapping> groupIdentityMappings,
-            final Duration expiration,
-            final String issuer
+            final Duration expiration
     ) {
         this.bearerTokenProvider = Objects.requireNonNull(bearerTokenProvider, "Bearer Token Provider required");
         this.userIdentityMappings = Objects.requireNonNull(userIdentityMappings, "User Identity Mappings required");
         this.groupIdentityMappings = Objects.requireNonNull(groupIdentityMappings, "Group Identity Mappings required");
         this.expiration = Objects.requireNonNull(expiration, "Expiration required");
-        this.issuer = Objects.requireNonNull(issuer, "Issuer required");
     }
 
     /**
@@ -121,7 +117,8 @@ public class Saml2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSu
 
     private String getBearerToken(final String identity, final Set<String> groups) {
         final Set<? extends GrantedAuthority> authorities = groups.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
-        final LoginAuthenticationToken loginAuthenticationToken = new LoginAuthenticationToken(identity, identity, expiration.toMillis(), issuer, authorities);
+        final Instant sessionExpiration = Instant.now().plus(expiration);
+        final LoginAuthenticationToken loginAuthenticationToken = new LoginAuthenticationToken(identity, sessionExpiration, authorities);
         return bearerTokenProvider.getBearerToken(loginAuthenticationToken);
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/token/LoginAuthenticationToken.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/token/LoginAuthenticationToken.java
@@ -21,56 +21,29 @@ import org.springframework.security.core.GrantedAuthority;
 
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Objects;
 
 /**
- * This is an Authentication Token for logging in. Once a user is authenticated, they can be issued an ID token.
+ * Login Authentication Token containing mapped Identity and Expiration Time to exchange for Application Bearer Token
  */
 public class LoginAuthenticationToken extends AbstractAuthenticationToken {
 
     private final String identity;
-    private final String username;
-    private final long expiration;
-    private final String issuer;
 
-    /**
-     * Creates a representation of the authentication token for a user.
-     *
-     * @param identity   The unique identifier for this user
-     * @param expiration The relative time to expiration in milliseconds
-     * @param issuer     The IdentityProvider implementation that generated this token
-     */
-    public LoginAuthenticationToken(final String identity, final long expiration, final String issuer) {
-        this(identity, null, expiration, issuer, null);
-    }
+    private final Instant expiration;
 
     /**
      * Creates a representation of the authentication token for a user.
      *
      * @param identity    The unique identifier for this user (cannot be null or empty)
-     * @param username    The preferred username for this user
-     * @param expiration  The relative time to expiration in milliseconds
-     * @param issuer      The IdentityProvider implementation that generated this token
-     */
-    public LoginAuthenticationToken(final String identity, final String username, final long expiration, final String issuer) {
-        this(identity, username, expiration, issuer, null);
-    }
-
-    /**
-     * Creates a representation of the authentication token for a user.
-     *
-     * @param identity    The unique identifier for this user (cannot be null or empty)
-     * @param username    The preferred username for this user
-     * @param expiration  The relative time to expiration in milliseconds
-     * @param issuer      The IdentityProvider implementation that generated this token
+     * @param expiration  Instant at which the authenticated token is no longer valid
      * @param authorities The authorities that have been granted this token.
      */
-    public LoginAuthenticationToken(final String identity, final String username, final long expiration, final String issuer, Collection<? extends GrantedAuthority> authorities) {
+    public LoginAuthenticationToken(final String identity, final Instant expiration, Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
         setAuthenticated(true);
         this.identity = identity;
-        this.username = username == null ? identity : username;
-        this.issuer = issuer;
-        this.expiration = Instant.now().plusMillis(expiration).toEpochMilli();
+        this.expiration = Objects.requireNonNull(expiration);
     }
 
     @Override
@@ -83,43 +56,17 @@ public class LoginAuthenticationToken extends AbstractAuthenticationToken {
         return identity;
     }
 
-    /**
-     * Returns the expiration instant in milliseconds. This value is an absolute point in time (i.e. Nov
-     * 16, 2015 11:30:00.000 GMT), not a relative time (i.e. 60 minutes). It is calculated by adding the
-     * relative expiration from the constructor to the timestamp at object creation.
-     *
-     * @return the expiration in millis
-     */
-    public long getExpiration() {
+    public Instant getExpiration() {
         return expiration;
-    }
-
-    public String getIssuer() {
-        return issuer;
     }
 
     @Override
     public String getName() {
-        return username;
+        return identity;
     }
 
     @Override
     public String toString() {
-        final Instant expirationTime = Instant.ofEpochMilli(expiration);
-        long remainingTime = expirationTime.toEpochMilli() - Instant.now().toEpochMilli();
-
-        return new StringBuilder("LoginAuthenticationToken for ")
-                .append(getName())
-                .append(" issued by ")
-                .append(getIssuer())
-                .append(" expiring at ")
-                .append(expirationTime)
-                .append(" [")
-                .append(getExpiration())
-                .append(" ms, ")
-                .append(remainingTime)
-                .append(" ms remaining]")
-                .toString();
+        return getName();
     }
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProviderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProviderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.jwt.provider;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+class StandardIssuerProviderTest {
+    private static final String HTTPS_SCHEME = "https";
+
+    private static final String LOCALHOST = "localhost.localdomain";
+
+    private static final int PORT = 8443;
+
+    private static final String EMPTY = "";
+
+    @Test
+    void testGetIssuer() {
+        final StandardIssuerProvider provider = new StandardIssuerProvider(LOCALHOST, PORT);
+
+        final URI issuer = provider.getIssuer();
+
+        assertNotNull(issuer);
+        assertEquals(HTTPS_SCHEME, issuer.getScheme());
+        assertEquals(LOCALHOST, issuer.getHost());
+        assertEquals(PORT, issuer.getPort());
+        assertEquals(EMPTY, issuer.getPath());
+        assertNull(issuer.getQuery());
+    }
+
+    @Test
+    void testGetIssuerNullHostResolved() {
+        final String localHost = getLocalHost();
+        assumeFalse(localHost == null);
+
+        final StandardIssuerProvider provider = new StandardIssuerProvider(null, PORT);
+
+        final URI issuer = provider.getIssuer();
+
+        assertNotNull(issuer);
+        assertEquals(HTTPS_SCHEME, issuer.getScheme());
+        assertEquals(localHost, issuer.getHost());
+        assertEquals(PORT, issuer.getPort());
+        assertEquals(EMPTY, issuer.getPath());
+        assertNull(issuer.getQuery());
+    }
+
+    private String getLocalHost() {
+        try {
+            final InetAddress localHostAddress = InetAddress.getLocalHost();
+            return localHostAddress.getCanonicalHostName();
+        } catch (final UnknownHostException e) {
+            return null;
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/saml2/web/authentication/Saml2AuthenticationSuccessHandlerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/saml2/web/authentication/Saml2AuthenticationSuccessHandlerTest.java
@@ -42,8 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
 class Saml2AuthenticationSuccessHandlerTest {
-    private static final String ISSUER = Saml2AuthenticationSuccessHandlerTest.class.getSimpleName();
-
     private static final Duration EXPIRATION = Duration.ofMinutes(1);
 
     private static final String IDENTITY = Authentication.class.getSimpleName();
@@ -103,8 +101,7 @@ class Saml2AuthenticationSuccessHandlerTest {
                 bearerTokenProvider,
                 Collections.singletonList(UPPER_IDENTITY_MAPPING),
                 Collections.singletonList(LOWER_IDENTITY_MAPPING),
-                EXPIRATION,
-                ISSUER
+                EXPIRATION
         );
         httpServletRequest = new MockHttpServletRequest();
         httpServletRequest.setServerPort(SERVER_PORT);


### PR DESCRIPTION
# Summary

[NIFI-12418](https://issues.apache.org/jira/browse/NIFI-12418) Corrects OpenID Connect Bearer Token refresh processing, preserving Identity Provider Group information after a token refresh occurs.

Following refactoring in NiFi 1.24.0 to pass Identity Provider Group membership in the `groups` claim of Application Bearer Tokens, the group membership is lost when an automatic Bearer Token refresh occurs. This applies only to OpenID Connect integration, and only impacts users with Identity Provider Group membership that is not supplied through a User Group Provider.

The correction streamlines the `LoginAuthenticationToken` class, removing unnecessary constructors to avoid ambiguity. It also introduces an Issuer Provider to return a standard application Bearer Token Issuer based on the configured host and port properties. Further changes to `LoginAuthenticationToken` include changing parameters to use `java.time.Instant` for greater clarity of the expiration time, as opposed to the primitive `long` number of seconds before expiration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
