### PR TITLE
NIFI-12516: The headers in the map that come back when replicating a …

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/okhttp/JacksonResponse.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/okhttp/JacksonResponse.java
@@ -231,7 +231,12 @@ public class JacksonResponse extends Response {
     }
 
     @Override
-    public String getHeaderString(String name) {
-        return responseHeaders.getFirst(name);
+    public String getHeaderString(final String name) {
+        final String headerValue = responseHeaders.getFirst(name);
+        if (headerValue != null) {
+            return headerValue;
+        }
+
+        return responseHeaders.getFirst(name.toLowerCase());
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiContentAccess.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiContentAccess.java
@@ -35,6 +35,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -113,11 +114,11 @@ public class StandardNiFiContentAccess implements ContentAccess {
             }
 
             // get the file name
-            final String contentDisposition = responseHeaders.getFirst("Content-Disposition");
+            final String contentDisposition = getHeader(responseHeaders, "content-disposition");
             final String filename = StringUtils.substringBetween(contentDisposition, "filename=\"", "\"");
 
             // get the content type
-            final String contentType = responseHeaders.getFirst("Content-Type");
+            final String contentType = getHeader(responseHeaders, "content-type");
 
             // create the downloadable content
             return new DownloadableContent(filename, contentType, nodeResponse.getInputStream());
@@ -157,6 +158,37 @@ public class StandardNiFiContentAccess implements ContentAccess {
             // invalid uri
             throw new IllegalArgumentException("The specified data reference URI is not valid.");
         }
+    }
+
+    /**
+     * Returns the value of the first header in the given header map whose name matches the given header name.
+     * In HTTP 2.0, all header names should be lower-case. Before that, they were not necessarily. The spec, however,
+     * indicates that header names are case-insensitive. That said, the code has them stored in a Map, and the keys in Maps
+     * are not case-insensitive. This method allows us to access the value of the first header with the given name,
+     * ignoring case.
+     *
+     * @param headers the map containing all headers
+     * @param headerName the case-insensitive name of the header to retrieve
+     * @return the value of the first header with the given name, or <code>null</code> if the header is not found
+     */
+    private String getHeader(final MultivaluedMap<String, String> headers, final String headerName) {
+        if (headers == null || headers.isEmpty() || headerName == null || headerName.isBlank()) {
+            return null;
+        }
+
+        final String exactMatch = headers.getFirst(headerName);
+        if (exactMatch != null) {
+            return exactMatch;
+        }
+
+        for (final Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(headerName)) {
+                final List<String> values = entry.getValue();
+                return values == null || values.isEmpty() ? null : values.get(0);
+            }
+        }
+
+        return null;
     }
 
     private DownloadableContent getFlowFileContent(final String connectionId, final String flowfileId, final String dataUri) {


### PR DESCRIPTION
…request used to be in the case given; however now they are all lowercased in the OkHttp Headers object. As a result, we need to ensure that we always use lower-case header names or check the map case-insensitive.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
