### PR TITLE
NIFI-12395 Upgrade Jackson JSON from 2.15.3 to 2.16.1

### DIFF
--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/AbstractByQueryElasticsearchTest.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/AbstractByQueryElasticsearchTest.java
@@ -135,12 +135,7 @@ public abstract class AbstractByQueryElasticsearchTest {
         runner.setProperty(ElasticsearchRestProcessor.QUERY, "not-json");
 
         final AssertionError assertionError = assertThrows(AssertionError.class, runner::run);
-        final String expected = String.format("Processor has 1 validation failures:\n" +
-                        "'%s' validated against 'not-json' is invalid because %s is not a valid JSON representation due to Unrecognized token 'not': was expecting" +
-                        " (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
-                        " at [Source: (String)\"not-json\"; line: 1, column: 4]\n",
-                ElasticsearchRestProcessor.QUERY.getName(), ElasticsearchRestProcessor.QUERY.getName());
-        assertEquals(expected, assertionError.getMessage());
+        assertTrue(assertionError.getMessage().contains("not-json"));
     }
 
     @Test
@@ -151,24 +146,7 @@ public abstract class AbstractByQueryElasticsearchTest {
         runner.setProperty(ElasticsearchRestProcessor.SCRIPT, "not-json-script");
 
         final AssertionError assertionError = assertThrows(AssertionError.class, runner::run);
-        String expected;
-        if (getTestProcessor() instanceof DeleteByQueryElasticsearch) {
-            // no SCRIPT in Query Builder
-            expected = "Processor has 1 validation failures:\n";
-        } else {
-            expected = "Processor has 2 validation failures:\n";
-        }
-        expected += String.format("'%s' validated against 'not-json' is invalid because %s is not a valid JSON representation due to Unrecognized token 'not': was expecting" +
-                        " (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
-                        " at [Source: (String)\"not-json\"; line: 1, column: 4]\n",
-                ElasticsearchRestProcessor.QUERY_CLAUSE.getName(), ElasticsearchRestProcessor.QUERY_CLAUSE.getName());
-        if (getTestProcessor() instanceof UpdateByQueryElasticsearch) {
-            expected += String.format("'%s' validated against 'not-json-script' is invalid because %s is not a valid JSON representation due to Unrecognized token 'not': was expecting " +
-                            "(JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
-                            " at [Source: (String)\"not-json-script\"; line: 1, column: 4]\n",
-                    ElasticsearchRestProcessor.SCRIPT.getName(), ElasticsearchRestProcessor.SCRIPT.getName());
-        }
-        assertEquals(expected, assertionError.getMessage());
+        assertTrue(assertionError.getMessage().contains("not-json"));
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/AbstractJsonQueryElasticsearchTest.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/AbstractJsonQueryElasticsearchTest.java
@@ -169,12 +169,7 @@ public abstract class AbstractJsonQueryElasticsearchTest<P extends AbstractJsonQ
             runner.assertValid();
         } else {
             final AssertionError assertionError = assertThrows(AssertionError.class, runner::run);
-            final String expected = String.format("Processor has 1 validation failures:\n" +
-                            "'%s' validated against 'not-json' is invalid because %s is not a valid JSON representation due to Unrecognized token 'not': was expecting" +
-                            " (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
-                            " at [Source: (String)\"not-json\"; line: 1, column: 4]\n",
-                    queryPropertyDescriptor.getName(), queryPropertyDescriptor.getName());
-            assertEquals(expected, assertionError.getMessage());
+            assertTrue(assertionError.getMessage().contains("not-json"));
         }
     }
 
@@ -190,36 +185,7 @@ public abstract class AbstractJsonQueryElasticsearchTest<P extends AbstractJsonQ
         runner.setProperty(ElasticsearchRestProcessor.SCRIPT_FIELDS, "not-json-script_fields");
 
         final AssertionError assertionError = assertThrows(AssertionError.class, runner::run);
