### PR TITLE
NIFI-12105: ExecuteStateless processor accepts additional NAR directories

### DIFF
--- a/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/pom.xml
+++ b/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/pom.xml
@@ -128,32 +128,93 @@
             <version>2.0.0-SNAPSHOT</version>
             <type>nar</type>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-property-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-jslt-nar</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-compress-nar</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+            <type>nar</type>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <finalName>nifi-stateless-processors-test-assembly</finalName>
-                    <attach>true</attach>
-                    <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>make shared resource</id>
+                        <id>stateless-core-dependencies</id>
                         <goals>
                             <goal>single</goal>
                         </goals>
                         <phase>process-test-resources</phase>
                         <configuration>
+                            <finalName>nifi-stateless-processors-test-assembly</finalName>
                             <archiverConfig>
                                 <defaultDirectoryMode>0775</defaultDirectoryMode>
                                 <directoryMode>0775</directoryMode>
                                 <fileMode>0664</fileMode>
                             </archiverConfig>
                             <descriptors>
-                                <descriptor>src/test/assembly/dependencies.xml</descriptor>
+                                <descriptor>src/test/assembly/dependencies-core.xml</descriptor>
+                            </descriptors>
+                            <tarLongFileMode>posix</tarLongFileMode>
+                            <formats>
+                                <format>dir</format>
+                            </formats>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jslt-dependency</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <configuration>
+                            <finalName>nifi-stateless-processors-test-assembly</finalName>
+                            <archiverConfig>
+                                <defaultDirectoryMode>0775</defaultDirectoryMode>
+                                <directoryMode>0775</directoryMode>
+                                <fileMode>0664</fileMode>
+                            </archiverConfig>
+                            <descriptors>
+                                <descriptor>src/test/assembly/dependencies-jslt.xml</descriptor>
+                            </descriptors>
+                            <tarLongFileMode>posix</tarLongFileMode>
+                            <formats>
+                                <format>dir</format>
+                            </formats>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compression-dependency</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <configuration>
+                            <finalName>nifi-stateless-processors-test-assembly</finalName>
+                            <archiverConfig>
+                                <defaultDirectoryMode>0775</defaultDirectoryMode>
+                                <directoryMode>0775</directoryMode>
+                                <fileMode>0664</fileMode>
+                            </archiverConfig>
+                            <descriptors>
+                                <descriptor>src/test/assembly/dependencies-compress.xml</descriptor>
                             </descriptors>
                             <tarLongFileMode>posix</tarLongFileMode>
                             <formats>
@@ -176,6 +237,8 @@
                         <exclude>src/test/resources/sleep.json</exclude>
                         <exclude>src/test/resources/throw-exception.json</exclude>
                         <exclude>src/test/resources/log-message.json</exclude>
+                        <exclude>src/test/resources/jslt-flow.json</exclude>
+                        <exclude>src/test/resources/jslt-compress-flow.json</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/src/test/assembly/dependencies-compress.xml
+++ b/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/src/test/assembly/dependencies-compress.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<assembly>
+    <id>compress</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <dependencySets>
+        <!-- Write out dependency artifacts to directory -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>.</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0664</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>*:nifi-compress-nar</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+
+</assembly>

--- a/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/src/test/assembly/dependencies-core.xml
+++ b/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/src/test/assembly/dependencies-core.xml
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 <assembly>
-    <id>bin</id>
+    <id>core</id>
     <includeBaseDirectory>false</includeBaseDirectory>
     <baseDirectory>nifi-execute-stateless-processor-assembly-${project.version}</baseDirectory>
 
@@ -41,6 +41,7 @@
                 <include>*:nifi-runtime</include>
                 <include>*:nifi-nar-utils</include>
                 <include>*:nifi-stateless-api</include>
+                <include>*:nifi-property-utils</include>
                 <include>*:slf4j-api</include>
             </includes>
         </dependencySet>

--- a/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/src/test/assembly/dependencies-jslt.xml
+++ b/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/src/test/assembly/dependencies-jslt.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<assembly>
+    <id>jslt</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <dependencySets>
+        <!-- Write out dependency artifacts to directory -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>.</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0664</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>*:nifi-jslt-nar</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+
+</assembly>

