### PR TITLE
NIFI-12394 when synching to a VersionedFlow, make sure processor references to new controller services are valid

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -1438,8 +1438,6 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                         // Find the same property descriptor in the component's CreatedExtension and replace it with the
                         // instance ID of the service
                         createdExtensions.stream().filter(ce -> ce.extension.equals(componentNode)).forEach(createdExtension -> {
-                            LOG.debug("Replacing CreatedExtension property {} old value {} with new value {}",
-                                    propertyName, createdExtension.propertyValues.get(propertyName) , value);
                             createdExtension.propertyValues.replace(propertyName, value);
                         });
                     } else {


### PR DESCRIPTION
NIFI-12394 when synching to a VersionedFlow, make sure processor references to new controller services are valid after the processor migrates the configuration of its properties.

This change is to update controller service references in the CreatedExtension properties. This is important when calling migrateConfiguration on the component, because that uses the CreatedExtension properties as its "original" properties to migrate.

- made sure CreatedExtension was created before the component is updated
- made controller service reference value "final" so I can use it inside lambda function
- fixed an unrelated but minor log INFO message problem
- added unit test for synchronizing a new process group with an external flow definition

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12394](https://issues.apache.org/jira/browse/NIFI-12394)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
