### PR TITLE
NIFI-12531 Parameter references are removed after property migration

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/StandardProcessorNode.java
@@ -2110,7 +2110,7 @@ public class StandardProcessorNode extends ProcessorNode implements Connectable 
             final List<ControllerServiceCreationDetails> servicesCreated = propertyConfig.getCreatedServices();
             servicesCreated.forEach(serviceFactory::create);
 
-            overwriteProperties(propertyConfig.getProperties());
+            overwriteProperties(propertyConfig.getRawProperties());
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/reporting/AbstractReportingTaskNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/reporting/AbstractReportingTaskNode.java
@@ -452,7 +452,7 @@ public abstract class AbstractReportingTaskNode extends AbstractComponentNode im
             final List<ControllerServiceCreationDetails> servicesCreated = propertyConfig.getCreatedServices();
             servicesCreated.forEach(serviceFactory::create);
 
-            overwriteProperties(propertyConfig.getProperties());
+            overwriteProperties(propertyConfig.getRawProperties());
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
@@ -858,7 +858,7 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
             final List<ControllerServiceCreationDetails> servicesCreated = propertyConfig.getCreatedServices();
             servicesCreated.forEach(serviceFactory::create);
 
-            overwriteProperties(propertyConfig.getProperties());
+            overwriteProperties(propertyConfig.getRawProperties());
         }
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/migration/StandardPropertyConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/migration/StandardPropertyConfiguration.java
@@ -57,6 +57,11 @@ public class StandardPropertyConfiguration implements PropertyConfiguration {
             return false;
         }
 
+        if (Objects.equals(propertyName, newName)) {
+            logger.debug("Will not update property [{}] for [{}] because the new name and the current name are the same", propertyName, componentDescription);
+            return false;
+        }
+
         final String effectivePropertyValue = effectiveProperties.remove(propertyName);
         effectiveProperties.put(newName, effectivePropertyValue);
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/migration/TestStandardPropertyConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/migration/TestStandardPropertyConfiguration.java
@@ -108,6 +108,18 @@ public class TestStandardPropertyConfiguration {
     }
 
     @Test
+    public void testRenamePropertyToSameName() {
+        assertFalse(config.renameProperty("a", "a"));
+
+        assertFalse(config.isModified());
+        assertTrue(config.hasProperty("a"));
+        assertTrue(config.isPropertySet("a"));
+
+        final Map<String, String> expectedProperties = new HashMap<>(originalProperties);
+        assertEquals(expectedProperties, config.getProperties());
+    }
+
+    @Test
     public void testRenameNullProperty() {
         assertTrue(config.renameProperty("c", "X"));
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -225,7 +225,7 @@ public class InvokeHTTP extends AbstractProcessor {
             .build();
 
     public static final PropertyDescriptor SOCKET_CONNECT_TIMEOUT = new PropertyDescriptor.Builder()
-            .name("Connection Timeout")
+            .name("Socket Connection Timeout")
             .description("Maximum time to wait for initial socket connection to the HTTP URL.")
             .required(true)
             .defaultValue("5 secs")

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -225,7 +225,7 @@ public class InvokeHTTP extends AbstractProcessor {
             .build();
 
     public static final PropertyDescriptor SOCKET_CONNECT_TIMEOUT = new PropertyDescriptor.Builder()
-            .name("Socket Connection Timeout")
+            .name("Connection Timeout")
             .description("Maximum time to wait for initial socket connection to the HTTP URL.")
             .required(true)
             .defaultValue("5 secs")
@@ -596,7 +596,6 @@ public class InvokeHTTP extends AbstractProcessor {
 
     @Override
     public void migrateProperties(final PropertyConfiguration config) {
-        config.renameProperty("Connection Timeout", SOCKET_CONNECT_TIMEOUT.getName());
         config.renameProperty("Read Timeout", SOCKET_READ_TIMEOUT.getName());
         config.renameProperty("Remote URL", HTTP_URL.getName());
         config.renameProperty("disable-http2", HTTP2_DISABLED.getName());


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12531](https://issues.apache.org/jira/browse/NIFI-12531)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
