### PR TITLE
NIFI-12478 Return Message Type as body for JMS Object Messages

### DIFF
--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSConsumer.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSConsumer.java
@@ -38,6 +38,7 @@ import javax.jms.StreamMessage;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -184,7 +185,8 @@ class JMSConsumer extends JMSWorker {
                 messageBody = MessageBodyToBytesConverter.toBytes((BytesMessage) message);
             } else if (message instanceof ObjectMessage) {
                 messageType = ObjectMessage.class.getSimpleName();
-                messageBody = MessageBodyToBytesConverter.toBytes((ObjectMessage) message);
+                // Return Message Type as body to avoid unsupported class references
+                messageBody = messageType.getBytes(StandardCharsets.UTF_8);
             } else if (message instanceof StreamMessage) {
                 messageType = StreamMessage.class.getSimpleName();
                 messageBody = MessageBodyToBytesConverter.toBytes((StreamMessage) message);

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/MessageBodyToBytesConverter.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/MessageBodyToBytesConverter.java
@@ -31,13 +31,11 @@ import javax.jms.BytesMessage;
 import javax.jms.JMSException;
 import javax.jms.MapMessage;
 import javax.jms.MessageEOFException;
-import javax.jms.ObjectMessage;
 import javax.jms.StreamMessage;
 import javax.jms.TextMessage;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.SerializationUtils;
 
 /**
  *
@@ -85,19 +83,6 @@ abstract class MessageBodyToBytesConverter {
             return IOUtils.toByteArray(is);
         } catch (Exception e) {
             throw new MessageConversionException("Failed to convert " + BytesMessage.class.getSimpleName() + " to byte[]", e);
-        }
-    }
-
-    /**
-     *
-     * @param message instance of {@link ObjectMessage}
-     * @return byte array representing the {@link ObjectMessage}
-     */
-    public static byte[] toBytes(ObjectMessage message) {
-        try {
-            return SerializationUtils.serialize(message.getObject());
-        } catch (Exception e) {
-            throw new MessageConversionException("Failed to convert " + ObjectMessage.class.getSimpleName() + " to byte[]", e);
         }
     }
 

--- a/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/JMSPublisherConsumerIT.java
+++ b/nifi-nar-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/JMSPublisherConsumerIT.java
@@ -18,7 +18,6 @@ package org.apache.nifi.jms.processors;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.SerializationUtils;
 import org.apache.nifi.jms.processors.JMSConsumer.JMSResponse;
 import org.apache.nifi.logging.ComponentLog;
 import org.junit.jupiter.api.Test;
@@ -70,9 +69,9 @@ public class JMSPublisherConsumerIT {
         };
 
         Consumer<JMSResponse> responseChecker = response -> {
-            assertEquals(
-                "stringAsObject",
-                SerializationUtils.deserialize(response.getMessageBody())
+            assertArrayEquals(
+                ObjectMessage.class.getSimpleName().getBytes(StandardCharsets.UTF_8),
+                response.getMessageBody()
             );
         };
 
@@ -447,7 +446,7 @@ public class JMSPublisherConsumerIT {
                     }
 
                     callbackInvoked.set(true);
-                    assertEquals("1", new String(response.getMessageBody()));
+                    assertEquals("2", new String(response.getMessageBody()));
                     acknowledge(response);
                 });
             }
@@ -464,7 +463,7 @@ public class JMSPublisherConsumerIT {
                         }
 
                         callbackInvoked.set(true);
-                        assertEquals("2", new String(response.getMessageBody()));
+                        assertEquals("1", new String(response.getMessageBody()));
                         throw new RuntimeException("intentional to avoid explicit ack");
                     });
                 }
@@ -483,7 +482,7 @@ public class JMSPublisherConsumerIT {
                         }
 
                         callbackInvoked.set(true);
-                        assertEquals("2", new String(response.getMessageBody()));
+                        assertEquals("1", new String(response.getMessageBody()));
                         acknowledge(response);
                     });
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -1166,7 +1166,6 @@
                                 !ITDeleteAzureBlobStorage_v12,
                                 !ITMoveAzureDataLakeStorage,
                                 !AzureGraphUserGroupProviderIT,
-                                !JMSPublisherConsumerIT#validateMessageRedeliveryWhenNotAcked,
                                 !GremlinClientServiceYamlSettingsAndBytecodeIT,
                                 !GremlinClientServiceControllerSettingsIT,
                                 !ITestConsumeEmail#validateUrl,


### PR DESCRIPTION
# Summary

[NIFI-12478](https://issues.apache.org/jira/browse/NIFI-12478) Updates supporting utilities for the `ConsumeJMS` Processor to return the Message Type as the body when receiving JMS [ObjectMessage](https://docs.oracle.com/javaee/7/api/javax/jms/ObjectMessage.html) types. This approach avoids various problems with attempting to serialize a wrapped opaque `Object` from a JMS `ObjectMessage`. Java Object serialization is not suitable for inter-operation with subsequent Processors, and the wrapped Object may reference classes that are not available on a given Java Virtual Machine. Rather than writing the message as an error, this approach allows NiFi flows to continue receiving `ObjectMessage` types and handling the associated metadata, while using a standard value of `ObjectMessage` as the bytes for the message body.

Additional changes include correcting expected values in a JMS integration test that previously resulted in failures.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
