### PR TITLE
NIFI-12621 Upgraded AWS SDK from 2.20.148 to 2.23.3

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -449,4 +449,9 @@
         <packageUrl regex="true">^pkg:maven/com\.azure/.*$</packageUrl>
         <cve>CVE-2023-36052</cve>
     </suppress>
+    <suppress>
+        <notes>software.amazon.ion:ion-java is newer than com.amazonaws.ion:ion-java and does not share the same vulnerabilities</notes>
+        <packageUrl regex="true">^pkg:maven/software\.amazon\.ion/ion\-java@.*$</packageUrl>
+        <cpe>cpe:/a:amazon:ion</cpe>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
-        <com.amazonaws.version>1.12.573</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.20.148</software.amazon.awssdk.version>
+        <com.amazonaws.version>1.12.637</com.amazonaws.version>
+        <software.amazon.awssdk.version>2.23.3</software.amazon.awssdk.version>
         <gson.version>2.10.1</gson.version>
         <io.fabric8.kubernetes.client.version>6.9.2</io.fabric8.kubernetes.client.version>
         <kotlin.version>1.9.10</kotlin.version>


### PR DESCRIPTION
# Summary

[NIFI-12621](https://issues.apache.org/jira/browse/NIFI-12621) Upgrades AWS SDK versions from 2.20.148 to 2.23.3 and from 1.12.573 to 1.12.637.

Additional updates include a dependency check suppression to avoid identifying the newer Amazon `ion-java` library with the older version, which has an associated vulnerability finding.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
