### PR TITLE
NIFI-12483 Streamline JMX Metrics Filtering Parameters

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/metrics/jmx/JmxMetricsFilterTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/metrics/jmx/JmxMetricsFilterTest.java
@@ -35,6 +35,7 @@ class JmxMetricsFilterTest {
     private static final String INVALID_REGEX = "(";
     private static final String TEST_BEAN_NAME_ONE = "testBean1";
     private static final String TEST_BEAN_NAME_TWO = "testBean2";
+    private static final String BEGIN_END_PATTERN = "^test.*$";
     private static final JmxMetricsResultDTO RESULT_ONE = new JmxMetricsResultDTO(TEST_BEAN_NAME_ONE, null, null);
     private static final JmxMetricsResultDTO RESULT_TWO = new JmxMetricsResultDTO(TEST_BEAN_NAME_TWO, null, null);
     private static List<JmxMetricsResultDTO> results;
@@ -49,6 +50,16 @@ class JmxMetricsFilterTest {
     @Test
     public void testNotProvidingFiltersReturnsAllMBeans() {
         final JmxMetricsFilter metricsFilter = new JmxMetricsFilter(ALLOW_ALL_PATTERN, EMPTY_STRING_PATTERN);
+
+        final Collection<JmxMetricsResultDTO> actual = metricsFilter.filter(results);
+
+        assertEquals(actual.size(), 2);
+        assertTrue(actual.containsAll(results));
+    }
+
+    @Test
+    public void testBeginEndPatternMatches() {
+        final JmxMetricsFilter metricsFilter = new JmxMetricsFilter(ALLOW_ALL_PATTERN, BEGIN_END_PATTERN);
 
         final Collection<JmxMetricsResultDTO> actual = metricsFilter.filter(results);
 


### PR DESCRIPTION
# Summary

[NIFI-12483](https://issues.apache.org/jira/browse/NIFI-12483) Streamlines JMX Metrics filtering parameter handling to run simpler string comparison when the request bean name filter parameter is provided. Application properties contain a default filter pattern that continues to apply before any request filter parameters, which is the optimal approach for providing a scoped set of JMX Metrics. The streamlined parameter parsing supports most existing use cases and also includes additional tests for a pattern with trailing wildcards.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
