### PR TITLE
NIFI-12578 Refactor components in compress bundle using current API methods

### DIFF
--- a/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/src/main/java/org/apache/nifi/processors/compress/property/CompressionStrategy.java
+++ b/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/src/main/java/org/apache/nifi/processors/compress/property/CompressionStrategy.java
@@ -16,14 +16,9 @@
  */
 package org.apache.nifi.processors.compress.property;
 
-import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.DescribedValue;
 
-import java.util.Arrays;
-import java.util.Optional;
-
 public enum CompressionStrategy implements DescribedValue {
-
     NONE("no compression", "No Compression", ""),
     MIME_TYPE_ATTRIBUTE("use mime.type attribute", "Use the [mime.type] attribute from the input FlowFile to determine the format", ""),
     GZIP("gzip", "GZIP", ".gz","application/gzip", "application/x-gzip"),
@@ -42,12 +37,6 @@ public enum CompressionStrategy implements DescribedValue {
     private final String value;
     private final String fileExtension;
     private final String[] mimeTypes;
-
-    public static Optional<CompressionStrategy> findValue(final String value) {
-        return Arrays.stream(CompressionStrategy.values())
-                .filter((compressionStrategy -> compressionStrategy.getValue().equalsIgnoreCase(value)))
-                .findFirst();
-    }
 
     CompressionStrategy(final String value, final String description, final String fileExtension, final String... mimeTypes) {
         this.value = value;
@@ -77,9 +66,5 @@ public enum CompressionStrategy implements DescribedValue {
 
     public String[] getMimeTypes() {
         return mimeTypes;
-    }
-
-    public AllowableValue asAllowableValue() {
-        return new AllowableValue(value, value, description);
     }
 }

--- a/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/src/test/java/org/apache/nifi/processors/compress/TestModifyCompression.java
+++ b/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/src/test/java/org/apache/nifi/processors/compress/TestModifyCompression.java
@@ -48,107 +48,107 @@ class TestModifyCompression {
 
     @Test
     public void testSnappyCompress() throws Exception {
-        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         runner.enqueue(getSamplePath("SampleFile.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), CompressionStrategy.SNAPPY.getMimeTypes()[0]);
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt.snappy");
     }
 
     @Test
     public void testSnappyDecompress() throws Exception {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         runner.enqueue(getSamplePath("SampleFile.txt.snappy"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt");
     }
 
     @Test
     public void testSnappyHadoopCompress() throws Exception {
-        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY_HADOOP.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY_HADOOP);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         runner.enqueue(getSamplePath("SampleFile.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), CompressionStrategy.SNAPPY_HADOOP.getMimeTypes()[0]);
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt.snappy");
     }
 
     @Test
     public void testSnappyHadoopDecompress() {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY_HADOOP.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY_HADOOP);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         runner.assertNotValid();
     }
 
     @Test
     public void testSnappyFramedCompress() throws Exception {
-        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY_FRAMED.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY_FRAMED);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         runner.enqueue(getSamplePath("SampleFile.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), CompressionStrategy.SNAPPY_FRAMED.getMimeTypes()[0]);
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt.sz");
     }
 
     @Test
     public void testSnappyFramedDecompress() throws Exception {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY_FRAMED.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.SNAPPY_FRAMED);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         runner.enqueue(getSamplePath("SampleFile.txt.sz"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt");
     }
 
     @Test
     public void testBzip2DecompressConcatenated() throws Exception {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.BZIP2.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.ORIGINAL.getValue());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.BZIP2);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.ORIGINAL);
 
         runner.enqueue(getSamplePath("SampleFileConcat.txt.bz2"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFileConcat.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFileConcat.txt.bz2"); // not updating filename
     }
 
     @Test
     public void testBzip2DecompressLz4FramedCompress() throws Exception {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.BZIP2.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.LZ4_FRAMED.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.BZIP2);
+        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.LZ4_FRAMED);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         runner.enqueue(getSamplePath("SampleFile.txt.bz2"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt.lz4");
 
         runner.clearTransferState();
@@ -156,27 +156,27 @@ class TestModifyCompression {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile1.txt.lz4");
     }
 
     @Test
     public void testProperMimeTypeFromBzip2() throws Exception {
-        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.BZIP2.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.ORIGINAL.getValue());
+        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.BZIP2);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.ORIGINAL);
 
         runner.enqueue(getSamplePath("SampleFile.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/x-bzip2");
     }
 
     @Test
     public void testBzip2DecompressWithBothMimeTypes() throws Exception {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.MIME_TYPE_ATTRIBUTE.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.MIME_TYPE_ATTRIBUTE);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         // ensure that we can decompress with a mime type of application/x-bzip2
         final Map<String, String> attributes = new HashMap<>();
@@ -185,7 +185,7 @@ class TestModifyCompression {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt");
 
@@ -198,21 +198,21 @@ class TestModifyCompression {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile1.txt");
     }
 
     @Test
     public void testGzipDecompress() throws Exception {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.GZIP.getValue());
-        assertTrue(runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue()).isValid());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.GZIP);
+        assertTrue(runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED).isValid());
 
         runner.enqueue(getSamplePath("/SampleFile.txt.gz"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt");
 
@@ -221,83 +221,82 @@ class TestModifyCompression {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile1.txt");
 
         runner.clearTransferState();
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.MIME_TYPE_ATTRIBUTE.getValue());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.MIME_TYPE_ATTRIBUTE);
         Map<String, String> attributes = new HashMap<>();
         attributes.put(CoreAttributes.MIME_TYPE.key(), CompressionStrategy.GZIP.getMimeTypes()[0]);
         runner.enqueue(getSamplePath("SampleFile.txt.gz"), attributes);
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt");
     }
 
     @Test
     public void testDeflateDecompress() throws Exception {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.DEFLATE.getValue());
-        assertTrue(runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue()).isValid());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.DEFLATE);
+        assertTrue(runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED).isValid());
 
         runner.enqueue(getSamplePath("SampleFile.txt.zlib"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         System.err.println(new String(flowFile.toByteArray()));
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt");
     }
 
-
     @Test
     public void testDeflateCompress() throws Exception {
         runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_LEVEL, "6");
-        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.DEFLATE.getValue());
-        assertTrue(runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue()).isValid());
+        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.DEFLATE);
+        assertTrue(runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED).isValid());
 
         runner.enqueue(getSamplePath("SampleFile.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt.zlib"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt.zlib");
     }
 
     @Test
     public void testFilenameUpdatedOnCompress() throws IOException {
-        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.GZIP.getValue());
-        assertTrue(runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue()).isValid());
+        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.GZIP);
+        assertTrue(runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED).isValid());
 
         runner.enqueue(getSamplePath("SampleFile.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt.gz");
 
     }
 
     @Test
     public void testDecompressFailure() throws IOException {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.GZIP.getValue());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.GZIP);
 
         byte[] data = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         runner.enqueue(data);
 
