### PR TITLE
NIFI-12530: Support CREATE TABLE in Oracle database adapters

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/Oracle12DatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/Oracle12DatabaseAdapter.java
@@ -22,11 +22,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.processors.standard.db.ColumnDescription;
 import org.apache.nifi.processors.standard.db.DatabaseAdapter;
+import org.apache.nifi.processors.standard.db.TableSchema;
 
 import static java.sql.Types.CHAR;
 import static java.sql.Types.CLOB;
@@ -253,4 +255,43 @@ public class Oracle12DatabaseAdapter implements DatabaseAdapter {
         }
     }
 
+    @Override
+    public boolean supportsCreateTableIfNotExists() {
+        return true;
+    }
+
+    /**
+     * Generates a CREATE TABLE statement using the specified table schema
+     * @param tableSchema The table schema including column information
+     * @param quoteTableName Whether to quote the table name in the generated DDL
+     * @param quoteColumnNames Whether to quote column names in the generated DDL
+     * @return A String containing DDL to create the specified table
+     */
+    @Override
+    public String getCreateTableStatement(TableSchema tableSchema, boolean quoteTableName, boolean quoteColumnNames) {
+        StringBuilder createTableStatement = new StringBuilder();
+
+        List<ColumnDescription> columns = tableSchema.getColumnsAsList();
+        List<String> columnsAndDatatypes = new ArrayList<>(columns.size());
+        Set<String> primaryKeyColumnNames = tableSchema.getPrimaryKeyColumnNames();
+        for (ColumnDescription column : columns) {
+            String sb = (quoteColumnNames ? getColumnQuoteString() : "")
+                    + column.getColumnName()
+                    + (quoteColumnNames ? getColumnQuoteString() : "")
+                    + " " + getSQLForDataType(column.getDataType())
+                    + (column.isNullable() ? "" : " NOT NULL")
+                    + (primaryKeyColumnNames != null && primaryKeyColumnNames.contains(column.getColumnName()) ? " PRIMARY KEY" : "");
+            columnsAndDatatypes.add(sb);
+        }
+
+        createTableStatement
+                .append("DECLARE\n\tsql_stmt long;\nBEGIN\n\tsql_stmt:='CREATE TABLE ")
+                .append(generateTableName(quoteTableName, tableSchema.getCatalogName(), tableSchema.getSchemaName(), tableSchema.getTableName(), tableSchema))
+                .append(" (")
+                .append(String.join(", ", columnsAndDatatypes))
+                .append(")';\nEXECUTE IMMEDIATE sql_stmt;\nEXCEPTION\n\tWHEN OTHERS THEN\n\t\tIF SQLCODE = -955 THEN\n\t\t\t")
+                .append("NULL;\n\t\tELSE\n\t\t\tRAISE;\n\t\tEND IF;\nEND;");
+
+        return createTableStatement.toString();
+    }
 }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/OracleDatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/OracleDatabaseAdapter.java
