### PR TITLE
NIFI-12487 Add CSRF Protection to Registry

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/csrf/CsrfCookieFilter.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/csrf/CsrfCookieFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.web.security.authentication.csrf;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Cross-Site Request Forgery Cookie Filter based on Spring Security recommendations for Single-Page Applications
+ */
+public class CsrfCookieFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain) throws ServletException, IOException {
+        // Get CSRF Token set from Request Attribute Handler
+        final CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+        // Invoking CsrfToken.getToken() causes deferred tokens to be loaded and set as response headers
+        csrfToken.getToken();
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/csrf/CsrfCookieName.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/csrf/CsrfCookieName.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.web.security.authentication.csrf;
+
+/**
+ * Cross-Site Request Forgery Mitigation Cookie Names
+ */
+public enum CsrfCookieName {
+    /** Cross-Site Request Forgery mitigation token requires Strict Same Site handling */
+    REQUEST_TOKEN("__Secure-Request-Token");
+
+    private final String cookieName;
+
+    CsrfCookieName(final String cookieName) {
+        this.cookieName = cookieName;
+    }
+
+    public String getCookieName() {
+        return cookieName;
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/csrf/CsrfRequestMatcher.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/csrf/CsrfRequestMatcher.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.web.security.authentication.csrf;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import static org.springframework.web.util.WebUtils.getCookie;
+
+/**
+ * Cross-Site Request Forgery Mitigation Request Matcher
+ */
+public class CsrfRequestMatcher implements RequestMatcher {
+
+    @Override
+    public boolean matches(final HttpServletRequest request) {
+        final boolean matches;
+
+        if (CsrfFilter.DEFAULT_CSRF_MATCHER.matches(request)) {
+            // Presence of Request Token Cookie requires invoking the CsrfFilter
+            final Cookie requestTokenCookie = getCookie(request, CsrfCookieName.REQUEST_TOKEN.getCookieName());
+            matches = requestTokenCookie != null;
+        } else {
+            matches = false;
+        }
+
+        return matches;
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/csrf/StandardCookieCsrfTokenRepository.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/csrf/StandardCookieCsrfTokenRepository.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.web.security.authentication.csrf;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.WebUtils;
+
+import java.time.Duration;
+import java.util.UUID;
+
+/**
+ * Standard implementation of CSRF Token Repository using stateless Spring Security double-submit cookie strategy
+ */
+public class StandardCookieCsrfTokenRepository implements CsrfTokenRepository {
+    private static final String REQUEST_HEADER = "Request-Token";
+
+    private static final String REQUEST_PARAMETER = "requestToken";
+
+    private static final Duration MAX_AGE_SESSION = Duration.ofSeconds(-1);
+
+    private static final Duration MAX_AGE_REMOVE = Duration.ZERO;
+
+    private static final String EMPTY_VALUE = "";
+
+    private static final String SAME_SITE_POLICY_STRICT = "Strict";
+
+    private static final String ROOT_PATH = "/";
+
+    private static final boolean SECURE_ENABLED = true;
+
+    /**
+     * Generate CSRF Token or return current Token when present in HTTP Servlet Request Cookie header
+     *
+     * @param httpServletRequest HTTP Servlet Request
+     * @return CSRF Token
+     */
+    @Override
+    public CsrfToken generateToken(final HttpServletRequest httpServletRequest) {
+        CsrfToken csrfToken = loadToken(httpServletRequest);
+        if (csrfToken == null) {
+            csrfToken = getCsrfToken(generateRandomToken());
+        }
+        return csrfToken;
+    }
+
+    /**
+     * Save CSRF Token in HTTP Servlet Response using defaults that allow JavaScript read for session cookies
+     *
+     * @param csrfToken CSRF Token to be saved or null indicated the token should be removed
+     * @param httpServletRequest HTTP Servlet Request
+     * @param httpServletResponse HTTP Servlet Response
+     */
+    @Override
+    public void saveToken(final CsrfToken csrfToken, final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse) {
+        if (csrfToken == null) {
+            final ResponseCookie responseCookie = getResponseCookie(EMPTY_VALUE, MAX_AGE_REMOVE);
+            httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+        } else {
+            final String token = csrfToken.getToken();
+            final ResponseCookie responseCookie = getResponseCookie(token, MAX_AGE_SESSION);
+            httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
+        }
+    }
+
+    /**
+     * Load CSRF Token from HTTP Servlet Request Cookie header
+     *
+     * @param httpServletRequest HTTP Servlet Request
+     * @return CSRF Token or null when Cookie header not found
+     */
+    @Override
+    public CsrfToken loadToken(final HttpServletRequest httpServletRequest) {
+        final Cookie cookie = WebUtils.getCookie(httpServletRequest, CsrfCookieName.REQUEST_TOKEN.getCookieName());
+        final String token = cookie == null ? null : cookie.getValue();
+        return StringUtils.hasLength(token) ? getCsrfToken(token) : null;
+    }
+
+    private CsrfToken getCsrfToken(final String token) {
+        return new DefaultCsrfToken(REQUEST_HEADER, REQUEST_PARAMETER, token);
+    }
+
+    private String generateRandomToken() {
+        return UUID.randomUUID().toString();
+    }
+
+    private ResponseCookie getResponseCookie(final String cookieValue, final Duration maxAge) {
+        return ResponseCookie.from(CsrfCookieName.REQUEST_TOKEN.getCookieName(), cookieValue)
+                .sameSite(SAME_SITE_POLICY_STRICT)
+                .secure(SECURE_ENABLED)
+                .path(ROOT_PATH)
+                .maxAge(maxAge)
+                .build();
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/csrf/StandardCsrfTokenRequestAttributeHandler.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/csrf/StandardCsrfTokenRequestAttributeHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.web.security.authentication.csrf;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
+import org.springframework.util.StringUtils;
+
+import java.util.function.Supplier;
+
+/**
+ * Cross-Site Request Forgery Mitigation Token Handler implementation supporting resolution using Request Header
+ */
+public class StandardCsrfTokenRequestAttributeHandler extends CsrfTokenRequestAttributeHandler {
+    private final XorCsrfTokenRequestAttributeHandler handler = new XorCsrfTokenRequestAttributeHandler();
+
+    /**
+     * Handle Request using standard Spring Security implementation
+     *
+     * @param request HTTP Servlet Request being handled
+     * @param response HTTP Servlet Response being handled
+     * @param csrfTokenSupplier Supplier for CSRF Token
+     */
+    @Override
+    public void handle(final HttpServletRequest request, final HttpServletResponse response, final Supplier<CsrfToken> csrfTokenSupplier) {
+        this.handler.handle(request, response, csrfTokenSupplier);
+    }
+
+    /**
+     * Resolve CSRF Token Value from HTTP Request Header
+     *
+     * @param request HTTP Servlet Request being processed
+     * @param csrfToken CSRF Token created from a CSRF Token Repository
+     * @return Token Value from Request Header or null when not found
+     */
+    @Override
+    public String resolveCsrfTokenValue(final HttpServletRequest request, final CsrfToken csrfToken) {
+        final String headerTokenValue = request.getHeader(csrfToken.getHeaderName());
+
+        final String resolvedToken;
+        if (StringUtils.hasText(headerTokenValue)) {
+            resolvedToken = super.resolveCsrfTokenValue(request, csrfToken);
+        } else {
+            resolvedToken = null;
+        }
+
+        return resolvedToken;
+    }
+}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/services/nf-registry.token.interceptor.js
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/services/nf-registry.token.interceptor.js
@@ -25,12 +25,13 @@ import NfStorage from 'services/nf-storage.service';
  */
 function NfRegistryTokenInterceptor(nfStorage) {
     this.nfStorage = nfStorage;
+    this.requestTokenPattern = /Request-Token=([^;]+)/;
 }
 NfRegistryTokenInterceptor.prototype = {
     constructor: NfRegistryTokenInterceptor,
 
     /**
-     * Injects the authorization token into the request headers.
+     * Injects the authorization token and request token cookie value into the request headers.
      *
      * @param request       angular HttpRequest.
      * @param next          angular HttpHandler.
@@ -40,6 +41,11 @@ NfRegistryTokenInterceptor.prototype = {
         var token = this.nfStorage.getItem('jwt');
         if (token) {
             request = request.clone({headers: request.headers.set('Authorization', 'Bearer ' + token)});
+        }
+        var requestTokenMatcher = this.requestTokenPattern.exec(document.cookie);
+        if (requestTokenMatcher) {
+            var requestToken = requestTokenMatcher[1];
+            request = request.clone({headers: request.headers.set('Request-Token', requestToken)});
         }
         return next.handle(request);
     }


### PR DESCRIPTION
# Summary

[NIFI-12487](https://issues.apache.org/jira/browse/NIFI-12487) Adds Cross-Site Request Forgery protection to NiFi Registry using the Spring Security CSRF Filter and several components that follow the same approach currently implemented for NiFi CSRF protection.

NiFi Registry does not use cookies for passing Application Bearer Tokens, and instead relies on the HTTP Authorization header to be populated using a custom JavaScript request interceptor. This approach mitigates a number of potential threats. Introducing the CSRF Filter provides an additional layer of protection. Following a strategy similar to NiFi, the CSRF Request Matcher is based on the default Spring Security HTTP Method matching plus the presence of the Request Token cookie. This enables programmatic clients to continue working without reconfiguration, while requiring browser-based clients to pass the `Request-Token` header, as implemented through updates to the JavaScript request interceptor.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
