### PR TITLE
NIFI-12558 Upgrade Jagged from 0.2.0 to 0.3.0

### DIFF
--- a/nifi-nar-bundles/nifi-cipher-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-cipher-bundle/pom.xml
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>com.exceptionfactory.jagged</groupId>
                 <artifactId>jagged-bom</artifactId>
-                <version>0.2.0</version>
+                <version>0.3.0</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
# Summary

[NIFI-12558](https://issues.apache.org/jira/browse/NIFI-12558) Upgrades Jagged libraries from 0.2.0 to [0.3.0](https://github.com/exceptionfactory/jagged/releases/tag/0.3.0) for the `EncryptContentAge` and `DecryptContentAge` Processors. Version 0.3.0 corrects an issue with concurrent usage of KeyAgreement objects that presents itself when configuring `DecryptContentAge` with more than one Concurrent Task.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
