### PR TITLE
NIFI-12557 Refactor components in kafka bundle using current API methods

### DIFF
--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
@@ -29,21 +29,21 @@ import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.annotation.lifecycle.OnUnscheduled;
 import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.kafka.shared.attribute.KafkaFlowFileAttribute;
-import org.apache.nifi.kafka.shared.property.KeyEncoding;
-import org.apache.nifi.kafka.shared.validation.KafkaClientCustomValidationFunction;
 import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
+import org.apache.nifi.kafka.shared.property.KeyEncoding;
 import org.apache.nifi.kafka.shared.property.provider.KafkaPropertyProvider;
 import org.apache.nifi.kafka.shared.property.provider.StandardKafkaPropertyProvider;
 import org.apache.nifi.kafka.shared.validation.DynamicPropertyValidator;
+import org.apache.nifi.kafka.shared.validation.KafkaClientCustomValidationFunction;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.AbstractProcessor;
-import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
@@ -86,13 +86,10 @@ import java.util.regex.Pattern;
 public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientComponent, VerifiableProcessor {
 
     static final AllowableValue OFFSET_EARLIEST = new AllowableValue("earliest", "earliest", "Automatically reset the offset to the earliest offset");
-
     static final AllowableValue OFFSET_LATEST = new AllowableValue("latest", "latest", "Automatically reset the offset to the latest offset");
-
     static final AllowableValue OFFSET_NONE = new AllowableValue("none", "none", "Throw exception to the consumer if no previous offset is found for the consumer's group");
 
     static final AllowableValue TOPIC_NAME = new AllowableValue("names", "names", "Topic is a full topic name or comma separated list of names");
-
     static final AllowableValue TOPIC_PATTERN = new AllowableValue("pattern", "pattern", "Topic is a regex using the Java Pattern syntax");
 
     static final PropertyDescriptor TOPICS = new PropertyDescriptor.Builder()
@@ -110,7 +107,7 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
             .description("Specifies whether the Topic(s) provided are a comma separated list of names or a single regular expression")
             .required(true)
             .allowableValues(TOPIC_NAME, TOPIC_PATTERN)
-            .defaultValue(TOPIC_NAME.getValue())
+            .defaultValue(TOPIC_NAME)
             .build();
 
     static final PropertyDescriptor GROUP_ID = new PropertyDescriptor.Builder()
@@ -129,7 +126,7 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
                     + "more on the server (e.g. because that data has been deleted). Corresponds to Kafka's 'auto.offset.reset' property.")
             .required(true)
             .allowableValues(OFFSET_EARLIEST, OFFSET_LATEST, OFFSET_NONE)
-            .defaultValue(OFFSET_LATEST.getValue())
+            .defaultValue(OFFSET_LATEST)
             .build();
 
     static final PropertyDescriptor KEY_ATTRIBUTE_ENCODING = new PropertyDescriptor.Builder()
@@ -137,7 +134,7 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
             .displayName("Key Attribute Encoding")
             .description("FlowFiles that are emitted have an attribute named '" + KafkaFlowFileAttribute.KAFKA_KEY + "'. This property dictates how the value of the attribute should be encoded.")
             .required(true)
-            .defaultValue(KeyEncoding.UTF8.getValue())
+            .defaultValue(KeyEncoding.UTF8)
             .allowableValues(KeyEncoding.class)
             .build();
 
@@ -248,42 +245,36 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
         .description("FlowFiles received from Kafka. Depending on demarcation strategy it is a flow file per message or a bundle of messages grouped by topic and partition.")
         .build();
 
-    static final List<PropertyDescriptor> DESCRIPTORS;
-    static final Set<Relationship> RELATIONSHIPS;
+    static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+            BOOTSTRAP_SERVERS,
+            TOPICS,
+            TOPIC_TYPE,
+            GROUP_ID,
+            COMMIT_OFFSETS,
+            MAX_UNCOMMITTED_TIME,
+            HONOR_TRANSACTIONS,
+            MESSAGE_DEMARCATOR,
+            SEPARATE_BY_KEY,
+            SECURITY_PROTOCOL,
+            SASL_MECHANISM,
+            SELF_CONTAINED_KERBEROS_USER_SERVICE,
+            KERBEROS_SERVICE_NAME,
+            SASL_USERNAME,
+            SASL_PASSWORD,
+            TOKEN_AUTHENTICATION,
+            AWS_PROFILE_NAME,
+            SSL_CONTEXT_SERVICE,
+            KEY_ATTRIBUTE_ENCODING,
+            AUTO_OFFSET_RESET,
+            MESSAGE_HEADER_ENCODING,
+            HEADER_NAME_REGEX,
+            MAX_POLL_RECORDS,
+            COMMS_TIMEOUT
+    );
+    static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
 
     private volatile ConsumerPool consumerPool = null;
     private final Set<ConsumerLease> activeLeases = Collections.synchronizedSet(new HashSet<>());
-
-    static {
-        final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(BOOTSTRAP_SERVERS);
-        descriptors.add(TOPICS);
-        descriptors.add(TOPIC_TYPE);
-        descriptors.add(GROUP_ID);
-        descriptors.add(COMMIT_OFFSETS);
-        descriptors.add(MAX_UNCOMMITTED_TIME);
-        descriptors.add(HONOR_TRANSACTIONS);
-        descriptors.add(MESSAGE_DEMARCATOR);
-        descriptors.add(SEPARATE_BY_KEY);
-        descriptors.add(SECURITY_PROTOCOL);
-        descriptors.add(SASL_MECHANISM);
-        descriptors.add(SELF_CONTAINED_KERBEROS_USER_SERVICE);
-        descriptors.add(KERBEROS_SERVICE_NAME);
-        descriptors.add(SASL_USERNAME);
-        descriptors.add(SASL_PASSWORD);
-        descriptors.add(TOKEN_AUTHENTICATION);
-        descriptors.add(AWS_PROFILE_NAME);
-        descriptors.add(SSL_CONTEXT_SERVICE);
-        descriptors.add(KEY_ATTRIBUTE_ENCODING);
-        descriptors.add(AUTO_OFFSET_RESET);
-        descriptors.add(MESSAGE_HEADER_ENCODING);
-        descriptors.add(HEADER_NAME_REGEX);
-        descriptors.add(MAX_POLL_RECORDS);
-        descriptors.add(COMMS_TIMEOUT);
-
-        DESCRIPTORS = Collections.unmodifiableList(descriptors);
-        RELATIONSHIPS = Collections.singleton(REL_SUCCESS);
-    }
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -369,7 +360,6 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
     }
 
     protected ConsumerPool createConsumerPool(final ProcessContext context, final ComponentLog log) {
-        final int maxLeases = context.getMaxConcurrentTasks();
         final Long maxUncommittedTime = context.getProperty(MAX_UNCOMMITTED_TIME).asTimePeriod(TimeUnit.MILLISECONDS);
         final boolean commitOffsets = context.getProperty(COMMIT_OFFSETS).asBoolean();
 
@@ -384,7 +374,7 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
         final String topicListing = context.getProperty(ConsumeKafka_2_6.TOPICS).evaluateAttributeExpressions().getValue();
         final String topicType = context.getProperty(ConsumeKafka_2_6.TOPIC_TYPE).evaluateAttributeExpressions().getValue();
         final List<String> topics = new ArrayList<>();
-        final String keyEncoding = context.getProperty(KEY_ATTRIBUTE_ENCODING).getValue();
+        final KeyEncoding keyEncoding = context.getProperty(KEY_ATTRIBUTE_ENCODING).asDescribedValue(KeyEncoding.class);
         final String securityProtocol = context.getProperty(SECURITY_PROTOCOL).getValue();
         final String bootstrapServers = context.getProperty(BOOTSTRAP_SERVERS).evaluateAttributeExpressions().getValue();
         final boolean honorTransactions = context.getProperty(HONOR_TRANSACTIONS).asBoolean();
@@ -414,11 +404,11 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
                 }
             }
 
