### PR TITLE
NIFI-8278 Added Credentials Type property to ADLSCredentialsControlle…

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/AbstractAzureQueueStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/AbstractAzureQueueStorage_v12.java
@@ -62,12 +62,7 @@ public abstract class AbstractAzureQueueStorage_v12 extends AbstractProcessor {
 
     public static final PropertyDescriptor ENDPOINT_SUFFIX = new PropertyDescriptor.Builder()
             .fromPropertyDescriptor(AzureStorageUtils.ENDPOINT_SUFFIX)
-            .displayName("Endpoint Suffix")
-            .description("Storage accounts in public Azure always use a common FQDN suffix. " +
-                    "Override this endpoint suffix with a different suffix in certain circumstances (like Azure Stack or non-public Azure regions).")
-            .required(true)
             .defaultValue(AzureServiceEndpoints.DEFAULT_QUEUE_ENDPOINT_SUFFIX)
-            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .build();
 
     public static final PropertyDescriptor STORAGE_CREDENTIALS_SERVICE = new PropertyDescriptor.Builder()

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/AzureStorageUtils.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/AzureStorageUtils.java
@@ -27,11 +27,13 @@ import org.apache.nifi.proxy.ProxyConfiguration;
 import org.apache.nifi.proxy.ProxySpec;
 import org.apache.nifi.proxy.SocksVersion;
 import org.apache.nifi.services.azure.storage.AzureStorageConflictResolutionStrategy;
+import org.apache.nifi.services.azure.storage.AzureStorageCredentialsType;
 import reactor.netty.http.client.HttpClient;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Collection;
+import java.util.EnumSet;
 
 public final class AzureStorageUtils {
     public static final String STORAGE_ACCOUNT_NAME_PROPERTY_DESCRIPTOR_NAME = "storage-account-name";
@@ -39,65 +41,68 @@ public final class AzureStorageUtils {
     public static final String STORAGE_SAS_TOKEN_PROPERTY_DESCRIPTOR_NAME = "storage-sas-token";
     public static final String STORAGE_ENDPOINT_SUFFIX_PROPERTY_DESCRIPTOR_NAME = "storage-endpoint-suffix";
 
+    public static final PropertyDescriptor CREDENTIALS_TYPE = new PropertyDescriptor.Builder()
+            .name("credentials-type")
+            .displayName("Credentials Type")
+            .description("Credentials type to be used for authenticating to Azure")
+            .required(true)
+            .allowableValues(EnumSet.of(
+                    AzureStorageCredentialsType.ACCOUNT_KEY,
+                    AzureStorageCredentialsType.SAS_TOKEN,
+                    AzureStorageCredentialsType.MANAGED_IDENTITY,
+                    AzureStorageCredentialsType.SERVICE_PRINCIPAL))
+            .defaultValue(AzureStorageCredentialsType.SAS_TOKEN)
+            .build();
+
     public static final String ACCOUNT_KEY_BASE_DESCRIPTION =
             "The storage account key. This is an admin-like password providing access to every container in this account. It is recommended " +
-            "one uses Shared Access Signature (SAS) token instead for fine-grained control with policies.";
+            "one uses Shared Access Signature (SAS) token, Managed Identity or Service Principal instead for fine-grained control with policies.";
 
     public static final String ACCOUNT_KEY_SECURITY_DESCRIPTION =
-            " There are certain risks in allowing the account key to be stored as a flowfile " +
+            " There are certain risks in allowing the account key to be stored as a FlowFile " +
             "attribute. While it does provide for a more flexible flow by allowing the account key to " +
-            "be fetched dynamically from a flowfile attribute, care must be taken to restrict access to " +
+            "be fetched dynamically from a FlowFile attribute, care must be taken to restrict access to " +
             "the event provenance data (e.g., by strictly controlling the policies governing provenance for this processor). " +
             "In addition, the provenance repositories may be put on encrypted disk partitions.";
 
     public static final PropertyDescriptor ACCOUNT_KEY = new PropertyDescriptor.Builder()
             .name(STORAGE_ACCOUNT_KEY_PROPERTY_DESCRIPTOR_NAME)
-            .displayName("Storage Account Key")
-            .description(ACCOUNT_KEY_BASE_DESCRIPTION + ACCOUNT_KEY_SECURITY_DESCRIPTION)
+            .displayName("Account Key")
+            .description(ACCOUNT_KEY_BASE_DESCRIPTION)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
-            .required(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .required(true)
             .sensitive(true)
+            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.ACCOUNT_KEY)
             .build();
 
     public static final String ACCOUNT_NAME_BASE_DESCRIPTION = "The storage account name.";
 
     public static final String ACCOUNT_NAME_SECURITY_DESCRIPTION =
-            " There are certain risks in allowing the account name to be stored as a flowfile " +
+            " There are certain risks in allowing the account name to be stored as a FlowFile " +
             "attribute. While it does provide for a more flexible flow by allowing the account name to " +
-            "be fetched dynamically from a flowfile attribute, care must be taken to restrict access to " +
+            "be fetched dynamically from a FlowFile attribute, care must be taken to restrict access to " +
             "the event provenance data (e.g., by strictly controlling the policies governing provenance for this processor). " +
             "In addition, the provenance repositories may be put on encrypted disk partitions.";
-
-    public static final String ACCOUNT_NAME_CREDENTIAL_SERVICE_DESCRIPTION =
-            " Instead of defining the Storage Account Name, Storage Account Key and SAS Token properties directly on the processor, " +
-            "the preferred way is to configure them through a controller service specified in the Storage Credentials property. " +
-            "The controller service can provide a common/shared configuration for multiple/all Azure processors. Furthermore, the credentials " +
-            "can also be looked up dynamically with the 'Lookup' version of the service.";
 
     public static final PropertyDescriptor ACCOUNT_NAME = new PropertyDescriptor.Builder()
             .name(STORAGE_ACCOUNT_NAME_PROPERTY_DESCRIPTOR_NAME)
             .displayName("Storage Account Name")
-            .description(ACCOUNT_NAME_BASE_DESCRIPTION + ACCOUNT_NAME_SECURITY_DESCRIPTION + ACCOUNT_NAME_CREDENTIAL_SERVICE_DESCRIPTION)
+            .description(ACCOUNT_NAME_BASE_DESCRIPTION)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
-            .required(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .required(true)
             .sensitive(true)
             .build();
 
     public static final PropertyDescriptor ENDPOINT_SUFFIX = new PropertyDescriptor.Builder()
             .name(STORAGE_ENDPOINT_SUFFIX_PROPERTY_DESCRIPTOR_NAME)
-            .displayName("Common Storage Account Endpoint Suffix")
-            .description(
-                    "Storage accounts in public Azure always use a common FQDN suffix. " +
-                    "Override this endpoint suffix with a different suffix in certain circumstances (like Azure Stack or non-public Azure regions). " +
-                    "The preferred way is to configure them through a controller service specified in the Storage Credentials property. " +
-                    "The controller service can provide a common/shared configuration for multiple/all Azure processors. Furthermore, the credentials " +
-                    "can also be looked up dynamically with the 'Lookup' version of the service.")
+            .displayName("Endpoint Suffix")
+            .description("Storage accounts in public Azure always use a common FQDN suffix. " +
+                    "Override this endpoint suffix with a different suffix in certain circumstances (like Azure Stack or non-public Azure regions).")
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
-            .required(false)
-            .sensitive(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .required(true)
             .build();
 
     public static final PropertyDescriptor CONTAINER = new PropertyDescriptor.Builder()
@@ -132,23 +137,24 @@ public final class AzureStorageUtils {
             .description("Specifies whether an existing blob will have its contents replaced upon conflict.")
             .build();
 
-    public static final String SAS_TOKEN_BASE_DESCRIPTION = "Shared Access Signature token, including the leading '?'. Specify either SAS token (recommended) or Account Key.";
+    public static final String SAS_TOKEN_BASE_DESCRIPTION = "Shared Access Signature token (the leading '?' may be included)";
 
     public static final String SAS_TOKEN_SECURITY_DESCRIPTION =
-            " There are certain risks in allowing the SAS token to be stored as a flowfile " +
+            " There are certain risks in allowing the SAS token to be stored as a FlowFile " +
             "attribute. While it does provide for a more flexible flow by allowing the SAS token to " +
-            "be fetched dynamically from a flowfile attribute, care must be taken to restrict access to " +
+            "be fetched dynamically from a FlowFile attribute, care must be taken to restrict access to " +
             "the event provenance data (e.g., by strictly controlling the policies governing provenance for this processor). " +
             "In addition, the provenance repositories may be put on encrypted disk partitions.";
 
-    public static final PropertyDescriptor PROP_SAS_TOKEN = new PropertyDescriptor.Builder()
+    public static final PropertyDescriptor SAS_TOKEN = new PropertyDescriptor.Builder()
             .name(STORAGE_SAS_TOKEN_PROPERTY_DESCRIPTOR_NAME)
             .displayName("SAS Token")
-            .description(SAS_TOKEN_BASE_DESCRIPTION + SAS_TOKEN_SECURITY_DESCRIPTION)
-            .required(false)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .description(SAS_TOKEN_BASE_DESCRIPTION)
+            .required(true)
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .sensitive(true)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SAS_TOKEN)
             .build();
 
     public static final PropertyDescriptor MANAGED_IDENTITY_CLIENT_ID = new PropertyDescriptor.Builder()
@@ -160,36 +166,40 @@ public final class AzureStorageUtils {
             .required(false)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.MANAGED_IDENTITY)
             .build();
 
     public static final PropertyDescriptor SERVICE_PRINCIPAL_TENANT_ID = new PropertyDescriptor.Builder()
             .name("service-principal-tenant-id")
             .displayName("Service Principal Tenant ID")
-            .description("Tenant ID of the Azure Active Directory hosting the Service Principal. The property is required when Service Principal authentication is used.")
+            .description("Tenant ID of the Azure Active Directory hosting the Service Principal.")
             .sensitive(true)
-            .required(false)
+            .required(true)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL)
             .build();
 
     public static final PropertyDescriptor SERVICE_PRINCIPAL_CLIENT_ID = new PropertyDescriptor.Builder()
             .name("service-principal-client-id")
             .displayName("Service Principal Client ID")
-            .description("Client ID (or Application ID) of the Client/Application having the Service Principal. The property is required when Service Principal authentication is used.")
+            .description("Client ID (or Application ID) of the Client/Application having the Service Principal.")
             .sensitive(true)
-            .required(false)
+            .required(true)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL)
             .build();
 
     public static final PropertyDescriptor SERVICE_PRINCIPAL_CLIENT_SECRET = new PropertyDescriptor.Builder()
             .name("service-principal-client-secret")
             .displayName("Service Principal Client Secret")
-            .description("Password of the Client/Application. The property is required when Service Principal authentication is used.")
+            .description("Password of the Client/Application.")
             .sensitive(true)
-            .required(false)
+            .required(true)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL)
             .build();
 
     private AzureStorageUtils() {
@@ -197,8 +207,10 @@ public final class AzureStorageUtils {
     }
 
     private static final ProxySpec[] PROXY_SPECS = {ProxySpec.HTTP, ProxySpec.SOCKS};
-    public static final PropertyDescriptor PROXY_CONFIGURATION_SERVICE
-            = ProxyConfiguration.createProxyConfigPropertyDescriptor(false, PROXY_SPECS);
+    public static final PropertyDescriptor PROXY_CONFIGURATION_SERVICE = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(ProxyConfiguration.createProxyConfigPropertyDescriptor(false, PROXY_SPECS))
+            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL, AzureStorageCredentialsType.MANAGED_IDENTITY)
+            .build();
 
     public static void validateProxySpec(ValidationContext context, Collection<ValidationResult> results) {
         ProxyConfiguration.validateProxySpec(context, results, PROXY_SPECS);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/ADLSCredentialsControllerService.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/ADLSCredentialsControllerService.java
@@ -16,28 +16,29 @@
  */
 package org.apache.nifi.services.azure.storage;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
-import org.apache.nifi.components.ValidationContext;
-import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
-import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processors.azure.AzureServiceEndpoints;
 import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.CREDENTIALS_TYPE;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.PROXY_CONFIGURATION_SERVICE;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID;
 
 /**
  * Provides credentials details for ADLS
@@ -51,45 +52,33 @@ public class ADLSCredentialsControllerService extends AbstractControllerService 
     public static final PropertyDescriptor ACCOUNT_NAME = new PropertyDescriptor.Builder()
             .fromPropertyDescriptor(AzureStorageUtils.ACCOUNT_NAME)
             .description(AzureStorageUtils.ACCOUNT_NAME_BASE_DESCRIPTION + AzureStorageUtils.ACCOUNT_NAME_SECURITY_DESCRIPTION)
-            .required(true)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor ACCOUNT_KEY = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(AzureStorageUtils.ACCOUNT_KEY)
+            .description(AzureStorageUtils.ACCOUNT_KEY_BASE_DESCRIPTION + AzureStorageUtils.ACCOUNT_KEY_SECURITY_DESCRIPTION)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    public static final PropertyDescriptor SAS_TOKEN = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(AzureStorageUtils.SAS_TOKEN)
+            .description(AzureStorageUtils.SAS_TOKEN_BASE_DESCRIPTION + AzureStorageUtils.SAS_TOKEN_SECURITY_DESCRIPTION)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
     public static final PropertyDescriptor ENDPOINT_SUFFIX = new PropertyDescriptor.Builder()
             .fromPropertyDescriptor(AzureStorageUtils.ENDPOINT_SUFFIX)
-            .displayName("Endpoint Suffix")
-            .description("Storage accounts in public Azure always use a common FQDN suffix. " +
-                    "Override this endpoint suffix with a different suffix in certain circumstances (like Azure Stack or non-public Azure regions).")
-            .required(true)
             .defaultValue(AzureServiceEndpoints.DEFAULT_ADLS_ENDPOINT_SUFFIX)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
-    public static final PropertyDescriptor USE_MANAGED_IDENTITY = new PropertyDescriptor.Builder()
-            .name("storage-use-managed-identity")
-            .displayName("Use Azure Managed Identity")
-            .description("Choose whether or not to use the managed identity of Azure VM/VMSS")
-            .required(false)
-            .defaultValue("false")
-            .allowableValues("true", "false")
-            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
-            .build();
-
-    public static final PropertyDescriptor MANAGED_IDENTITY_CLIENT_ID = AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID;
-
-    public static final PropertyDescriptor SERVICE_PRINCIPAL_TENANT_ID = AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID;
-
-    public static final PropertyDescriptor SERVICE_PRINCIPAL_CLIENT_ID = AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID;
-
-    public static final PropertyDescriptor SERVICE_PRINCIPAL_CLIENT_SECRET = AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET;
-
-    public static final PropertyDescriptor PROXY_CONFIGURATION_SERVICE = AzureStorageUtils.PROXY_CONFIGURATION_SERVICE;
-
     private static final List<PropertyDescriptor> PROPERTIES = List.of(
             ACCOUNT_NAME,
             ENDPOINT_SUFFIX,
-            AzureStorageUtils.ACCOUNT_KEY,
-            AzureStorageUtils.PROP_SAS_TOKEN,
-            USE_MANAGED_IDENTITY,
+            CREDENTIALS_TYPE,
+            ACCOUNT_KEY,
+            SAS_TOKEN,
             MANAGED_IDENTITY_CLIENT_ID,
             SERVICE_PRINCIPAL_TENANT_ID,
             SERVICE_PRINCIPAL_CLIENT_ID,
@@ -105,66 +94,26 @@ public class ADLSCredentialsControllerService extends AbstractControllerService 
     }
 
     @Override
-    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
-        final List<ValidationResult> results = new ArrayList<>();
+    public void migrateProperties(PropertyConfiguration config) {
+        if (!config.hasProperty(CREDENTIALS_TYPE)) {
+            final String propNameUseManagedIdentity = "storage-use-managed-identity";
 
-        final boolean accountKeySet = StringUtils.isNotBlank(validationContext.getProperty(AzureStorageUtils.ACCOUNT_KEY).getValue());
-        final boolean sasTokenSet = StringUtils.isNotBlank(validationContext.getProperty(AzureStorageUtils.PROP_SAS_TOKEN).getValue());
-        final boolean useManagedIdentitySet = validationContext.getProperty(USE_MANAGED_IDENTITY).asBoolean();
-
-        final boolean servicePrincipalTenantIdSet = StringUtils.isNotBlank(validationContext.getProperty(SERVICE_PRINCIPAL_TENANT_ID).getValue());
-        final boolean servicePrincipalClientIdSet = StringUtils.isNotBlank(validationContext.getProperty(SERVICE_PRINCIPAL_CLIENT_ID).getValue());
-        final boolean servicePrincipalClientSecretSet = StringUtils.isNotBlank(validationContext.getProperty(SERVICE_PRINCIPAL_CLIENT_SECRET).getValue());
-
-        final boolean servicePrincipalSet = servicePrincipalTenantIdSet || servicePrincipalClientIdSet || servicePrincipalClientSecretSet;
-
-        final String managedIdentityClientId = validationContext.getProperty(MANAGED_IDENTITY_CLIENT_ID).getValue();
-
-        if (!onlyOneSet(accountKeySet, sasTokenSet, useManagedIdentitySet, servicePrincipalSet)) {
-            results.add(new ValidationResult.Builder().subject(this.getClass().getSimpleName())
-                .valid(false)
-                .explanation("one and only one authentication method of [Account Key, SAS Token, Managed Identity, Service Principal] should be used")
-                .build());
-        } else {
-            if (servicePrincipalSet) {
-                final String template = "'%s' must be set when Service Principal authentication is being configured";
-                if (!servicePrincipalTenantIdSet) {
-                    results.add(new ValidationResult.Builder().subject(this.getClass().getSimpleName())
-                            .valid(false)
-                            .explanation(String.format(template, SERVICE_PRINCIPAL_TENANT_ID.getDisplayName()))
-                            .build());
-                }
-                if (!servicePrincipalClientIdSet) {
-                    results.add(new ValidationResult.Builder().subject(this.getClass().getSimpleName())
-                            .valid(false)
-                            .explanation(String.format(template, SERVICE_PRINCIPAL_CLIENT_ID.getDisplayName()))
-                            .build());
-                }
-                if (!servicePrincipalClientSecretSet) {
-                    results.add(new ValidationResult.Builder().subject(this.getClass().getSimpleName())
-                            .valid(false)
-                            .explanation(String.format(template, SERVICE_PRINCIPAL_CLIENT_SECRET.getDisplayName()))
-                            .build());
-                }
+            if (config.isPropertySet(ACCOUNT_KEY)) {
+                config.setProperty(CREDENTIALS_TYPE, AzureStorageCredentialsType.ACCOUNT_KEY.getValue());
+            } else if (config.isPropertySet(SAS_TOKEN)) {
+                config.setProperty(CREDENTIALS_TYPE, AzureStorageCredentialsType.SAS_TOKEN.getValue());
+            } else if (config.isPropertySet(SERVICE_PRINCIPAL_TENANT_ID)) {
+                config.setProperty(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL.getValue());
+            } else {
+                config.getPropertyValue(propNameUseManagedIdentity).ifPresent(value -> {
+                    if ("true".equals(value)) {
+                        config.setProperty(CREDENTIALS_TYPE, AzureStorageCredentialsType.MANAGED_IDENTITY.getValue());
+                    }
+                });
             }
 
-            if (!useManagedIdentitySet && StringUtils.isNotEmpty(managedIdentityClientId)) {
-                results.add(new ValidationResult.Builder().subject(this.getClass().getSimpleName())
-                        .valid(false)
-                        .explanation(String.format("'%s' can only be configured when '%s' is set to true", MANAGED_IDENTITY_CLIENT_ID.getDisplayName(), USE_MANAGED_IDENTITY.getDisplayName()))
-                        .build());
-            }
+            config.removeProperty(propNameUseManagedIdentity);
         }
-
-        return results;
-    }
-
-    private boolean onlyOneSet(Boolean... checks) {
-        long nrOfSet = Arrays.stream(checks)
-            .filter(check -> check)
-            .count();
-
-        return nrOfSet == 1;
     }
 
     @OnEnabled
@@ -177,10 +126,11 @@ public class ADLSCredentialsControllerService extends AbstractControllerService 
         ADLSCredentialsDetails.Builder credentialsBuilder = ADLSCredentialsDetails.Builder.newBuilder();
 
         setValue(credentialsBuilder, ACCOUNT_NAME, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setAccountName, attributes);
-        setValue(credentialsBuilder, AzureStorageUtils.ACCOUNT_KEY, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setAccountKey, attributes);
-        setValue(credentialsBuilder, AzureStorageUtils.PROP_SAS_TOKEN, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setSasToken, attributes);
+        setValue(credentialsBuilder, ACCOUNT_KEY, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setAccountKey, attributes);
+        setValue(credentialsBuilder, SAS_TOKEN, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setSasToken, attributes);
         setValue(credentialsBuilder, ENDPOINT_SUFFIX, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setEndpointSuffix, attributes);
-        setValue(credentialsBuilder, USE_MANAGED_IDENTITY, PropertyValue::asBoolean, ADLSCredentialsDetails.Builder::setUseManagedIdentity, attributes);
+        setValue(credentialsBuilder, CREDENTIALS_TYPE, property -> property.asDescribedValue(AzureStorageCredentialsType.class) == AzureStorageCredentialsType.MANAGED_IDENTITY,
+                ADLSCredentialsDetails.Builder::setUseManagedIdentity, attributes);
         setValue(credentialsBuilder, MANAGED_IDENTITY_CLIENT_ID, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setManagedIdentityClientId, attributes);
         setValue(credentialsBuilder, SERVICE_PRINCIPAL_TENANT_ID, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setServicePrincipalTenantId, attributes);
         setValue(credentialsBuilder, SERVICE_PRINCIPAL_CLIENT_ID, PropertyValue::getValue, ADLSCredentialsDetails.Builder::setServicePrincipalClientId, attributes);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureStorageCredentialsControllerService_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureStorageCredentialsControllerService_v12.java
@@ -23,14 +23,21 @@ import org.apache.nifi.annotation.lifecycle.OnEnabled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
-import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processors.azure.AzureServiceEndpoints;
 import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ACCOUNT_KEY;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ACCOUNT_NAME;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.CREDENTIALS_TYPE;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.PROXY_CONFIGURATION_SERVICE;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SAS_TOKEN;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID;
 
 /**
  * Provides credentials details for Azure Storage processors
@@ -41,81 +48,12 @@ import java.util.Map;
 @CapabilityDescription("Provides credentials for Azure Storage processors using Azure Storage client library v12.")
 public class AzureStorageCredentialsControllerService_v12 extends AbstractControllerService implements AzureStorageCredentialsService_v12 {
 
-    public static final PropertyDescriptor ACCOUNT_NAME = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(AzureStorageUtils.ACCOUNT_NAME)
-            .description(AzureStorageUtils.ACCOUNT_NAME_BASE_DESCRIPTION)
-            .required(true)
-            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
-            .build();
-
     public static final PropertyDescriptor ENDPOINT_SUFFIX = new PropertyDescriptor.Builder()
             .fromPropertyDescriptor(AzureStorageUtils.ENDPOINT_SUFFIX)
-            .displayName("Endpoint Suffix")
-            .description("Storage accounts in public Azure always use a common FQDN suffix. " +
-                    "Override this endpoint suffix with a different suffix in certain circumstances (like Azure Stack or non-public Azure regions).")
-            .required(true)
             .defaultValue(AzureServiceEndpoints.DEFAULT_BLOB_ENDPOINT_SUFFIX)
-            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .build();
 
-    public static final PropertyDescriptor CREDENTIALS_TYPE = new PropertyDescriptor.Builder()
-            .name("credentials-type")
-            .displayName("Credentials Type")
-            .description("Credentials type to be used for authenticating to Azure")
-            .required(true)
-            .allowableValues(new AzureStorageCredentialsType[]{
-                    AzureStorageCredentialsType.ACCOUNT_KEY, AzureStorageCredentialsType.SAS_TOKEN,
-                    AzureStorageCredentialsType.MANAGED_IDENTITY, AzureStorageCredentialsType.SERVICE_PRINCIPAL
-            })
-            .defaultValue(AzureStorageCredentialsType.SAS_TOKEN)
-            .build();
-
-    public static final PropertyDescriptor ACCOUNT_KEY = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(AzureStorageUtils.ACCOUNT_KEY)
-            .displayName("Account Key")
-            .description(AzureStorageUtils.ACCOUNT_KEY_BASE_DESCRIPTION)
-            .required(true)
-            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
-            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.ACCOUNT_KEY)
-            .build();
-
-    public static final PropertyDescriptor SAS_TOKEN = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(AzureStorageUtils.PROP_SAS_TOKEN)
-            .description(AzureStorageUtils.SAS_TOKEN_BASE_DESCRIPTION)
-            .required(true)
-            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
-            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SAS_TOKEN)
-            .build();
-
-    public static final PropertyDescriptor MANAGED_IDENTITY_CLIENT_ID = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID)
-            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.MANAGED_IDENTITY)
-            .build();
-
-    public static final PropertyDescriptor SERVICE_PRINCIPAL_TENANT_ID = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID)
-            .required(true)
-            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL)
-            .build();
-
-    public static final PropertyDescriptor SERVICE_PRINCIPAL_CLIENT_ID = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID)
-            .required(true)
-            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL)
-            .build();
-
-    public static final PropertyDescriptor SERVICE_PRINCIPAL_CLIENT_SECRET = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET)
-            .required(true)
-            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL)
-            .build();
-
-    public static final PropertyDescriptor PROXY_CONFIGURATION_SERVICE = new PropertyDescriptor.Builder()
-            .fromPropertyDescriptor(AzureStorageUtils.PROXY_CONFIGURATION_SERVICE)
-            .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL, AzureStorageCredentialsType.MANAGED_IDENTITY)
-            .build();
-
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             ACCOUNT_NAME,
             ENDPOINT_SUFFIX,
             CREDENTIALS_TYPE,
@@ -126,7 +64,7 @@ public class AzureStorageCredentialsControllerService_v12 extends AbstractContro
             SERVICE_PRINCIPAL_CLIENT_ID,
             SERVICE_PRINCIPAL_CLIENT_SECRET,
             PROXY_CONFIGURATION_SERVICE
-    ));
+    );
 
     private ConfigurationContext context;
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorage_v12IT.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureBlobStorage_v12IT.java
@@ -82,12 +82,12 @@ public abstract class AbstractAzureBlobStorage_v12IT extends AbstractAzureStorag
     protected void setUpCredentials() throws Exception {
         AzureStorageCredentialsService_v12 service = new AzureStorageCredentialsControllerService_v12();
         runner.addControllerService(SERVICE_ID, service);
-        runner.setProperty(service, AzureStorageCredentialsControllerService_v12.ACCOUNT_NAME, getAccountName());
+        runner.setProperty(service, AzureStorageUtils.ACCOUNT_NAME, getAccountName());
         if (getEndpointSuffix() != null) {
-            runner.setProperty(service, AzureStorageCredentialsControllerService_v12.ENDPOINT_SUFFIX, getEndpointSuffix());
+            runner.setProperty(service, AzureStorageUtils.ENDPOINT_SUFFIX, getEndpointSuffix());
         }
-        runner.setProperty(service, AzureStorageCredentialsControllerService_v12.CREDENTIALS_TYPE, AzureStorageCredentialsType.ACCOUNT_KEY);
-        runner.setProperty(service, AzureStorageCredentialsControllerService_v12.ACCOUNT_KEY, getAccountKey());
+        runner.setProperty(service, AzureStorageUtils.CREDENTIALS_TYPE, AzureStorageCredentialsType.ACCOUNT_KEY);
+        runner.setProperty(service, AzureStorageUtils.ACCOUNT_KEY, getAccountKey());
         runner.enableControllerService(service);
 
         runner.setProperty(AbstractAzureBlobProcessor_v12.STORAGE_CREDENTIALS_SERVICE, SERVICE_ID);

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/queue/AbstractTestAzureQueueStorage_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/queue/AbstractTestAzureQueueStorage_v12.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.processors.azure.storage.queue;
 
+import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.services.azure.storage.AzureStorageCredentialsControllerService_v12;
 import org.apache.nifi.services.azure.storage.AzureStorageCredentialsService_v12;
@@ -29,8 +30,8 @@ public abstract class AbstractTestAzureQueueStorage_v12 {
 
     protected void setupStorageCredentialsService() throws InitializationException {
         runner.addControllerService(CREDENTIALS_SERVICE_IDENTIFIER, credentialsService);
-        runner.setProperty(credentialsService, AzureStorageCredentialsControllerService_v12.ACCOUNT_NAME, "account-name");
-        runner.setProperty(credentialsService, AzureStorageCredentialsControllerService_v12.CREDENTIALS_TYPE, AzureStorageCredentialsType.ACCOUNT_KEY);
-        runner.setProperty(credentialsService, AzureStorageCredentialsControllerService_v12.ACCOUNT_KEY, "account-key");
+        runner.setProperty(credentialsService, AzureStorageUtils.ACCOUNT_NAME, "account-name");
+        runner.setProperty(credentialsService, AzureStorageUtils.CREDENTIALS_TYPE, AzureStorageCredentialsType.ACCOUNT_KEY);
+        runner.setProperty(credentialsService, AzureStorageUtils.ACCOUNT_KEY, "account-key");
     }
 }

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/services/azure/storage/TestADLSCredentialsControllerService.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/services/azure/storage/TestADLSCredentialsControllerService.java
@@ -58,154 +58,15 @@ public class TestADLSCredentialsControllerService {
 
     @Test
     public void testNotValidBecauseAccountNameMissing() {
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountKey();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseNoCredentialsIsSet() {
-        configureAccountName();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothAccountKeyAndSasTokenSpecified() {
-        configureAccountName();
-
-        configureAccountKey();
-        configureSasToken();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothAccountKeyAndUseManagedIdentitySpecified() {
-        configureAccountName();
-
-        configureAccountKey();
-        configureUseManagedIdentity();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothAccountKeyAndServicePrincipalTenantIdSpecified() {
-        configureAccountName();
-
-        configureAccountKey();
-        configureServicePrincipalTenantId();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothAccountKeyAndServicePrincipalClientIdSpecified() {
-        configureAccountName();
-
-        configureAccountKey();
-        configureServicePrincipalClientId();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothAccountKeyAndServicePrincipalClientSecretSpecified() {
-        configureAccountName();
-
-        configureAccountKey();
-        configureServicePrincipalClientSecret();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothSasTokenAndUseManagedIdentitySpecified() {
-        configureAccountName();
-
-        configureSasToken();
-        configureUseManagedIdentity();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothSasTokenAndServicePrincipalTenantIdSpecified() {
-        configureAccountName();
-
-        configureSasToken();
-        configureServicePrincipalTenantId();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothSasTokenAndServicePrincipalClientIdSpecified() {
-        configureAccountName();
-
-        configureSasToken();
-        configureServicePrincipalClientId();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothSasTokenAndServicePrincipalClientSecretSpecified() {
-        configureAccountName();
-
-        configureSasToken();
-        configureServicePrincipalClientSecret();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothUseManagedIdentityAndServicePrincipalTenantIdSpecified() {
-        configureAccountName();
-
-        configureUseManagedIdentity();
-        configureServicePrincipalTenantId();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothUseManagedIdentityAndServicePrincipalClientIdSpecified() {
-        configureAccountName();
-
-        configureUseManagedIdentity();
-        configureServicePrincipalClientId();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseBothUseManagedIdentityAndServicePrincipalClientSecretSpecified() {
-        configureAccountName();
-
-        configureUseManagedIdentity();
-        configureServicePrincipalClientSecret();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
-    public void testNotValidBecauseAllCredentialsSpecified() throws Exception {
-        configureAccountName();
-
-        configureAccountKey();
-        configureSasToken();
-        configureUseManagedIdentity();
-        configureServicePrincipalTenantId();
-        configureServicePrincipalClientId();
-        configureServicePrincipalClientSecret();
 
         runner.assertNotValid(credentialsService);
     }
 
     @Test
     public void testNotValidWithEmptyEndpointSuffix() {
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountName();
         configureAccountKey();
 
@@ -214,6 +75,7 @@ public class TestADLSCredentialsControllerService {
     }
     @Test
     public void testNotValidWithWhitespaceEndpointSuffix() {
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountName();
         configureAccountKey();
 
@@ -223,6 +85,7 @@ public class TestADLSCredentialsControllerService {
 
     @Test
     public void testValidWithAccountNameAndAccountKey() {
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountName();
         configureAccountKey();
 
@@ -231,6 +94,7 @@ public class TestADLSCredentialsControllerService {
 
     @Test
     public void testValidWithAccountNameAndSasToken() {
+        configureCredentialsType(AzureStorageCredentialsType.SAS_TOKEN);
         configureAccountName();
         configureSasToken();
 
@@ -239,14 +103,15 @@ public class TestADLSCredentialsControllerService {
 
     @Test
     public void testValidWithAccountNameAndUseManagedIdentity() {
+        configureCredentialsType(AzureStorageCredentialsType.MANAGED_IDENTITY);
         configureAccountName();
-        configureUseManagedIdentity();
 
         runner.assertValid(credentialsService);
     }
 
     @Test
     public void testValidWithAccountNameAndServicePrincipalWithClientSecret() {
+        configureCredentialsType(AzureStorageCredentialsType.SERVICE_PRINCIPAL);
         configureAccountName();
         configureServicePrincipalTenantId();
         configureServicePrincipalClientId();
@@ -256,17 +121,8 @@ public class TestADLSCredentialsControllerService {
     }
 
     @Test
-    public void testNotValidBecauseManagedIdentityClientIdSpecifiedButUseManagedIdentityIsFalse() {
-        configureAccountName();
-        configureAccountKey();
-
-        configureManagedIdentityClientId();
-
-        runner.assertNotValid(credentialsService);
-    }
-
-    @Test
     public void testNotValidBecauseNoTenantIdSpecifiedForServicePrincipal() {
+        configureCredentialsType(AzureStorageCredentialsType.SERVICE_PRINCIPAL);
         configureAccountName();
 
         configureServicePrincipalClientId();
@@ -277,6 +133,7 @@ public class TestADLSCredentialsControllerService {
 
     @Test
     public void testNotValidBecauseNoClientIdSpecifiedForServicePrincipal() {
+        configureCredentialsType(AzureStorageCredentialsType.SERVICE_PRINCIPAL);
         configureAccountName();
 
         configureServicePrincipalTenantId();
@@ -287,6 +144,7 @@ public class TestADLSCredentialsControllerService {
 
     @Test
     public void testNotValidBecauseNoClientSecretSpecifiedForServicePrincipal() {
+        configureCredentialsType(AzureStorageCredentialsType.SERVICE_PRINCIPAL);
         configureAccountName();
 
         configureServicePrincipalTenantId();
@@ -298,6 +156,7 @@ public class TestADLSCredentialsControllerService {
     @Test
     public void testGetCredentialsDetailsWithAccountKey() throws Exception {
         // GIVEN
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountName();
         configureAccountKey();
 
@@ -321,6 +180,7 @@ public class TestADLSCredentialsControllerService {
     @Test
     public void testGetCredentialsDetailsWithAccountKeyUsingEL() throws Exception {
         // GIVEN
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountNameUsingEL();
         configureAccountKeyUsingEL();
 
@@ -344,6 +204,7 @@ public class TestADLSCredentialsControllerService {
     @Test
     public void testGetCredentialsDetailsWithSasToken() throws Exception {
         // GIVEN
+        configureCredentialsType(AzureStorageCredentialsType.SAS_TOKEN);
         configureAccountName();
         configureSasToken();
 
@@ -366,6 +227,7 @@ public class TestADLSCredentialsControllerService {
 
     @Test
     public void testGetCredentialsDetailsWithSasTokenUsingEL() throws Exception {
+        configureCredentialsType(AzureStorageCredentialsType.SAS_TOKEN);
         configureAccountName();
         configureSasTokenUsingEL();
 
@@ -386,8 +248,8 @@ public class TestADLSCredentialsControllerService {
     @Test
     public void testGetCredentialsDetailsWithSystemAssignedManagedIdentity() throws Exception {
         // GIVEN
+        configureCredentialsType(AzureStorageCredentialsType.MANAGED_IDENTITY);
         configureAccountName();
-        configureUseManagedIdentity();
 
         runner.enableControllerService(credentialsService);
 
@@ -409,8 +271,8 @@ public class TestADLSCredentialsControllerService {
     @Test
     public void testGetCredentialsDetailsWithUserAssignedManagedIdentity() throws Exception {
         // GIVEN
+        configureCredentialsType(AzureStorageCredentialsType.MANAGED_IDENTITY);
         configureAccountName();
-        configureUseManagedIdentity();
         configureManagedIdentityClientId();
 
         runner.enableControllerService(credentialsService);
@@ -433,6 +295,7 @@ public class TestADLSCredentialsControllerService {
     @Test
     public void testGetCredentialsDetailsWithServicePrincipalWithClientSecret() throws Exception {
         // GIVEN
+        configureCredentialsType(AzureStorageCredentialsType.SERVICE_PRINCIPAL);
         configureAccountName();
         configureServicePrincipalTenantId();
         configureServicePrincipalClientId();
@@ -458,6 +321,7 @@ public class TestADLSCredentialsControllerService {
     @Test
     public void testGetCredentialsDetailsWithSetEndpointSuffix() throws Exception {
         // GIVEN
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountName();
         configureAccountKey();
         configureEndpointSuffix();
@@ -474,6 +338,7 @@ public class TestADLSCredentialsControllerService {
     @Test
     public void testGetCredentialsDetailsWithSetEndpointSuffixUsingEL() throws Exception {
         // GIVEN
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountName();
         configureAccountKey();
         configureEndpointSuffixUsingEL();
@@ -486,13 +351,16 @@ public class TestADLSCredentialsControllerService {
         // THEN
         assertEquals(END_POINT_SUFFIX_VALUE, actual.getEndpointSuffix());
     }
+    private void configureCredentialsType(AzureStorageCredentialsType credentialsType) {
+        runner.setProperty(credentialsService, AzureStorageUtils.CREDENTIALS_TYPE, credentialsType);
+    }
 
     private void configureAccountName() {
-        runner.setProperty(credentialsService, ADLSCredentialsControllerService.ACCOUNT_NAME, ACCOUNT_NAME_VALUE);
+        runner.setProperty(credentialsService, AzureStorageUtils.ACCOUNT_NAME, ACCOUNT_NAME_VALUE);
     }
 
     private void configureAccountNameUsingEL() {
-        configurePropertyUsingEL(ADLSCredentialsControllerService.ACCOUNT_NAME, "account.name", ACCOUNT_NAME_VALUE);
+        configurePropertyUsingEL(AzureStorageUtils.ACCOUNT_NAME, "account.name", ACCOUNT_NAME_VALUE);
     }
 
     private void configureAccountKey() {
@@ -504,41 +372,37 @@ public class TestADLSCredentialsControllerService {
     }
 
     private void configureSasToken() {
-        runner.setProperty(credentialsService, AzureStorageUtils.PROP_SAS_TOKEN, SAS_TOKEN_VALUE);
+        runner.setProperty(credentialsService, AzureStorageUtils.SAS_TOKEN, SAS_TOKEN_VALUE);
     }
 
     private void configureSasTokenUsingEL() {
         String variableName = "sas.token";
-        configurePropertyUsingEL(AzureStorageUtils.PROP_SAS_TOKEN, variableName, SAS_TOKEN_VALUE);
-    }
-
-    private void configureUseManagedIdentity() {
-        runner.setProperty(credentialsService, ADLSCredentialsControllerService.USE_MANAGED_IDENTITY, "true");
+        configurePropertyUsingEL(AzureStorageUtils.SAS_TOKEN, variableName, SAS_TOKEN_VALUE);
     }
 
     private void configureManagedIdentityClientId() {
-        runner.setProperty(credentialsService, ADLSCredentialsControllerService.MANAGED_IDENTITY_CLIENT_ID, MANAGED_IDENTITY_CLIENT_ID_VALUE);
+        runner.setProperty(credentialsService, AzureStorageUtils.MANAGED_IDENTITY_CLIENT_ID, MANAGED_IDENTITY_CLIENT_ID_VALUE);
     }
 
     private void configureEndpointSuffix() {
-        runner.setProperty(credentialsService, ADLSCredentialsControllerService.ENDPOINT_SUFFIX, END_POINT_SUFFIX_VALUE);
+        runner.setProperty(credentialsService, AzureStorageUtils.ENDPOINT_SUFFIX, END_POINT_SUFFIX_VALUE);
     }
 
     private void configureEndpointSuffixUsingEL() {
         String variableName = "endpoint.suffix";
-        configurePropertyUsingEL(ADLSCredentialsControllerService.ENDPOINT_SUFFIX, variableName, END_POINT_SUFFIX_VALUE);
+        configurePropertyUsingEL(AzureStorageUtils.ENDPOINT_SUFFIX, variableName, END_POINT_SUFFIX_VALUE);
     }
 
     private void configureServicePrincipalTenantId() {
-        runner.setProperty(credentialsService, ADLSCredentialsControllerService.SERVICE_PRINCIPAL_TENANT_ID, SERVICE_PRINCIPAL_TENANT_ID_VALUE);
+        runner.setProperty(credentialsService, AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID, SERVICE_PRINCIPAL_TENANT_ID_VALUE);
     }
 
     private void configureServicePrincipalClientId() {
-        runner.setProperty(credentialsService, ADLSCredentialsControllerService.SERVICE_PRINCIPAL_CLIENT_ID, SERVICE_PRINCIPAL_CLIENT_ID_VALUE);
+        runner.setProperty(credentialsService, AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID, SERVICE_PRINCIPAL_CLIENT_ID_VALUE);
     }
 
     private void configureServicePrincipalClientSecret() {
-        runner.setProperty(credentialsService, ADLSCredentialsControllerService.SERVICE_PRINCIPAL_CLIENT_SECRET, SERVICE_PRINCIPAL_CLIENT_SECRET_VALUE);
+        runner.setProperty(credentialsService, AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET, SERVICE_PRINCIPAL_CLIENT_SECRET_VALUE);
     }
 
     private void configurePropertyUsingEL(PropertyDescriptor propertyDescriptor, String variableName, String variableValue) {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/services/azure/storage/TestAzureStorageCredentialsControllerService_v12.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/services/azure/storage/TestAzureStorageCredentialsControllerService_v12.java
@@ -26,16 +26,14 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 
 import static org.apache.nifi.processors.azure.AzureServiceEndpoints.DEFAULT_BLOB_ENDPOINT_SUFFIX;
-import static org.apache.nifi.services.azure.storage.AzureStorageCredentialsControllerService_v12.ACCOUNT_NAME;
-import static org.apache.nifi.services.azure.storage.AzureStorageCredentialsControllerService_v12.CREDENTIALS_TYPE;
-import static org.apache.nifi.services.azure.storage.AzureStorageCredentialsControllerService_v12.ENDPOINT_SUFFIX;
-import static org.apache.nifi.services.azure.storage.AzureStorageCredentialsControllerService_v12.SERVICE_PRINCIPAL_CLIENT_ID;
-import static org.apache.nifi.services.azure.storage.AzureStorageCredentialsControllerService_v12.SERVICE_PRINCIPAL_CLIENT_SECRET;
-import static org.apache.nifi.services.azure.storage.AzureStorageCredentialsControllerService_v12.SERVICE_PRINCIPAL_TENANT_ID;
-import static org.apache.nifi.services.azure.storage.AzureStorageCredentialsType.ACCOUNT_KEY;
-import static org.apache.nifi.services.azure.storage.AzureStorageCredentialsType.MANAGED_IDENTITY;
-import static org.apache.nifi.services.azure.storage.AzureStorageCredentialsType.SAS_TOKEN;
-import static org.apache.nifi.services.azure.storage.AzureStorageCredentialsType.SERVICE_PRINCIPAL;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ACCOUNT_KEY;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ACCOUNT_NAME;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.CREDENTIALS_TYPE;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.ENDPOINT_SUFFIX;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SAS_TOKEN;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_ID;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_CLIENT_SECRET;
+import static org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.SERVICE_PRINCIPAL_TENANT_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -63,7 +61,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
 
     @Test
     public void testNotValidBecauseAccountNameMissing() {
-        configureCredentialsType(ACCOUNT_KEY);
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountKey();
 
         runner.assertNotValid(credentialsService);
@@ -72,7 +70,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testAccountKeyCredentialsTypeValid() {
         configureAccountName();
-        configureCredentialsType(ACCOUNT_KEY);
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountKey();
 
         runner.assertValid(credentialsService);
@@ -81,7 +79,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testAccountKeyCredentialsTypeNotValidBecauseAccountKeyMissing() {
         configureAccountName();
-        configureCredentialsType(ACCOUNT_KEY);
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
 
         runner.assertNotValid(credentialsService);
     }
@@ -89,7 +87,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testSasTokenCredentialsTypeValid() {
         configureAccountName();
-        configureCredentialsType(SAS_TOKEN);
+        configureCredentialsType(AzureStorageCredentialsType.SAS_TOKEN);
         configureSasToken();
 
         runner.assertValid(credentialsService);
@@ -98,7 +96,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testSasTokenCredentialsTypeNotValidBecauseSasTokenMissing() {
         configureAccountName();
-        configureCredentialsType(SAS_TOKEN);
+        configureCredentialsType(AzureStorageCredentialsType.SAS_TOKEN);
 
         runner.assertNotValid(credentialsService);
     }
@@ -106,7 +104,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testManagedIdentityCredentialsTypeValid() {
         configureAccountName();
-        configureCredentialsType(MANAGED_IDENTITY);
+        configureCredentialsType(AzureStorageCredentialsType.MANAGED_IDENTITY);
 
         runner.assertValid(credentialsService);
     }
@@ -114,7 +112,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testServicePrincipalCredentialsTypeValid() {
         configureAccountName();
-        configureCredentialsType(SERVICE_PRINCIPAL);
+        configureCredentialsType(AzureStorageCredentialsType.SERVICE_PRINCIPAL);
         configureServicePrincipalTenantId();
         configureServicePrincipalClientId();
         configureServicePrincipalClientSecret();
@@ -125,7 +123,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testServicePrincipalCredentialsTypeNotValidBecauseTenantIdMissing() {
         configureAccountName();
-        configureCredentialsType(SERVICE_PRINCIPAL);
+        configureCredentialsType(AzureStorageCredentialsType.SERVICE_PRINCIPAL);
         configureServicePrincipalClientId();
         configureServicePrincipalClientSecret();
 
@@ -135,7 +133,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testServicePrincipalCredentialsTypeNotValidBecauseClientIdMissing() {
         configureAccountName();
-        configureCredentialsType(SERVICE_PRINCIPAL);
+        configureCredentialsType(AzureStorageCredentialsType.SERVICE_PRINCIPAL);
         configureServicePrincipalTenantId();
         configureServicePrincipalClientSecret();
 
@@ -145,7 +143,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testServicePrincipalCredentialsTypeNotValidBecauseClientSecretMissing() {
         configureAccountName();
-        configureCredentialsType(SERVICE_PRINCIPAL);
+        configureCredentialsType(AzureStorageCredentialsType.SERVICE_PRINCIPAL);
         configureServicePrincipalTenantId();
         configureServicePrincipalClientId();
 
@@ -155,7 +153,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testGetCredentialsDetailsWithAccountKey() {
         configureAccountName();
-        configureCredentialsType(ACCOUNT_KEY);
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountKey();
 
         runner.enableControllerService(credentialsService);
@@ -164,7 +162,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
 
         assertEquals(ACCOUNT_NAME_VALUE, actual.getAccountName());
         assertEquals(DEFAULT_BLOB_ENDPOINT_SUFFIX, actual.getEndpointSuffix());
-        assertEquals(ACCOUNT_KEY, actual.getCredentialsType());
+        assertEquals(AzureStorageCredentialsType.ACCOUNT_KEY, actual.getCredentialsType());
         assertEquals(ACCOUNT_KEY_VALUE, actual.getAccountKey());
         assertNull(actual.getSasToken());
         assertNull(actual.getServicePrincipalTenantId());
@@ -175,7 +173,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testGetCredentialsDetailsWithSasToken() {
         configureAccountName();
-        configureCredentialsType(SAS_TOKEN);
+        configureCredentialsType(AzureStorageCredentialsType.SAS_TOKEN);
         configureSasToken();
 
         runner.enableControllerService(credentialsService);
@@ -184,7 +182,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
 
         assertEquals(ACCOUNT_NAME_VALUE, actual.getAccountName());
         assertEquals(DEFAULT_BLOB_ENDPOINT_SUFFIX, actual.getEndpointSuffix());
-        assertEquals(SAS_TOKEN, actual.getCredentialsType());
+        assertEquals(AzureStorageCredentialsType.SAS_TOKEN, actual.getCredentialsType());
         assertNull(actual.getAccountKey());
         assertEquals(SAS_TOKEN_VALUE, actual.getSasToken());
         assertNull(actual.getServicePrincipalTenantId());
@@ -195,7 +193,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testGetCredentialsDetailsWithManagedIdentity() {
         configureAccountName();
-        configureCredentialsType(MANAGED_IDENTITY);
+        configureCredentialsType(AzureStorageCredentialsType.MANAGED_IDENTITY);
 
         runner.enableControllerService(credentialsService);
 
@@ -203,7 +201,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
 
         assertEquals(ACCOUNT_NAME_VALUE, actual.getAccountName());
         assertEquals(DEFAULT_BLOB_ENDPOINT_SUFFIX, actual.getEndpointSuffix());
-        assertEquals(MANAGED_IDENTITY, actual.getCredentialsType());
+        assertEquals(AzureStorageCredentialsType.MANAGED_IDENTITY, actual.getCredentialsType());
         assertNull(actual.getAccountKey());
         assertNull(actual.getSasToken());
         assertNull(actual.getServicePrincipalTenantId());
@@ -214,7 +212,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     @Test
     public void testGetCredentialsDetailsWithServicePrincipal() {
         configureAccountName();
-        configureCredentialsType(SERVICE_PRINCIPAL);
+        configureCredentialsType(AzureStorageCredentialsType.SERVICE_PRINCIPAL);
         configureServicePrincipalTenantId();
         configureServicePrincipalClientId();
         configureServicePrincipalClientSecret();
@@ -225,7 +223,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
 
         assertEquals(ACCOUNT_NAME_VALUE, actual.getAccountName());
         assertEquals(DEFAULT_BLOB_ENDPOINT_SUFFIX, actual.getEndpointSuffix());
-        assertEquals(SERVICE_PRINCIPAL, actual.getCredentialsType());
+        assertEquals(AzureStorageCredentialsType.SERVICE_PRINCIPAL, actual.getCredentialsType());
         assertNull(actual.getAccountKey());
         assertNull(actual.getSasToken());
         assertEquals(SERVICE_PRINCIPAL_TENANT_ID_VALUE, actual.getServicePrincipalTenantId());
@@ -237,7 +235,7 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     public void testGetCredentialsDetailsWithCustomEndpointSuffix() {
         configureAccountName();
         configureEndpointSuffix();
-        configureCredentialsType(ACCOUNT_KEY);
+        configureCredentialsType(AzureStorageCredentialsType.ACCOUNT_KEY);
         configureAccountKey();
 
         runner.enableControllerService(credentialsService);
@@ -260,11 +258,11 @@ public class TestAzureStorageCredentialsControllerService_v12 {
     }
 
     private void configureAccountKey() {
-        runner.setProperty(credentialsService, AzureStorageCredentialsControllerService_v12.ACCOUNT_KEY, ACCOUNT_KEY_VALUE);
+        runner.setProperty(credentialsService, ACCOUNT_KEY, ACCOUNT_KEY_VALUE);
     }
 
     private void configureSasToken() {
-        runner.setProperty(credentialsService, AzureStorageCredentialsControllerService_v12.SAS_TOKEN, SAS_TOKEN_VALUE);
+        runner.setProperty(credentialsService, SAS_TOKEN, SAS_TOKEN_VALUE);
     }
 
     private void configureServicePrincipalTenantId() {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/storage/AzureStorageCredentialsType.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-services-api/src/main/java/org/apache/nifi/services/azure/storage/AzureStorageCredentialsType.java
@@ -26,26 +26,27 @@ public enum AzureStorageCredentialsType implements DescribedValue {
     SERVICE_PRINCIPAL("Service Principal", "Azure Active Directory Service Principal with Client Id / Client Secret of a registered application"),
     ACCESS_TOKEN("Access Token", "Access Token provided by custom controller service implementations");
 
-    private final String label;
+    private final String displayName;
     private final String description;
 
-    AzureStorageCredentialsType(String label, String description) {
-        this.label = label;
+    AzureStorageCredentialsType(String displayName, String description) {
+        this.displayName = displayName;
         this.description = description;
     }
 
     @Override
     public String getValue() {
-        return this.name();
+        return name();
     }
 
     @Override
     public String getDisplayName() {
-        return this.label;
+        return displayName;
     }
 
     @Override
     public String getDescription() {
-        return this.description;
+        return description;
     }
 }
+


### PR DESCRIPTION
…rService

Used migrateProperties() for migrating old flows to the new property structure. Moved common properties to AzureStorageUtils and also updated/consolidated some property descriptions, etc. AzureStorageCredentialsType now implements DescribedValue and the new allowable value APIs are in use.

# Summary

[NIFI-8278](https://issues.apache.org/jira/browse/NIFI-8278)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