@@ -191,26 +191,27 @@ public class OracleDatabaseAdapter implements DatabaseAdapter {
      */
     @Override
     public String getCreateTableStatement(TableSchema tableSchema, boolean quoteTableName, boolean quoteColumnNames) {
-        StringBuilder createTableStatement = new StringBuilder();
+        StringBuilder createTableStatement = new StringBuilder()
+                .append("DECLARE\n\tsql_stmt long;\nBEGIN\n\tsql_stmt:='CREATE TABLE ")
+                .append(generateTableName(quoteTableName, tableSchema.getCatalogName(), tableSchema.getSchemaName(), tableSchema.getTableName(), tableSchema))
+                .append(" (");
 
         List<ColumnDescription> columns = tableSchema.getColumnsAsList();
-        List<String> columnsAndDatatypes = new ArrayList<>(columns.size());
         Set<String> primaryKeyColumnNames = tableSchema.getPrimaryKeyColumnNames();
-        for (ColumnDescription column : columns) {
-            String sb = (quoteColumnNames ? getColumnQuoteString() : "")
-                    + column.getColumnName()
-                    + (quoteColumnNames ? getColumnQuoteString() : "")
-                    + " " + getSQLForDataType(column.getDataType())
-                    + (column.isNullable() ? "" : " NOT NULL")
-                    + (primaryKeyColumnNames != null && primaryKeyColumnNames.contains(column.getColumnName()) ? " PRIMARY KEY" : "");
-            columnsAndDatatypes.add(sb);
+        for (int i = 0; i < columns.size(); i++) {
+            ColumnDescription column = columns.get(i);
+            createTableStatement
+                    .append((i != 0) ? ", " : "")
+                    .append(quoteColumnNames ? getColumnQuoteString() : "")
+                    .append(column.getColumnName())
+                    .append(quoteColumnNames ? getColumnQuoteString() : "")
+                    .append(" ")
+                    .append(getSQLForDataType(column.getDataType()))
+                    .append(column.isNullable() ? "" : " NOT NULL")
+                    .append(primaryKeyColumnNames != null && primaryKeyColumnNames.contains(column.getColumnName()) ? " PRIMARY KEY" : "");
         }
 
         createTableStatement
-                .append("DECLARE\n\tsql_stmt long;\nBEGIN\n\tsql_stmt:='CREATE TABLE ")
-                .append(generateTableName(quoteTableName, tableSchema.getCatalogName(), tableSchema.getSchemaName(), tableSchema.getTableName(), tableSchema))
-                .append(" (")
-                .append(String.join(", ", columnsAndDatatypes))
                 .append(")';\nEXECUTE IMMEDIATE sql_stmt;\nEXCEPTION\n\tWHEN OTHERS THEN\n\t\tIF SQLCODE = -955 THEN\n\t\t\t")
                 .append("NULL;\n\t\tELSE\n\t\t\tRAISE;\n\t\tEND IF;\nEND;");
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestOracle12DatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestOracle12DatabaseAdapter.java
@@ -152,7 +152,6 @@ public class TestOracle12DatabaseAdapter {
         // THEN
         testGetUpsertStatement(tableName, columnNames, uniqueKeyColumnNames, expected);
     }
-
     @Test
     public void testGetCreateTableStatement() {
         assertTrue(db.supportsCreateTableIfNotExists());
@@ -170,6 +169,7 @@ public class TestOracle12DatabaseAdapter {
         String actualStatement = db.getCreateTableStatement(tableSchema, true, true);
         assertEquals(expectedStatement, actualStatement);
     }
+
 
     private void testGetUpsertStatement(String tableName, List<String> columnNames, Collection<String> uniqueKeyColumnNames, IllegalArgumentException expected) {
         final IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestOracle12DatabaseAdapter.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestOracle12DatabaseAdapter.java
@@ -16,12 +16,15 @@
  */
 package org.apache.nifi.processors.standard.db.impl;
 
+import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.nifi.processors.standard.db.ColumnDescription;
 import org.apache.nifi.processors.standard.db.DatabaseAdapter;
+import org.apache.nifi.processors.standard.db.TableSchema;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -148,6 +151,24 @@ public class TestOracle12DatabaseAdapter {
         // WHEN
         // THEN
         testGetUpsertStatement(tableName, columnNames, uniqueKeyColumnNames, expected);
+    }
+
+    @Test
+    public void testGetCreateTableStatement() {
+        assertTrue(db.supportsCreateTableIfNotExists());
+        final List<ColumnDescription> columns = Arrays.asList(
+                new ColumnDescription("col1", Types.INTEGER, true, 4, false),
+                new ColumnDescription("col2", Types.VARCHAR, false, 2000, true)
+        );
+        TableSchema tableSchema = new TableSchema("USERS", null, "TEST_TABLE", columns, true, Collections.singleton("COL1"), db.getColumnQuoteString());
+
+        String expectedStatement = "DECLARE\n\tsql_stmt long;\nBEGIN\n\tsql_stmt:='CREATE TABLE "
+                // Strings are returned as VARCHAR2(2000) regardless of reported size and that VARCHAR2 is not in java.sql.Types
+                + "\"USERS\".\"TEST_TABLE\" (\"col1\" INTEGER NOT NULL, \"col2\" VARCHAR2(2000))';"
+                + "\nEXECUTE IMMEDIATE sql_stmt;\nEXCEPTION\n\tWHEN OTHERS THEN\n\t\tIF SQLCODE = -955 THEN\n\t\t\t"
+                + "NULL;\n\t\tELSE\n\t\t\tRAISE;\n\t\tEND IF;\nEND;";
+        String actualStatement = db.getCreateTableStatement(tableSchema, true, true);
+        assertEquals(expectedStatement, actualStatement);
     }
 
     private void testGetUpsertStatement(String tableName, List<String> columnNames, Collection<String> uniqueKeyColumnNames, IllegalArgumentException expected) {


### PR DESCRIPTION
# Summary

[NIFI-12530](https://issues.apache.org/jira/browse/NIFI-12530) This PR adds support for CREATE TABLE (via UpdateDatabaseRecord) for the two existing Oracle database adapters.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