-        String expected;
-        if (runner.getProcessor() instanceof ConsumeElasticsearch) {
-            // ConsumeElasticsearch doesn't use QUERY_CLAUSE
-            expected = "Processor has 5 validation failures:\n";
-        } else {
-            expected = String.format("Processor has 6 validation failures:\n" +
-                            "'%s' validated against 'not-json' is invalid because %s is not a valid JSON representation due to Unrecognized token 'not': was expecting" +
-                            " (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
-                            " at [Source: (String)\"not-json\"; line: 1, column: 4]\n",
-                    ElasticsearchRestProcessor.QUERY_CLAUSE.getName(), ElasticsearchRestProcessor.QUERY_CLAUSE.getName());
-        }
-        expected += String.format("'%s' validated against '-1' is invalid because not a positive value\n" +
-                        "'%s' validated against 'not-json-sort' is invalid because %s is not a valid JSON representation due to Unrecognized token 'not': was expecting" +
-                        " (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
-                        " at [Source: (String)\"not-json-sort\"; line: 1, column: 4]\n" +
-                        "'%s' validated against 'not-json-aggs' is invalid because %s is not a valid JSON representation due to Unrecognized token 'not': was expecting" +
-                        " (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
-                        " at [Source: (String)\"not-json-aggs\"; line: 1, column: 4]\n" +
-                        "'%s' validated against 'not-json-fields' is invalid because %s is not a valid JSON representation due to Unrecognized token 'not': was expecting" +
-                        " (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
-                        " at [Source: (String)\"not-json-fields\"; line: 1, column: 4]\n" +
-                        "'%s' validated against 'not-json-script_fields' is invalid because %s is not a valid JSON representation due to Unrecognized token 'not': was expecting" +
-                        " (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
-                        " at [Source: (String)\"not-json-script_fields\"; line: 1, column: 4]\n",
-                ElasticsearchRestProcessor.SIZE.getName(),
-                ElasticsearchRestProcessor.SORT.getName(), ElasticsearchRestProcessor.SORT.getName(),
-                ElasticsearchRestProcessor.AGGREGATIONS.getName(), ElasticsearchRestProcessor.AGGREGATIONS.getName(),
-                ElasticsearchRestProcessor.FIELDS.getName(), ElasticsearchRestProcessor.FIELDS.getName(),
-                ElasticsearchRestProcessor.SCRIPT_FIELDS.getName(), ElasticsearchRestProcessor.SCRIPT_FIELDS.getName());
-        assertEquals(expected, assertionError.getMessage());
+        assertTrue(assertionError.getMessage().contains("not-json"));
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJsonTest.java
+++ b/nifi-nar-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJsonTest.java
@@ -441,8 +441,7 @@ public class PutElasticsearchJsonTest extends AbstractPutElasticsearchTest<PutEl
         runner.assertTransferCount(PutElasticsearchJson.REL_FAILED_DOCUMENTS, 0);
         runner.assertTransferCount(PutElasticsearchRecord.REL_ERROR_RESPONSES, 0);
 
-        runner.getFlowFilesForRelationship(PutElasticsearchJson.REL_FAILURE).get(0).assertAttributeEquals("elasticsearch.put.error",
-                "Unrecognized token 'not': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n" +
-                        " at [Source: (String)\"not-json\"; line: 1, column: 4]");
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(PutElasticsearchJson.REL_FAILURE).get(0);
+        assertTrue(flowFile.getAttribute("elasticsearch.put.error").contains("not"));
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
@@ -305,8 +305,8 @@ class TestJsonTreeRowRecordReader {
     void testReadJSONStringTooLong() {
         final StreamConstraintsException mre = assertThrows(StreamConstraintsException.class, () ->
                 testReadAccountJson("src/test/resources/json/bank-account-multiline.json", false, StreamReadConstraints.builder().maxStringLength(2).build()));
-        assertTrue(mre.getMessage().contains("maximum length"));
-        assertTrue(mre.getMessage().contains("(2)"));
+        assertTrue(mre.getMessage().contains("maximum"));
+        assertTrue(mre.getMessage().contains("2"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <derby.version>10.17.1.0</derby.version>
         <ranger.version>2.4.0</ranger.version>
         <jetty.version>10.0.18</jetty.version>
-        <jackson.bom.version>2.15.3</jackson.bom.version>
+        <jackson.bom.version>2.16.1</jackson.bom.version>
         <avro.version>1.11.3</avro.version>
         <jaxb.runtime.version>2.3.9</jaxb.runtime.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>


### PR DESCRIPTION
# Summary

[NIFI-12395](https://issues.apache.org/jira/browse/NIFI-12395) Upgrades Jackson JSON dependencies from 2.15.3 to [2.16.1](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.16).

Additional changes include adjusting several unit tests to use more lenient error message comparison instead of expecting exact wording from specific versions of Jackson.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
