### PR TITLE
NIFI-12511 Correct lib Directory Assembly Configuration

### DIFF
--- a/nifi-assembly/src/main/assembly/common.xml
+++ b/nifi-assembly/src/main/assembly/common.xml
@@ -190,6 +190,15 @@
             </unpackOptions>
         </dependencySet>
 
+        <!-- NAR bundles -->
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>false</useTransitiveDependencies>
+            <includes>
+                <include>org.apache.nifi:*:nar</include>
+            </includes>
+        </dependencySet>
     </dependencySets>
     <fileSets>
         <fileSet>

--- a/nifi-assembly/src/main/assembly/core.xml
+++ b/nifi-assembly/src/main/assembly/core.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<component>
+    <dependencySets>
+        <!-- Core libraries -->
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0664</fileMode>
+            <useProjectArtifact>false</useProjectArtifact>
+            <includes>
+                <!-- Logging -->
+                <include>org.slf4j:slf4j-api</include>
+                <include>org.slf4j:log4j-over-slf4j</include>
+                <include>org.slf4j:jcl-over-slf4j</include>
+                <include>org.slf4j:jul-to-slf4j</include>
+                <include>ch.qos.logback:logback-classic</include>
+                <include>ch.qos.logback:logback-core</include>
+                <!-- Servlet API -->
+                <include>javax.servlet:javax.servlet-api</include>
+                <include>org.eclipse.jetty.toolchain:jetty-schemas</include>
+                <!-- Apache NiFi -->
+                <include>org.apache.nifi:nifi-api</include>
+                <include>org.apache.nifi:nifi-framework-api</include>
+                <include>org.apache.nifi:nifi-nar-utils</include>
+                <include>org.apache.nifi:nifi-per-process-group-logging</include>
+                <include>org.apache.nifi:nifi-properties</include>
+                <include>org.apache.nifi:nifi-property-utils</include>
+                <include>org.apache.nifi:nifi-python-framework-api</include>
+                <include>org.apache.nifi:nifi-runtime</include>
+                <include>org.apache.nifi:nifi-server-api</include>
+                <include>org.apache.nifi:nifi-stateless-api</include>
+                <include>org.apache.nifi:nifi-stateless-bootstrap</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+</component>

--- a/nifi-assembly/src/main/assembly/dependencies.xml
+++ b/nifi-assembly/src/main/assembly/dependencies.xml
@@ -19,30 +19,7 @@
     <baseDirectory>nifi-${project.version}</baseDirectory>
 
     <componentDescriptors>
+        <componentDescriptor>src/main/assembly/core.xml</componentDescriptor>
         <componentDescriptor>src/main/assembly/common.xml</componentDescriptor>
     </componentDescriptors>
-
-    <dependencySets>
-        <!-- Write out all dependency artifacts to lib directory -->
-        <dependencySet>
-            <scope>runtime</scope>
-            <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>lib</outputDirectory>
-            <directoryMode>0770</directoryMode>
-            <fileMode>0664</fileMode>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
-            <excludes>
-                <exclude>*:nifi-bootstrap</exclude>
-                <exclude>*:nifi-property-protection-api</exclude>
-                <exclude>*:nifi-property-protection-factory</exclude>
-                <exclude>*:nifi-resources</exclude>
-                <exclude>*:nifi-docs</exclude>
-                <exclude>*:nifi-single-user-utils</exclude>
-                <exclude>*:nifi-flow-encryptor</exclude>
-                <!-- exclude AspectJ library from lib included in the aspectj subdir -->
-                <exclude>org.aspectj:aspectjweaver</exclude>
-            </excludes>
-        </dependencySet>
-    </dependencySets>
-
 </assembly>

--- a/nifi-assembly/src/main/assembly/ranger.xml
+++ b/nifi-assembly/src/main/assembly/ranger.xml
@@ -24,27 +24,11 @@
     <baseDirectory>nifi-${project.version}</baseDirectory>
 
     <componentDescriptors>
+        <componentDescriptor>src/main/assembly/core.xml</componentDescriptor>
         <componentDescriptor>src/main/assembly/common.xml</componentDescriptor>
     </componentDescriptors>
 
     <dependencySets>
-        <!-- Write out all dependency artifacts to lib directory, exclude Ranger dependencies -->
-        <dependencySet>
-            <scope>runtime</scope>
-            <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>lib</outputDirectory>
-            <directoryMode>0770</directoryMode>
-            <fileMode>0660</fileMode>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
-            <excludes>
-                <exclude>*:nifi-bootstrap</exclude>
-                <exclude>*:nifi-property-protection-api</exclude>
-                <exclude>*:nifi-property-protection-factory</exclude>
-                <exclude>*:nifi-resources</exclude>
-                <exclude>*:nifi-docs</exclude>
-                <exclude>org.apache.nifi:nifi-ranger-resources:jar</exclude>
-            </excludes>
-        </dependencySet>
         <!-- Write out dependencies for Ranger's credentialbuilder to ext/ranger/install/lib -->
         <dependencySet>
             <scope>runtime</scope>


### PR DESCRIPTION
# Summary

[NIFI-12511](https://issues.apache.org/jira/browse/NIFI-12511) Corrects the `lib` directory configuration in the `nifi-assembly` module, providing a shared `core.xml` descriptor that includes only the required JAR files. Changes include introducing a new entry in the `common.xml` for NAR bundles and removing the duplicative `lib` definitions. This approach corrects settings that were not included in the `ranger.xml` and also eliminates unnecessary JAR files included in the standard build.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
