### PR TITLE
NIFI-12489 Upgrade Apache POI from 5.2.4 to 5.2.5

### DIFF
--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
     <properties>
         <spring.integration.version>5.5.18</spring.integration.version>
-        <poi.version>5.2.4</poi.version>
+        <poi.version>5.2.5</poi.version>
     </properties>
 
     <dependencies>

--- a/nifi-nar-bundles/nifi-media-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/pom.xml
@@ -26,7 +26,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <poi.version>5.2.4</poi.version>
+        <poi.version>5.2.5</poi.version>
     </properties>
 
     <modules>

--- a/nifi-nar-bundles/nifi-poi-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-poi-bundle/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>nifi-poi-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <poi.version>5.2.4</poi.version>
+        <poi.version>5.2.5</poi.version>
     </properties>
     <modules>
         <module>nifi-poi-nar</module>


### PR DESCRIPTION
# Summary

[NIFI-12489](https://issues.apache.org/jira/browse/NIFI-12489) Upgrades Apache POI from 5.2.4 to [5.2.5](https://poi.apache.org/changes.html#5.2.5). Version 5.2.5 consists primarily of transitive dependency updates, most of which are already updated through project managed dependencies.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
