### PR TITLE
NIFI-12089 Fix typo in additionalDetails of CSVReader

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/resources/docs/org.apache.nifi.csv.CSVReader/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/resources/docs/org.apache.nifi.csv.CSVReader/additionalDetails.html
@@ -193,13 +193,13 @@ first customer!"<br />
   "type": "record",
   "fields": [
     { "name": "id", "type": "int" },
-    { "name": "name": "type": "string" },
-    { "name": "balance": "type": "double" },
+    { "name": "name", "type": "string" },
+    { "name": "balance", "type": "double" },
     { "name": "join_date", "type": {
       "type": "int",
       "logicalType": "date"
     }},
-    { "name": "notes": "type": "string" }
+    { "name": "notes", "type": "string" }
   ]
 }
 </pre>
@@ -333,9 +333,9 @@ first customer!"<br />
   "type": "record",
   "fields": [
     { "name": "id", "type": "int" },
-    { "name": "name": "type": "string" },
-    { "name": "balance": "type": "double" },
-    { "name": "memo": "type": "string" }
+    { "name": "name", "type": "string" },
+    { "name": "balance", "type": "double" },
+    { "name": "memo", "type": "string" }
   ]
 }
 </pre>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12089](https://issues.apache.org/jira/browse/NIFI-12089)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
