### PR TITLE
NIFI-12517 Enabled an attribute to be considered JSON even if it has leading and trailing spaces.

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IsJsonEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/IsJsonEvaluator.java
@@ -17,7 +17,6 @@
 package org.apache.nifi.attribute.expression.language.evaluation.functions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.attribute.expression.language.EvaluationContext;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.BooleanQueryResult;
@@ -37,13 +36,15 @@ public class IsJsonEvaluator extends BooleanEvaluator {
     @Override
     public QueryResult<Boolean> evaluate(EvaluationContext evaluationContext) {
         final String subjectValue = subject.evaluate(evaluationContext).getValue();
-        if (StringUtils.isNotBlank(subjectValue)
-                && (isPossibleJsonArray(subjectValue) || isPossibleJsonObject(subjectValue))) {
-            try {
-                MAPPER.readTree(subjectValue);
-                return new BooleanQueryResult(true);
-            } catch (IOException ignored) {
-                //IOException ignored
+        if (subjectValue != null) {
+            final String trimmedSubjectValue = subjectValue.trim();
+            if (isPossibleJsonArray(trimmedSubjectValue) || isPossibleJsonObject(trimmedSubjectValue)) {
+                try {
+                    MAPPER.readTree(trimmedSubjectValue);
+                    return new BooleanQueryResult(true);
+                } catch (IOException ignored) {
+                    //IOException ignored
+                }
             }
         }
         return new BooleanQueryResult(false);

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -2498,6 +2498,7 @@ public class TestQuery {
     void testIsJson() {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("jsonObj", "{\"name\":\"John\", \"age\":30, \"car\":null}");
+        attributes.put("jsonObjWithLeadingAndTrailingingSpaces", "\n{\"name\":\"John\", \"age\":30, \"car\":null}\n");
         attributes.put("jsonObjMissingStartingBrace", "\"name\":\"John\", \"age\":30, \"car\":null}");
         attributes.put("jsonObjMissingEndingBrace", "{\"name\":\"John\", \"age\":30, \"car\":null");
         attributes.put("jsonArray", "[\"Ford\", \"BMW\", \"Fiat\"]");
@@ -2512,6 +2513,7 @@ public class TestQuery {
         attributes.put("nullAttr", "null");
 
         verifyEquals("${jsonObj:isJson()}", attributes, true);
+        verifyEquals("${jsonObjWithLeadingAndTrailingingSpaces:isJson()}", attributes, true);
         verifyEquals("${jsonObjMissingStartingBrace:isJson()}", attributes, false);
         verifyEquals("${jsonObjMissingEndingBrace:isJson()}", attributes, false);
         verifyEquals("${jsonArray:isJson()}", attributes, true);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToJSON.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToJSON.java
@@ -324,9 +324,9 @@ public class AttributesToJSON extends AbstractProcessor {
         Map<String, Object> formattedAttributes = new LinkedHashMap<>();
         for (Map.Entry<String, Object> entry : flowFileAttributes.entrySet()) {
             String value = (String) entry.getValue();
-            if(value != null) {
+            if (value != null) {
                 final String trimmedValue = value.trim();
-                if(isPossibleJsonArray(trimmedValue) || isPossibleJsonObject(trimmedValue)) {
+                if (isPossibleJsonArray(trimmedValue) || isPossibleJsonObject(trimmedValue)) {
                     formattedAttributes.put(entry.getKey(), OBJECT_MAPPER.readTree(trimmedValue));
                     continue;
                 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToJSON.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToJSON.java
@@ -324,11 +324,14 @@ public class AttributesToJSON extends AbstractProcessor {
         Map<String, Object> formattedAttributes = new LinkedHashMap<>();
         for (Map.Entry<String, Object> entry : flowFileAttributes.entrySet()) {
             String value = (String) entry.getValue();
-            if (StringUtils.isNotBlank(value) && (isPossibleJsonArray(value) || isPossibleJsonObject(value))) {
-                formattedAttributes.put(entry.getKey(), OBJECT_MAPPER.readTree(value));
-            } else {
-                formattedAttributes.put(entry.getKey(), value);
+            if(value != null) {
+                final String trimmedValue = value.trim();
+                if(isPossibleJsonArray(trimmedValue) || isPossibleJsonObject(trimmedValue)) {
+                    formattedAttributes.put(entry.getKey(), OBJECT_MAPPER.readTree(trimmedValue));
+                    continue;
+                }
             }
+            formattedAttributes.put(entry.getKey(), value);
         }
 
         return formattedAttributes;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestAttributesToJSON.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestAttributesToJSON.java
@@ -27,7 +27,6 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.ThrowingSupplier;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestAttributesToJSON.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestAttributesToJSON.java
@@ -566,7 +566,7 @@ public class TestAttributesToJSON {
                 "    \"size\": \"Large\",\n" +
                 "    \"color\": \"Red\"\n" +
                 "}\n";
-        assertDoesNotThrow((ThrowingSupplier<Object>) () -> MAPPER.readValue(jsonBetweenLeadingAndTrailingSpaces, Map.class));
+        assertDoesNotThrow(() -> MAPPER.readValue(jsonBetweenLeadingAndTrailingSpaces, Map.class));
 
         final TestRunner testRunner = TestRunners.newTestRunner(new AttributesToJSON());
         testRunner.setProperty(AttributesToJSON.DESTINATION, AttributesToJSON.DESTINATION_CONTENT);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestAttributesToJSON.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestAttributesToJSON.java
@@ -17,6 +17,7 @@
 
 package org.apache.nifi.processors.standard;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
@@ -26,6 +27,7 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingSupplier;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -42,6 +44,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -53,6 +56,8 @@ public class TestAttributesToJSON {
 
     private static final String TEST_ATTRIBUTE_KEY = "TestAttribute";
     private static final String TEST_ATTRIBUTE_VALUE = "TestValue";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Test
     public void testInvalidUserSuppliedAttributeList() {
@@ -109,8 +114,7 @@ public class TestAttributesToJSON {
         String json = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS)
                 .get(0).getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME);
 
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, String> val = mapper.readValue(json, HashMap.class);
+        Map<String, String> val = MAPPER.readValue(json, HashMap.class);
 
         assertNull(val.get(NON_PRESENT_ATTRIBUTE_KEY));
     }
@@ -139,8 +143,7 @@ public class TestAttributesToJSON {
         String json = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS)
                 .get(0).getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME);
 
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, String> val = mapper.readValue(json, HashMap.class);
+        Map<String, String> val = MAPPER.readValue(json, HashMap.class);
 
         assertEquals(val.get(NON_PRESENT_ATTRIBUTE_KEY), "");
     }
@@ -188,8 +191,7 @@ public class TestAttributesToJSON {
         String json = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS)
                 .get(0).getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME);
 
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, String> val = mapper.readValue(json, HashMap.class);
+        Map<String, String> val = MAPPER.readValue(json, HashMap.class);
         assertTrue(val.get(TEST_ATTRIBUTE_KEY).equals(TEST_ATTRIBUTE_VALUE));
     }
 
@@ -234,8 +236,7 @@ public class TestAttributesToJSON {
         String json = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS)
                 .get(0).getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME);
 
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, String> val = mapper.readValue(json, HashMap.class);
+        Map<String, String> val = MAPPER.readValue(json, HashMap.class);
         assertTrue(val.get(TEST_ATTRIBUTE_KEY).equals(TEST_ATTRIBUTE_VALUE));
         assertTrue(val.size() == 1);
     }
@@ -262,8 +263,7 @@ public class TestAttributesToJSON {
         String json = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS)
                 .get(0).getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME);
 
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, String> val = mapper.readValue(json, HashMap.class);
+        Map<String, String> val = MAPPER.readValue(json, HashMap.class);
         assertTrue(val.get(TEST_ATTRIBUTE_KEY).equals(TEST_ATTRIBUTE_VALUE));
         assertTrue(val.size() == 1);
     }
@@ -290,8 +290,7 @@ public class TestAttributesToJSON {
         String json = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS)
                 .get(0).getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME);
 
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, String> val = mapper.readValue(json, HashMap.class);
+        Map<String, String> val = MAPPER.readValue(json, HashMap.class);
 
         //If a Attribute is requested but does not exist then it is placed in the JSON with an empty string
         assertTrue(val.get("NonExistingAttribute").equals(""));
@@ -320,8 +319,7 @@ public class TestAttributesToJSON {
         String json = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS)
                 .get(0).getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME);
 
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, String> val = mapper.readValue(json, HashMap.class);
+        Map<String, String> val = MAPPER.readValue(json, HashMap.class);
         assertEquals(TEST_ATTRIBUTE_VALUE, val.get(TEST_ATTRIBUTE_KEY));
         assertEquals(TEST_ATTRIBUTE_VALUE, val.get(CoreAttributes.PATH.key()));
         assertEquals(2, val.size());
@@ -349,8 +347,7 @@ public class TestAttributesToJSON {
         String json = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS)
                 .get(0).getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME);
 
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, String> val = mapper.readValue(json, HashMap.class);
+        Map<String, String> val = MAPPER.readValue(json, HashMap.class);
         assertEquals(TEST_ATTRIBUTE_VALUE, val.get(CoreAttributes.PATH.key()));
         assertEquals(1, val.size());
     }
@@ -372,8 +369,7 @@ public class TestAttributesToJSON {
         testRunner.assertTransferCount(AttributesToJSON.REL_SUCCESS, 1);
         testRunner.assertTransferCount(AttributesToJSON.REL_FAILURE, 0);
 
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, String> val = mapper.readValue(testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS).get(0).toByteArray(), HashMap.class);
+        Map<String, String> val = MAPPER.readValue(testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS).get(0).toByteArray(), HashMap.class);
         assertEquals(TEST_ATTRIBUTE_VALUE, val.get(TEST_ATTRIBUTE_KEY));
         assertEquals(1, val.size());
     }
@@ -399,7 +395,7 @@ public class TestAttributesToJSON {
 
         assertEquals(AttributesToJSON.APPLICATION_JSON, flowFile.getAttribute(CoreAttributes.MIME_TYPE.key()));
 
-        Map<String, String> val = new ObjectMapper().readValue(flowFile.toByteArray(), HashMap.class);
+        Map<String, String> val = MAPPER.readValue(flowFile.toByteArray(), HashMap.class);
         assertEquals(3, val.size());
         Set<String> coreAttributes = Arrays.stream(CoreAttributes.values()).map(CoreAttributes::key).collect(Collectors.toSet());
         val.keySet().forEach(k -> assertTrue(coreAttributes.contains(k)));
@@ -425,7 +421,7 @@ public class TestAttributesToJSON {
 
         assertNull(flowFile.getAttribute(CoreAttributes.MIME_TYPE.key()));
 
-        Map<String, String> val = new ObjectMapper().readValue(flowFile.getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME), HashMap.class);
+        Map<String, String> val = MAPPER.readValue(flowFile.getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME), HashMap.class);
         assertEquals(3, val.size());
         Set<String> coreAttributes = Arrays.stream(CoreAttributes.values()).map(CoreAttributes::key).collect(Collectors.toSet());
         val.keySet().forEach(k -> assertTrue(coreAttributes.contains(k)));
@@ -455,7 +451,7 @@ public class TestAttributesToJSON {
 
         MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS).get(0);
 
-        Map<String, String> val = new ObjectMapper().readValue(flowFile.getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME), HashMap.class);
+        Map<String, String> val = MAPPER.readValue(flowFile.getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME), HashMap.class);
         assertTrue(val.keySet().contains("delimited.header.column.1"));
         assertTrue(val.keySet().contains("delimited.header.column.2"));
         assertTrue(val.keySet().contains("delimited.header.column.3"));