-            return new ConsumerPool(maxLeases, demarcator, separateByKey, props, topics, maxUncommittedTime, keyEncoding, securityProtocol,
+            return new ConsumerPool(demarcator, separateByKey, props, topics, maxUncommittedTime, keyEncoding, securityProtocol,
                 bootstrapServers, log, honorTransactions, charset, headerNamePattern, partitionsToConsume, commitOffsets);
         } else if (topicType.equals(TOPIC_PATTERN.getValue())) {
             final Pattern topicPattern = Pattern.compile(topicListing.trim());
-            return new ConsumerPool(maxLeases, demarcator, separateByKey, props, topicPattern, maxUncommittedTime, keyEncoding, securityProtocol,
+            return new ConsumerPool(demarcator, separateByKey, props, topicPattern, maxUncommittedTime, keyEncoding, securityProtocol,
                 bootstrapServers, log, honorTransactions, charset, headerNamePattern, partitionsToConsume, commitOffsets);
         } else {
             getLogger().error("Subscription type has an unknown value {}", topicType);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumerPool.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumerPool.java
@@ -26,6 +26,8 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.ConfigVerificationResult.Outcome;
+import org.apache.nifi.kafka.shared.property.KeyEncoding;
+import org.apache.nifi.kafka.shared.property.KeyFormat;
 import org.apache.nifi.kafka.shared.property.OutputStrategy;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.ProcessContext;
@@ -66,7 +68,7 @@ public class ConsumerPool implements Closeable {
     private final Long maxWaitMillis;
     private final ComponentLog logger;
     private final byte[] demarcatorBytes;
-    private final String keyEncoding;
+    private final KeyEncoding keyEncoding;
     private final String securityProtocol;
     private final String bootstrapServers;
     private final boolean honorTransactions;
@@ -78,7 +80,7 @@ public class ConsumerPool implements Closeable {
     private final int[] partitionsToConsume;
     private final boolean commitOffsets;
     private final OutputStrategy outputStrategy;
-    private final String keyFormat;
+    private final KeyFormat keyFormat;
     private final RecordReaderFactory keyReaderFactory;
     private final AtomicLong consumerCreatedCountRef = new AtomicLong();
     private final AtomicLong consumerClosedCountRef = new AtomicLong();
@@ -92,7 +94,6 @@ public class ConsumerPool implements Closeable {
      * configured consumers if the broker reported lag time for all topics is
      * below a certain threshold.
      *
-     * @param maxConcurrentLeases max allowable consumers at once
      * @param demarcator bytes to use as demarcator between messages; null or
      * empty means no demarcator
      * @param kafkaProperties properties to use to initialize kafka consumers
@@ -106,13 +107,12 @@ public class ConsumerPool implements Closeable {
      * @param logger the logger to report any errors/warnings
      */
     public ConsumerPool(
-            final int maxConcurrentLeases,
             final byte[] demarcator,
             final boolean separateByKey,
             final Map<String, Object> kafkaProperties,
             final List<String> topics,
             final Long maxWaitMillis,
-            final String keyEncoding,
+            final KeyEncoding keyEncoding,
             final String securityProtocol,
             final String bootstrapServers,
             final ComponentLog logger,
@@ -146,13 +146,12 @@ public class ConsumerPool implements Closeable {
     }
 
     public ConsumerPool(
-            final int maxConcurrentLeases,
             final byte[] demarcator,
             final boolean separateByKey,
             final Map<String, Object> kafkaProperties,
             final Pattern topics,
             final Long maxWaitMillis,
-            final String keyEncoding,
+            final KeyEncoding keyEncoding,
             final String securityProtocol,
             final String bootstrapServers,
             final ComponentLog logger,
@@ -186,7 +185,6 @@ public class ConsumerPool implements Closeable {
     }
 
     public ConsumerPool(
-            final int maxConcurrentLeases,
             final RecordReaderFactory readerFactory,
             final RecordSetWriterFactory writerFactory,
             final Map<String, Object> kafkaProperties,
@@ -199,11 +197,11 @@ public class ConsumerPool implements Closeable {
             final Charset headerCharacterSet,
             final Pattern headerNamePattern,
             final boolean separateByKey,
-            final String keyEncoding,
+            final KeyEncoding keyEncoding,
             final int[] partitionsToConsume,
             final boolean commitOffsets,
             final OutputStrategy outputStrategy,
-            final String keyFormat,
+            final KeyFormat keyFormat,
             final RecordReaderFactory keyReaderFactory) {
         this.pooledLeases = new LinkedBlockingQueue<>();
         this.maxWaitMillis = maxWaitMillis;
@@ -230,7 +228,6 @@ public class ConsumerPool implements Closeable {
     }
 
     public ConsumerPool(
-            final int maxConcurrentLeases,
             final RecordReaderFactory readerFactory,
             final RecordSetWriterFactory writerFactory,
             final Map<String, Object> kafkaProperties,
@@ -243,11 +240,11 @@ public class ConsumerPool implements Closeable {
             final Charset headerCharacterSet,
             final Pattern headerNamePattern,
             final boolean separateByKey,
-            final String keyEncoding,
+            final KeyEncoding keyEncoding,
             final int[] partitionsToConsume,
             final boolean commitOffsets,
             final OutputStrategy outputStrategy,
-            final String keyFormat,
+            final KeyFormat keyFormat,
             final RecordReaderFactory keyReaderFactory) {
         this.pooledLeases = new LinkedBlockingQueue<>();
         this.maxWaitMillis = maxWaitMillis;

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/InFlightMessageTracker.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/InFlightMessageTracker.java
@@ -17,15 +17,15 @@
 
 package org.apache.nifi.processors.kafka.pubsub;
 
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.nifi.flowfile.FlowFile;
-import org.apache.nifi.logging.ComponentLog;
 
 public class InFlightMessageTracker {
     private final ConcurrentMap<FlowFile, Counts> messageCountsByFlowFile = new ConcurrentHashMap<>();
@@ -124,7 +124,7 @@ public class InFlightMessageTracker {
 
     private boolean isComplete() {
         return messageCountsByFlowFile.keySet().stream()
-            .allMatch(flowFile -> isComplete(flowFile));
+            .allMatch(this::isComplete);
     }
 
     void awaitCompletion(final long millis) throws InterruptedException, TimeoutException {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
@@ -38,14 +38,14 @@ import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.kafka.shared.attribute.StandardTransitUriProvider;
-import org.apache.nifi.kafka.shared.property.PublishStrategy;
-import org.apache.nifi.kafka.shared.transaction.TransactionIdSupplier;
-import org.apache.nifi.kafka.shared.validation.KafkaClientCustomValidationFunction;
-import org.apache.nifi.kafka.shared.property.FailureStrategy;
-import org.apache.nifi.kafka.shared.property.provider.KafkaPropertyProvider;
 import org.apache.nifi.kafka.shared.component.KafkaPublishComponent;
+import org.apache.nifi.kafka.shared.property.FailureStrategy;
+import org.apache.nifi.kafka.shared.property.PublishStrategy;
+import org.apache.nifi.kafka.shared.property.provider.KafkaPropertyProvider;
 import org.apache.nifi.kafka.shared.property.provider.StandardKafkaPropertyProvider;
+import org.apache.nifi.kafka.shared.transaction.TransactionIdSupplier;
 import org.apache.nifi.kafka.shared.validation.DynamicPropertyValidator;
+import org.apache.nifi.kafka.shared.validation.KafkaClientCustomValidationFunction;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.DataUnit;
@@ -69,10 +69,7 @@ import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.RecordSet;
 
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -84,9 +81,9 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
+import static org.apache.nifi.expression.ExpressionLanguageScope.ENVIRONMENT;
 import static org.apache.nifi.expression.ExpressionLanguageScope.FLOWFILE_ATTRIBUTES;
 import static org.apache.nifi.expression.ExpressionLanguageScope.NONE;
-import static org.apache.nifi.expression.ExpressionLanguageScope.ENVIRONMENT;
 import static org.apache.nifi.kafka.shared.attribute.KafkaFlowFileAttribute.KAFKA_CONSUMER_OFFSETS_COMMITTED;
 
 @Tags({"Apache", "Kafka", "Record", "csv", "json", "avro", "logs", "Put", "Send", "Message", "PubSub", "2.6"})
@@ -163,12 +160,12 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         .required(true)
         .build();
 
-    static final PropertyDescriptor PUBLISH_STRATEGY = new PropertyDescriptor.Builder()
+    static final PropertyDescriptor PUBLISH_STRATEGY = new Builder()
             .name("publish-strategy")
             .displayName("Publish Strategy")
             .description("The format used to publish the incoming FlowFile record to Kafka.")
             .required(true)
-            .defaultValue(PublishStrategy.USE_VALUE.getValue())
+            .defaultValue(PublishStrategy.USE_VALUE)
             .allowableValues(PublishStrategy.class)
             .build();
 
@@ -178,7 +175,7 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         .description("The name of a field in the Input Records that should be used as the Key for the Kafka message.")
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .expressionLanguageSupported(FLOWFILE_ATTRIBUTES)
-        .dependsOn(PUBLISH_STRATEGY, PublishStrategy.USE_VALUE.getValue())
+        .dependsOn(PUBLISH_STRATEGY, PublishStrategy.USE_VALUE)
         .required(false)
         .build();
 
@@ -189,7 +186,7 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         .required(true)
         .expressionLanguageSupported(NONE)
         .allowableValues(DELIVERY_BEST_EFFORT, DELIVERY_ONE_NODE, DELIVERY_REPLICATED)
-        .defaultValue(DELIVERY_REPLICATED.getValue())
+        .defaultValue(DELIVERY_REPLICATED)
         .build();
 
     static final PropertyDescriptor METADATA_WAIT_TIME = new Builder()
@@ -228,7 +225,7 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         .displayName("Partitioner class")
         .description("Specifies which class to use to compute a partition id for a message. Corresponds to Kafka's 'partitioner.class' property.")
         .allowableValues(ROUND_ROBIN_PARTITIONING, RANDOM_PARTITIONING, RECORD_PATH_PARTITIONING, EXPRESSION_LANGUAGE_PARTITIONING)
-        .defaultValue(RANDOM_PARTITIONING.getValue())
+        .defaultValue(RANDOM_PARTITIONING)
         .required(false)
         .build();
 
@@ -259,7 +256,7 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
             + "If not specified, no FlowFile attributes will be added as headers.")
         .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
         .expressionLanguageSupported(NONE)
-        .dependsOn(PUBLISH_STRATEGY, PublishStrategy.USE_VALUE.getValue())
+        .dependsOn(PUBLISH_STRATEGY, PublishStrategy.USE_VALUE)
         .required(false)
         .build();
     static final PropertyDescriptor USE_TRANSACTIONS = new Builder()
@@ -292,12 +289,12 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         .defaultValue("UTF-8")
         .required(false)
         .build();
-    static final PropertyDescriptor RECORD_KEY_WRITER = new PropertyDescriptor.Builder()
+    static final PropertyDescriptor RECORD_KEY_WRITER = new Builder()
             .name("record-key-writer")
             .displayName("Record Key Writer")
             .description("The Record Key Writer to use for outgoing FlowFiles")
             .identifiesControllerService(RecordSetWriterFactory.class)
-            .dependsOn(PUBLISH_STRATEGY, PublishStrategy.USE_WRAPPER.getValue())
+            .dependsOn(PUBLISH_STRATEGY, PublishStrategy.USE_WRAPPER)
             .build();
     static final PropertyDescriptor RECORD_METADATA_STRATEGY = new Builder()
         .name("Record Metadata Strategy")
@@ -306,8 +303,8 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
             "Partitioner class properties")
         .required(true)
         .allowableValues(RECORD_METADATA_FROM_PROPERTIES, RECORD_METADATA_FROM_RECORD)
-        .defaultValue(RECORD_METADATA_FROM_PROPERTIES.getValue())
-        .dependsOn(PUBLISH_STRATEGY, PublishStrategy.USE_WRAPPER.getValue())
+        .defaultValue(RECORD_METADATA_FROM_PROPERTIES)
+        .dependsOn(PUBLISH_STRATEGY, PublishStrategy.USE_WRAPPER)
         .build();
 
     static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -320,51 +317,41 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         .description("Any FlowFile that cannot be sent to Kafka will be routed to this Relationship")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES;
-    private static final Set<Relationship> RELATIONSHIPS;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            BOOTSTRAP_SERVERS,
+            TOPIC,
+            RECORD_READER,
+            RECORD_WRITER,
+            USE_TRANSACTIONS,
+            TRANSACTIONAL_ID_PREFIX,
+            FAILURE_STRATEGY,
+            DELIVERY_GUARANTEE,
+            PUBLISH_STRATEGY,
+            RECORD_KEY_WRITER,
+            RECORD_METADATA_STRATEGY,
+            ATTRIBUTE_NAME_REGEX,
+            MESSAGE_HEADER_ENCODING,
+            SECURITY_PROTOCOL,
+            SASL_MECHANISM,
+            SELF_CONTAINED_KERBEROS_USER_SERVICE,
+            KERBEROS_SERVICE_NAME,
+            SASL_USERNAME,
+            SASL_PASSWORD,
+            TOKEN_AUTHENTICATION,
+            AWS_PROFILE_NAME,
+            SSL_CONTEXT_SERVICE,
+            MESSAGE_KEY_FIELD,
+            MAX_REQUEST_SIZE,
+            ACK_WAIT_TIME,
+            METADATA_WAIT_TIME,
+            PARTITION_CLASS,
+            PARTITION,
+            COMPRESSION_CODEC
+    );
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
 
     private volatile PublisherPool publisherPool = null;
     private final RecordPathCache recordPathCache = new RecordPathCache(25);
-
-    static {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(BOOTSTRAP_SERVERS);
-        properties.add(TOPIC);
-        properties.add(RECORD_READER);
-        properties.add(RECORD_WRITER);
-        properties.add(USE_TRANSACTIONS);
-        properties.add(TRANSACTIONAL_ID_PREFIX);
-        properties.add(FAILURE_STRATEGY);
-        properties.add(DELIVERY_GUARANTEE);
-        properties.add(PUBLISH_STRATEGY);
-        properties.add(RECORD_KEY_WRITER);
-        properties.add(RECORD_METADATA_STRATEGY);
-        properties.add(ATTRIBUTE_NAME_REGEX);
-        properties.add(MESSAGE_HEADER_ENCODING);
-        properties.add(SECURITY_PROTOCOL);
-        properties.add(SASL_MECHANISM);
-        properties.add(SELF_CONTAINED_KERBEROS_USER_SERVICE);
-        properties.add(KERBEROS_SERVICE_NAME);
-        properties.add(SASL_USERNAME);
-        properties.add(SASL_PASSWORD);
-        properties.add(TOKEN_AUTHENTICATION);
-        properties.add(AWS_PROFILE_NAME);
-        properties.add(SSL_CONTEXT_SERVICE);
-        properties.add(MESSAGE_KEY_FIELD);
-        properties.add(MAX_REQUEST_SIZE);
-        properties.add(ACK_WAIT_TIME);
-        properties.add(METADATA_WAIT_TIME);
-        properties.add(PARTITION_CLASS);
-        properties.add(PARTITION);
-        properties.add(COMPRESSION_CODEC);
-
-        PROPERTIES = Collections.unmodifiableList(properties);
-
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_FAILURE);
-        RELATIONSHIPS = Collections.unmodifiableSet(relationships);
-    }
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -452,7 +439,7 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         final boolean useTransactions = context.getProperty(USE_TRANSACTIONS).asBoolean();
         final String transactionalIdPrefix = context.getProperty(TRANSACTIONAL_ID_PREFIX).evaluateAttributeExpressions().getValue();
         Supplier<String> transactionalIdSupplier = new TransactionIdSupplier(transactionalIdPrefix);
-        final PublishStrategy publishStrategy = PublishStrategy.valueOf(context.getProperty(PUBLISH_STRATEGY).getValue());
+        final PublishStrategy publishStrategy = context.getProperty(PUBLISH_STRATEGY).asDescribedValue(PublishStrategy.class);
 
         final String charsetName = context.getProperty(MESSAGE_HEADER_ENCODING).evaluateAttributeExpressions().getValue();
         final Charset charset = Charset.forName(charsetName);
@@ -629,12 +616,10 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
     }
 
     private PublishFailureStrategy getFailureStrategy(final ProcessContext context) {
-        final String strategy = context.getProperty(FAILURE_STRATEGY).getValue();
-        if (FailureStrategy.ROLLBACK.getValue().equals(strategy)) {
-            return (session, flowFiles) -> session.rollback();
-        } else {
-            return (session, flowFiles) -> session.transfer(flowFiles, REL_FAILURE);
-        }
+        return switch (context.getProperty(FAILURE_STRATEGY).asDescribedValue(FailureStrategy.class)) {
+            case ROUTE_TO_FAILURE -> (session, flowFiles) -> session.transfer(flowFiles, REL_FAILURE);
+            case ROLLBACK -> (session, flowFiles) -> session.rollback();
+        };
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
@@ -41,13 +41,13 @@ import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.kafka.shared.attribute.KafkaFlowFileAttribute;
 import org.apache.nifi.kafka.shared.attribute.StandardTransitUriProvider;
-import org.apache.nifi.kafka.shared.transaction.TransactionIdSupplier;
-import org.apache.nifi.kafka.shared.validation.KafkaClientCustomValidationFunction;
+import org.apache.nifi.kafka.shared.component.KafkaPublishComponent;
 import org.apache.nifi.kafka.shared.property.FailureStrategy;
 import org.apache.nifi.kafka.shared.property.provider.KafkaPropertyProvider;
-import org.apache.nifi.kafka.shared.component.KafkaPublishComponent;
 import org.apache.nifi.kafka.shared.property.provider.StandardKafkaPropertyProvider;
+import org.apache.nifi.kafka.shared.transaction.TransactionIdSupplier;
 import org.apache.nifi.kafka.shared.validation.DynamicPropertyValidator;
+import org.apache.nifi.kafka.shared.validation.KafkaClientCustomValidationFunction;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.DataUnit;
@@ -62,10 +62,7 @@ import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -128,7 +125,7 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
         .description("The name of the Kafka Topic to publish to.")
         .required(true)
         .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .expressionLanguageSupported(FLOWFILE_ATTRIBUTES)
         .build();
 
     static final PropertyDescriptor DELIVERY_GUARANTEE = new PropertyDescriptor.Builder()
@@ -138,7 +135,7 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
         .required(true)
         .expressionLanguageSupported(ExpressionLanguageScope.NONE)
         .allowableValues(DELIVERY_BEST_EFFORT, DELIVERY_ONE_NODE, DELIVERY_REPLICATED)
-        .defaultValue(DELIVERY_REPLICATED.getValue())
+        .defaultValue(DELIVERY_REPLICATED)
         .build();
 
     static final PropertyDescriptor METADATA_WAIT_TIME = new PropertyDescriptor.Builder()
@@ -182,7 +179,7 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
             + "data loss on Kafka. During a topic compaction on Kafka, messages will be deduplicated based on this key.")
         .required(false)
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .expressionLanguageSupported(FLOWFILE_ATTRIBUTES)
         .build();
 
     static final PropertyDescriptor KEY_ATTRIBUTE_ENCODING = new PropertyDescriptor.Builder()
@@ -190,7 +187,7 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
         .displayName("Key Attribute Encoding")
         .description("FlowFiles that are emitted have an attribute named '" + KafkaFlowFileAttribute.KAFKA_KEY + "'. This property dictates how the value of the attribute should be encoded.")
         .required(true)
-        .defaultValue(UTF8_ENCODING.getValue())
+        .defaultValue(UTF8_ENCODING)
         .allowableValues(UTF8_ENCODING, HEX_ENCODING)
         .build();
 
@@ -199,7 +196,7 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
         .displayName("Message Demarcator")
         .required(false)
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .expressionLanguageSupported(FLOWFILE_ATTRIBUTES)
         .description("Specifies the string (interpreted as UTF-8) to use for demarcating multiple messages within "
             + "a single FlowFile. If not specified, the entire content of the FlowFile will be used as a single message. If specified, the "
             + "contents of the FlowFile will be split on this delimiter and each section sent as a separate Kafka message. "
@@ -211,7 +208,7 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
         .displayName("Partitioner class")
         .description("Specifies which class to use to compute a partition id for a message. Corresponds to Kafka's 'partitioner.class' property.")
         .allowableValues(ROUND_ROBIN_PARTITIONING, RANDOM_PARTITIONING, EXPRESSION_LANGUAGE_PARTITIONING)
-        .defaultValue(RANDOM_PARTITIONING.getValue())
+        .defaultValue(RANDOM_PARTITIONING)
         .required(false)
         .build();
 
@@ -285,47 +282,37 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
         .description("Any FlowFile that cannot be sent to Kafka will be routed to this Relationship")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES;
-    private static final Set<Relationship> RELATIONSHIPS;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            BOOTSTRAP_SERVERS,
+            TOPIC,
+            USE_TRANSACTIONS,
+            TRANSACTIONAL_ID_PREFIX,
+            MESSAGE_DEMARCATOR,
+            FAILURE_STRATEGY,
+            DELIVERY_GUARANTEE,
+            ATTRIBUTE_NAME_REGEX,
+            MESSAGE_HEADER_ENCODING,
+            SECURITY_PROTOCOL,
+            SASL_MECHANISM,
+            SELF_CONTAINED_KERBEROS_USER_SERVICE,
+            KERBEROS_SERVICE_NAME,
+            SASL_USERNAME,
+            SASL_PASSWORD,
+            AWS_PROFILE_NAME,
+            TOKEN_AUTHENTICATION,
+            SSL_CONTEXT_SERVICE,
+            KEY,
+            KEY_ATTRIBUTE_ENCODING,
+            MAX_REQUEST_SIZE,
+            ACK_WAIT_TIME,
+            METADATA_WAIT_TIME,
+            PARTITION_CLASS,
+            PARTITION,
+            COMPRESSION_CODEC
+    );
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
 
     private volatile PublisherPool publisherPool = null;
-
-    static {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(BOOTSTRAP_SERVERS);
-        properties.add(TOPIC);
-        properties.add(USE_TRANSACTIONS);
-        properties.add(TRANSACTIONAL_ID_PREFIX);
-        properties.add(MESSAGE_DEMARCATOR);
-        properties.add(FAILURE_STRATEGY);
-        properties.add(DELIVERY_GUARANTEE);
-        properties.add(ATTRIBUTE_NAME_REGEX);
-        properties.add(MESSAGE_HEADER_ENCODING);
-        properties.add(SECURITY_PROTOCOL);
-        properties.add(SASL_MECHANISM);
-        properties.add(SELF_CONTAINED_KERBEROS_USER_SERVICE);
-        properties.add(KERBEROS_SERVICE_NAME);
-        properties.add(SASL_USERNAME);
-        properties.add(SASL_PASSWORD);
-        properties.add(AWS_PROFILE_NAME);
-        properties.add(TOKEN_AUTHENTICATION);
-        properties.add(SSL_CONTEXT_SERVICE);
-        properties.add(KEY);
-        properties.add(KEY_ATTRIBUTE_ENCODING);
-        properties.add(MAX_REQUEST_SIZE);
-        properties.add(ACK_WAIT_TIME);
-        properties.add(METADATA_WAIT_TIME);
-        properties.add(PARTITION_CLASS);
-        properties.add(PARTITION);
-        properties.add(COMPRESSION_CODEC);
-
-        PROPERTIES = Collections.unmodifiableList(properties);
-
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_FAILURE);
-        RELATIONSHIPS = Collections.unmodifiableSet(relationships);
-    }
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -527,12 +514,10 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
     }
 
     private PublishFailureStrategy getFailureStrategy(final ProcessContext context) {
-        final String strategy = context.getProperty(FAILURE_STRATEGY).getValue();
-        if (FailureStrategy.ROLLBACK.getValue().equals(strategy)) {
-            return (session, flowFiles) -> session.rollback();
-        } else {
-            return (session, flowFiles) -> session.transfer(flowFiles, REL_FAILURE);
-        }
+        return switch (context.getProperty(FAILURE_STRATEGY).asDescribedValue(FailureStrategy.class)) {
+            case ROUTE_TO_FAILURE -> (session, flowFiles) -> session.transfer(flowFiles, REL_FAILURE);
+            case ROLLBACK -> (session, flowFiles) -> session.rollback();
+        };
     }
 
     private byte[] getMessageKey(final FlowFile flowFile, final ProcessContext context) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishResult.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishResult.java
@@ -27,7 +27,7 @@ public interface PublishResult {
 
     Exception getReasonForFailure(FlowFile flowFile);
 
-    public static PublishResult EMPTY = new PublishResult() {
+    PublishResult EMPTY = new PublishResult() {
         @Override
         public boolean isFailure() {
             return false;

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublisherLease.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublisherLease.java
@@ -17,35 +17,14 @@
 
 package org.apache.nifi.processors.kafka.pubsub;
 
-import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
-import java.util.regex.Pattern;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.ConfigVerificationResult.Outcome;
@@ -57,17 +36,30 @@ import org.apache.nifi.schema.access.SchemaNotFoundException;
 import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.RecordSetWriter;
 import org.apache.nifi.serialization.RecordSetWriterFactory;
-import org.apache.nifi.serialization.SimpleRecordSchema;
 import org.apache.nifi.serialization.WriteResult;
-import org.apache.nifi.serialization.record.MapRecord;
 import org.apache.nifi.serialization.record.Record;
-import org.apache.nifi.serialization.record.RecordField;
-import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.RecordSet;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.apache.nifi.stream.io.exception.TokenTooLargeException;
 import org.apache.nifi.stream.io.util.StreamDemarcator;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.regex.Pattern;
 
 public class PublisherLease implements Closeable {
     private final ComponentLog logger;
@@ -211,7 +203,7 @@ public class PublisherLease implements Closeable {
                 final byte[] messageContent;
                 final byte[] messageKey;
                 Integer partition;
-                if (PublishStrategy.USE_WRAPPER.equals(publishStrategy)) {
+                if (publishStrategy == PublishStrategy.USE_WRAPPER) {
                     headers = toHeadersWrapper(record.getValue("headers"));
                     final Object key = record.getValue("key");
                     final Object value = record.getValue("value");
@@ -220,8 +212,7 @@ public class PublisherLease implements Closeable {
 
                     if (metadataStrategy == PublishMetadataStrategy.USE_RECORD_METADATA) {
                         final Object metadataObject = record.getValue("metadata");
-                        if (metadataObject instanceof Record) {
-                            final Record metadataRecord = (Record) metadataObject;
+                        if (metadataObject instanceof Record metadataRecord) {
                             final String recordTopic = metadataRecord.getAsString("topic");
                             topic = recordTopic == null ? explicitTopic : recordTopic;
 
@@ -277,52 +268,13 @@ public class PublisherLease implements Closeable {
 
     private List<Header> toHeadersWrapper(final Object fieldHeaders) {
         final List<Header> headers = new ArrayList<>();
-        if (fieldHeaders instanceof Record) {
-            final Record recordHeaders = (Record) fieldHeaders;
+        if (fieldHeaders instanceof Record recordHeaders) {
             for (String fieldName : recordHeaders.getRawFieldNames()) {
                 final String fieldValue = recordHeaders.getAsString(fieldName);
                 headers.add(new RecordHeader(fieldName, fieldValue.getBytes(StandardCharsets.UTF_8)));
             }
         }
         return headers;
-    }
-
-    private static final RecordField FIELD_TOPIC = new RecordField("topic", RecordFieldType.STRING.getDataType());
-    private static final RecordField FIELD_PARTITION = new RecordField("partition", RecordFieldType.INT.getDataType());
-    private static final RecordField FIELD_TIMESTAMP = new RecordField("timestamp", RecordFieldType.TIMESTAMP.getDataType());
-    private static final RecordSchema SCHEMA_METADATA = new SimpleRecordSchema(Arrays.asList(
-            FIELD_TOPIC, FIELD_PARTITION, FIELD_TIMESTAMP));
-    private static final RecordField FIELD_METADATA = new RecordField("metadata", RecordFieldType.RECORD.getRecordDataType(SCHEMA_METADATA));
-    private static final RecordField FIELD_HEADERS = new RecordField("headers", RecordFieldType.MAP.getMapDataType(RecordFieldType.STRING.getDataType()));
-
-    private Record toWrapperRecord(final Record record, final List<Header> headers,
-                                   final String messageKeyField, final String topic) {
-        final Record recordKey = (Record) record.getValue(messageKeyField);
-        final RecordSchema recordSchemaKey = ((recordKey == null) ? null : recordKey.getSchema());
-        final RecordField fieldKey = new RecordField("key", RecordFieldType.RECORD.getRecordDataType(recordSchemaKey));
-        final RecordField fieldValue = new RecordField("value", RecordFieldType.RECORD.getRecordDataType(record.getSchema()));
-        final RecordSchema schemaWrapper = new SimpleRecordSchema(Arrays.asList(FIELD_METADATA, FIELD_HEADERS, fieldKey, fieldValue));
-
-        final Map<String, Object> valuesMetadata = new HashMap<>();
-        valuesMetadata.put("topic", topic);
-        valuesMetadata.put("timestamp", getTimestamp());
-        final Record recordMetadata = new MapRecord(SCHEMA_METADATA, valuesMetadata);
-
-        final Map<String, Object> valuesHeaders = new HashMap<>();
-        for (Header header : headers) {
-            valuesHeaders.put(header.key(), new String(header.value(), headerCharacterSet));
-        }
-
-        final Map<String, Object> valuesWrapper = new HashMap<>();
-        valuesWrapper.put("metadata", recordMetadata);
-        valuesWrapper.put("headers", valuesHeaders);
-        valuesWrapper.put("key", record.getValue(messageKeyField));
-        valuesWrapper.put("value", record);
-        return new MapRecord(schemaWrapper, valuesWrapper);
-    }
-
-    protected long getTimestamp() {
-        return System.currentTimeMillis();
     }
 
     private List<Header> toHeaders(final FlowFile flowFile, final Map<String, ?> additionalAttributes) {
@@ -351,87 +303,61 @@ public class PublisherLease implements Closeable {
 
     private byte[] toByteArray(final String name, final Object object, final RecordSetWriterFactory writerFactory, final FlowFile flowFile)
             throws IOException, SchemaNotFoundException, MalformedRecordException {
-        if (object == null) {
-            return null;
-        } else if (object instanceof Record) {
-            if (writerFactory == null) {
-                throw new MalformedRecordException("Record has a key that is itself a record, but the 'Record Key Writer' of the processor was not configured. If Records are expected to have a " +
-                    "Record as the key, the 'Record Key Writer' property must be set.");
-            }
+        return switch (object) {
+            case null -> null;
+            case Record record -> {
+                if (writerFactory == null) {
+                    throw new MalformedRecordException("Record has a key that is itself a record, but the 'Record Key Writer' of the processor was not configured. If Records are expected to have a " +
+                            "Record as the key, the 'Record Key Writer' property must be set.");
+                }
 
-            final Record record = (Record) object;
-            final RecordSchema schema = writerFactory.getSchema(flowFile.getAttributes(), record.getSchema());
-            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                 final RecordSetWriter writer = writerFactory.createWriter(logger, schema, baos, flowFile)) {
-                writer.write(record);
-                writer.flush();
-                return baos.toByteArray();
+                final RecordSchema schema = writerFactory.getSchema(flowFile.getAttributes(), record.getSchema());
+                try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                     final RecordSetWriter writer = writerFactory.createWriter(logger, schema, baos, flowFile)) {
+                    writer.write(record);
+                    writer.flush();
+                    yield baos.toByteArray();
+                }
             }
-        } else if (object instanceof Byte[]) {
-            final Byte[] bytesUppercase = (Byte[]) object;
-            final byte[] bytes = new byte[bytesUppercase.length];
-            for (int i = 0; (i < bytesUppercase.length); ++i) {
-                bytes[i] = bytesUppercase[i];
+            case Byte[] bytesUppercase -> {
+                final byte[] bytes = new byte[bytesUppercase.length];
+                for (int i = 0; (i < bytesUppercase.length); ++i) {
+                    bytes[i] = bytesUppercase[i];
+                }
+                yield bytes;
             }
-            return bytes;
-        } else if (object instanceof String) {
-            final String string = (String) object;
-            return string.getBytes(StandardCharsets.UTF_8);
-        } else {
-            throw new MalformedRecordException(String.format("Couldn't convert %s record data to byte array.", name));
-        }
+            case String string -> string.getBytes(StandardCharsets.UTF_8);
+            default ->
+                    throw new MalformedRecordException(String.format("Couldn't convert %s record data to byte array.", name));
+        };
     }
 
     private byte[] getMessageKey(final FlowFile flowFile, final RecordSetWriterFactory writerFactory,
                                  final Object keyValue) throws IOException, SchemaNotFoundException {
-        final byte[] messageKey;
-        if (keyValue == null) {
-            messageKey = null;
-        } else if (keyValue instanceof byte[]) {
-            messageKey = (byte[]) keyValue;
-        } else if (keyValue instanceof Byte[]) {
-            // This case exists because in our Record API we currently don't have a BYTES type, we use an Array of type
-            // Byte, which creates a Byte[] instead of a byte[]. We should address this in the future, but we should
-            // account for the log here.
-            final Byte[] bytes = (Byte[]) keyValue;
-            final byte[] bytesPrimitive = new byte[bytes.length];
-            for (int i = 0; i < bytes.length; i++) {
-                bytesPrimitive[i] = bytes[i];
-            }
-            messageKey = bytesPrimitive;
-        } else if (keyValue instanceof Record) {
-            final Record keyRecord = (Record) keyValue;
-            try (final ByteArrayOutputStream os = new ByteArrayOutputStream(1024)) {
-                try (final RecordSetWriter writerKey = writerFactory.createWriter(logger, keyRecord.getSchema(), os, flowFile)) {
-                    writerKey.write(keyRecord);
-                    writerKey.flush();
+        return switch (keyValue) {
+            case null -> null;
+            case byte[] bytes1 -> bytes1;
+            case Byte[] bytes -> {
+                // This case exists because in our Record API we currently don't have a BYTES type, we use an Array of type
+                // Byte, which creates a Byte[] instead of a byte[]. We should address this in the future, but we should
+                // account for the log here.
+                final byte[] bytesPrimitive = new byte[bytes.length];
+                for (int i = 0; i < bytes.length; i++) {
+                    bytesPrimitive[i] = bytes[i];
                 }
-                messageKey = os.toByteArray();
+                yield bytesPrimitive;
             }
-        } else {
-            final String keyString = keyValue.toString();
-            messageKey = keyString.getBytes(StandardCharsets.UTF_8);
-        }
-        return messageKey;
-    }
-
-    private void addHeaders(final FlowFile flowFile, final Map<String, String> additionalAttributes, final ProducerRecord<?, ?> record) {
-        if (attributeNameRegex == null) {
-            return;
-        }
-
-        final Headers headers = record.headers();
-        for (final Map.Entry<String, String> entry : flowFile.getAttributes().entrySet()) {
-            if (attributeNameRegex.matcher(entry.getKey()).matches()) {
-                headers.add(entry.getKey(), entry.getValue().getBytes(headerCharacterSet));
+            case Record keyRecord -> {
+                try (final ByteArrayOutputStream os = new ByteArrayOutputStream(1024)) {
+                    try (final RecordSetWriter writerKey = writerFactory.createWriter(logger, keyRecord.getSchema(), os, flowFile)) {
+                        writerKey.write(keyRecord);
+                        writerKey.flush();
+                    }
+                    yield os.toByteArray();
+                }
             }
-        }
-
-        for (final Map.Entry<String, String> entry : additionalAttributes.entrySet()) {
-            if (attributeNameRegex.matcher(entry.getKey()).matches()) {
-                headers.add(entry.getKey(), entry.getValue().getBytes(headerCharacterSet));
-            }
-        }
+            default -> keyValue.toString().getBytes(StandardCharsets.UTF_8);
+        };
     }
 
     protected void publish(final FlowFile flowFile, final byte[] messageKey, final byte[] messageContent, final String topic, final InFlightMessageTracker tracker, final Integer partition) {
@@ -445,15 +371,12 @@ public class PublisherLease implements Closeable {
         final Integer moddedPartition = partition == null ? null : Math.abs(partition) % (producer.partitionsFor(topic).size());
         final ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(topic, moddedPartition, messageKey, messageContent, headers);
 
-        producer.send(record, new Callback() {
-            @Override
-            public void onCompletion(final RecordMetadata metadata, final Exception exception) {
-                if (exception == null) {
-                    tracker.incrementAcknowledgedCount(flowFile);
-                } else {
-                    tracker.fail(flowFile, exception);
-                    poison();
-                }
+        producer.send(record, (metadata, exception) -> {
+            if (exception == null) {
+                tracker.incrementAcknowledgedCount(flowFile);
+            } else {
+                tracker.fail(flowFile, exception);
+                poison();
             }
         });
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublisherPool.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublisherPool.java
@@ -19,9 +19,9 @@ package org.apache.nifi.processors.kafka.pubsub;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.kafka.shared.property.PublishStrategy;
 import org.apache.nifi.logging.ComponentLog;
-import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.serialization.RecordSetWriterFactory;
 
 import java.io.Closeable;
@@ -45,7 +45,7 @@ public class PublisherPool implements Closeable {
     private final Charset headerCharacterSet;
     private final PublishStrategy publishStrategy;
     private final RecordSetWriterFactory recordKeyWriterFactory;
-    private Supplier<String> transactionalIdSupplier;
+    private final Supplier<String> transactionalIdSupplier;
 
     private volatile boolean closed = false;
 
@@ -86,7 +86,7 @@ public class PublisherPool implements Closeable {
         }
 
         final Producer<byte[], byte[]> producer = new KafkaProducer<>(properties);
-        final PublisherLease lease = new PublisherLease(producer, maxMessageSize, maxAckWaitMillis, logger,
+        return new PublisherLease(producer, maxMessageSize, maxAckWaitMillis, logger,
                 useTransactions, attributeNameRegex, headerCharacterSet, publishStrategy, recordKeyWriterFactory) {
             private volatile boolean closed = false;
 
@@ -112,8 +112,6 @@ public class PublisherPool implements Closeable {
                 }
             }
         };
-
-        return lease;
     }
 
     public synchronized boolean isClosed() {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/record/sink/kafka/KafkaRecordSink_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/record/sink/kafka/KafkaRecordSink_2_6.java
@@ -33,14 +33,13 @@ import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
-import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
 import org.apache.nifi.kafka.shared.property.provider.KafkaPropertyProvider;
 import org.apache.nifi.kafka.shared.property.provider.StandardKafkaPropertyProvider;
-import org.apache.nifi.kafka.shared.validation.KafkaClientCustomValidationFunction;
 import org.apache.nifi.kafka.shared.validation.DynamicPropertyValidator;
+import org.apache.nifi.kafka.shared.validation.KafkaClientCustomValidationFunction;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.record.sink.RecordSinkService;
@@ -57,9 +56,7 @@ import org.apache.nifi.stream.io.exception.TokenTooLargeException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +102,7 @@ public class KafkaRecordSink_2_6 extends AbstractControllerService implements Ka
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .allowableValues(DELIVERY_BEST_EFFORT, DELIVERY_ONE_NODE, DELIVERY_REPLICATED)
-            .defaultValue(DELIVERY_BEST_EFFORT.getValue())
+            .defaultValue(DELIVERY_BEST_EFFORT)
             .build();
 
     static final PropertyDescriptor METADATA_WAIT_TIME = new PropertyDescriptor.Builder()
@@ -159,7 +156,22 @@ public class KafkaRecordSink_2_6 extends AbstractControllerService implements Ka
             .required(false)
             .build();
 
-    private List<PropertyDescriptor> properties;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            BOOTSTRAP_SERVERS,
+            TOPIC,
+            RecordSinkService.RECORD_WRITER_FACTORY,
+            DELIVERY_GUARANTEE,
+            MESSAGE_HEADER_ENCODING,
+            SECURITY_PROTOCOL,
+            SELF_CONTAINED_KERBEROS_USER_SERVICE,
+            KERBEROS_SERVICE_NAME,
+            SSL_CONTEXT_SERVICE,
+            MAX_REQUEST_SIZE,
+            ACK_WAIT_TIME,
+            METADATA_WAIT_TIME,
+            COMPRESSION_CODEC
+    );
+
     private volatile RecordSetWriterFactory writerFactory;
     private volatile int maxMessageSize;
     private volatile long maxAckWaitMillis;
@@ -167,27 +179,8 @@ public class KafkaRecordSink_2_6 extends AbstractControllerService implements Ka
     private volatile Producer<byte[], byte[]> producer;
 
     @Override
-    protected void init(final ControllerServiceInitializationContext context) {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(BOOTSTRAP_SERVERS);
-        properties.add(TOPIC);
-        properties.add(RecordSinkService.RECORD_WRITER_FACTORY);
-        properties.add(DELIVERY_GUARANTEE);
-        properties.add(MESSAGE_HEADER_ENCODING);
-        properties.add(SECURITY_PROTOCOL);
-        properties.add(SELF_CONTAINED_KERBEROS_USER_SERVICE);
-        properties.add(KERBEROS_SERVICE_NAME);
-        properties.add(SSL_CONTEXT_SERVICE);
-        properties.add(MAX_REQUEST_SIZE);
-        properties.add(ACK_WAIT_TIME);
-        properties.add(METADATA_WAIT_TIME);
-        properties.add(COMPRESSION_CODEC);
-        this.properties = Collections.unmodifiableList(properties);
-    }
-
-    @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/ConsumerPoolTest.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/ConsumerPoolTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.nifi.kafka.shared.property.KeyEncoding;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
@@ -71,13 +72,12 @@ public class ConsumerPoolTest {
         mockReporter = mock(ProvenanceReporter.class);
         when(mockSession.getProvenanceReporter()).thenReturn(mockReporter);
         testPool = new ConsumerPool(
-                1,
                 null,
                 false,
                 Collections.emptyMap(),
                 Collections.singletonList("nifi"),
                 100L,
-                "utf-8",
+                KeyEncoding.UTF8,
                 "ssl",
                 "localhost",
                 logger,
@@ -92,13 +92,12 @@ public class ConsumerPoolTest {
             }
         };
         testDemarcatedPool = new ConsumerPool(
-                1,
                 "--demarcator--".getBytes(StandardCharsets.UTF_8),
                 false,
                 Collections.emptyMap(),
                 Collections.singletonList("nifi"),
                 100L,
-                "utf-8",
+                KeyEncoding.UTF8,
                 "ssl",
                 "localhost",
                 logger,
@@ -183,13 +182,12 @@ public class ConsumerPoolTest {
     @Test
     public void testConsumerNotCreatedOnDemandWhenUsingStaticAssignment() {
         final ConsumerPool staticAssignmentPool = new ConsumerPool(
-            1,
-            null,
+                null,
             false,
             Collections.emptyMap(),
             Collections.singletonList("nifi"),
             100L,
-            "utf-8",
+            KeyEncoding.UTF8,
             "ssl",
             "localhost",
             logger,
@@ -212,13 +210,13 @@ public class ConsumerPoolTest {
                 partition2Lease = staticAssignmentPool.obtainConsumer(mockSession, mockContext);
                 assertNotSame(lease, partition2Lease);
                 assertEquals(1, partition2Lease.getAssignedPartitions().size());
-                assertEquals(2, partition2Lease.getAssignedPartitions().get(0).partition());
+                assertEquals(2, partition2Lease.getAssignedPartitions().getFirst().partition());
 
                 partition3Lease = staticAssignmentPool.obtainConsumer(mockSession, mockContext);
                 assertNotSame(lease, partition3Lease);
                 assertNotSame(partition2Lease, partition3Lease);
                 assertEquals(1, partition3Lease.getAssignedPartitions().size());
-                assertEquals(3, partition3Lease.getAssignedPartitions().get(0).partition());
+                assertEquals(3, partition3Lease.getAssignedPartitions().getFirst().partition());
 
                 final ConsumerLease nullLease = staticAssignmentPool.obtainConsumer(mockSession, mockContext);
                 assertNull(nullLease);
@@ -230,7 +228,7 @@ public class ConsumerPoolTest {
                 assertNotNull(partition2Lease);
 
                 assertEquals(1, partition2Lease.getAssignedPartitions().size());
-                assertEquals(2, partition2Lease.getAssignedPartitions().get(0).partition());
+                assertEquals(2, partition2Lease.getAssignedPartitions().getFirst().partition());
 
                 assertNull(staticAssignmentPool.obtainConsumer(mockSession, mockContext));
             } finally {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestConsumeKafkaRecordKey_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestConsumeKafkaRecordKey_2_6.java
@@ -76,13 +76,13 @@ public class TestConsumeKafkaRecordKey_2_6 {
         runner.assertValid();
         runner.setProperty(ConsumeKafkaRecord_2_6.OUTPUT_STRATEGY, "foo");
         runner.assertNotValid();
-        runner.setProperty(ConsumeKafkaRecord_2_6.OUTPUT_STRATEGY, OutputStrategy.USE_VALUE.getValue());
+        runner.setProperty(ConsumeKafkaRecord_2_6.OUTPUT_STRATEGY, OutputStrategy.USE_VALUE);
         runner.assertValid();
-        runner.setProperty(ConsumeKafkaRecord_2_6.OUTPUT_STRATEGY, OutputStrategy.USE_WRAPPER.getValue());
+        runner.setProperty(ConsumeKafkaRecord_2_6.OUTPUT_STRATEGY, OutputStrategy.USE_WRAPPER);
         runner.assertValid();
         runner.setProperty(ConsumeKafkaRecord_2_6.KEY_FORMAT, "foo");
         runner.assertNotValid();
-        runner.setProperty(ConsumeKafkaRecord_2_6.KEY_FORMAT, KeyFormat.RECORD.getValue());
+        runner.setProperty(ConsumeKafkaRecord_2_6.KEY_FORMAT, KeyFormat.RECORD);
         runner.assertValid();
         runner.setProperty(ConsumeKafkaRecord_2_6.KEY_RECORD_READER, "no-record-reader");
         runner.assertNotValid();

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestConsumeKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestConsumeKafkaRecord_2_6.java
@@ -208,7 +208,7 @@ public class TestConsumeKafkaRecord_2_6 {
         runner.setProperty(ConsumeKafkaRecord_2_6.SECURITY_PROTOCOL, SecurityProtocol.SASL_PLAINTEXT.name());
         runner.assertNotValid();
 
-        runner.setProperty(ConsumeKafkaRecord_2_6.SASL_MECHANISM, SaslMechanism.PLAIN.getValue());
+        runner.setProperty(ConsumeKafkaRecord_2_6.SASL_MECHANISM, SaslMechanism.PLAIN);
         runner.assertNotValid();
 
         runner.setProperty(ConsumeKafkaRecord_2_6.SASL_USERNAME, "user1");
@@ -230,7 +230,7 @@ public class TestConsumeKafkaRecord_2_6 {
         runner.setProperty(ConsumeKafkaRecord_2_6.SECURITY_PROTOCOL, SecurityProtocol.SASL_PLAINTEXT.name());
         runner.assertNotValid();
 
-        runner.setProperty(ConsumeKafkaRecord_2_6.SASL_MECHANISM, SaslMechanism.SCRAM_SHA_256.getValue());
+        runner.setProperty(ConsumeKafkaRecord_2_6.SASL_MECHANISM, SaslMechanism.SCRAM_SHA_256);
         runner.assertNotValid();
 
         runner.setProperty(ConsumeKafkaRecord_2_6.SASL_USERNAME, "user1");
@@ -252,7 +252,7 @@ public class TestConsumeKafkaRecord_2_6 {
         runner.setProperty(ConsumeKafkaRecord_2_6.SECURITY_PROTOCOL, SecurityProtocol.SASL_PLAINTEXT.name());
         runner.assertNotValid();
 
-        runner.setProperty(ConsumeKafkaRecord_2_6.SASL_MECHANISM, SaslMechanism.SCRAM_SHA_512.getValue());
+        runner.setProperty(ConsumeKafkaRecord_2_6.SASL_MECHANISM, SaslMechanism.SCRAM_SHA_512);
         runner.assertNotValid();
 
         runner.setProperty(ConsumeKafkaRecord_2_6.SASL_USERNAME, "user1");

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestConsumeKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestConsumeKafka_2_6.java
@@ -93,7 +93,7 @@ public class TestConsumeKafka_2_6 {
         runner.setProperty(ConsumeKafka_2_6.AUTO_OFFSET_RESET, ConsumeKafka_2_6.OFFSET_EARLIEST);
 
         runner.setProperty(ConsumeKafka_2_6.SECURITY_PROTOCOL, SecurityProtocol.SASL_PLAINTEXT.name());
-        runner.setProperty(ConsumeKafka_2_6.SASL_MECHANISM, SaslMechanism.GSSAPI.getValue());
+        runner.setProperty(ConsumeKafka_2_6.SASL_MECHANISM, SaslMechanism.GSSAPI);
         runner.assertNotValid();
 
         runner.setProperty(ConsumeKafka_2_6.KERBEROS_SERVICE_NAME, "kafka");

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestInFlightMessageTracker.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestInFlightMessageTracker.java
@@ -66,19 +66,20 @@ public class TestInFlightMessageTracker {
         tracker.incrementSentCount(flowFile);
         verifyNotComplete(tracker);
 
-        final ExecutorService exec = Executors.newFixedThreadPool(1);
-        final Future<?> future = exec.submit(() -> {
-            try {
-                tracker.awaitCompletion(10000L);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+        try (ExecutorService exec = Executors.newFixedThreadPool(1)) {
+            final Future<?> future  = exec.submit(() -> {
+                try {
+                    tracker.awaitCompletion(10000L);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
 
-        tracker.incrementAcknowledgedCount(flowFile);
-        tracker.incrementAcknowledgedCount(flowFile);
+            tracker.incrementAcknowledgedCount(flowFile);
+            tracker.incrementAcknowledgedCount(flowFile);
 
-        future.get();
+            future.get();
+        }
     }
 
     private void verifyNotComplete(final InFlightMessageTracker tracker) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafkaMock.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafkaMock.java
@@ -266,7 +266,7 @@ public class TestPublishKafkaMock {
         final String valueString = mapper.writeValueAsString(valueNode);
         assertEquals(valueString, new String(producedRecord.value(), UTF_8));
         final List<MockFlowFile> success = runner.getFlowFilesForRelationship(PublishKafkaRecord_2_6.REL_SUCCESS);
-        final MockFlowFile flowFile1 = success.iterator().next();
+        final MockFlowFile flowFile1 = success.getFirst();
         assertNotNull(flowFile1.getAttribute("uuid"));
     }
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafkaMockParameterized.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafkaMockParameterized.java
@@ -260,11 +260,7 @@ public class TestPublishKafkaMockParameterized {
                 patternAttributeName,
                 UTF_8,
                 null,
-                null) {
-            @Override
-            protected long getTimestamp() {
-                return 1000000000000L;
-            }
-        };
+                null
+        );
     }
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafkaRecordKey_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafkaRecordKey_2_6.java
@@ -46,13 +46,12 @@ public class TestPublishKafkaRecordKey_2_6 {
     private static final String TOPIC_NAME = "unit-test";
 
     private PublisherPool mockPool;
-    private PublisherLease mockLease;
     private TestRunner runner;
 
     @BeforeEach
     public void setup() throws InitializationException, IOException {
         mockPool = mock(PublisherPool.class);
-        mockLease = mock(PublisherLease.class);
+        PublisherLease mockLease = mock(PublisherLease.class);
         Mockito.doCallRealMethod().when(mockLease).publish(any(FlowFile.class), any(RecordSet.class), any(RecordSetWriterFactory.class),
             any(RecordSchema.class), any(String.class), any(String.class), nullable(Function.class), any(PublishMetadataStrategy.class));
 
@@ -89,9 +88,9 @@ public class TestPublishKafkaRecordKey_2_6 {
         runner.assertValid();
         runner.setProperty(PublishKafkaRecord_2_6.PUBLISH_STRATEGY, "foo");
         runner.assertNotValid();
-        runner.setProperty(PublishKafkaRecord_2_6.PUBLISH_STRATEGY, PublishStrategy.USE_VALUE.getValue());
+        runner.setProperty(PublishKafkaRecord_2_6.PUBLISH_STRATEGY, PublishStrategy.USE_VALUE);
         runner.assertValid();
-        runner.setProperty(PublishKafkaRecord_2_6.PUBLISH_STRATEGY, PublishStrategy.USE_WRAPPER.getValue());
+        runner.setProperty(PublishKafkaRecord_2_6.PUBLISH_STRATEGY, PublishStrategy.USE_WRAPPER);
         runner.assertValid();
         runner.setProperty(PublishKafkaRecord_2_6.RECORD_KEY_WRITER, "no-record-writer");
         runner.assertNotValid();

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafkaRecordMockParameterized.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafkaRecordMockParameterized.java
@@ -314,11 +314,7 @@ public class TestPublishKafkaRecordMockParameterized {
                 patternAttributeName,
                 UTF_8,
                 publishStrategy,
-                keyWriterFactory) {
-            @Override
-            protected long getTimestamp() {
-                return 1000000000000L;
-            }
-        };
+                keyWriterFactory
+        );
     }
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafkaRecord_2_6.java
@@ -156,7 +156,7 @@ public class TestPublishKafkaRecord_2_6 {
 
     @Test
     public void testSingleFailureWithRollback() throws IOException {
-        runner.setProperty(PublishKafkaRecord_2_6.FAILURE_STRATEGY, FailureStrategy.ROLLBACK.getValue());
+        runner.setProperty(PublishKafkaRecord_2_6.FAILURE_STRATEGY, FailureStrategy.ROLLBACK);
 
         final MockFlowFile flowFile = runner.enqueue("John Doe, 48");
 
@@ -190,7 +190,7 @@ public class TestPublishKafkaRecord_2_6 {
 
     @Test
     public void testFailureWhenCreatingTransactionWithRollback() {
-        runner.setProperty(PublishKafkaRecord_2_6.FAILURE_STRATEGY, FailureStrategy.ROLLBACK.getValue());
+        runner.setProperty(PublishKafkaRecord_2_6.FAILURE_STRATEGY, FailureStrategy.ROLLBACK);
         runner.enqueue("John Doe, 48");
 
         doAnswer((Answer<Object>) invocationOnMock -> {
@@ -225,7 +225,7 @@ public class TestPublishKafkaRecord_2_6 {
 
     @Test
     public void testMultipleFailuresWithRollback() throws IOException {
-        runner.setProperty(PublishKafkaRecord_2_6.FAILURE_STRATEGY, FailureStrategy.ROLLBACK.getValue());
+        runner.setProperty(PublishKafkaRecord_2_6.FAILURE_STRATEGY, FailureStrategy.ROLLBACK);
         final Set<FlowFile> flowFiles = new HashSet<>();
         flowFiles.add(runner.enqueue("John Doe, 48"));
         flowFiles.add(runner.enqueue("John Doe, 48"));
@@ -299,7 +299,7 @@ public class TestPublishKafkaRecord_2_6 {
         verify(mockLease, times(0)).poison();
         verify(mockLease, times(1)).close();
 
-        final MockFlowFile mff = runner.getFlowFilesForRelationship(PublishKafkaRecord_2_6.REL_SUCCESS).get(0);
+        final MockFlowFile mff = runner.getFlowFilesForRelationship(PublishKafkaRecord_2_6.REL_SUCCESS).getFirst();
         mff.assertAttributeEquals("msg.count", "0");
     }
 
@@ -424,7 +424,7 @@ public class TestPublishKafkaRecord_2_6 {
             @Override
             public int getSuccessfulMessageCount(FlowFile flowFile) {
                 Integer count = msgCounts.get(flowFile);
-                return count == null ? 0 : count.intValue();
+                return count == null ? 0 : count;
             }
 
             @Override

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/test/java/org/apache/nifi/processors/kafka/pubsub/TestPublishKafka_2_6.java
@@ -140,7 +140,7 @@ public class TestPublishKafka_2_6 {
 
     @Test
     public void testSingleFailureWithRollback() throws IOException {
-        runner.setProperty(PublishKafka_2_6.FAILURE_STRATEGY, FailureStrategy.ROLLBACK.getValue());
+        runner.setProperty(PublishKafka_2_6.FAILURE_STRATEGY, FailureStrategy.ROLLBACK);
         final MockFlowFile flowFile = runner.enqueue("hello world");
 
         when(mockLease.complete()).thenReturn(createFailurePublishResult(flowFile));
@@ -156,7 +156,7 @@ public class TestPublishKafka_2_6 {
 
     @Test
     public void testMultipleFailuresWithRollback() throws IOException {
-        runner.setProperty(PublishKafka_2_6.FAILURE_STRATEGY, FailureStrategy.ROLLBACK.getValue());
+        runner.setProperty(PublishKafka_2_6.FAILURE_STRATEGY, FailureStrategy.ROLLBACK);
 
         final Set<FlowFile> flowFiles = new HashSet<>();
         flowFiles.add(runner.enqueue("hello world"));
@@ -294,7 +294,7 @@ public class TestPublishKafka_2_6 {
             @Override
             public int getSuccessfulMessageCount(FlowFile flowFile) {
                 Integer count = msgCounts.get(flowFile);
-                return count == null ? 0 : count.intValue();
+                return count == null ? 0 : count;
             }
 
             @Override

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
@@ -56,7 +56,7 @@ public interface KafkaClientComponent {
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .allowableValues(SaslMechanism.getAvailableSaslMechanisms())
-            .defaultValue(SaslMechanism.GSSAPI.getValue())
+            .defaultValue(SaslMechanism.GSSAPI)
             .build();
 
     PropertyDescriptor SASL_USERNAME = new PropertyDescriptor.Builder()
@@ -68,9 +68,9 @@ public interface KafkaClientComponent {
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .dependsOn(
                     SASL_MECHANISM,
-                    SaslMechanism.PLAIN.getValue(),
-                    SaslMechanism.SCRAM_SHA_256.getValue(),
-                    SaslMechanism.SCRAM_SHA_512.getValue()
+                    SaslMechanism.PLAIN,
+                    SaslMechanism.SCRAM_SHA_256,
+                    SaslMechanism.SCRAM_SHA_512
             )
             .build();
 
@@ -84,9 +84,9 @@ public interface KafkaClientComponent {
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .dependsOn(
                     SASL_MECHANISM,
-                    SaslMechanism.PLAIN.getValue(),
-                    SaslMechanism.SCRAM_SHA_256.getValue(),
-                    SaslMechanism.SCRAM_SHA_512.getValue()
+                    SaslMechanism.PLAIN,
+                    SaslMechanism.SCRAM_SHA_256,
+                    SaslMechanism.SCRAM_SHA_512
             )
             .build();
 
@@ -99,8 +99,8 @@ public interface KafkaClientComponent {
             .defaultValue(Boolean.FALSE.toString())
             .dependsOn(
                     SASL_MECHANISM,
-                    SaslMechanism.SCRAM_SHA_256.getValue(),
-                    SaslMechanism.SCRAM_SHA_512.getValue()
+                    SaslMechanism.SCRAM_SHA_256,
+                    SaslMechanism.SCRAM_SHA_512
             )
             .build();
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaPublishComponent.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaPublishComponent.java
@@ -29,6 +29,6 @@ public interface KafkaPublishComponent extends KafkaClientComponent {
             .description("Specifies how the processor handles a FlowFile if it is unable to publish the data to Kafka")
             .required(true)
             .allowableValues(FailureStrategy.class)
-            .defaultValue(FailureStrategy.ROUTE_TO_FAILURE.getValue())
+            .defaultValue(FailureStrategy.ROUTE_TO_FAILURE)
             .build();
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProvider.java
@@ -20,7 +20,6 @@ import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
 import org.apache.nifi.kafka.shared.property.SaslMechanism;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -29,15 +28,13 @@ import java.util.Map;
 public class DelegatingLoginConfigProvider implements LoginConfigProvider {
     private static final LoginConfigProvider SCRAM_PROVIDER = new ScramLoginConfigProvider();
 
-    private static final Map<SaslMechanism, LoginConfigProvider> PROVIDERS = new LinkedHashMap<>();
-
-    static {
-        PROVIDERS.put(SaslMechanism.GSSAPI, new KerberosDelegatingLoginConfigProvider());
-        PROVIDERS.put(SaslMechanism.PLAIN, new PlainLoginConfigProvider());
-        PROVIDERS.put(SaslMechanism.SCRAM_SHA_256, SCRAM_PROVIDER);
-        PROVIDERS.put(SaslMechanism.SCRAM_SHA_512, SCRAM_PROVIDER);
-        PROVIDERS.put(SaslMechanism.AWS_MSK_IAM, new AwsMskIamLoginConfigProvider());
-    }
+    private static final Map<SaslMechanism, LoginConfigProvider> PROVIDERS = Map.of(
+            SaslMechanism.GSSAPI, new KerberosDelegatingLoginConfigProvider(),
+            SaslMechanism.PLAIN, new PlainLoginConfigProvider(),
+            SaslMechanism.SCRAM_SHA_256, SCRAM_PROVIDER,
+            SaslMechanism.SCRAM_SHA_512, SCRAM_PROVIDER,
+            SaslMechanism.AWS_MSK_IAM, new AwsMskIamLoginConfigProvider()
+    );
 
     /**
      * Get JAAS configuration using configured username and password properties
@@ -47,8 +44,7 @@ public class DelegatingLoginConfigProvider implements LoginConfigProvider {
      */
     @Override
     public String getConfiguration(final PropertyContext context) {
-        final String saslMechanismProperty = context.getProperty(KafkaClientComponent.SASL_MECHANISM).getValue();
-        final SaslMechanism saslMechanism = SaslMechanism.getSaslMechanism(saslMechanismProperty);
+        final SaslMechanism saslMechanism = context.getProperty(KafkaClientComponent.SASL_MECHANISM).asDescribedValue(SaslMechanism.class);
         final LoginConfigProvider loginConfigProvider = PROVIDERS.getOrDefault(saslMechanism, SCRAM_PROVIDER);
         return loginConfigProvider.getConfiguration(context);
     }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/FailureStrategy.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/FailureStrategy.java
@@ -23,14 +23,11 @@ import org.apache.nifi.components.DescribedValue;
  */
 public enum FailureStrategy implements DescribedValue {
     ROUTE_TO_FAILURE("Route to Failure", "Route to Failure", "When unable to publish records to Kafka, the FlowFile will be routed to the failure relationship."),
-
     ROLLBACK("Rollback", "Rollback", "When unable to publish records to Kafka, the FlowFile will be placed back on the queue so that it will be retried. " +
             "For flows where FlowFile ordering is important, this strategy can be used along with ensuring that the each processor uses only a single Concurrent Task.");
 
     private final String value;
-
     private final String displayName;
-
     private final String description;
 
     FailureStrategy(final String value, final String displayName, final String description) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/KafkaClientProperty.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/KafkaClientProperty.java
@@ -21,23 +21,15 @@ package org.apache.nifi.kafka.shared.property;
  */
 public enum KafkaClientProperty {
     SASL_JAAS_CONFIG("sasl.jaas.config"),
-
     SASL_LOGIN_CLASS("sasl.login.class"),
-
     SASL_CLIENT_CALLBACK_HANDLER_CLASS("sasl.client.callback.handler.class"),
 
     SSL_KEYSTORE_LOCATION("ssl.keystore.location"),
-
     SSL_KEYSTORE_PASSWORD("ssl.keystore.password"),
-
     SSL_KEYSTORE_TYPE("ssl.keystore.type"),
-
     SSL_KEY_PASSWORD("ssl.key.password"),
-
     SSL_TRUSTSTORE_LOCATION("ssl.truststore.location"),
-
     SSL_TRUSTSTORE_PASSWORD("ssl.truststore.password"),
-
     SSL_TRUSTSTORE_TYPE("ssl.truststore.type");
 
     private final String property;

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/KeyEncoding.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/KeyEncoding.java
@@ -23,15 +23,11 @@ import org.apache.nifi.components.DescribedValue;
  */
 public enum KeyEncoding implements DescribedValue {
     UTF8("utf-8", "UTF-8 Encoded", "The key is interpreted as a UTF-8 Encoded string."),
-
     HEX("hex", "Hex Encoded", "The key is interpreted as arbitrary binary data and is encoded using hexadecimal characters with uppercase letters"),
-
     DO_NOT_ADD("do-not-add", "Do Not Add Key as Attribute","The key will not be added as an Attribute");
 
     private final String value;
-
     private final String displayName;
-
     private final String description;
 
     KeyEncoding(final String value, final String displayName, final String description) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/KeyFormat.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/KeyFormat.java
@@ -23,15 +23,11 @@ import org.apache.nifi.components.DescribedValue;
  */
 public enum KeyFormat implements DescribedValue {
     STRING("string", "String", "Format the Kafka ConsumerRecord key as a UTF-8 string."),
-
     BYTE_ARRAY("byte-array", "Byte Array", "Format the Kafka ConsumerRecord key as a byte array."),
-
     RECORD("record", "Record", "Format the Kafka ConsumerRecord key as a record.");
 
     private final String value;
-
     private final String displayName;
-
     private final String description;
 
     KeyFormat(final String value, final String displayName, final String description) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/OutputStrategy.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/OutputStrategy.java
@@ -23,13 +23,10 @@ import org.apache.nifi.components.DescribedValue;
  */
 public enum OutputStrategy implements DescribedValue {
     USE_VALUE("USE_VALUE", "Use Content as Value", "Write only the Kafka Record value to the FlowFile record."),
-
     USE_WRAPPER("USE_WRAPPER", "Use Wrapper", "Write the Kafka Record key, value, headers, and metadata into the FlowFile record. (See processor usage for more information.)");
 
     private final String value;
-
     private final String displayName;
-
     private final String description;
 
     OutputStrategy(final String value, final String displayName, final String description) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/PublishStrategy.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/PublishStrategy.java
@@ -23,11 +23,9 @@ import org.apache.nifi.components.DescribedValue;
  */
 public enum PublishStrategy implements DescribedValue {
     USE_VALUE( "Use Content as Record Value", "Write only the FlowFile content to the Kafka Record value."),
-
     USE_WRAPPER("Use Wrapper", "Write the Kafka Record key, value, headers, and metadata into the Kafka Record value.  (See processor usage for more information.)");
 
     private final String displayName;
-
     private final String description;
 
     PublishStrategy(final String displayName, final String description) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
@@ -19,42 +19,27 @@ package org.apache.nifi.kafka.shared.property;
 import org.apache.nifi.components.DescribedValue;
 import org.apache.nifi.kafka.shared.property.provider.StandardKafkaPropertyProvider;
 
-import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.Optional;
 
 /**
  * Enumeration of supported Kafka SASL Mechanisms
  */
 public enum SaslMechanism implements DescribedValue {
     GSSAPI("GSSAPI", "GSSAPI", "General Security Services API for Kerberos authentication"),
-
     PLAIN("PLAIN", "PLAIN", "Plain username and password authentication"),
-
     SCRAM_SHA_256("SCRAM-SHA-256", "SCRAM-SHA-256", "Salted Challenge Response Authentication Mechanism using SHA-512 with username and password"),
-
     SCRAM_SHA_512("SCRAM-SHA-512", "SCRAM-SHA-512", "Salted Challenge Response Authentication Mechanism using SHA-256 with username and password"),
-
     AWS_MSK_IAM("AWS_MSK_IAM", "AWS_MSK_IAM", "Allows to use AWS IAM for authentication and authorization against Amazon MSK clusters that have AWS IAM enabled " +
             "as an authentication mechanism. The IAM credentials will be found using the AWS Default Credentials Provider Chain.");
 
     private final String value;
-
     private final String displayName;
-
     private final String description;
 
     SaslMechanism(final String value, final String displayName, final String description) {
         this.value = value;
         this.displayName = displayName;
         this.description = description;
-    }
-
-    public static SaslMechanism getSaslMechanism(final String value) {
-        final Optional<SaslMechanism> foundSaslMechanism = Arrays.stream(SaslMechanism.values())
-                .filter(saslMechanism -> saslMechanism.getValue().equals(value))
-                .findFirst();
-        return foundSaslMechanism.orElseThrow(() -> new IllegalArgumentException(String.format("SaslMechanism value [%s] not found", value)));
     }
 
     public static EnumSet<SaslMechanism> getAvailableSaslMechanisms() {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SecurityProtocol.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SecurityProtocol.java
@@ -21,10 +21,7 @@ package org.apache.nifi.kafka.shared.property;
  */
 public enum SecurityProtocol {
     PLAINTEXT,
-
     SSL,
-
     SASL_PLAINTEXT,
-
     SASL_SSL
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProvider.java
@@ -16,20 +16,6 @@
  */
 package org.apache.nifi.kafka.shared.property.provider;
 
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SASL_MECHANISM;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SECURITY_PROTOCOL;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SSL_CONTEXT_SERVICE;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_CLIENT_CALLBACK_HANDLER_CLASS;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_JAAS_CONFIG;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_LOGIN_CLASS;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_LOCATION;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_PASSWORD;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_TYPE;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEY_PASSWORD;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_LOCATION;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_PASSWORD;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_TYPE;
-
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.context.PropertyContext;
@@ -48,6 +34,20 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
+
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SASL_MECHANISM;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SECURITY_PROTOCOL;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SSL_CONTEXT_SERVICE;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_CLIENT_CALLBACK_HANDLER_CLASS;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_JAAS_CONFIG;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_LOGIN_CLASS;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_LOCATION;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_PASSWORD;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_TYPE;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEY_PASSWORD;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_LOCATION;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_PASSWORD;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_TYPE;
 
 /**
  * Standard implementation of Kafka Property Provider based on shared Kafka Property Descriptors
@@ -86,10 +86,10 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
             final String loginConfig = LOGIN_CONFIG_PROVIDER.getConfiguration(context);
             properties.put(SASL_JAAS_CONFIG.getProperty(), loginConfig);
 
-            final SaslMechanism saslMechanism = SaslMechanism.getSaslMechanism(context.getProperty(SASL_MECHANISM).getValue());
-            if (SaslMechanism.GSSAPI == saslMechanism && isCustomKerberosLoginFound()) {
+            final SaslMechanism saslMechanism = context.getProperty(SASL_MECHANISM).asDescribedValue(SaslMechanism.class);
+            if (saslMechanism == SaslMechanism.GSSAPI && isCustomKerberosLoginFound()) {
                 properties.put(SASL_LOGIN_CLASS.getProperty(), SASL_GSSAPI_CUSTOM_LOGIN_CLASS);
-            } else if (SaslMechanism.AWS_MSK_IAM == saslMechanism && isAwsMskIamCallbackHandlerFound()) {
+            } else if (saslMechanism == SaslMechanism.AWS_MSK_IAM && isAwsMskIamCallbackHandlerFound()) {
                 properties.put(SASL_CLIENT_CALLBACK_HANDLER_CLASS.getProperty(), SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
             }
         }
@@ -138,17 +138,12 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
     }
 
     private Set<PropertyDescriptor> getPropertyDescriptors(final PropertyContext context) {
-        final Set<PropertyDescriptor> propertyDescriptors;
-        if (context instanceof ConfigurationContext) {
-            final ConfigurationContext configurationContext = (ConfigurationContext) context;
-            propertyDescriptors = configurationContext.getProperties().keySet();
-        } else if (context instanceof ProcessContext) {
-            final ProcessContext processContext = (ProcessContext) context;
-            propertyDescriptors = processContext.getProperties().keySet();
-        } else {
-            throw new IllegalArgumentException(String.format("Property Context [%s] not supported", context.getClass().getName()));
-        }
-        return propertyDescriptors;
+        return switch (context) {
+            case ConfigurationContext configurationContext -> configurationContext.getProperties().keySet();
+            case ProcessContext processContext -> processContext.getProperties().keySet();
+            default ->
+                    throw new IllegalArgumentException(String.format("Property Context [%s] not supported", context.getClass().getName()));
+        };
     }
 
     private void setProperty(final Map<String, Object> properties, final String propertyName, final String propertyValue) {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
@@ -51,10 +51,10 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
 
     private static final String JND_LOGIN_MODULE_EXPLANATION = "The JndiLoginModule is not allowed in the JAAS configuration";
 
-    private static final List<String> USERNAME_PASSWORD_SASL_MECHANISMS = Arrays.asList(
-            SaslMechanism.PLAIN.getValue(),
-            SaslMechanism.SCRAM_SHA_256.getValue(),
-            SaslMechanism.SCRAM_SHA_512.getValue()
+    private static final List<SaslMechanism> USERNAME_PASSWORD_SASL_MECHANISMS = Arrays.asList(
+            SaslMechanism.PLAIN,
+            SaslMechanism.SCRAM_SHA_256,
+            SaslMechanism.SCRAM_SHA_512
     );
 
     private static final List<String> SASL_PROTOCOLS = Arrays.asList(
@@ -94,10 +94,10 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
     }
 
     private void validateKerberosCredentials(final ValidationContext validationContext, final Collection<ValidationResult> results) {
-        final String saslMechanism = validationContext.getProperty(SASL_MECHANISM).getValue();
+        final SaslMechanism saslMechanism = validationContext.getProperty(SASL_MECHANISM).asDescribedValue(SaslMechanism.class);
         final String securityProtocol = validationContext.getProperty(SECURITY_PROTOCOL).getValue();
 
-        if (SaslMechanism.GSSAPI.name().equals(saslMechanism) && SASL_PROTOCOLS.contains(securityProtocol)) {
+        if (saslMechanism == SaslMechanism.GSSAPI && SASL_PROTOCOLS.contains(securityProtocol)) {
             final String serviceName = validationContext.getProperty(KERBEROS_SERVICE_NAME).evaluateAttributeExpressions().getValue();
             if (isEmpty(serviceName)) {
                 final String explanation = String.format("[%s] required for [%s] value [%s]", KERBEROS_SERVICE_NAME.getDisplayName(), SASL_MECHANISM.getDisplayName(), SaslMechanism.GSSAPI);
@@ -123,7 +123,7 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
     }
 
     private void validateUsernamePassword(final ValidationContext validationContext, final Collection<ValidationResult> results) {
-        final String saslMechanism = validationContext.getProperty(SASL_MECHANISM).getValue();
+        final SaslMechanism saslMechanism = validationContext.getProperty(SASL_MECHANISM).asDescribedValue(SaslMechanism.class);
 
         if (USERNAME_PASSWORD_SASL_MECHANISMS.contains(saslMechanism)) {
             final String username = validationContext.getProperty(SASL_USERNAME).evaluateAttributeExpressions().getValue();
@@ -151,9 +151,9 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
     private void validateAwsMskIamMechanism(final ValidationContext validationContext, final Collection<ValidationResult> results) {
         final PropertyValue saslMechanismProperty = validationContext.getProperty(SASL_MECHANISM);
         if (saslMechanismProperty.isSet()) {
-            final SaslMechanism saslMechanism = SaslMechanism.getSaslMechanism(saslMechanismProperty.getValue());
+            final SaslMechanism saslMechanism = saslMechanismProperty.asDescribedValue(SaslMechanism.class);
 
-            if (SaslMechanism.AWS_MSK_IAM == saslMechanism && !StandardKafkaPropertyProvider.isAwsMskIamCallbackHandlerFound()) {
+            if (saslMechanism == SaslMechanism.AWS_MSK_IAM && !StandardKafkaPropertyProvider.isAwsMskIamCallbackHandlerFound()) {
                 final String explanation = String.format("[%s] required class not found: Kafka modules must be compiled with AWS MSK enabled",
                         StandardKafkaPropertyProvider.SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
 
@@ -170,7 +170,4 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
         return string == null || string.isEmpty();
     }
 
-    private boolean isNotEmpty(final String string) {
-        return string != null && !string.isEmpty();
-    }
 }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProviderTest.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProviderTest.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DelegatingLoginConfigProviderTest {
 
     private static final String PLAIN_LOGIN_MODULE = "PlainLoginModule";
-
     private static final String SCRAM_LOGIN_MODULE = "ScramLoginModule";
 
     DelegatingLoginConfigProvider provider;
@@ -47,7 +46,7 @@ class DelegatingLoginConfigProviderTest {
 
     @Test
     void testGetConfigurationPlain() {
-        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.PLAIN.getValue());
+        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.PLAIN);
         final PropertyContext propertyContext = runner.getProcessContext();
 
         final String configuration = provider.getConfiguration(propertyContext);
@@ -58,7 +57,7 @@ class DelegatingLoginConfigProviderTest {
 
     @Test
     void testGetConfigurationScram() {
-        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.SCRAM_SHA_512.getValue());
+        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.SCRAM_SHA_512);
         final PropertyContext propertyContext = runner.getProcessContext();
 
         final String configuration = provider.getConfiguration(propertyContext);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProviderTest.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProviderTest.java
@@ -65,7 +65,7 @@ class StandardKafkaPropertyProviderTest {
         final SecurityProtocol securityProtocol = SecurityProtocol.SASL_PLAINTEXT;
 
         runner.setProperty(KafkaClientComponent.SECURITY_PROTOCOL, securityProtocol.name());
-        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.SCRAM_SHA_256.getValue());
+        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.SCRAM_SHA_256);
         final PropertyContext propertyContext = runner.getProcessContext();
 
         final Map<String, Object> properties = provider.getProperties(propertyContext);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunctionTest.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunctionTest.java
@@ -38,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class KafkaClientCustomValidationFunctionTest {
 
     private static final String JAAS_CONFIG_JNDI_LOGIN_MODULE = "com.sun.security.auth.module.JndiLoginModule required debug=true;";
-
     private static final String JAAS_CONFIG_PLACEHOLDER = "jaas.config";
 
     TestRunner runner;
@@ -63,7 +62,7 @@ class KafkaClientCustomValidationFunctionTest {
     @Test
     void testApplyKerberosSaslWithoutCredentialsInvalid() {
         runner.setProperty(KafkaClientComponent.SECURITY_PROTOCOL, SecurityProtocol.SASL_PLAINTEXT.name());
-        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.GSSAPI.getValue());
+        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.GSSAPI);
 
         final ValidationContext validationContext = getValidationContext();
         final Collection<ValidationResult> results = validationFunction.apply(validationContext);
@@ -74,7 +73,7 @@ class KafkaClientCustomValidationFunctionTest {
     @Test
     void testApplyKerberosSaslSystemPropertyWithoutServiceNameInvalid() {
         runner.setProperty(KafkaClientComponent.SECURITY_PROTOCOL, SecurityProtocol.SASL_PLAINTEXT.name());
-        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.GSSAPI.getValue());
+        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.GSSAPI);
 
         System.setProperty(KafkaClientCustomValidationFunction.JAVA_SECURITY_AUTH_LOGIN_CONFIG, JAAS_CONFIG_PLACEHOLDER);
 
@@ -87,7 +86,7 @@ class KafkaClientCustomValidationFunctionTest {
     @Test
     void testApplyKerberosSaslSystemPropertyValid() {
         runner.setProperty(KafkaClientComponent.SECURITY_PROTOCOL, SecurityProtocol.SASL_PLAINTEXT.name());
-        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.GSSAPI.getValue());
+        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.GSSAPI);
         runner.setProperty(KafkaClientComponent.KERBEROS_SERVICE_NAME, KafkaClientComponent.KERBEROS_SERVICE_NAME.getName());
 
         System.setProperty(KafkaClientCustomValidationFunction.JAVA_SECURITY_AUTH_LOGIN_CONFIG, JAAS_CONFIG_PLACEHOLDER);
@@ -101,7 +100,7 @@ class KafkaClientCustomValidationFunctionTest {
     @Test
     void testApplyPlainUsernameWithoutPasswordInvalid() {
         runner.setProperty(KafkaClientComponent.SASL_USERNAME, KafkaClientComponent.SASL_USERNAME.getName());
-        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.PLAIN.getValue());
+        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.PLAIN);
 
         final ValidationContext validationContext = getValidationContext();
         final Collection<ValidationResult> results = validationFunction.apply(validationContext);
@@ -112,7 +111,7 @@ class KafkaClientCustomValidationFunctionTest {
     @Test
     void testApplyPlainPasswordWithoutUsernameInvalid() {
         runner.setProperty(KafkaClientComponent.SASL_PASSWORD, KafkaClientComponent.SASL_PASSWORD.getName());
-        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.PLAIN.getValue());
+        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.PLAIN);
 
         final ValidationContext validationContext = getValidationContext();
         final Collection<ValidationResult> results = validationFunction.apply(validationContext);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Refactor tests and components in `cipher` bundle to use updated APIs from [NIFI-12452](https://issues.apache.org/jira/browse/NIFI-12452).

Additionally, makes use of newer Java APIs, e.g. `List.of` and `Set.of` for declaration of relationships and properties.

[NIFI-12557](https://issues.apache.org/jira/browse/NIFI-12557)

This time I've deleted several methods and fields from the `PublisherLease` I couldn't find any use of.

Also I noticed, that the parameter `maxConcurrentLeases` in several constructors of `ConsumerPool` is not actually used. The value provided is always from `ProcessContext::getMaxConcurrentTasks`. 
However, its use was removed as part of NIFI-8021. I removed this unused parameter as well.

All tests were still passing after the removal.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
