### PR TITLE
NIFI-12475 Disable Bypass Validation by Default in PutMongoRecord

### DIFF
--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoRecord.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoRecord.java
@@ -115,9 +115,13 @@ public class PutMongoRecord extends AbstractMongoProcessor {
     static final PropertyDescriptor BYPASS_VALIDATION = new PropertyDescriptor.Builder()
             .name("bypass-validation")
             .displayName("Bypass Validation")
-            .description("Bypass schema validation during insert/upsert")
+            .description("""
+                    Enable or disable bypassing document schema validation during insert or update operations.
+                    Bypassing document validation is a Privilege Action in MongoDB.
+                    Enabling this property can result in authorization errors for users with limited privileges.
+            """)
             .allowableValues("True", "False")
-            .defaultValue("True")
+            .defaultValue("False")
             .required(true)
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .build();


### PR DESCRIPTION
# Summary

[NIFI-12475](https://issues.apache.org/jira/browse/NIFI-12475) Updates the default setting for the `Bypass Validation` property in `PutMongoRecord` to `False`.

As noted in the expanded property description and the referenced Jira issue, bypassing document validation requires additional permissions beyond basic insert and update privileges. This property should be set to `False` by default to align with the same behavior in `PutMongo`, and also to highlight the elevated permissions required as described in [MongoDB Privilege Actions](https://www.mongodb.com/docs/manual/reference/privilege-actions/#mongodb-authaction-bypassDocumentValidation) documentation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
