### PR TITLE
NIFI-12637: Handle migrating Proxy properties for InvokeHTTP

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -597,6 +597,20 @@ public class InvokeHTTP extends AbstractProcessor {
 
     @Override
     public void migrateProperties(final PropertyConfiguration config) {
+        if (config.isPropertySet("Proxy Host")) {
+            final Map<String, String> serviceProperties = new HashMap<>();
+            serviceProperties.put("proxy-type", config.getRawPropertyValue("Proxy Type").map(String::toUpperCase).orElse(null));
+            serviceProperties.put("proxy-server-host", config.getRawPropertyValue("Proxy Host").orElse(null));
+            serviceProperties.put("proxy-server-port", config.getRawPropertyValue("Proxy Port").orElse(null));
+            serviceProperties.put("proxy-user-name", config.getRawPropertyValue("invokehttp-proxy-user").orElse(null));
+            serviceProperties.put("proxy-user-password", config.getRawPropertyValue("invokehttp-proxy-password").orElse(null));
+
+            final String serviceId = config.createControllerService("org.apache.nifi.proxy.StandardProxyConfigurationService", serviceProperties);
+            config.setProperty(PROXY_CONFIGURATION_SERVICE, serviceId);
+        } else {
+            config.removeProperty("Proxy Type");
+        }
+
         config.renameProperty("Read Timeout", SOCKET_READ_TIMEOUT.getName());
         config.renameProperty("Remote URL", HTTP_URL.getName());
         config.renameProperty("disable-http2", HTTP2_DISABLED.getName());


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
