### PR TITLE
NIFI-12620 Upgrade JLine from 3.24.1 to 3.25.0

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <guava.version>32.1.2-jre</guava.version>
-        <jline.version>3.24.1</jline.version>
+        <jline.version>3.25.0</jline.version>
     </properties>
 
     <build>


### PR DESCRIPTION
# Summary

[NIFI-12620](https://issues.apache.org/jira/browse/NIFI-12620) Upgrades JLine dependencies in the Toolkit CLI from 3.24.1 to 3.25.0, resolving CVE-2023-50572, which impacts GroovyEngine usage. NiFi Toolkit CLI use of JLine does not include references to the GroovyEngine class.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
