### PR TITLE
NIFI-12518 Upgrade Calcite Avatica from 1.23.0 to 1.24.0

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <ant.version>1.10.14</ant.version>
         <calcite.avatica.version>1.6.0</calcite.avatica.version>
-        <avatica.version>1.23.0</avatica.version>
+        <avatica.version>1.24.0</avatica.version>
     </properties>
 
     <!-- Managed Dependency Versions for referenced modules required based on different parent bundle project -->

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -116,7 +116,7 @@
     <properties>
         <hive3.version>3.1.3</hive3.version>
         <hive.version>${hive3.version}</hive.version>
-        <avatica.version>1.23.0</avatica.version>
+        <avatica.version>1.24.0</avatica.version>
         <calcite.version>1.36.0</calcite.version>
         <calcite.avatica.version>1.6.0</calcite.avatica.version>
     </properties>


### PR DESCRIPTION
# Summary

[NIFI-12518](https://issues.apache.org/jira/browse/NIFI-12518) Upgrades Apache Calcite Avatica dependencies from 1.23.0 to [1.24.0](https://calcite.apache.org/avatica/docs/history.html#v1-24-0), incorporating several bug fixes and transitive dependency updates.

This update can be backported to the support branch, but that branch does not include the `nifi-code-coverage` module, so the change would be limited to the `nifi-hive-bundle` module.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
