### PR TITLE
NIFI-12610: Correcting default_value example in Python Developer guide

### DIFF
--- a/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
@@ -315,7 +315,7 @@ class PrettyPrintJson(FlowFileTransform):
         numspaces = PropertyDescriptor(name="Number of Spaces",
             description="Number of spaces to use for pretty-printing",
             validators=[StandardValidators.POSITIVE_INTEGER_VALIDATOR],
-            defaultValue="4",
+            default_value="4",
             required=True)
         self.descriptors = [numspaces]
 


### PR DESCRIPTION

# Summary

[NIFI-12610](https://issues.apache.org/jira/browse/NIFI-12610)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
