### PR TITLE
NIFI-12651: Add case-insensitive field retrieval option for Record and Schema

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/MapRecord.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/MapRecord.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 public class MapRecord implements Record {
     private static final Logger logger = LoggerFactory.getLogger(MapRecord.class);
@@ -137,7 +138,16 @@ public class MapRecord implements Record {
 
     @Override
     public Object getValue(final String fieldName) {
-        final Optional<RecordField> fieldOption = schema.getField(fieldName);
+        return getValue(fieldName, (f) -> schema.getField(f));
+    }
+
+    @Override
+    public Object caseInsensitiveGetValue(final String fieldName) {
+        return getValue(fieldName, (f) -> schema.caseInsensitiveGetField(f));
+    }
+
+    private Object getValue(final String fieldName, Function<String, Optional<RecordField>> getField) {
+        final Optional<RecordField> fieldOption = getField.apply(fieldName);
         if (fieldOption.isPresent()) {
             return getValue(fieldOption.get());
         }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/Record.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/Record.java
@@ -87,6 +87,8 @@ public interface Record {
 
     Object getValue(String fieldName);
 
+    Object caseInsensitiveGetValue(String fieldName);
+
     Object getValue(RecordField field);
 
     String getAsString(String fieldName);

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordSchema.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordSchema.java
@@ -73,6 +73,12 @@ public interface RecordSchema {
     Optional<RecordField> getField(String fieldName);
 
     /**
+     * @param fieldName the name of the field
+     * @return an Optional RecordField for the field with the given name as case-insensitive
+     */
+    Optional<RecordField> caseInsensitiveGetField(String fieldName);
+
+    /**
      * @return the SchemaIdentifier, which provides various attributes for identifying a schema
      */
     SchemaIdentifier getIdentifier();

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/TestSimpleRecordSchema.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/TestSimpleRecordSchema.java
@@ -27,11 +27,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestSimpleRecordSchema {
 
@@ -185,6 +187,40 @@ class TestSimpleRecordSchema {
 
         assertThrows(StackOverflowError.class, () -> schema1.equals(schema2));
         assertThrows(StackOverflowError.class, () -> schema2.equals(schema1));
+    }
+
+    @Test
+    void testCaseInsensitiveGetFieldWithSameLowerCaseFieldName() {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("hello", RecordFieldType.STRING.getDataType()));
+        fields.add(new RecordField("Hello", RecordFieldType.STRING.getDataType()));
+
+        SimpleRecordSchema recordSchema = new SimpleRecordSchema(fields);
+
+        assertThrows(IllegalArgumentException.class, () -> recordSchema.caseInsensitiveGetField("HELLO"));
+    }
+
+    @Test
+    void testCaseInsensitiveGetFieldWithSameLowerCaseAlias() {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("hello", RecordFieldType.STRING.getDataType(), null, set("foo", "BAR")));
+        fields.add(new RecordField("goodbye", RecordFieldType.STRING.getDataType(), null, set("baz", "Bar")));
+
+        SimpleRecordSchema recordSchema = new SimpleRecordSchema(fields);
+
+        assertThrows(IllegalArgumentException.class, () -> recordSchema.caseInsensitiveGetField("GoodBye"));
+    }
+
+    @Test
+    void testCaseInsensitiveGetField() {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("hello", RecordFieldType.STRING.getDataType()));
+
+        SimpleRecordSchema recordSchema = new SimpleRecordSchema(fields);
+
+        Optional<RecordField> field = recordSchema.caseInsensitiveGetField("HELLO");
+        assertTrue(field.isPresent());
+        assertEquals("hello", field.get().getFieldName());
     }
 
     private SimpleRecordSchema createSchemaWithTwoFields(String nameOfField1, String nameOfField2,

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestMapRecord.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestMapRecord.java
@@ -234,4 +234,20 @@ public class TestMapRecord {
         }
     }
 
+    @Test
+    public void testCaseInsensitiveGetValue() {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("foo", RecordFieldType.STRING.getDataType(), "hello", set("bar", "baz")));
+
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+        final Map<String, Object> values = new LinkedHashMap<>();
+        values.put("baz", 1);
+        values.put("bar", 33);
+
+        final Record record = new MapRecord(schema, values);
+        assertEquals(33, record.caseInsensitiveGetValue("FOO"));
+        assertEquals(33, record.caseInsensitiveGetValue("bAR"));
+        assertEquals(33, record.caseInsensitiveGetValue("BaZ"));
+    }
+
 }

--- a/nifi-nar-bundles/nifi-accumulo-bundle/nifi-accumulo-processors/src/main/java/org/apache/nifi/accumulo/data/KeySchema.java
+++ b/nifi-nar-bundles/nifi-accumulo-bundle/nifi-accumulo-processors/src/main/java/org/apache/nifi/accumulo/data/KeySchema.java
@@ -100,6 +100,11 @@ public class KeySchema implements RecordSchema {
     }
 
     @Override
+    public Optional<RecordField> caseInsensitiveGetField(String fieldName) {
+        throw new NotImplementedException("Case-insensitive field retrieval from Accumulo KeySchema is not implemented.");
+    }
+
+    @Override
     public SchemaIdentifier getIdentifier() {
         return SchemaIdentifier.builder().name("AccumuloKeySchema").version(1).branch("nifi-accumulo").build();
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

The idea is to create a separate map in the Schema with lowercase names and a separate method where the ‘fieldName’ parameter is also lowercased to make the retrieval case-insensitive.
The new value map is created with **lazy evaluation** strategy so it’s only generated when there is a method call for it. With this approach we are not storing the same mapping twice.

[NIFI-12651](https://issues.apache.org/jira/browse/NIFI-12651)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