@@ -485,7 +481,7 @@ public class TestAttributesToJSON {
         List<MockFlowFile> flowFilesForRelationship = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS);
         MockFlowFile flowFile = flowFilesForRelationship.get(0);
         assertEquals(AttributesToJSON.APPLICATION_JSON, flowFile.getAttribute(CoreAttributes.MIME_TYPE.key()));
-        Map<String, Object> val = new ObjectMapper().readValue(flowFile.toByteArray(), Map.class);
+        Map<String, Object> val = MAPPER.readValue(flowFile.toByteArray(), Map.class);
         assertInstanceOf(expectedClass, val.get(TEST_ATTRIBUTE_KEY));
     }
 
@@ -516,8 +512,7 @@ public class TestAttributesToJSON {
 
         String json = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS)
                 .get(0).getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME);
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> val = mapper.readValue(json, Map.class);
+        Map<String, Object> val = MAPPER.readValue(json, Map.class);
         assertInstanceOf(expectedClass, val.get(TEST_ATTRIBUTE_KEY));
     }
 
@@ -560,8 +555,34 @@ public class TestAttributesToJSON {
 
         String json = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS)
                 .get(0).getAttribute(AttributesToJSON.JSON_ATTRIBUTE_NAME);
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> val = mapper.readValue(json, Map.class);
+        Map<String, Object> val = MAPPER.readValue(json, Map.class);
         assertInstanceOf(String.class, val.get(TEST_ATTRIBUTE_KEY));