-        assertTrue(runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue()).isValid());
+        assertTrue(runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED).isValid());
         runner.run();
         runner.assertQueueEmpty();
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_FAILURE, 1);
 
-        runner.getFlowFilesForRelationship(ModifyCompression.REL_FAILURE).get(0).assertContentEquals(data);
+        runner.getFlowFilesForRelationship(ModifyCompression.REL_FAILURE).getFirst().assertContentEquals(data);
 
-        final LogMessage errorMessage = runner.getLogger().getErrorMessages().iterator().next();
+        final LogMessage errorMessage = runner.getLogger().getErrorMessages().getFirst();
         assertNotNull(errorMessage);
 
         final Optional<Object> exceptionFound = Arrays.stream(errorMessage.getArgs()).filter(Exception.class::isInstance).findFirst();
@@ -306,80 +305,80 @@ class TestModifyCompression {
 
     @Test
     public void testLz4FramedCompress() throws Exception {
-        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.LZ4_FRAMED.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.LZ4_FRAMED);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         runner.enqueue(getSamplePath("SampleFile.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), CompressionStrategy.LZ4_FRAMED.getMimeTypes()[0]);
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt.lz4");
     }
 
     @Test
     public void testLz4FramedDecompress() throws Exception {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.LZ4_FRAMED.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.LZ4_FRAMED);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         runner.enqueue(getSamplePath("SampleFile.txt.lz4"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt");
     }
 
     @Test
     public void testZstdCompress() throws Exception {
-        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.ZSTD.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.ZSTD);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         runner.enqueue(getSamplePath("SampleFile.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), CompressionStrategy.ZSTD.getMimeTypes()[0]);
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt.zst");
     }
 
     @Test
     public void testZstdDecompress() throws Exception {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.ZSTD.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.ZSTD);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
         runner.enqueue(getSamplePath("SampleFile.txt.zst"));
         runner.run();
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt");
     }
 
     @Test
     public void testBrotliCompress() throws Exception {
-        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.BROTLI.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.OUTPUT_COMPRESSION_STRATEGY, CompressionStrategy.BROTLI);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
 
         runner.enqueue(getSamplePath("SampleFile.txt"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/x-brotli");
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt.br");
     }
 
     @Test
     public void testBrotliDecompress() throws Exception {
-        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.BROTLI.getValue());
-        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED.getValue());
+        runner.setProperty(ModifyCompression.INPUT_COMPRESSION_STRATEGY, CompressionStrategy.BROTLI);
+        runner.setProperty(ModifyCompression.OUTPUT_FILENAME_STRATEGY, FilenameStrategy.UPDATED);
         runner.enqueue(getSamplePath("SampleFile.txt.br"));
         runner.run();
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt");
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Refactor tests and components in `compress` bundle to use updated APIs from [NIFI-12452](https://issues.apache.org/jira/browse/NIFI-12452).

Additionally, makes use of newer Java APIs, e.g. `List.of` and `Set.of` for declaration of relationships and properties.

[NIFI-12578](https://issues.apache.org/jira/browse/NIFI-12578)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
