### PR TITLE
NIFI-12509 Changing default TTL of HazelcastMapCacheClient

### DIFF
--- a/nifi-nar-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/src/main/java/org/apache/nifi/hazelcast/services/cacheclient/HazelcastMapCacheClient.java
+++ b/nifi-nar-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/src/main/java/org/apache/nifi/hazelcast/services/cacheclient/HazelcastMapCacheClient.java
@@ -78,10 +78,11 @@ public class HazelcastMapCacheClient extends AbstractControllerService implement
             .name("hazelcast-entry-ttl")
             .displayName("Hazelcast Entry Lifetime")
             .description("Indicates how long the written entries should exist in Hazelcast. Setting it to '0 secs' means that the data" +
-                    "will exists until its deletion or until the Hazelcast server is shut down.")
+                    "will exists until its deletion or until the Hazelcast server is shut down. Using `EmbeddedHazelcastCacheManager` as" +
+                    "cache manager will not provide policies to limit the size of the cache.")
             .required(true)
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
-            .defaultValue("0 secs") // Note: in case of Hazelcast IMap, negative value would mean "map default" which might be overridden by a different client.
+            .defaultValue("5 min") // Note: in case of Hazelcast IMap, negative value would mean "map default" which might be overridden by a different client.
             .build();
 
     private static final long STARTING_REVISION = 1;


### PR DESCRIPTION
Current default TTL is 0, which in terms of Hazelcast means that the cache will be ever-growing. Having Max Size Policy on the imap (backs the cache) can be reached via instance (server side) so it looks to be a valid setup to user 0 TTL. This makes it unreasonable to not allow the value at this point. Note: `EmbeddedHazelcastCacheManager` has currently no opportunity to set such a Max Size Policy.

# Summary

[NIFI-12509](https://issues.apache.org/jira/browse/NIFI-12509)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
