### PR TITLE
NIFI-12493 Update Documentation References to Java 21

### DIFF
--- a/minifi/minifi-assembly/README.md
+++ b/minifi/minifi-assembly/README.md
@@ -39,7 +39,7 @@ Specific goals for MiNiFi are comprised of:
 Perspectives of the role of MiNiFi should be from the perspective of the agent acting immediately at, or directly adjacent to, source sensors, systems, or servers.
 
 ## Requirements
-* JRE 17
+* Java 21
 
 ## Getting Started
 

--- a/minifi/minifi-c2/minifi-c2-assembly/README.md
+++ b/minifi/minifi-c2/minifi-c2-assembly/README.md
@@ -26,7 +26,7 @@ MiNiFi is a child project effort of Apache NiFi.  The MiNiFi C2 Server aids in t
 - [Export Control](#export-control)
 
 ## Requirements
-* JRE 17
+* Java 21
 * Apache Maven 3
 
 ## Getting Started

--- a/minifi/minifi-docs/src/main/markdown/System_Admin_Guide.md
+++ b/minifi/minifi-docs/src/main/markdown/System_Admin_Guide.md
@@ -382,7 +382,7 @@ This is an example of a simple query to get the health of all the processors and
 ```
 User:minifi-0.0.1-SNAPSHOT user ./bin/minifi.sh flowStatus processor:all:health
 
-Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_74.jdk/Contents/Home
+Java home: /Library/Java/JavaVirtualMachines/jdk/Contents/Home
 MiNiFi home: /Users/user/projects/nifi-minifi/minifi-assembly/target/minifi-0.0.1-SNAPSHOT-bin/minifi-0.0.1-SNAPSHOT
 
 Bootstrap Config File: /Users/user/projects/nifi-minifi/minifi-assembly/target/minifi-0.0.1-SNAPSHOT-bin/minifi-0.0.1-SNAPSHOT/conf/bootstrap.conf

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi-env.bat
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi-env.bat
@@ -18,7 +18,7 @@ rem
 
 
 rem The java implementation to use
-rem set JAVA_HOME="C:\Program Files\Java\jdk1.8.0"
+rem set JAVA_HOME="C:\Program Files\Java\jdk"
 
 set MINIFI_ROOT=%~sdp0..\
 

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi-env.sh
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi-env.sh
@@ -17,7 +17,7 @@
 #
 
 # The java implementation to use.
-#export JAVA_HOME=/usr/java/jdk1.8.0/
+#export JAVA_HOME=/usr/java/jdk/
 
 export MINIFI_HOME=$(cd "${SCRIPT_DIR}" && cd .. && pwd)
 

--- a/nifi-assembly/README.md
+++ b/nifi-assembly/README.md
@@ -68,7 +68,7 @@ If you have questions, you can reach out to our mailing list: dev@nifi.apache.or
 - IRC: #nifi on [irc.freenode.net](http://webchat.freenode.net/?channels=#nifi)
 
 ## Requirements
-* JDK 1.8 or higher
+* Java 21
 
 ## License
 

--- a/nifi-commons/nifi-metrics/src/main/java/org/apache/nifi/metrics/jvm/JvmMetrics.java
+++ b/nifi-commons/nifi-metrics/src/main/java/org/apache/nifi/metrics/jvm/JvmMetrics.java
@@ -143,7 +143,7 @@ public interface JvmMetrics {
      * Returns the name of the currently-running jvm.
      *
      * @return the name of the currently-running jvm, eg  "Java HotSpot(TM) Client VM"
-     * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#getProperties()">System.getProperties()</a>
+     * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/System.html#getProperties()">System.getProperties()</a>
      */
     String name();
 

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -23,7 +23,7 @@ Apache NiFi Team <dev@nifi.apache.org>
 == System Requirements
 Apache NiFi can run on something as simple as a laptop, but it can also be clustered across many enterprise-class servers. Therefore, the amount of hardware and memory needed will depend on the size and nature of the dataflow involved. The data is stored on disk while NiFi is processing it. So NiFi needs to have sufficient disk space allocated for its various repositories, particularly the content repository, flowfile repository, and provenance repository (see the <<system_properties>> section for more information about these repositories). NiFi has the following minimum system requirements:
 
-* Requires Java 17
+* Requires Java 21
 * Use of Python-based Processors (beta feature) requires Python 3.9+
 * Supported Operating Systems:
 ** Linux
@@ -81,17 +81,17 @@ See the <<system_properties>> section of this guide for more information about c
 
 The binary build of Apache NiFi that is provided by the Apache mirrors does not contain every NAR file that is part of the official release. This is due to size constraints imposed by the mirrors to reduce the expenses associated with hosting such a large project. The Developer Guide link:developer-guide.html#build[has a list] of optional Maven profiles that can be activated to build a binary distribution of NiFi with these extra capabilities.
 
-To execute build, download Java 17 from https://www.adoptium.net[Adoptium] or whichever distribution of the JDK your team uses (Adoptium is the rebranding of AdoptOpenJDK which is one of the most popular). Then install https://maven.apache.org[Apache Maven].
+Java 21 is required for building and running Apache NiFi.
 
 The next step is to download a copy of the Apache NiFi source code from the https://nifi.apache.org/download.html[NiFi Downloads page]. The reason you need the source build is that it includes a module called `nifi-assembly` which is the Maven module that builds a binary distribution. Expand the archive and run a Maven clean build. The following example shows how to build a distribution that activates the `graph` and `media` bundle profiles to add in support for graph databases and Apache Tika content and metadata extraction.
 
 `cd <nifi_source_folder>/nifi-assembly`
 
-`mvn clean install -Pinclude-grpc,include-graph,include-media`
+`./mvnw clean install -Pinclude-grpc,include-graph,include-media`
 
 There is also a specific profile allowing you to build NiFi with all of the additional bundles that are not included by default:
 
-`mvn clean install -Pinclude-all`
+`./mvnw clean install -Pinclude-all`
 
 This will include bundles such as gRPC, Atlas, Hive, Hive 1_1, Hive 3, Media, Rules, SQL Reporting, Accumulo, Ranger, ASN1, Snowflake, Iceberg, etc.
 
@@ -331,7 +331,7 @@ may be set:
 |==================================================================================================================================================
 
 Each property should take the form of a comma-separated list of common cipher names as specified
-link:https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html[here^].  Regular expressions
+link:https://docs.oracle.com/en/java/javase/21/docs/specs/security/standard-names.html[here^].  Regular expressions
 (for example `^.*GCM_SHA256$`) may also be specified.
 
 The semantics match the use of the following Jetty APIs:
@@ -2851,7 +2851,7 @@ Failure to do so, may result in errors similar to the following:
 2016-01-08 16:08:57,888 ERROR [pool-26-thread-1-SendThread(localhost:2181)] o.a.zookeeper.client.ZooKeeperSaslClient An error: (java.security.PrivilegedActionException: javax.security.sasl.SaslException: GSS initiate failed [Caused by GSSException: No valid credentials provided (Mechanism level: Server not found in Kerberos database (7) - LOOKING_UP_SERVER)]) occurred when evaluating ZooKeeper Quorum Member's  received SASL token. ZooKeeper Client will go to AUTH_FAILED state.
 
 If there are problems communicating or authenticating with Kerberos, this
-link:https://docs.oracle.com/en/java/javase/17/security/troubleshooting.html[Troubleshooting Guide^] may be of value.
+link:https://docs.oracle.com/en/java/javase/21/security/troubleshooting.html[Troubleshooting Guide^] may be of value.
 
 One of the most important notes in the above Troubleshooting guide is the mechanism for turning on Debug output for Kerberos.
 This is done by setting the `sun.security.krb5.debug` environment variable.

--- a/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/expression-language-guide.adoc
@@ -2196,7 +2196,7 @@ Divide. This is to preserve backwards compatibility and to not force rounding er
 [.function]
 === math
 
-*Description*: [.description]#ADVANCED FEATURE. This expression is designed to be used by advanced users only. It utilizes Java Reflection to run arbitrary java.lang.Math static methods. The exact API will depend on the version of Java you are running. The Java 17 API can be found here: link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Math.html[https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Math.html^]
+*Description*: [.description]#ADVANCED FEATURE. This expression is designed to be used by advanced users only. It utilizes Java Reflection to run arbitrary java.lang.Math static methods. The exact API will depend on the version of Java you are running. The Java API can be found here: link:https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Math.html[https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Math.html^]
  +
 In order to run the correct method, the parameter types must be correct. The Expression Language "Number" (whole number) type is interpreted as a Java "long". The "Decimal" type is interpreted as a Java "double". Running the desired method may require calling "toNumber()" or "toDecimal()" in order to "cast" the value to the desired type. This also is important to remember when cascading "math()" calls since the return type depends on the method that was run.#
 
@@ -2615,7 +2615,7 @@ names begin with the letter `a`.
 
 *Description*: [.description]#Returns a URI compliant with RFC 2396. This includes encoding non-US-ASCII characters and
 quoting illegal characters with octets. This expression utilizes the
-link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/URI.html[java.net.URI^] class to build a URI.
+link:https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URI.html[java.net.URI^] class to build a URI.
 As described in the API, a hierarchical URI consists of seven components represented with the following types:#
 |============================================================================
 | Component   | Type

--- a/nifi-docs/src/main/asciidoc/nifi-in-depth.adoc
+++ b/nifi-docs/src/main/asciidoc/nifi-in-depth.adoc
@@ -113,8 +113,8 @@ At a high level, this flow reaches out to a seed URL configured in the InvokeHTT
 
 The flow also detects duplicate URLs and prevents processing them again, emails the user when keywords are found, logs all successful HTTP requests, and bundles up the successful requests to be compressed and archived on disk.
 
-NOTE: To use this flow you need to configure a couple options. First a DistributedMapCacheServer controller service must be added with default properties. Also to get emails, the PutEmail processor must be configured with your email credentials. Finally, to use HTTPS the StandardSSLContextService must be configured with proper key and trust stores. Remember that the truststore must be configured with the proper Certificate Authorities in order to work for websites. The command below is an example of using the "keytool" command to add the default Java 1.8.0_60 CAs to a truststore called myTrustStore:
-keytool -importkeystore -srckeystore /Library/Java/JavaVirtualMachines/jdk1.8.0_60.jdk/Contents/Home/jre/lib/security/cacerts  -destkeystore myTrustStore
+NOTE: To use this flow you need to configure a couple options. First a DistributedMapCacheServer controller service must be added with default properties. Also to get emails, the PutEmail processor must be configured with your email credentials. Finally, to use HTTPS the StandardSSLContextService must be configured with proper key and trust stores. Remember that the truststore must be configured with the proper Certificate Authorities in order to work for websites. The command below is an example of using the "keytool" command to add the default Java CAs to a truststore called myTrustStore:
+keytool -importkeystore -srckeystore /Library/Java/JavaVirtualMachines/jdk/Contents/Home/jre/lib/security/cacerts  -destkeystore myTrustStore
 
 
 === WebCrawler Flow

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.bat
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.bat
@@ -18,7 +18,7 @@ rem
 
 
 rem The java implementation to use
-rem set JAVA_HOME="C:\Program Files\Java\jdk1.8.0"
+rem set JAVA_HOME="C:\Program Files\Java\jdk"
 
 set NIFI_ROOT=%~sdp0..\
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.cmd
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.cmd
@@ -17,7 +17,7 @@ rem    limitations under the License.
 rem
 
 rem Set Java version
-rem set JAVA_HOME="C:\Program Files\Java\jdk1.8.0"
+rem set JAVA_HOME="C:\Program Files\Java\jdk"
 
 rem Set application home directory based on parent directory of script location
 pushd %~dp0..

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.sh
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi-env.sh
@@ -23,7 +23,7 @@
 # this script.
 
 # The java implementation to use.
-#export JAVA_HOME=/usr/java/jdk1.8.0/
+#export JAVA_HOME=/usr/java/jdk/
 
 setOrDefault() {
   envvar="$1"

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
@@ -49,7 +49,7 @@ java.arg.headless=-Djava.awt.headless=true
 java.arg.curatorLogOnlyFirstConnectionIssue=-Dcurator-log-only-first-connection-issue-as-error-level=true
 
 # Requires JAAS to use only the provided JAAS configuration to authenticate a Subject, without using any "fallback" methods (such as prompting for username/password)
-# Please see https://docs.oracle.com/en/java/javase/17/security/single-sign-using-kerberos-java1.html, section "EXCEPTIONS TO THE MODEL"
+# Please see https://docs.oracle.com/en/java/javase/21/security/single-sign-using-kerberos-java1.html, section "EXCEPTIONS TO THE MODEL"
 java.arg.securityAuthUseSubjectCredsOnly=-Djavax.security.auth.useSubjectCredsOnly=true
 
 # The following options configure a Java Agent to handle native library loading.

--- a/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/AbstractMongoProcessor.java
+++ b/nifi-nar-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/AbstractMongoProcessor.java
@@ -148,7 +148,7 @@ public abstract class AbstractMongoProcessor extends AbstractProcessor {
         .displayName("Date Format")
         .description("The date format string to use for formatting Date fields that are returned from Mongo. It is only " +
                 "applied when the JSON output format is set to Standard JSON. Full documentation for format characters can be " +
-                "found here: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/text/SimpleDateFormat.html")
+                "found here: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/text/SimpleDateFormat.html")
         .defaultValue("yyyy-MM-dd'T'HH:mm:ss'Z'")
         .addValidator((subject, input, context) -> {
             ValidationResult.Builder result = new ValidationResult.Builder()

--- a/nifi-registry/nifi-registry-assembly/README.md
+++ b/nifi-registry/nifi-registry-assembly/README.md
@@ -25,7 +25,7 @@ Registry—a subproject of Apache NiFi—is a complementary application that pro
 
 ## Requirements
 
-* Java 1.8 (above 1.8.0_45)
+* Java 21
 
 ## Getting Started
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
@@ -116,7 +116,7 @@ may be set:
 |==================================================================================================================================================
 
 Each property should take the form of a comma-separated list of common cipher names as specified
-link:https://docs.oracle.com/en/java/javase/17/docs/specs/security/standard-names.html[here^].  Regular expressions
+link:https://docs.oracle.com/en/java/javase/21/docs/specs/security/standard-names.html[here^].  Regular expressions
 (for example `^.*GCM_SHA256$`) may also be specified.
 
 The semantics match the use of the following Jetty APIs:

--- a/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
@@ -23,7 +23,7 @@ Apache NiFi Team <dev@nifi.apache.org>
 
 NiFi Registry has the following minimum system requirements:
 
-* Requires Java Development Kit (JDK) 17
+* Requires Java 21
 
 WARNING: When running Registry with only a JRE you may encounter the following error as Flyway (database migration tool) attempts to utilize a resource from the JDK: +
  +

--- a/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/bin/nifi-registry-env.sh
+++ b/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/bin/nifi-registry-env.sh
@@ -17,7 +17,7 @@
 #
 
 # The java implementation to use.
-#export JAVA_HOME=/usr/java/jdk1.8.0/
+#export JAVA_HOME=/usr/java/jdk/
 
 export NIFI_REGISTRY_HOME=$(cd "${SCRIPT_DIR}" && cd .. && pwd)
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/resources/keys/README.md
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/resources/keys/README.md
@@ -60,7 +60,7 @@ Requirements:
 - keytool (included with Java)
 - openssl (included/available on most platforms)
 
-If you do not have docker, you can substitute the nifi-toolkit binary, which is available for download from https://nifi.apache.org and should run on any platform with Java 1.8. 
+If you do not have docker, you can substitute the nifi-toolkit binary, which is available for download from https://nifi.apache.org and should run on any platform with Java. 
 
 ### New Service Keys
 
@@ -164,7 +164,7 @@ Requirements:
 - keytool (included with Java)
 - openssl (included/available on most platforms)
 
-If you do not have docker, you can substitute the nifi-toolkit binary, which is available for download from https://nifi.apache.org and should run on any platform with Java 1.8. 
+If you do not have docker, you can substitute the nifi-toolkit binary, which is available for download from https://nifi.apache.org and should run on any platform with Java. 
 
 The steps for regenerating these test keys are:
 

--- a/nifi-stateless/nifi-stateless-resources/src/main/resources/bin/nifi-stateless-env.sh
+++ b/nifi-stateless/nifi-stateless-resources/src/main/resources/bin/nifi-stateless-env.sh
@@ -17,7 +17,7 @@
 #
 
 # The java implementation to use.
-#export JAVA_HOME=/usr/java/jdk1.8.0/
+#export JAVA_HOME=/usr/java/jdk/
 
 export NIFI_HOME=$(cd "${SCRIPT_DIR}" && cd .. && pwd)
 


### PR DESCRIPTION
# Summary

[NIFI-12493](https://issues.apache.org/jira/browse/NIFI-12493) Updates documentation references to indicate that Java 21 is the minimum required version. Additional changes include removing the need to download Apache Maven and instead referencing the Apache Maven Wrapper command.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
