### PR TITLE
NIFI-12631 Upgraded Apache MINA SSHD from 2.11.0 to 2.12.0

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -30,6 +30,7 @@
         <ant.version>1.10.14</ant.version>
         <calcite.avatica.version>1.6.0</calcite.avatica.version>
         <avatica.version>1.24.0</avatica.version>
+        <org.apache.sshd.version>2.12.0</org.apache.sshd.version>
     </properties>
 
     <!-- Managed Dependency Versions for referenced modules required based on different parent bundle project -->
@@ -107,6 +108,22 @@
                 <groupId>com.couchbase.client</groupId>
                 <artifactId>core-io</artifactId>
                 <version>1.7.24</version>
+            </dependency>
+            <!-- SSHD from Registry and other modules -->
+            <dependency>
+                <groupId>org.apache.sshd</groupId>
+                <artifactId>sshd-core</artifactId>
+                <version>${org.apache.sshd.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sshd</groupId>
+                <artifactId>sshd-sftp</artifactId>
+                <version>${org.apache.sshd.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sshd</groupId>
+                <artifactId>sshd-osgi</artifactId>
+                <version>${org.apache.sshd.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <yammer.metrics.version>2.2.0</yammer.metrics.version>
         <jolt.version>0.1.8</jolt.version>
-        <org.apache.sshd.version>2.11.0</org.apache.sshd.version>
+        <org.apache.sshd.version>2.12.0</org.apache.sshd.version>
         <tika.version>2.9.1</tika.version>
     </properties>
     <dependencyManagement>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -41,7 +41,7 @@
         <flyway.tests.version>9.5.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>6.7.0.202309050840-r</jgit.version>
-        <org.apache.sshd.version>2.11.0</org.apache.sshd.version>
+        <org.apache.sshd.version>2.12.0</org.apache.sshd.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-12631](https://issues.apache.org/jira/browse/NIFI-12631) Upgrades Apache MINA SSHD from 2.11.0 to [2.12.0](https://mina.apache.org/sshd-project/download_2.12.0.html) incorporating several bug fixes, including strict key exchange support for mitigating CVE-2023-48795.

This upgrade applies to the main branch only, due to an incompatibility with JGit 5 on the support branch.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