--- a/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/src/test/resources/jslt-compress-flow.json
+++ b/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/src/test/resources/jslt-compress-flow.json
@@ -1,0 +1,423 @@
+{
+  "flowContents": {
+    "identifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+    "instanceIdentifier": "fc646a49-018b-1000-5cb2-37fc54983e37",
+    "name": "jslt-compress-flow",
+    "comments": "",
+    "position": {
+      "x": 1389.0,
+      "y": 408.0
+    },
+    "processGroups": [],
+    "remoteProcessGroups": [],
+    "processors": [
+      {
+        "identifier": "1d143bd9-51a5-3e7a-906a-7ac9ec497672",
+        "instanceIdentifier": "fc648ca8-018b-1000-a8dd-fc45b5f9db3f",
+        "name": "JSLTTransformJSON",
+        "comments": "",
+        "position": {
+          "x": 1208.0,
+          "y": 280.0
+        },
+        "type": "org.apache.nifi.processors.jslt.JSLTTransformJSON",
+        "bundle": {
+          "group": "org.apache.nifi",
+          "artifact": "nifi-jslt-nar",
+          "version": "2.0.0-SNAPSHOT"
+        },
+        "properties": {
+          "jslt-transform-pretty_print": "false",
+          "jslt-transform-result-filter": ". != null and . != {} and . != []",
+          "jslt-transform-transformation": ".name",
+          "jslt-transform-cache-size": "1",
+          "jslt-transform-transformation-strategy": "EACH_OBJECT"
+        },
+        "propertyDescriptors": {
+          "jslt-transform-pretty_print": {
+            "name": "jslt-transform-pretty_print",
+            "displayName": "Pretty Print",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          },
+          "jslt-transform-result-filter": {
+            "name": "jslt-transform-result-filter",
+            "displayName": "Transform Result Filter",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          },
+          "jslt-transform-transformation": {
+            "name": "jslt-transform-transformation",
+            "displayName": "JSLT Transformation",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false,
+            "resourceDefinition": {
+              "cardinality": "SINGLE",
+              "resourceTypes": [
+                "FILE",
+                "TEXT"
+              ]
+            }
+          },
+          "jslt-transform-cache-size": {
+            "name": "jslt-transform-cache-size",
+            "displayName": "Transform Cache Size",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          },
+          "jslt-transform-transformation-strategy": {
+            "name": "jslt-transform-transformation-strategy",
+            "displayName": "Transformation Strategy",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          }
+        },
+        "style": {},
+        "schedulingPeriod": "0 sec",
+        "schedulingStrategy": "TIMER_DRIVEN",
+        "executionNode": "ALL",
+        "penaltyDuration": "30 sec",
+        "yieldDuration": "1 sec",
+        "bulletinLevel": "WARN",
+        "runDurationMillis": 0,
+        "concurrentlySchedulableTaskCount": 1,
+        "autoTerminatedRelationships": [],
+        "scheduledState": "ENABLED",
+        "retryCount": 10,
+        "retriedRelationships": [],
+        "backoffMechanism": "PENALIZE_FLOWFILE",
+        "maxBackoffPeriod": "10 mins",
+        "componentType": "PROCESSOR",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      },
+      {
+        "identifier": "52b14610-18a4-334c-ac38-5e2cea125e9a",
+        "instanceIdentifier": "fca0d278-018b-1000-a210-fd4d738ea0e7",
+        "name": "ModifyCompression",
+        "comments": "",
+        "position": {
+          "x": 1208.0,
+          "y": 472.0
+        },
+        "type": "org.apache.nifi.processors.compress.ModifyCompression",
+        "bundle": {
+          "group": "org.apache.nifi",
+          "artifact": "nifi-compress-nar",
+          "version": "2.0.0-SNAPSHOT"
+        },
+        "properties": {
+          "Output Compression Level": "1",
+          "Input Compression Strategy": "no compression",
+          "Output Compression Strategy": "gzip",
+          "Output Filename Strategy": "UPDATED"
+        },
+        "propertyDescriptors": {
+          "Output Compression Level": {
+            "name": "Output Compression Level",
+            "displayName": "Output Compression Level",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          },
+          "Input Compression Strategy": {
+            "name": "Input Compression Strategy",
+            "displayName": "Input Compression Strategy",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          },
+          "Output Compression Strategy": {
+            "name": "Output Compression Strategy",
+            "displayName": "Output Compression Strategy",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          },
+          "Output Filename Strategy": {
+            "name": "Output Filename Strategy",
+            "displayName": "Output Filename Strategy",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          }
+        },
+        "style": {},
+        "schedulingPeriod": "0 sec",
+        "schedulingStrategy": "TIMER_DRIVEN",
+        "executionNode": "ALL",
+        "penaltyDuration": "30 sec",
+        "yieldDuration": "1 sec",
+        "bulletinLevel": "WARN",
+        "runDurationMillis": 0,
+        "concurrentlySchedulableTaskCount": 1,
+        "autoTerminatedRelationships": [],
+        "scheduledState": "ENABLED",
+        "retryCount": 10,
+        "retriedRelationships": [],
+        "backoffMechanism": "PENALIZE_FLOWFILE",
+        "maxBackoffPeriod": "10 mins",
+        "componentType": "PROCESSOR",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      }
+    ],
+    "inputPorts": [
+      {
+        "identifier": "05506a5d-3d47-309e-a2f9-ccdf620fc7bb",
+        "instanceIdentifier": "fc647f65-018b-1000-a0c0-693b42308743",
+        "name": "input",
+        "position": {
+          "x": 1265.0,
+          "y": 128.0
+        },
+        "type": "INPUT_PORT",
+        "concurrentlySchedulableTaskCount": 1,
+        "scheduledState": "ENABLED",
+        "allowRemoteAccess": false,
+        "portFunction": "STANDARD",
+        "componentType": "INPUT_PORT",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      }
+    ],
+    "outputPorts": [
+      {
+        "identifier": "a21e1073-b62e-3f2c-af10-0df16221e97e",
+        "instanceIdentifier": "fc64eadc-018b-1000-549e-85726a49e708",
+        "name": "failure",
+        "position": {
+          "x": 1600.0,
+          "y": 696.0
+        },
+        "type": "OUTPUT_PORT",
+        "concurrentlySchedulableTaskCount": 1,
+        "scheduledState": "ENABLED",
+        "allowRemoteAccess": false,
+        "portFunction": "STANDARD",
+        "componentType": "OUTPUT_PORT",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      },
+      {
+        "identifier": "a0a4d4cb-5e8c-313b-8d72-322c238f7d94",
+        "instanceIdentifier": "fc64d691-018b-1000-e8e3-16301be6f952",
+        "name": "success",
+        "position": {
+          "x": 1128.0,
+          "y": 704.0
+        },
+        "type": "OUTPUT_PORT",
+        "concurrentlySchedulableTaskCount": 1,
+        "scheduledState": "ENABLED",
+        "allowRemoteAccess": false,
+        "portFunction": "STANDARD",
+        "componentType": "OUTPUT_PORT",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      }
+    ],
+    "connections": [
+      {
+        "identifier": "e81b2c0b-479e-36ef-adc2-aa2daa60db55",
+        "instanceIdentifier": "fca12acd-018b-1000-7451-7989cee33fd1",
+        "name": "",
+        "source": {
+          "id": "52b14610-18a4-334c-ac38-5e2cea125e9a",
+          "type": "PROCESSOR",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "ModifyCompression",
+          "comments": "",
+          "instanceIdentifier": "fca0d278-018b-1000-a210-fd4d738ea0e7"
+        },
+        "destination": {
+          "id": "a0a4d4cb-5e8c-313b-8d72-322c238f7d94",
+          "type": "OUTPUT_PORT",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "success",
+          "instanceIdentifier": "fc64d691-018b-1000-e8e3-16301be6f952"
+        },
+        "labelIndex": 1,
+        "zIndex": 0,
+        "selectedRelationships": [
+          "success"
+        ],
+        "backPressureObjectThreshold": 10000,
+        "backPressureDataSizeThreshold": "1 GB",
+        "flowFileExpiration": "0 sec",
+        "prioritizers": [],
+        "bends": [],
+        "loadBalanceStrategy": "DO_NOT_LOAD_BALANCE",
+        "partitioningAttribute": "",
+        "loadBalanceCompression": "DO_NOT_COMPRESS",
+        "componentType": "CONNECTION",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      },
+      {
+        "identifier": "7588b92d-ff24-3c32-b48f-dbefc67b0373",
+        "instanceIdentifier": "fca13b80-018b-1000-86a2-7b666001ec00",
+        "name": "",
+        "source": {
+          "id": "52b14610-18a4-334c-ac38-5e2cea125e9a",
+          "type": "PROCESSOR",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "ModifyCompression",
+          "comments": "",
+          "instanceIdentifier": "fca0d278-018b-1000-a210-fd4d738ea0e7"
+        },
+        "destination": {
+          "id": "a21e1073-b62e-3f2c-af10-0df16221e97e",
+          "type": "OUTPUT_PORT",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "failure",
+          "instanceIdentifier": "fc64eadc-018b-1000-549e-85726a49e708"
+        },
+        "labelIndex": 1,
+        "zIndex": 0,
+        "selectedRelationships": [
+          "failure"
+        ],
+        "backPressureObjectThreshold": 10000,
+        "backPressureDataSizeThreshold": "1 GB",
+        "flowFileExpiration": "0 sec",
+        "prioritizers": [],
+        "bends": [],
+        "loadBalanceStrategy": "DO_NOT_LOAD_BALANCE",
+        "partitioningAttribute": "",
+        "loadBalanceCompression": "DO_NOT_COMPRESS",
+        "componentType": "CONNECTION",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      },
+      {
+        "identifier": "ca1b97b0-b158-3e74-afc9-8b1ce3f9a52e",
+        "instanceIdentifier": "fc6508de-018b-1000-b1a0-a664e9eced65",
+        "name": "",
+        "source": {
+          "id": "1d143bd9-51a5-3e7a-906a-7ac9ec497672",
+          "type": "PROCESSOR",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "JSLTTransformJSON",
+          "comments": "",
+          "instanceIdentifier": "fc648ca8-018b-1000-a8dd-fc45b5f9db3f"
+        },
+        "destination": {
+          "id": "52b14610-18a4-334c-ac38-5e2cea125e9a",
+          "type": "PROCESSOR",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "ModifyCompression",
+          "comments": "",
+          "instanceIdentifier": "fca0d278-018b-1000-a210-fd4d738ea0e7"
+        },
+        "labelIndex": 1,
+        "zIndex": 0,
+        "selectedRelationships": [
+          "success"
+        ],
+        "backPressureObjectThreshold": 10000,
+        "backPressureDataSizeThreshold": "1 GB",
+        "flowFileExpiration": "0 sec",
+        "prioritizers": [],
+        "bends": [],
+        "loadBalanceStrategy": "DO_NOT_LOAD_BALANCE",
+        "partitioningAttribute": "",
+        "loadBalanceCompression": "DO_NOT_COMPRESS",
+        "componentType": "CONNECTION",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      },
+      {
+        "identifier": "52f6fd29-6c71-3bf6-a4f8-6bc1790cf014",
+        "instanceIdentifier": "fc64a5ba-018b-1000-86f3-d0035c35ba1b",
+        "name": "",
+        "source": {
+          "id": "05506a5d-3d47-309e-a2f9-ccdf620fc7bb",
+          "type": "INPUT_PORT",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "input",
+          "instanceIdentifier": "fc647f65-018b-1000-a0c0-693b42308743"
+        },
+        "destination": {
+          "id": "1d143bd9-51a5-3e7a-906a-7ac9ec497672",
+          "type": "PROCESSOR",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "JSLTTransformJSON",
+          "comments": "",
+          "instanceIdentifier": "fc648ca8-018b-1000-a8dd-fc45b5f9db3f"
+        },
+        "labelIndex": 1,
+        "zIndex": 0,
+        "selectedRelationships": [
+          ""
+        ],
+        "backPressureObjectThreshold": 10000,
+        "backPressureDataSizeThreshold": "1 GB",
+        "flowFileExpiration": "0 sec",
+        "prioritizers": [],
+        "bends": [],
+        "loadBalanceStrategy": "DO_NOT_LOAD_BALANCE",
+        "partitioningAttribute": "",
+        "loadBalanceCompression": "DO_NOT_COMPRESS",
+        "componentType": "CONNECTION",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      },
+      {
+        "identifier": "79321aac-35cb-3600-8364-099dba9014f0",
+        "instanceIdentifier": "fc6518f9-018b-1000-a271-819fb66c5dc8",
+        "name": "",
+        "source": {
+          "id": "1d143bd9-51a5-3e7a-906a-7ac9ec497672",
+          "type": "PROCESSOR",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "JSLTTransformJSON",
+          "comments": "",
+          "instanceIdentifier": "fc648ca8-018b-1000-a8dd-fc45b5f9db3f"
+        },
+        "destination": {
+          "id": "a21e1073-b62e-3f2c-af10-0df16221e97e",
+          "type": "OUTPUT_PORT",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "failure",
+          "instanceIdentifier": "fc64eadc-018b-1000-549e-85726a49e708"
+        },
+        "labelIndex": 0,
+        "zIndex": 0,
+        "selectedRelationships": [
+          "failure"
+        ],
+        "backPressureObjectThreshold": 10000,
+        "backPressureDataSizeThreshold": "1 GB",
+        "flowFileExpiration": "0 sec",
+        "prioritizers": [],
+        "bends": [
+          {
+            "x": 1720.0,
+            "y": 344.0
+          }
+        ],
+        "loadBalanceStrategy": "DO_NOT_LOAD_BALANCE",
+        "partitioningAttribute": "",
+        "loadBalanceCompression": "DO_NOT_COMPRESS",
+        "componentType": "CONNECTION",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      }
+    ],
+    "labels": [],
+    "funnels": [],
+    "controllerServices": [],
+    "defaultFlowFileExpiration": "0 sec",
+    "defaultBackPressureObjectThreshold": 10000,
+    "defaultBackPressureDataSizeThreshold": "1 GB",
+    "scheduledState": "ENABLED",
+    "executionEngine": "INHERITED",
+    "maxConcurrentTasks": 1,
+    "statelessFlowTimeout": "1 min",
+    "logFileSuffix": "",
+    "componentType": "PROCESS_GROUP",
+    "flowFileOutboundPolicy": "STREAM_WHEN_AVAILABLE",
+    "flowFileConcurrency": "UNBOUNDED"
+  },
+  "externalControllerServices": {},
+  "parameterContexts": {},
+  "flowEncodingVersion": "1.0",
+  "parameterProviders": {},
+  "latest": false
+}

