### PR TITLE
NIFI-12634 Ignore Blank Prefix Values in Kubernetes Components

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-leader-election/src/main/java/org/apache/nifi/kubernetes/leader/election/KubernetesLeaderElectionManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-leader-election/src/main/java/org/apache/nifi/kubernetes/leader/election/KubernetesLeaderElectionManager.java
@@ -80,7 +80,8 @@ public class KubernetesLeaderElectionManager extends TrackedLeaderElectionManage
      * Kubernetes Leader Election Manager constructor with NiFi Properties
      */
     public KubernetesLeaderElectionManager(final NiFiProperties nifiProperties) {
-        this.roleIdPrefix = nifiProperties.getProperty(NiFiProperties.CLUSTER_LEADER_ELECTION_KUBERNETES_LEASE_PREFIX);
+        final String leasePrefix = nifiProperties.getProperty(NiFiProperties.CLUSTER_LEADER_ELECTION_KUBERNETES_LEASE_PREFIX);
+        this.roleIdPrefix = leasePrefix == null || leasePrefix.isBlank() ? null : leasePrefix;
         executorService = createExecutorService();
         leaderElectionCommandProvider = createLeaderElectionCommandProvider();
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/pom.xml
@@ -50,6 +50,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-expression-language</artifactId>
             <scope>test</scope>
         </dependency>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/main/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProvider.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/main/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProvider.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
 import org.apache.nifi.components.AbstractConfigurableComponent;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.components.Validator;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.components.state.StateProvider;
@@ -48,7 +49,6 @@ import org.apache.nifi.components.state.StateProviderInitializationContext;
 import org.apache.nifi.kubernetes.client.ServiceAccountNamespaceProvider;
 import org.apache.nifi.kubernetes.client.StandardKubernetesClientProvider;
 import org.apache.nifi.logging.ComponentLog;
-import org.apache.nifi.processor.util.StandardValidators;
 
 /**
  * State Provider implementation based on Kubernetes ConfigMaps with Base64 encoded keys to meet Kubernetes constraints
@@ -57,7 +57,7 @@ public class KubernetesConfigMapStateProvider extends AbstractConfigurableCompon
     static final PropertyDescriptor CONFIG_MAP_NAME_PREFIX = new PropertyDescriptor.Builder()
         .name("ConfigMap Name Prefix")
         .description("Optional prefix that the Provider will prepend to Kubernetes ConfigMap names. The resulting ConfigMap name will contain nifi-component and the component identifier.")
-        .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+        .addValidator(Validator.VALID)
         .required(false)
         .build();
 
@@ -126,8 +126,9 @@ public class KubernetesConfigMapStateProvider extends AbstractConfigurableCompon
         this.namespace = new ServiceAccountNamespaceProvider().getNamespace();
 
         final PropertyValue configMapNamePrefixProperty = context.getProperty(CONFIG_MAP_NAME_PREFIX);
-        final String configMapNamePrefix = configMapNamePrefixProperty.isSet() ? configMapNamePrefixProperty.getValue() + PREFIX_SEPARATOR : EMPTY_PREFIX;
+        final String prefixPropertyValue = configMapNamePrefixProperty.getValue();
 
+        final String configMapNamePrefix = prefixPropertyValue == null || prefixPropertyValue.isBlank() ? EMPTY_PREFIX : prefixPropertyValue + PREFIX_SEPARATOR;
         configMapNameFormat = String.format(CONFIG_MAP_NAME_FORMAT, configMapNamePrefix);
         configMapNamePattern = Pattern.compile(String.format(CONFIG_MAP_NAME_PATTERN_FORMAT, configMapNamePrefix));
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/test/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProviderTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/test/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProviderTest.java
@@ -24,11 +24,14 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServerExtension;
 import io.fabric8.mockwebserver.dsl.HttpMethod;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.components.state.StateMap;
 import org.apache.nifi.components.state.StateProviderInitializationContext;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.parameter.ParameterLookup;
+import org.apache.nifi.util.MockProcessContext;
+import org.apache.nifi.util.MockValidationContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,6 +75,8 @@ class KubernetesConfigMapStateProviderTest {
 
     private static final String CONFIG_MAP_NAME_PREFIX_VALUE = "label";
 
+    private static final String EMPTY = "";
+
     @Mock
     StateProviderInitializationContext context;
 
@@ -97,11 +102,18 @@ class KubernetesConfigMapStateProviderTest {
     }
 
     @Test
-    void testInitializeShutdown() {
-        setContext();
-        provider.initialize(context);
+    void testInitializeValidateShutdown() {
+        setContextWithConfigMapNamePrefix(EMPTY);
 
+        provider.initialize(context);
         assertEquals(IDENTIFIER, provider.getIdentifier());
+
+        final MockProcessContext processContext = new MockProcessContext(provider);
+        processContext.setProperty(KubernetesConfigMapStateProvider.CONFIG_MAP_NAME_PREFIX, EMPTY);
+        final MockValidationContext validationContext = new MockValidationContext(processContext, null);
+        final Collection<ValidationResult> results = provider.validate(validationContext);
+
+        assertTrue(results.isEmpty());
 
         provider.shutdown();
     }
@@ -299,7 +311,7 @@ class KubernetesConfigMapStateProviderTest {
 
     @Test
     void testSetStateGetStateWithPrefix() throws IOException {
-        setContextWithProperties();
+        setContextWithConfigMapNamePrefix(CONFIG_MAP_NAME_PREFIX_VALUE);
         provider.initialize(context);
 
         final Map<String, String> state = Collections.singletonMap(STATE_PROPERTY, STATE_VALUE);
@@ -317,7 +329,7 @@ class KubernetesConfigMapStateProviderTest {
 
     @Test
     void testSetStateGetStoredComponentIdsWithPrefix() throws IOException {
-        setContextWithProperties();
+        setContextWithConfigMapNamePrefix(CONFIG_MAP_NAME_PREFIX_VALUE);
         provider.initialize(context);
 
         final Collection<String> initialStoredComponentIds = provider.getStoredComponentIds();
@@ -340,10 +352,10 @@ class KubernetesConfigMapStateProviderTest {
                 .thenReturn(new StandardPropertyValue(null, null, ParameterLookup.EMPTY));
     }
 
-    private void setContextWithProperties() {
+    private void setContextWithConfigMapNamePrefix(final String configMapNamePrefix) {
         setContext();
         when(context.getProperty(KubernetesConfigMapStateProvider.CONFIG_MAP_NAME_PREFIX))
-                .thenReturn(new StandardPropertyValue(CONFIG_MAP_NAME_PREFIX_VALUE, null, ParameterLookup.EMPTY));
+                .thenReturn(new StandardPropertyValue(configMapNamePrefix, null, ParameterLookup.EMPTY));
     }
 
     private void assertStateEquals(final Map<String, String> expected, final StateMap stateMap) {


### PR DESCRIPTION
# Summary

[NIFI-12634](https://issues.apache.org/jira/browse/NIFI-12634) Updates `KubernetesConfigMapStateProvider` and `KubernetesLeaderElectionManager` to ignore blank prefix values as provided in default configuration files.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
