### PR TITLE
NIFI-12638: Add Use Case documentation on how to use QueryRecord as a…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryRecord.java
@@ -169,6 +169,25 @@ import static org.apache.nifi.util.db.JdbcProperties.DEFAULT_SCALE;
         should be connected to the next Processor in our flow.
         """
 )
+@UseCase(
+    description = "Route record-oriented data for processing based on its contents",
+    keywords = {"record", "route", "conditional processing", "field"},
+    configuration = """
+        "Record Reader" should be set to a Record Reader that is appropriate for your data.
+        "Record Writer" should be set to a Record Writer that writes out data in the desired format.
+
+        For each route that you want to create, add a new property.
+        The name of the property should be a short description of the data that should be selected for the route.
+        Its value is a SQL statement that selects all columns from a table named `FLOW_FILE`. The WHERE clause selects the data that should be included in the route.
+        It is recommended to always quote column names using double-quotes in order to avoid conflicts with SQL keywords.
+
+        A new outbound relationship is created for each property that is added. The name of the relationship is the same as the property name.
+
+        For example, to route data based on whether or not it is a large transaction, we would add two properties:
+        `small transaction` would have a value such as `SELECT * FROM FLOWFILE WHERE transactionTotal < 100`
+        `large transaction` would have a value of `SELECT * FROM FLOWFILE WHERE transactionTotal >= 100`
+        """
+)
 public class QueryRecord extends AbstractProcessor {
 
     public static final String ROUTE_ATTRIBUTE_KEY = "QueryRecord.Route";


### PR DESCRIPTION
… router

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
