### PR TITLE
NIFI-12625 - Python version support in docs

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -24,7 +24,7 @@ Apache NiFi Team <dev@nifi.apache.org>
 Apache NiFi can run on something as simple as a laptop, but it can also be clustered across many enterprise-class servers. Therefore, the amount of hardware and memory needed will depend on the size and nature of the dataflow involved. The data is stored on disk while NiFi is processing it. So NiFi needs to have sufficient disk space allocated for its various repositories, particularly the content repository, flowfile repository, and provenance repository (see the <<system_properties>> section for more information about these repositories). NiFi has the following minimum system requirements:
 
 * Requires Java 21
-* Use of Python-based Processors (beta feature) requires Python 3.9+
+* Use of Python-based Processors (beta feature) requires Python 3.9, 3.10 or 3.11
 * Supported Operating Systems:
 ** Linux
 ** Unix
@@ -231,7 +231,7 @@ The `name` attribute must start with `deprecation`, followed by the component cl
 
 NiFi is a Java-based application. NiFi 2.0 introduces support for a Python-based Processor API. This capability is still
 considered to be in "Beta" mode and should not be used in production. By default, support for Python-based Processors is disabled. In order to enable it,
-Python 3.9+ must be installed on the NiFi node.
+Python 3.9, 3.10 or 3.11 must be installed on the NiFi node (Python 3.12 is not supported yet).
 
 The following properties may be used to configure the Python 3 installation and process management. These properties are all located under the
 "Python Extensions" heading in the _nifi.properties_ file:

--- a/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
@@ -427,7 +427,7 @@ that there are no longer any invocations of the `transform` method running when 
 [[requirements]]
 == Requirements
 
-The Python API requires that Python 3.9+ is available on the machine hosting NiFi.
+The Python API requires that Python 3.9, 3.10 or 3.11 is available on the machine hosting NiFi (Python 3.12 is not supported yet).
 
 Each Processor may have its own list of requirements / dependencies. These are made available to the Processor by creating a separate
 environment for each Processor implementation (not for each instance of a Processor on the canvas). PyPI is then used to install these


### PR DESCRIPTION
# Summary

[NIFI-12625](https://issues.apache.org/jira/browse/NIFI-12625) - Python version support in docs to specify that using Python 3.12 may cause error at the moment

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
