### PR TITLE
NIFI-12545 Update components in iceberg bundle using current API methods

### DIFF
--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/catalog/IcebergCatalogFactory.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/catalog/IcebergCatalogFactory.java
@@ -41,14 +41,10 @@ public class IcebergCatalogFactory {
     }
 
     public Catalog create() {
-        switch (catalogService.getCatalogType()) {
-            case HIVE:
-                return initHiveCatalog(catalogService);
-            case HADOOP:
-                return initHadoopCatalog(catalogService);
-            default:
-                throw new IllegalArgumentException("Unknown catalog type: " + catalogService.getCatalogType());
-        }
+        return switch (catalogService.getCatalogType()) {
+            case HIVE -> initHiveCatalog(catalogService);
+            case HADOOP -> initHadoopCatalog(catalogService);
+        };
     }
 
     private Catalog initHiveCatalog(IcebergCatalogService catalogService) {

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
@@ -187,8 +187,7 @@ public class GenericDataConverters {
             if (data == null) {
                 return null;
             }
-            if (data instanceof BigDecimal) {
-                BigDecimal bigDecimal = (BigDecimal) data;
+            if (data instanceof BigDecimal bigDecimal) {
                 Validate.isTrue(bigDecimal.scale() == scale, "Cannot write value as decimal(%s,%s), wrong scale %s for value: %s", precision, scale, bigDecimal.scale(), data);
                 Validate.isTrue(bigDecimal.precision() <= precision, "Cannot write value as decimal(%s,%s), invalid precision %s for value: %s",
                         precision, scale, bigDecimal.precision(), data);

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
@@ -512,7 +512,7 @@ public class TestIcebergRecordConverter {
         List<GenericRecord> results = readFrom(format, PRIMITIVES_SCHEMA, tempFile.toInputFile());
 
         assertEquals(results.size(), 1);
-        GenericRecord resultRecord = results.get(0);
+        GenericRecord resultRecord = results.getFirst();
 
         LocalDateTime localDateTime = LocalDateTime.of(2017, 4, 4, 14, 20, 33, 789000000);
         OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(-5));
@@ -555,7 +555,7 @@ public class TestIcebergRecordConverter {
         List<GenericRecord> results = readFrom(format, PRIMITIVES_SCHEMA, tempFile.toInputFile());
 
         assertEquals(results.size(), 1);
-        GenericRecord resultRecord = results.get(0);
+        GenericRecord resultRecord = results.getFirst();
 
         LocalDateTime localDateTime = LocalDateTime.of(2017, 4, 4, 14, 20, 33, 789000000);
         OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(-5));
@@ -598,7 +598,7 @@ public class TestIcebergRecordConverter {
         results = readFrom(format, PRIMITIVES_SCHEMA, tempFile.toInputFile());
 
         assertEquals(results.size(), 1);
-        resultRecord = results.get(0);
+        resultRecord = results.getFirst();
         assertNull(resultRecord.get(0, String.class));
         assertNull(resultRecord.get(1, Integer.class));
         assertNull(resultRecord.get(2, Float.class));
@@ -641,7 +641,7 @@ public class TestIcebergRecordConverter {
         List<GenericRecord> results = readFrom(format, PRIMITIVES_SCHEMA, tempFile.toInputFile());
 
         assertEquals(results.size(), 1);
-        GenericRecord resultRecord = results.get(0);
+        GenericRecord resultRecord = results.getFirst();
 
         LocalDateTime localDateTime = LocalDateTime.of(2017, 4, 4, 14, 20, 33, 789000000);
         OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(-5));
@@ -699,7 +699,7 @@ public class TestIcebergRecordConverter {
         List<GenericRecord> results = readFrom(format, COMPATIBLE_PRIMITIVES_SCHEMA, tempFile.toInputFile());
 
         assertEquals(results.size(), 1);
-        GenericRecord resultRecord = results.get(0);
+        GenericRecord resultRecord = results.getFirst();
 
         LocalDateTime localDateTime = LocalDateTime.of(2017, 4, 4, 14, 20, 33, 789000000);
         OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(-5));
@@ -737,8 +737,7 @@ public class TestIcebergRecordConverter {
         List<GenericRecord> results = readFrom(format, STRUCT_SCHEMA, tempFile.toInputFile());
 
         assertEquals(1, results.size());
-        assertInstanceOf(GenericRecord.class, results.get(0));
-        GenericRecord resultRecord = results.get(0);
+        GenericRecord resultRecord = results.getFirst();
 
         assertEquals(1, resultRecord.size());
         assertInstanceOf(GenericRecord.class, resultRecord.get(0));
@@ -767,8 +766,7 @@ public class TestIcebergRecordConverter {
         List<GenericRecord> results = readFrom(format, LIST_SCHEMA, tempFile.toInputFile());
 
         assertEquals(1, results.size());
-        assertInstanceOf(GenericRecord.class, results.get(0));
-        GenericRecord resultRecord = results.get(0);
+        GenericRecord resultRecord = results.getFirst();
 
         assertEquals(1, resultRecord.size());
         assertInstanceOf(List.class, resultRecord.get(0));
@@ -797,8 +795,7 @@ public class TestIcebergRecordConverter {
         List<GenericRecord> results = readFrom(format, MAP_SCHEMA, tempFile.toInputFile());
 
         assertEquals(1, results.size());
-        assertInstanceOf(GenericRecord.class, results.get(0));
-        GenericRecord resultRecord = results.get(0);
+        GenericRecord resultRecord = results.getFirst();
 
         assertEquals(1, resultRecord.size());
         assertInstanceOf(Map.class, resultRecord.get(0));
@@ -837,8 +834,7 @@ public class TestIcebergRecordConverter {
         List<GenericRecord> results = readFrom(format, CASE_INSENSITIVE_SCHEMA, tempFile.toInputFile());
 
         assertEquals(1, results.size());
-        assertInstanceOf(GenericRecord.class, results.get(0));
-        GenericRecord resultRecord = results.get(0);
+        GenericRecord resultRecord = results.getFirst();
 
         assertEquals("Text1", resultRecord.get(0, String.class));
         assertEquals("Text2", resultRecord.get(1, String.class));
@@ -861,8 +857,7 @@ public class TestIcebergRecordConverter {
         List<GenericRecord> results = readFrom(format, UNORDERED_SCHEMA, tempFile.toInputFile());
 
         assertEquals(1, results.size());
-        assertInstanceOf(GenericRecord.class, results.get(0));
-        GenericRecord resultRecord = results.get(0);
+        GenericRecord resultRecord = results.getFirst();
 
         assertEquals("value1", resultRecord.get(0, String.class));
 
@@ -926,15 +921,12 @@ public class TestIcebergRecordConverter {
     }
 
     private ArrayList<GenericRecord> readFrom(FileFormat format, Schema schema, InputFile inputFile) throws IOException {
-        switch (format) {
-            case AVRO:
-                return readFromAvro(schema, inputFile);
-            case ORC:
-                return readFromOrc(schema, inputFile);
-            case PARQUET:
-                return readFromParquet(schema, inputFile);
-        }
-        throw new IOException("Unknown file format: " + format);
+        return switch (format) {
+            case AVRO -> readFromAvro(schema, inputFile);
+            case ORC -> readFromOrc(schema, inputFile);
+            case PARQUET -> readFromParquet(schema, inputFile);
+            default -> throw new IOException("Unknown file format: " + format);
+        };
     }
 
     private void writeToAvro(Schema schema, GenericRecord record, OutputFile outputFile) throws IOException {

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestPutIcebergWithHadoopCatalog.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestPutIcebergWithHadoopCatalog.java
@@ -138,7 +138,7 @@ public class TestPutIcebergWithHadoopCatalog {
         Table table = catalog.loadTable(TABLE_IDENTIFIER);
 
         runner.assertTransferCount(PutIceberg.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).getFirst();
 
         Assertions.assertTrue(table.spec().isPartitioned());
         Assertions.assertEquals("4", flowFile.getAttribute(ICEBERG_RECORD_COUNT));
@@ -165,7 +165,7 @@ public class TestPutIcebergWithHadoopCatalog {
         Table table = catalog.loadTable(TABLE_IDENTIFIER);
 
         runner.assertTransferCount(PutIceberg.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).getFirst();
 
         Assertions.assertTrue(table.spec().isPartitioned());
         Assertions.assertEquals("4", flowFile.getAttribute(ICEBERG_RECORD_COUNT));
@@ -193,7 +193,7 @@ public class TestPutIcebergWithHadoopCatalog {
         Table table = catalog.loadTable(TABLE_IDENTIFIER);
 
         runner.assertTransferCount(PutIceberg.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).getFirst();
 
         Assertions.assertTrue(table.spec().isPartitioned());
         Assertions.assertEquals("4", flowFile.getAttribute(ICEBERG_RECORD_COUNT));

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestPutIcebergWithHiveCatalog.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestPutIcebergWithHiveCatalog.java
@@ -169,7 +169,7 @@ public class TestPutIcebergWithHiveCatalog {
                 .build();
 
         runner.assertTransferCount(PutIceberg.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).getFirst();
 
         String tableLocation = new URI(table.location()).getPath();
         assertTrue(table.spec().isPartitioned());
@@ -206,7 +206,7 @@ public class TestPutIcebergWithHiveCatalog {
                 .build();
 
         runner.assertTransferCount(PutIceberg.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).getFirst();
 
         String tableLocation = new URI(table.location()).getPath();
         assertTrue(table.spec().isPartitioned());
@@ -244,7 +244,7 @@ public class TestPutIcebergWithHiveCatalog {
                 .build();
 
         runner.assertTransferCount(PutIceberg.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).getFirst();
 
         String tableLocation = new URI(table.location()).getPath();
         assertTrue(table.spec().isPartitioned());
@@ -286,7 +286,7 @@ public class TestPutIcebergWithHiveCatalog {
                 .build();
 
         runner.assertTransferCount(PutIceberg.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutIceberg.REL_SUCCESS).getFirst();
 
         assertTrue(table.spec().isUnpartitioned());
         assertEquals("4", flowFile.getAttribute(ICEBERG_RECORD_COUNT));
@@ -299,7 +299,7 @@ public class TestPutIcebergWithHiveCatalog {
     private void assertProvenanceEvents() {
         final List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();
         assertEquals(1, provenanceEvents.size());
-        final ProvenanceEventRecord sendEvent = provenanceEvents.get(0);
+        final ProvenanceEventRecord sendEvent = provenanceEvents.getFirst();
         assertEquals(ProvenanceEventType.SEND, sendEvent.getEventType());
         assertTrue(sendEvent.getTransitUri().endsWith(CATALOG_NAME + ".db/" + TABLE_NAME));
     }

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/util/IcebergTestUtils.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/util/IcebergTestUtils.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -88,7 +87,7 @@ public class IcebergTestUtils {
         List<Path> dataFiles = Files.walk(Paths.get(tableLocation + "/data"))
                 .filter(Files::isRegularFile)
                 .filter(path -> !path.getFileName().toString().startsWith("."))
-                .collect(Collectors.toList());
+                .toList();
 
         assertEquals(numberOfDataFiles, dataFiles.size());
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Refactor tests and components in `iceberg` bundle to use updated APIs from [NIFI-12452](https://issues.apache.org/jira/browse/NIFI-12452).

Additionally, makes use of newer Java APIs, e.g. `List.of` and `Set.of` for declaration of relationships and properties.

[NIFI-12545](https://issues.apache.org/jira/browse/NIFI-12545)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
