### PR TITLE
NIFI-12640 Move servlet-api and jetty-schemas to nifi-jetty-bundle

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -98,16 +98,6 @@ language governing permissions and limitations under the License. -->
         </plugins>
     </build>
     <dependencies>
-        <dependency> <!-- handling this explicitly  Must be in root lib -->
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency> <!-- handling this explicitly  Must be in root lib -->
-            <groupId>org.eclipse.jetty.toolchain</groupId>
-            <artifactId>jetty-schemas</artifactId>
-            <scope>compile</scope>
-        </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>

--- a/nifi-assembly/src/main/assembly/core.xml
+++ b/nifi-assembly/src/main/assembly/core.xml
@@ -29,9 +29,6 @@
                 <include>org.slf4j:jul-to-slf4j</include>
                 <include>ch.qos.logback:logback-classic</include>
                 <include>ch.qos.logback:logback-core</include>
-                <!-- Servlet API -->
-                <include>jakarta.servlet:jakarta.servlet-api</include>
-                <include>org.eclipse.jetty.toolchain:jetty-schemas</include>
                 <!-- Apache NiFi -->
                 <include>org.apache.nifi:nifi-api</include>
                 <include>org.apache.nifi:nifi-framework-api</include>

--- a/nifi-external/nifi-kafka-connect/nifi-kafka-connector-assembly/pom.xml
+++ b/nifi-external/nifi-kafka-connect/nifi-kafka-connector-assembly/pom.xml
@@ -45,17 +45,6 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
 
-
-        <dependency> <!-- handling this explicitly  Must be in root lib -->
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency> <!-- handling this explicitly  Must be in root lib -->
-            <groupId>org.eclipse.jetty.toolchain</groupId>
-            <artifactId>jetty-schemas</artifactId>
-            <scope>compile</scope>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/nifi-external/nifi-kafka-connect/nifi-kafka-connector/pom.xml
+++ b/nifi-external/nifi-kafka-connect/nifi-kafka-connector/pom.xml
@@ -51,17 +51,6 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
 
-
-        <dependency> <!-- handling this explicitly  Must be in root lib -->
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency> <!-- handling this explicitly  Must be in root lib -->
-            <groupId>org.eclipse.jetty.toolchain</groupId>
-            <artifactId>jetty-schemas</artifactId>
-            <scope>compile</scope>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -196,6 +196,8 @@
 
     <!-- Logger for managing logging statements for jetty -->
     <logger name="org.eclipse.jetty" level="INFO"/>
+    <!-- Suppress non-error messages related to Logback ServletContainerInitializer -->
+    <logger name="org.eclipse.jetty.ee10.annotations.AnnotationConfiguration" level="WARN"/>
 
     <!-- Suppress non-error messages due to excessive logging by class or library -->
     <logger name="org.springframework" level="ERROR"/>

--- a/nifi-nar-bundles/nifi-jetty-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-jetty-bundle/pom.xml
@@ -35,6 +35,16 @@
             <artifactId>nifi-framework-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.toolchain</groupId>
+            <artifactId>jetty-schemas</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <scope>compile</scope>

--- a/nifi-stateless/nifi-stateless-assembly/pom.xml
+++ b/nifi-stateless/nifi-stateless-assembly/pom.xml
@@ -76,16 +76,6 @@
 
         <!-- 3rd party dependencies in rootlib directory -->
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.toolchain</groupId>
-            <artifactId>jetty-schemas</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>compile</scope>

--- a/nifi-system-tests/nifi-system-test-suite/pom.xml
+++ b/nifi-system-tests/nifi-system-test-suite/pom.xml
@@ -164,16 +164,6 @@
             <artifactId>jersey-hk2</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency> <!-- handling this explicitly  Must be in root lib -->
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency> <!-- handling this explicitly  Must be in root lib -->
-            <groupId>org.eclipse.jetty.toolchain</groupId>
-            <artifactId>jetty-schemas</artifactId>
-            <scope>compile</scope>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>


### PR DESCRIPTION
# Summary

[NIFI-12640](https://issues.apache.org/jira/browse/NIFI-12640) Moves the `servlet-api` and `jetty-schemas` JAR libraries from the root `lib` directory to the `nifi-jetty-bundle` NAR.

[NIFI-3694](https://issues.apache.org/jira/browse/NIFI-3694) Moved these libraries to the root `lib` directory due to Logback `ServletContextInitializer` issues with Jetty 9.

Jetty 12 has different behavior that avoids startup failures related to `ServletContainerInitializer` implementations, instead logging an informational message. NiFi already disables the Logback `ServletContainerInitializer` using an environment variable, so it is not required for any logging operations.

Moving the `servlet-api` and `jetty-schemas` JAR libraries to `nifi-jetty-bundle` maintains their position at the effective root of the NAR Class Loading hierarchy while keeping them packaged in the Jetty NAR.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