+    }
+
+    @Test
+    public void testAttributeWithJsonBetweenLeadingAndTrailingSpaces() throws JsonProcessingException {
+        final String jsonBetweenLeadingAndTrailingSpaces = "\n{\n" +
+                "    \"fruit\": \"Apple\",\n" +
+                "    \"size\": \"Large\",\n" +
+                "    \"color\": \"Red\"\n" +
+                "}\n";
+        assertDoesNotThrow((ThrowingSupplier<Object>) () -> MAPPER.readValue(jsonBetweenLeadingAndTrailingSpaces, Map.class));
+
+        final TestRunner testRunner = TestRunners.newTestRunner(new AttributesToJSON());
+        testRunner.setProperty(AttributesToJSON.DESTINATION, AttributesToJSON.DESTINATION_CONTENT);
+        testRunner.setProperty(AttributesToJSON.JSON_HANDLING_STRATEGY,
+                AttributesToJSON.JsonHandlingStrategy.NESTED.getValue());
+
+        ProcessSession session = testRunner.getProcessSessionFactory().createSession();
+        FlowFile ff = session.create();
+        ff = session.putAttribute(ff, TEST_ATTRIBUTE_KEY, jsonBetweenLeadingAndTrailingSpaces);
+        testRunner.enqueue(ff);
+        testRunner.run();
+
+        testRunner.assertTransferCount(AttributesToJSON.REL_FAILURE, 0);
+        testRunner.assertTransferCount(AttributesToJSON.REL_SUCCESS, 1);
+        MockFlowFile result = testRunner.getFlowFilesForRelationship(AttributesToJSON.REL_SUCCESS).get(0);
+        Map<String, Object> attributes = MAPPER.readValue(result.getContent(), Map.class);
+        assertInstanceOf(Map.class, attributes.get(TEST_ATTRIBUTE_KEY));
     }
 }


### PR DESCRIPTION


<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12517](https://issues.apache.org/jira/browse/NIFI-12517)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
