### PR TITLE
NIFI-12567 - Prevent NPE in CuratorLeaderElectionManager.getLeadershipChangeCount

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/leader/election/CuratorLeaderElectionManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/leader/election/CuratorLeaderElectionManager.java
@@ -238,7 +238,7 @@ public class CuratorLeaderElectionManager implements LeaderElectionManager {
             final TimedBuffer<TimestampedLong> buffer = entry.getValue();
 
             final TimestampedLong aggregateValue = buffer.getAggregateValue(System.currentTimeMillis() - TimeUnit.MILLISECONDS.convert(duration, unit));
-            final int leadershipChanges = aggregateValue.getValue().intValue();
+            final int leadershipChanges = (aggregateValue == null) ? 0 : aggregateValue.getValue().intValue();
             leadershipChangesPerRole.put(roleName, leadershipChanges);
         }
 


### PR DESCRIPTION
# Summary

[NIFI-12567](https://issues.apache.org/jira/browse/NIFI-12567) - NPE in CuratorLeaderElectionManager.getLeadershipChangeCount

Since NiFi 1.10, a NPE can happen in the code of CuratorLeaderElectionManager.getLeadershipChangeCount when trying to get diagnostic data for a NiFi node:

````
ERROR org.apache.nifi.diagnostics.bootstrap.BootstrapDiagnosticsFactory: Failed to obtain diagnostics information from class org.apache.nifi.diagnostics.bootstrap.tasks.ClusterDiagnosticTask
java.lang.NullPointerException: null
	at org.apache.nifi.controller.leader.election.CuratorLeaderElectionManager.getLeadershipChangeCount(CuratorLeaderElectionManager.java:241)
	at org.apache.nifi.diagnostics.bootstrap.tasks.ClusterDiagnosticTask.captureDump(ClusterDiagnosticTask.java:75)
	at org.apache.nifi.diagnostics.bootstrap.BootstrapDiagnosticsFactory.create(BootstrapDiagnosticsFactory.java:58)
	at org.apache.nifi.BootstrapListener.writeDiagnostics(BootstrapListener.java:288)
	at org.apache.nifi.BootstrapListener.access$600(BootstrapListener.java:41)
	at org.apache.nifi.BootstrapListener$Listener$1.run(BootstrapListener.java:240)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748) 
 ````

The problematic line is here:

https://github.com/apache/nifi/blob/support/nifi-1.x/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/leader/election/CuratorLeaderElectionManager.java#L241

This problem does not exist in NiFi 2.x as we have a proper null check at

https://github.com/apache/nifi/blob/main/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-leader-election-shared/src/main/java/org/apache/nifi/controller/leader/election/TrackedLeaderElectionManager.java#L60

This PR is adding a similar null check in the NiFi 1.x support line.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