--- a/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/src/test/resources/jslt-flow.json
+++ b/nifi-nar-bundles/nifi-stateless-processor-bundle/nifi-stateless-processor-tests/src/test/resources/jslt-flow.json
@@ -1,0 +1,277 @@
+{
+  "flowContents": {
+    "identifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+    "instanceIdentifier": "fc646a49-018b-1000-5cb2-37fc54983e37",
+    "name": "jslt-flow",
+    "comments": "",
+    "position": {
+      "x": 1389.0,
+      "y": 408.0
+    },
+    "processGroups": [],
+    "remoteProcessGroups": [],
+    "processors": [
+      {
+        "identifier": "1d143bd9-51a5-3e7a-906a-7ac9ec497672",
+        "instanceIdentifier": "fc648ca8-018b-1000-a8dd-fc45b5f9db3f",
+        "name": "JSLTTransformJSON",
+        "comments": "",
+        "position": {
+          "x": 1208.0,
+          "y": 280.0
+        },
+        "type": "org.apache.nifi.processors.jslt.JSLTTransformJSON",
+        "bundle": {
+          "group": "org.apache.nifi",
+          "artifact": "nifi-jslt-nar",
+          "version": "2.0.0-SNAPSHOT"
+        },
+        "properties": {
+          "jslt-transform-pretty_print": "false",
+          "jslt-transform-result-filter": ". != null and . != {} and . != []",
+          "jslt-transform-transformation": ".name",
+          "jslt-transform-cache-size": "1",
+          "jslt-transform-transformation-strategy": "EACH_OBJECT"
+        },
+        "propertyDescriptors": {
+          "jslt-transform-pretty_print": {
+            "name": "jslt-transform-pretty_print",
+            "displayName": "Pretty Print",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          },
+          "jslt-transform-result-filter": {
+            "name": "jslt-transform-result-filter",
+            "displayName": "Transform Result Filter",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          },
+          "jslt-transform-transformation": {
+            "name": "jslt-transform-transformation",
+            "displayName": "JSLT Transformation",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false,
+            "resourceDefinition": {
+              "cardinality": "SINGLE",
+              "resourceTypes": [
+                "FILE",
+                "TEXT"
+              ]
+            }
+          },
+          "jslt-transform-cache-size": {
+            "name": "jslt-transform-cache-size",
+            "displayName": "Transform Cache Size",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          },
+          "jslt-transform-transformation-strategy": {
+            "name": "jslt-transform-transformation-strategy",
+            "displayName": "Transformation Strategy",
+            "identifiesControllerService": false,
+            "sensitive": false,
+            "dynamic": false
+          }
+        },
+        "style": {},
+        "schedulingPeriod": "0 sec",
+        "schedulingStrategy": "TIMER_DRIVEN",
+        "executionNode": "ALL",
+        "penaltyDuration": "30 sec",
+        "yieldDuration": "1 sec",
+        "bulletinLevel": "WARN",
+        "runDurationMillis": 0,
+        "concurrentlySchedulableTaskCount": 1,
+        "autoTerminatedRelationships": [],
+        "scheduledState": "ENABLED",
+        "retryCount": 10,
+        "retriedRelationships": [],
+        "backoffMechanism": "PENALIZE_FLOWFILE",
+        "maxBackoffPeriod": "10 mins",
+        "componentType": "PROCESSOR",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      }
+    ],
+    "inputPorts": [
+      {
+        "identifier": "05506a5d-3d47-309e-a2f9-ccdf620fc7bb",
+        "instanceIdentifier": "fc647f65-018b-1000-a0c0-693b42308743",
+        "name": "input",
+        "position": {
+          "x": 1265.0,
+          "y": 128.0
+        },
+        "type": "INPUT_PORT",
+        "concurrentlySchedulableTaskCount": 1,
+        "scheduledState": "ENABLED",
+        "allowRemoteAccess": false,
+        "portFunction": "STANDARD",
+        "componentType": "INPUT_PORT",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      }
+    ],
+    "outputPorts": [
+      {
+        "identifier": "a21e1073-b62e-3f2c-af10-0df16221e97e",
+        "instanceIdentifier": "fc64eadc-018b-1000-549e-85726a49e708",
+        "name": "failure",
+        "position": {
+          "x": 1424.0,
+          "y": 512.0
+        },
+        "type": "OUTPUT_PORT",
+        "concurrentlySchedulableTaskCount": 1,
+        "scheduledState": "ENABLED",
+        "allowRemoteAccess": false,
+        "portFunction": "STANDARD",
+        "componentType": "OUTPUT_PORT",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      },
+      {
+        "identifier": "a0a4d4cb-5e8c-313b-8d72-322c238f7d94",
+        "instanceIdentifier": "fc64d691-018b-1000-e8e3-16301be6f952",
+        "name": "success",
+        "position": {
+          "x": 1104.0,
+          "y": 520.0
+        },
+        "type": "OUTPUT_PORT",
+        "concurrentlySchedulableTaskCount": 1,
+        "scheduledState": "ENABLED",
+        "allowRemoteAccess": false,
+        "portFunction": "STANDARD",
+        "componentType": "OUTPUT_PORT",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      }
+    ],
+    "connections": [
+      {
+        "identifier": "ca1b97b0-b158-3e74-afc9-8b1ce3f9a52e",
+        "instanceIdentifier": "fc6508de-018b-1000-b1a0-a664e9eced65",
+        "name": "",
+        "source": {
+          "id": "1d143bd9-51a5-3e7a-906a-7ac9ec497672",
+          "type": "PROCESSOR",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "JSLTTransformJSON",
+          "comments": "",
+          "instanceIdentifier": "fc648ca8-018b-1000-a8dd-fc45b5f9db3f"
+        },
+        "destination": {
+          "id": "a0a4d4cb-5e8c-313b-8d72-322c238f7d94",
+          "type": "OUTPUT_PORT",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "success",
+          "instanceIdentifier": "fc64d691-018b-1000-e8e3-16301be6f952"
+        },
+        "labelIndex": 1,
+        "zIndex": 0,
+        "selectedRelationships": [
+          "success"
+        ],
+        "backPressureObjectThreshold": 10000,
+        "backPressureDataSizeThreshold": "1 GB",
+        "flowFileExpiration": "0 sec",
+        "prioritizers": [],
+        "bends": [],
+        "loadBalanceStrategy": "DO_NOT_LOAD_BALANCE",
+        "partitioningAttribute": "",
+        "loadBalanceCompression": "DO_NOT_COMPRESS",
+        "componentType": "CONNECTION",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      },
+      {
+        "identifier": "52f6fd29-6c71-3bf6-a4f8-6bc1790cf014",
+        "instanceIdentifier": "fc64a5ba-018b-1000-86f3-d0035c35ba1b",
+        "name": "",
+        "source": {
+          "id": "05506a5d-3d47-309e-a2f9-ccdf620fc7bb",
+          "type": "INPUT_PORT",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "input",
+          "instanceIdentifier": "fc647f65-018b-1000-a0c0-693b42308743"
+        },
+        "destination": {
+          "id": "1d143bd9-51a5-3e7a-906a-7ac9ec497672",
+          "type": "PROCESSOR",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "JSLTTransformJSON",
+          "comments": "",
+          "instanceIdentifier": "fc648ca8-018b-1000-a8dd-fc45b5f9db3f"
+        },
+        "labelIndex": 1,
+        "zIndex": 0,
+        "selectedRelationships": [
+          ""
+        ],
+        "backPressureObjectThreshold": 10000,
+        "backPressureDataSizeThreshold": "1 GB",
+        "flowFileExpiration": "0 sec",
+        "prioritizers": [],
+        "bends": [],
+        "loadBalanceStrategy": "DO_NOT_LOAD_BALANCE",
+        "partitioningAttribute": "",
+        "loadBalanceCompression": "DO_NOT_COMPRESS",
+        "componentType": "CONNECTION",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      },
+      {
+        "identifier": "79321aac-35cb-3600-8364-099dba9014f0",
+        "instanceIdentifier": "fc6518f9-018b-1000-a271-819fb66c5dc8",
+        "name": "",
+        "source": {
+          "id": "1d143bd9-51a5-3e7a-906a-7ac9ec497672",
+          "type": "PROCESSOR",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "JSLTTransformJSON",
+          "comments": "",
+          "instanceIdentifier": "fc648ca8-018b-1000-a8dd-fc45b5f9db3f"
+        },
+        "destination": {
+          "id": "a21e1073-b62e-3f2c-af10-0df16221e97e",
+          "type": "OUTPUT_PORT",
+          "groupId": "c680fa77-5e72-334f-b7c1-e2d6918ce73a",
+          "name": "failure",
+          "instanceIdentifier": "fc64eadc-018b-1000-549e-85726a49e708"
+        },
+        "labelIndex": 1,
+        "zIndex": 0,
+        "selectedRelationships": [
+          "failure"
+        ],
+        "backPressureObjectThreshold": 10000,
+        "backPressureDataSizeThreshold": "1 GB",
+        "flowFileExpiration": "0 sec",
+        "prioritizers": [],
+        "bends": [],
+        "loadBalanceStrategy": "DO_NOT_LOAD_BALANCE",
+        "partitioningAttribute": "",
+        "loadBalanceCompression": "DO_NOT_COMPRESS",
+        "componentType": "CONNECTION",
+        "groupIdentifier": "c680fa77-5e72-334f-b7c1-e2d6918ce73a"
+      }
+    ],
+    "labels": [],
+    "funnels": [],
+    "controllerServices": [],
+    "defaultFlowFileExpiration": "0 sec",
+    "defaultBackPressureObjectThreshold": 10000,
+    "defaultBackPressureDataSizeThreshold": "1 GB",
+    "scheduledState": "ENABLED",
+    "executionEngine": "INHERITED",
+    "maxConcurrentTasks": 1,
+    "statelessFlowTimeout": "1 min",
+    "componentType": "PROCESS_GROUP",
+    "flowFileOutboundPolicy": "STREAM_WHEN_AVAILABLE",
+    "flowFileConcurrency": "UNBOUNDED"
+  },
+  "externalControllerServices": {},
+  "parameterContexts": {},
+  "flowEncodingVersion": "1.0",
+  "parameterProviders": {},
+  "latest": false
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12105](https://issues.apache.org/jira/browse/NIFI-12105)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
