### PR TITLE
NIFI-12660 - adding missing Filter property in QueryPinecone

### DIFF
--- a/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/vectorstores/QueryPinecone.py
+++ b/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/vectorstores/QueryPinecone.py
@@ -132,6 +132,7 @@ class QueryPinecone(FlowFileTransform):
                   PINECONE_ENV,
                   INDEX_NAME,
                   QUERY,
+                  FILTER,
                   NUMBER_OF_RESULTS,
                   NAMESPACE,
                   TEXT_KEY,


### PR DESCRIPTION
# Summary

[NIFI-12660](https://issues.apache.org/jira/browse/NIFI-12660) - adding missing Filter property in QueryPinecone

Caused by https://github.com/apache/nifi/commit/f402970132adb9e22840d5aae8117cf4d44262d7

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
