### PR TITLE
NIFI-12647: Added @MultiProcessorUseCase to explain ListFile/FetchFil…

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
@@ -23,6 +23,8 @@ import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.Restricted;
 import org.apache.nifi.annotation.behavior.Restriction;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.MultiProcessorUseCase;
+import org.apache.nifi.annotation.documentation.ProcessorConfiguration;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.AllowableValue;
@@ -70,6 +72,50 @@ import java.util.concurrent.TimeUnit;
                         requiredPermission = RequiredPermission.WRITE_FILESYSTEM,
                         explanation = "Provides operator the ability to delete any file that NiFi has access to.")
         }
+)
+@MultiProcessorUseCase(
+    description = "Ingest all files from a directory into NiFi",
+    keywords = {"local", "files", "filesystem", "ingest", "ingress", "get", "source", "input", "fetch"},
+    configurations = {
+        @ProcessorConfiguration(processorClass = ListFile.class,
+            configuration = """
+                Configure the "Input Directory" property to point to the directory that you want to ingest files from.
+                Set the "Input Directory Location" property to "Local"
+                Optionally, set "Minimum File Age" to a small value such as "1 min" to avoid ingesting files that are still being written to.
+
+                Connect the 'success' Relationship to the FetchFile processor.
+                """
+        ),
+        @ProcessorConfiguration(processorClass = FetchFile.class,
+            configuration = """
+                Set the "File to Fetch" property to `${absolute.path}/${filename}`
+                Set the "Completion Strategy" property to `None`
+                """
+        )
+    }
+)
+@MultiProcessorUseCase(
+    description = "Ingest specific files from a directory into NiFi, filtering on filename",
+    keywords = {"local", "files", "filesystem", "ingest", "ingress", "get", "source", "input", "fetch", "filter"},
+    configurations = {
+        @ProcessorConfiguration(processorClass = ListFile.class,
+            configuration = """
+                Configure the "Input Directory" property to point to the directory that you want to ingest files from.
+                Set the "Input Directory Location" property to "Local"
+                Set the "File Filter" property to a Regular Expression that matches the filename (without path) of the files that you want to ingest. \
+                For example, to ingest all .jpg files, set the value to `.*\\.jpg`
+                Optionally, set "Minimum File Age" to a small value such as "1 min" to avoid ingesting files that are still being written to.
+
+                Connect the 'success' Relationship to the FetchFile processor.
+                """
+        ),
+        @ProcessorConfiguration(processorClass = FetchFile.class,
+            configuration = """
+                Set the "File to Fetch" property to `${absolute.path}/${filename}`
+                Set the "Completion Strategy" property to `None`
+                """
+        )
+    }
 )
 public class FetchFile extends AbstractProcessor {
     static final AllowableValue COMPLETION_NONE = new AllowableValue("None", "None", "Leave the file as-is");


### PR DESCRIPTION
…e together

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
