### PR TITLE
NIFI-6730 AMQP QoS support

### DIFF
--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPConsumer.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AMQPConsumer.java
@@ -43,7 +43,8 @@ final class AMQPConsumer extends AMQPWorker {
     private final boolean autoAcknowledge;
     private final Consumer consumer;
 
-    AMQPConsumer(final Connection connection, final String queueName, final boolean autoAcknowledge, ComponentLog processorLog) throws IOException {
+    AMQPConsumer(final Connection connection, final String queueName, final boolean autoAcknowledge, final int prefetchCount,
+            ComponentLog processorLog) throws IOException {
         super(connection, processorLog);
         this.validateStringProperty("queueName", queueName);
         this.queueName = queueName;
@@ -80,6 +81,7 @@ final class AMQPConsumer extends AMQPWorker {
             }
         };
 
+        channel.basicQos(prefetchCount);
         channel.basicConsume(queueName, autoAcknowledge, consumer);
     }
 

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -121,7 +121,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         .description("The maximum number of unacknowledged messages for the consumer. If consumer has this number of unacknowledged messages, AMQP broker will "
                + "no longer send new messages until consumer acknowledges some of the messages already delivered to it."
                + "Allowed values: from 0 to 65535. 0 means no limit")
-        .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+        .addValidator(StandardValidators.createLongValidator(0, 65535, true))
         .expressionLanguageSupported(ExpressionLanguageScope.NONE)
         .defaultValue("0")
         .required(true)
@@ -333,21 +333,5 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
     @Override
     public Set<Relationship> getRelationships() {
         return relationships;
-    }
-
-    @Override
-    protected Collection<ValidationResult> customValidate(ValidationContext context) {
-        List<ValidationResult> results = new ArrayList<>(super.customValidate(context));
-
-        int prefetchCount = context.getProperty(PREFETCH_COUNT).asInteger();
-        if (prefetchCount < 0 || prefetchCount > 65535) {
-            results.add(new ValidationResult.Builder()
-                    .subject("Prefetch configuration")
-                    .valid(false)
-                    .explanation("prefetch count must be between 0 and 65535")
-                    .build());
-        }
-
-        return results;
     }
 }

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -37,8 +37,6 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.components.ValidationContext;
-import org.apache.nifi.components.ValidationResult;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.Collection;
 
 @Tags({"amqp", "rabbit", "get", "message", "receive", "consume"})
 @InputRequirement(Requirement.INPUT_FORBIDDEN)

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -316,8 +316,8 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         try {
             final String queueName = context.getProperty(QUEUE).getValue();
             final boolean autoAcknowledge = context.getProperty(AUTO_ACKNOWLEDGE).asBoolean();
-            final AMQPConsumer amqpConsumer = new AMQPConsumer(connection, queueName, autoAcknowledge,
-                    context.getProperty(PREFETCH_COUNT).asInteger(), getLogger());
+            final int prefetchCount =  context.getProperty(PREFETCH_COUNT).asInteger();
+            final AMQPConsumer amqpConsumer = new AMQPConsumer(connection, queueName, autoAcknowledge, prefetchCount, getLogger());
 
             return amqpConsumer;
         } catch (final IOException ioe) {

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -112,6 +112,16 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         .defaultValue("10")
         .required(true)
         .build();
+    static final PropertyDescriptor PREFETCH_COUNT = new PropertyDescriptor.Builder()
+        .name("prefetch.count")
+        .displayName("Prefetch Count")
+        .description("The maximum number of unacknowledged messages for the consumer. If consumer has this number of unacknowledged messages, AMQP broker will "
+               + "no longer send new messages until consumer acknowledges some of the messages already delivered to it. 0 means no limit")
+        .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
+        .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+        .defaultValue("0")
+        .required(true)
+        .build();
 
     public static final PropertyDescriptor HEADER_FORMAT = new PropertyDescriptor.Builder()
         .name("header.format")
@@ -167,6 +177,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         properties.add(QUEUE);
         properties.add(AUTO_ACKNOWLEDGE);
         properties.add(BATCH_SIZE);
+        properties.add(PREFETCH_COUNT);
         properties.add(HEADER_FORMAT);
         properties.add(HEADER_KEY_PREFIX);
         properties.add(HEADER_SEPARATOR);
@@ -301,7 +312,8 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         try {
             final String queueName = context.getProperty(QUEUE).getValue();
             final boolean autoAcknowledge = context.getProperty(AUTO_ACKNOWLEDGE).asBoolean();
-            final AMQPConsumer amqpConsumer = new AMQPConsumer(connection, queueName, autoAcknowledge, getLogger());
+            final AMQPConsumer amqpConsumer = new AMQPConsumer(connection, queueName, autoAcknowledge,
+                    context.getProperty(PREFETCH_COUNT).asInteger(), getLogger());
 
             return amqpConsumer;
         } catch (final IOException ioe) {

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
@@ -42,8 +42,8 @@ import org.junit.jupiter.api.Test;
 
 public class AMQPConsumerTest {
 
-    private ComponentLog processorLog;
     private static final int DEFAULT_PREFETCH_COUNT = 0;
+    private ComponentLog processorLog;
 
     @BeforeEach
     public void setUp() {

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
 public class AMQPConsumerTest {
 
     private ComponentLog processorLog;
+    private static final int DEFAULT_PREFETCH_COUNT = 0;
 
     @BeforeEach
     public void setUp() {
@@ -55,7 +56,7 @@ public class AMQPConsumerTest {
         final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
 
         final TestConnection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
-        final AMQPConsumer consumer = new AMQPConsumer(connection, "queue1", true, 0, processorLog);
+        final AMQPConsumer consumer = new AMQPConsumer(connection, "queue1", true, DEFAULT_PREFETCH_COUNT, processorLog);
         consumer.getChannel().basicPublish("myExchange", "key1", new BasicProperties(), new byte[0]);
 
         consumer.close();
@@ -69,7 +70,7 @@ public class AMQPConsumerTest {
         final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
 
         final TestConnection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
-        final AMQPConsumer consumer = new AMQPConsumer(connection, "queue1", true, 0, processorLog);
+        final AMQPConsumer consumer = new AMQPConsumer(connection, "queue1", true, DEFAULT_PREFETCH_COUNT, processorLog);
 
         assertFalse(consumer.closed);
 
@@ -80,14 +81,14 @@ public class AMQPConsumerTest {
 
     @Test
     public void failOnNullConnection() {
-        assertThrows(IllegalArgumentException.class, () -> new AMQPConsumer(null, null, true, 0, processorLog));
+        assertThrows(IllegalArgumentException.class, () -> new AMQPConsumer(null, null, true, DEFAULT_PREFETCH_COUNT, processorLog));
     }
 
     @Test
     public void failOnNullQueueName() {
         assertThrows(IllegalArgumentException.class, () -> {
             Connection conn = new TestConnection(null, null);
-            new AMQPConsumer(conn, null, true, 0, processorLog);
+            new AMQPConsumer(conn, null, true, DEFAULT_PREFETCH_COUNT, processorLog);
         });
     }
 
@@ -95,7 +96,7 @@ public class AMQPConsumerTest {
     public void failOnEmptyQueueName() {
         assertThrows(IllegalArgumentException.class, () -> {
             Connection conn = new TestConnection(null, null);
-            new AMQPConsumer(conn, " ", true, 0, processorLog);
+            new AMQPConsumer(conn, " ", true, DEFAULT_PREFETCH_COUNT, processorLog);
         });
     }
 
@@ -103,7 +104,7 @@ public class AMQPConsumerTest {
     public void failOnNonExistingQueue() {
         assertThrows(IOException.class, () -> {
             Connection conn = new TestConnection(null, null);
-            try (AMQPConsumer consumer = new AMQPConsumer(conn, "hello", true, 0, processorLog)) {
+            try (AMQPConsumer consumer = new AMQPConsumer(conn, "hello", true, DEFAULT_PREFETCH_COUNT, processorLog)) {
                 consumer.consume();
             }
         });
@@ -117,7 +118,7 @@ public class AMQPConsumerTest {
         exchangeToRoutingKeymap.put("", "queue1");
 
         Connection conn = new TestConnection(exchangeToRoutingKeymap, routingMap);
-        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1", true, 0, processorLog)) {
+        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1", true, DEFAULT_PREFETCH_COUNT, processorLog)) {
             GetResponse response = consumer.consume();
             assertNull(response);
         }
@@ -132,7 +133,7 @@ public class AMQPConsumerTest {
 
         Connection conn = new TestConnection(exchangeToRoutingKeymap, routingMap);
         conn.createChannel().basicPublish("myExchange", "key1", null, "hello Joe".getBytes());
-        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1", true, 0, processorLog)) {
+        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1", true, DEFAULT_PREFETCH_COUNT, processorLog)) {
             GetResponse response = consumer.consume();
             assertNotNull(response);
         }

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
@@ -55,7 +55,7 @@ public class AMQPConsumerTest {
         final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
 
         final TestConnection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
-        final AMQPConsumer consumer = new AMQPConsumer(connection, "queue1", true, processorLog);
+        final AMQPConsumer consumer = new AMQPConsumer(connection, "queue1", true, 0, processorLog);
         consumer.getChannel().basicPublish("myExchange", "key1", new BasicProperties(), new byte[0]);
 
         consumer.close();
@@ -69,7 +69,7 @@ public class AMQPConsumerTest {
         final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
 
         final TestConnection connection = new TestConnection(exchangeToRoutingKeymap, routingMap);
-        final AMQPConsumer consumer = new AMQPConsumer(connection, "queue1", true, processorLog);
+        final AMQPConsumer consumer = new AMQPConsumer(connection, "queue1", true, 0, processorLog);
 
         assertFalse(consumer.closed);
 
@@ -80,14 +80,14 @@ public class AMQPConsumerTest {
 
     @Test
     public void failOnNullConnection() {
-        assertThrows(IllegalArgumentException.class, () -> new AMQPConsumer(null, null, true, processorLog));
+        assertThrows(IllegalArgumentException.class, () -> new AMQPConsumer(null, null, true, 0, processorLog));
     }
 
     @Test
     public void failOnNullQueueName() {
         assertThrows(IllegalArgumentException.class, () -> {
             Connection conn = new TestConnection(null, null);
-            new AMQPConsumer(conn, null, true, processorLog);
+            new AMQPConsumer(conn, null, true, 0, processorLog);
         });
     }
 
@@ -95,7 +95,7 @@ public class AMQPConsumerTest {
     public void failOnEmptyQueueName() {
         assertThrows(IllegalArgumentException.class, () -> {
             Connection conn = new TestConnection(null, null);
-            new AMQPConsumer(conn, " ", true, processorLog);
+            new AMQPConsumer(conn, " ", true, 0, processorLog);
         });
     }
 
@@ -103,7 +103,7 @@ public class AMQPConsumerTest {
     public void failOnNonExistingQueue() {
         assertThrows(IOException.class, () -> {
             Connection conn = new TestConnection(null, null);
-            try (AMQPConsumer consumer = new AMQPConsumer(conn, "hello", true, processorLog)) {
+            try (AMQPConsumer consumer = new AMQPConsumer(conn, "hello", true, 0, processorLog)) {
                 consumer.consume();
             }
         });
@@ -117,7 +117,7 @@ public class AMQPConsumerTest {
         exchangeToRoutingKeymap.put("", "queue1");
 
         Connection conn = new TestConnection(exchangeToRoutingKeymap, routingMap);
-        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1", true, processorLog)) {
+        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1", true, 0, processorLog)) {
             GetResponse response = consumer.consume();
             assertNull(response);
         }
@@ -132,9 +132,20 @@ public class AMQPConsumerTest {
 
         Connection conn = new TestConnection(exchangeToRoutingKeymap, routingMap);
         conn.createChannel().basicPublish("myExchange", "key1", null, "hello Joe".getBytes());
-        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1", true, processorLog)) {
+        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1", true, 0, processorLog)) {
             GetResponse response = consumer.consume();
             assertNotNull(response);
+        }
+    }
+
+    @Test
+    public void validatePrefetchSet() throws Exception {
+        final Map<String, List<String>> routingMap = Collections.singletonMap("key1", Arrays.asList("queue1"));
+        final Map<String, String> exchangeToRoutingKeymap = Collections.singletonMap("myExchange", "key1");
+        Connection conn = new TestConnection(exchangeToRoutingKeymap, routingMap);
+        try (AMQPConsumer consumer = new AMQPConsumer(conn, "queue1", true, 100, processorLog)) {
+            TestChannel channel = (TestChannel)consumer.getChannel();
+            assertEquals(100, channel.getPrefetchCount());
         }
     }
 }

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/ConsumeAMQPTest.java
@@ -393,7 +393,9 @@ public class ConsumeAMQPTest {
                     throw new IllegalStateException("Consumer already created");
                 }
 
-                consumer = new AMQPConsumer(connection, context.getProperty(ConsumeAMQP.QUEUE).getValue(), context.getProperty(ConsumeAMQP.AUTO_ACKNOWLEDGE).asBoolean(), getLogger());
+                consumer = new AMQPConsumer(connection, context.getProperty(ConsumeAMQP.QUEUE).getValue(),
+                        context.getProperty(ConsumeAMQP.AUTO_ACKNOWLEDGE).asBoolean(), context.getProperty(ConsumeAMQP.PREFETCH_COUNT).asInteger(),
+                        getLogger());
                 return consumer;
             } catch (IOException e) {
                 throw new ProcessException(e);

--- a/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/TestChannel.java
+++ b/nifi-nar-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/TestChannel.java
@@ -77,6 +77,7 @@ class TestChannel implements Channel {
     private long deliveryTag = 0L;
     private final BitSet acknowledgments = new BitSet();
     private final BitSet nacks = new BitSet();
+    private int prefetchCount = 0;
 
     public TestChannel(Map<String, String> exchangeToRoutingKeyMappings,
             Map<String, List<String>> routingKeyToQueueMappings) {
@@ -222,8 +223,11 @@ class TestChannel implements Channel {
 
     @Override
     public void basicQos(int prefetchCount) throws IOException {
-        throw new UnsupportedOperationException("This method is not currently supported as it is not used by current API in testing");
+        this.prefetchCount = prefetchCount;
+    }
 
+    public int getPrefetchCount() {
+        return this.prefetchCount;
     }
 
     @Override


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-6730](https://issues.apache.org/jira/browse/NIFI-6730)
Implement basicQos (prefetch count) support in ConsumeAMQP processor.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
