### PR TITLE
NIFI-12618 Upgrade Azure SDK BOM from 1.2.18 to 1.2.19

### DIFF
--- a/nifi-commons/nifi-property-protection-azure/pom.xml
+++ b/nifi-commons/nifi-property-protection-azure/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.18</version>
+                <version>1.2.19</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -444,4 +444,9 @@
         <packageUrl regex="true">^pkg:maven/info\.picocli/picocli@.*$</packageUrl>
         <cve>CVE-2015-0897</cve>
     </suppress>
+    <suppress>
+        <notes>CVE-2023-36052 applies to Azure CLI not Azure Java libraries</notes>
+        <packageUrl regex="true">^pkg:maven/com\.azure/.*$</packageUrl>
+        <cve>CVE-2023-36052</cve>
+    </suppress>
 </suppressions>

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -27,8 +27,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <azure.sdk.bom.version>1.2.18</azure.sdk.bom.version>
-        <msal4j.version>1.14.0</msal4j.version>
+        <azure.sdk.bom.version>1.2.19</azure.sdk.bom.version>
+        <msal4j.version>1.14.2</msal4j.version>
         <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>
 


### PR DESCRIPTION
# Summary

[NIFI-12618](https://issues.apache.org/jira/browse/NIFI-12618) Upgrades Azure SDK Bill of Materials dependencies from 1.2.18 to 1.2.19, incorporating the latest Azure SDK libraries for various components.

Additional changes include upgrading MSAL4J from 1.14.0 to 1.14.2 and adding CVE-2023-36052 to the list of suppressed findings for the OWASP Plugin as the vulnerability applies to the Azure CLI and not Azure Java packages.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
