### PR TITLE
NIFI-12642 Added support for FileResourceService in PutS3Object

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
@@ -40,6 +40,15 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-resource-transfer</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-file-resource-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-aws-abstract-processors</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
@@ -138,6 +147,12 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-proxy-configuration</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-file-resource-service</artifactId>
             <version>2.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -508,7 +508,7 @@ public class PutS3Object extends AbstractS3Processor {
         final FlowFile ff = flowFile;
         final Map<String, String> attributes = new HashMap<>();
         final String ffFilename = ff.getAttributes().get(CoreAttributes.FILENAME.key());
-        final ResourceTransferSource resourceTransferSource = ResourceTransferSource.valueOf(context.getProperty(RESOURCE_TRANSFER_SOURCE).getValue());
+        final ResourceTransferSource resourceTransferSource = context.getProperty(RESOURCE_TRANSFER_SOURCE).asAllowableValue(ResourceTransferSource.class);
 
         attributes.put(S3_BUCKET_KEY, bucket);
         attributes.put(S3_OBJECT_KEY, key);

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -53,14 +53,15 @@ import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.fileresource.service.api.FileResource;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.processor.io.InputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.transfer.ResourceTransferSource;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -86,6 +87,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
+
+import static org.apache.nifi.processors.transfer.ResourceTransferProperties.FILE_RESOURCE_SERVICE;
+import static org.apache.nifi.processors.transfer.ResourceTransferProperties.RESOURCE_TRANSFER_SOURCE;
+import static org.apache.nifi.processors.transfer.ResourceTransferUtils.getFileResource;
 
 @SupportsBatching
 @SeeAlso({FetchS3Object.class, DeleteS3Object.class, ListS3.class})
@@ -261,6 +266,8 @@ public class PutS3Object extends AbstractS3Processor {
             KEY,
             S3_REGION,
             AWS_CREDENTIALS_PROVIDER_SERVICE,
+            RESOURCE_TRANSFER_SOURCE,
+            FILE_RESOURCE_SERVICE,
             STORAGE_CLASS,
             ENCRYPTION_SERVICE,
             SERVER_SIDE_ENCRYPTION,
@@ -501,6 +508,8 @@ public class PutS3Object extends AbstractS3Processor {
         final FlowFile ff = flowFile;
         final Map<String, String> attributes = new HashMap<>();
         final String ffFilename = ff.getAttributes().get(CoreAttributes.FILENAME.key());
+        final ResourceTransferSource resourceTransferSource = ResourceTransferSource.valueOf(context.getProperty(RESOURCE_TRANSFER_SOURCE).getValue());
+
         attributes.put(S3_BUCKET_KEY, bucket);
         attributes.put(S3_OBJECT_KEY, key);
 
@@ -517,331 +526,328 @@ public class PutS3Object extends AbstractS3Processor {
         /*
          * Then
          */
-        try {
-            final FlowFile flowFileCopy = flowFile;
-            session.read(flowFile, new InputStreamCallback() {
-                @Override
-                public void process(final InputStream in) throws IOException {
-                    final ObjectMetadata objectMetadata = new ObjectMetadata();
-                    objectMetadata.setContentLength(ff.getSize());
+        final FlowFile flowFileCopy = session.clone(flowFile);
+        try (InputStream in = getFileResource(resourceTransferSource, context, flowFile.getAttributes())
+                .map(FileResource::getInputStream)
+                .orElseGet(() -> session.read(flowFileCopy))) {
+            final ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentLength(ff.getSize());
 
-                    final String contentType = context.getProperty(CONTENT_TYPE)
-                            .evaluateAttributeExpressions(ff).getValue();
-                    if (contentType != null) {
-                        objectMetadata.setContentType(contentType);
-                        attributes.put(S3_CONTENT_TYPE, contentType);
+            final String contentType = context.getProperty(CONTENT_TYPE)
+                    .evaluateAttributeExpressions(ff).getValue();
+            if (contentType != null) {
+                objectMetadata.setContentType(contentType);
+                attributes.put(S3_CONTENT_TYPE, contentType);
+            }
+
+            final String cacheControl = context.getProperty(CACHE_CONTROL)
+                    .evaluateAttributeExpressions(ff).getValue();
+            if (cacheControl != null) {
+                objectMetadata.setCacheControl(cacheControl);
+                attributes.put(S3_CACHE_CONTROL, cacheControl);
+            }
+
+            final String contentDisposition = context.getProperty(CONTENT_DISPOSITION).getValue();
+            String fileName = URLEncoder.encode(ff.getAttribute(CoreAttributes.FILENAME.key()), StandardCharsets.UTF_8);
+            if (contentDisposition != null && contentDisposition.equals(CONTENT_DISPOSITION_INLINE)) {
+                objectMetadata.setContentDisposition(CONTENT_DISPOSITION_INLINE);
+                attributes.put(S3_CONTENT_DISPOSITION, CONTENT_DISPOSITION_INLINE);
+            } else if (contentDisposition != null && contentDisposition.equals(CONTENT_DISPOSITION_ATTACHMENT)) {
+                String contentDispositionValue = CONTENT_DISPOSITION_ATTACHMENT + "; filename=\"" + fileName + "\"";
+                objectMetadata.setContentDisposition(contentDispositionValue);
+                attributes.put(S3_CONTENT_DISPOSITION, contentDispositionValue);
+            } else {
+                objectMetadata.setContentDisposition(fileName);
+            }
+
+            final String expirationRule = context.getProperty(EXPIRATION_RULE_ID)
+                    .evaluateAttributeExpressions(ff).getValue();
+            if (expirationRule != null) {
+                objectMetadata.setExpirationTimeRuleId(expirationRule);
+            }
+
+            final Map<String, String> userMetadata = new HashMap<>();
+            for (final Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
+                if (entry.getKey().isDynamic()) {
+                    final String value = context.getProperty(
+                            entry.getKey()).evaluateAttributeExpressions(ff).getValue();
+                    userMetadata.put(entry.getKey().getName(), value);
+                }
+            }
+
+            final String serverSideEncryption = context.getProperty(SERVER_SIDE_ENCRYPTION).getValue();
+            AmazonS3EncryptionService encryptionService = null;
+
+            if (!serverSideEncryption.equals(NO_SERVER_SIDE_ENCRYPTION)) {
+                objectMetadata.setSSEAlgorithm(serverSideEncryption);
+                attributes.put(S3_SSE_ALGORITHM, serverSideEncryption);
+            } else {
+                encryptionService = context.getProperty(ENCRYPTION_SERVICE).asControllerService(AmazonS3EncryptionService.class);
+            }
+
+            if (!userMetadata.isEmpty()) {
+                objectMetadata.setUserMetadata(userMetadata);
+            }
+
+            if (ff.getSize() <= multipartThreshold) {
+                //----------------------------------------
+                // single part upload
+                //----------------------------------------
+                final PutObjectRequest request = new PutObjectRequest(bucket, key, in, objectMetadata);
+                if (encryptionService != null) {
+                    encryptionService.configurePutObjectRequest(request, objectMetadata);
+                    attributes.put(S3_ENCRYPTION_STRATEGY, encryptionService.getStrategyName());
+                }
+
+                request.setStorageClass(StorageClass.valueOf(context.getProperty(STORAGE_CLASS).getValue()));
+                final AccessControlList acl = createACL(context, ff);
+                if (acl != null) {
+                    request.setAccessControlList(acl);
+                }
+
+                final CannedAccessControlList cannedAcl = createCannedACL(context, ff);
+                if (cannedAcl != null) {
+                    request.withCannedAcl(cannedAcl);
+                }
+
+                if (context.getProperty(OBJECT_TAGS_PREFIX).isSet()) {
+                    request.setTagging(new ObjectTagging(getObjectTags(context, flowFileCopy)));
+                }
+
+                try {
+                    final PutObjectResult result = s3.putObject(request);
+                    if (result.getVersionId() != null) {
+                        attributes.put(S3_VERSION_ATTR_KEY, result.getVersionId());
                     }
-
-                    final String cacheControl = context.getProperty(CACHE_CONTROL)
-                            .evaluateAttributeExpressions(ff).getValue();
-                    if (cacheControl != null) {
-                        objectMetadata.setCacheControl(cacheControl);
-                        attributes.put(S3_CACHE_CONTROL, cacheControl);
+                    if (result.getETag() != null) {
+                        attributes.put(S3_ETAG_ATTR_KEY, result.getETag());
                     }
-
-                    final String contentDisposition = context.getProperty(CONTENT_DISPOSITION).getValue();
-                    String fileName = URLEncoder.encode(ff.getAttribute(CoreAttributes.FILENAME.key()), StandardCharsets.UTF_8);
-                    if (contentDisposition != null && contentDisposition.equals(CONTENT_DISPOSITION_INLINE)) {
-                        objectMetadata.setContentDisposition(CONTENT_DISPOSITION_INLINE);
-                        attributes.put(S3_CONTENT_DISPOSITION, CONTENT_DISPOSITION_INLINE);
-                    } else if (contentDisposition != null && contentDisposition.equals(CONTENT_DISPOSITION_ATTACHMENT)) {
-                        String contentDispositionValue = CONTENT_DISPOSITION_ATTACHMENT + "; filename=\"" + fileName + "\"";
-                        objectMetadata.setContentDisposition(contentDispositionValue);
-                        attributes.put(S3_CONTENT_DISPOSITION, contentDispositionValue);
+                    if (result.getExpirationTime() != null) {
+                        attributes.put(S3_EXPIRATION_ATTR_KEY, result.getExpirationTime().toString());
+                    }
+                    if (result.getMetadata().getStorageClass() != null) {
+                        attributes.put(S3_STORAGECLASS_ATTR_KEY, result.getMetadata().getStorageClass());
                     } else {
-                        objectMetadata.setContentDisposition(fileName);
+                        attributes.put(S3_STORAGECLASS_ATTR_KEY, StorageClass.Standard.toString());
                     }
-
-                    final String expirationRule = context.getProperty(EXPIRATION_RULE_ID)
-                            .evaluateAttributeExpressions(ff).getValue();
-                    if (expirationRule != null) {
-                        objectMetadata.setExpirationTimeRuleId(expirationRule);
+                    if (userMetadata.size() > 0) {
+                        StringBuilder userMetaBldr = new StringBuilder();
+                        for (String userKey : userMetadata.keySet()) {
+                            userMetaBldr.append(userKey).append("=").append(userMetadata.get(userKey));
+                        }
+                        attributes.put(S3_USERMETA_ATTR_KEY, userMetaBldr.toString());
                     }
+                    attributes.put(S3_API_METHOD_ATTR_KEY, S3_API_METHOD_PUTOBJECT);
+                } catch (AmazonClientException e) {
+                    getLogger().info("Failure completing upload flowfile={} bucket={} key={} reason={}",
+                            ffFilename, bucket, key, e.getMessage());
+                    throw (e);
+                }
+            } else {
+                //----------------------------------------
+                // multipart upload
+                //----------------------------------------
 
-                    final Map<String, String> userMetadata = new HashMap<>();
-                    for (final Map.Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
-                        if (entry.getKey().isDynamic()) {
-                            final String value = context.getProperty(
-                                    entry.getKey()).evaluateAttributeExpressions(ff).getValue();
-                            userMetadata.put(entry.getKey().getName(), value);
-                        }
-                    }
-
-                    final String serverSideEncryption = context.getProperty(SERVER_SIDE_ENCRYPTION).getValue();
-                    AmazonS3EncryptionService encryptionService = null;
-
-                    if (!serverSideEncryption.equals(NO_SERVER_SIDE_ENCRYPTION)) {
-                        objectMetadata.setSSEAlgorithm(serverSideEncryption);
-                        attributes.put(S3_SSE_ALGORITHM, serverSideEncryption);
-                    } else {
-                        encryptionService = context.getProperty(ENCRYPTION_SERVICE).asControllerService(AmazonS3EncryptionService.class);
-                    }
-
-                    if (!userMetadata.isEmpty()) {
-                        objectMetadata.setUserMetadata(userMetadata);
-                    }
-
-                    if (ff.getSize() <= multipartThreshold) {
-                        //----------------------------------------
-                        // single part upload
-                        //----------------------------------------
-                        final PutObjectRequest request = new PutObjectRequest(bucket, key, in, objectMetadata);
-                        if (encryptionService != null) {
-                            encryptionService.configurePutObjectRequest(request, objectMetadata);
-                            attributes.put(S3_ENCRYPTION_STRATEGY, encryptionService.getStrategyName());
-                        }
-
-                        request.setStorageClass(StorageClass.valueOf(context.getProperty(STORAGE_CLASS).getValue()));
-                        final AccessControlList acl = createACL(context, ff);
-                        if (acl != null) {
-                            request.setAccessControlList(acl);
-                        }
-
-                        final CannedAccessControlList cannedAcl = createCannedACL(context, ff);
-                        if (cannedAcl != null) {
-                            request.withCannedAcl(cannedAcl);
-                        }
-
-                        if (context.getProperty(OBJECT_TAGS_PREFIX).isSet()) {
-                            request.setTagging(new ObjectTagging(getObjectTags(context, flowFileCopy)));
-                        }
-
-                        try {
-                            final PutObjectResult result = s3.putObject(request);
-                            if (result.getVersionId() != null) {
-                                attributes.put(S3_VERSION_ATTR_KEY, result.getVersionId());
-                            }
-                            if (result.getETag() != null) {
-                                attributes.put(S3_ETAG_ATTR_KEY, result.getETag());
-                            }
-                            if (result.getExpirationTime() != null) {
-                                attributes.put(S3_EXPIRATION_ATTR_KEY, result.getExpirationTime().toString());
-                            }
-                            if (result.getMetadata().getStorageClass() != null) {
-                                attributes.put(S3_STORAGECLASS_ATTR_KEY, result.getMetadata().getStorageClass());
-                            } else {
-                                attributes.put(S3_STORAGECLASS_ATTR_KEY, StorageClass.Standard.toString());
-                            }
-                            if (userMetadata.size() > 0) {
-                                StringBuilder userMetaBldr = new StringBuilder();
-                                for (String userKey : userMetadata.keySet()) {
-                                    userMetaBldr.append(userKey).append("=").append(userMetadata.get(userKey));
-                                }
-                                attributes.put(S3_USERMETA_ATTR_KEY, userMetaBldr.toString());
-                            }
-                            attributes.put(S3_API_METHOD_ATTR_KEY, S3_API_METHOD_PUTOBJECT);
-                        } catch (AmazonClientException e) {
-                            getLogger().info("Failure completing upload flowfile={} bucket={} key={} reason={}",
-                                    ffFilename, bucket, key, e.getMessage());
-                            throw (e);
-                        }
-                    } else {
-                        //----------------------------------------
-                        // multipart upload
-                        //----------------------------------------
-
-                        // load or create persistent state
-                        //------------------------------------------------------------
-                        MultipartState currentState;
-                        try {
-                            currentState = getLocalStateIfInS3(s3, bucket, cacheKey);
-                            if (currentState != null) {
-                                if (currentState.getPartETags().size() > 0) {
-                                    final PartETag lastETag = currentState.getPartETags().get(
-                                            currentState.getPartETags().size() - 1);
-                                    getLogger().info("Resuming upload for flowfile='{}' bucket='{}' key='{}' " +
-                                                    "uploadID='{}' filePosition='{}' partSize='{}' storageClass='{}' " +
-                                                    "contentLength='{}' partsLoaded={} lastPart={}/{}",
-                                            ffFilename, bucket, key, currentState.getUploadId(),
-                                            currentState.getFilePosition(), currentState.getPartSize(),
-                                            currentState.getStorageClass().toString(),
-                                            currentState.getContentLength(),
-                                            currentState.getPartETags().size(),
-                                            Integer.toString(lastETag.getPartNumber()),
-                                            lastETag.getETag());
-                                } else {
-                                    getLogger().info("Resuming upload for flowfile='{}' bucket='{}' key='{}' " +
-                                                    "uploadID='{}' filePosition='{}' partSize='{}' storageClass='{}' " +
-                                                    "contentLength='{}' no partsLoaded",
-                                            ffFilename, bucket, key, currentState.getUploadId(),
-                                            currentState.getFilePosition(), currentState.getPartSize(),
-                                            currentState.getStorageClass().toString(),
-                                            currentState.getContentLength());
-                                }
-                            } else {
-                                currentState = new MultipartState();
-                                currentState.setPartSize(multipartPartSize);
-                                currentState.setStorageClass(
-                                        StorageClass.valueOf(context.getProperty(STORAGE_CLASS).getValue()));
-                                currentState.setContentLength(ff.getSize());
-                                persistLocalState(cacheKey, currentState);
-                                getLogger().info("Starting new upload for flowfile='{}' bucket='{}' key='{}'",
-                                        ffFilename, bucket, key);
-                            }
-                        } catch (IOException e) {
-                            getLogger().error("IOException initiating cache state while processing flow files: " +
-                                    e.getMessage());
-                            throw (e);
-                        }
-
-                        // initiate multipart upload or find position in file
-                        //------------------------------------------------------------
-                        if (currentState.getUploadId().isEmpty()) {
-                            final InitiateMultipartUploadRequest initiateRequest = new InitiateMultipartUploadRequest(bucket, key, objectMetadata);
-                            if (encryptionService != null) {
-                                encryptionService.configureInitiateMultipartUploadRequest(initiateRequest, objectMetadata);
-                                attributes.put(S3_ENCRYPTION_STRATEGY, encryptionService.getStrategyName());
-                            }
-                            initiateRequest.setStorageClass(currentState.getStorageClass());
-
-                            final AccessControlList acl = createACL(context, ff);
-                            if (acl != null) {
-                                initiateRequest.setAccessControlList(acl);
-                            }
-                            final CannedAccessControlList cannedAcl = createCannedACL(context, ff);
-                            if (cannedAcl != null) {
-                                initiateRequest.withCannedACL(cannedAcl);
-                            }
-
-                            if (context.getProperty(OBJECT_TAGS_PREFIX).isSet()) {
-                                initiateRequest.setTagging(new ObjectTagging(getObjectTags(context, flowFileCopy)));
-                            }
-
-                            try {
-                                final InitiateMultipartUploadResult initiateResult =
-                                        s3.initiateMultipartUpload(initiateRequest);
-                                currentState.setUploadId(initiateResult.getUploadId());
-                                currentState.getPartETags().clear();
-                                try {
-                                    persistLocalState(cacheKey, currentState);
-                                } catch (Exception e) {
-                                    getLogger().info("Exception saving cache state while processing flow file: " +
-                                            e.getMessage());
-                                    throw (new ProcessException("Exception saving cache state", e));
-                                }
-                                getLogger().info("Success initiating upload flowfile={} available={} position={} " +
-                                                "length={} bucket={} key={} uploadId={}",
-                                        new Object[]{ffFilename, in.available(), currentState.getFilePosition(),
-                                                currentState.getContentLength(), bucket, key,
-                                                currentState.getUploadId()});
-                                if (initiateResult.getUploadId() != null) {
-                                    attributes.put(S3_UPLOAD_ID_ATTR_KEY, initiateResult.getUploadId());
-                                }
-                            } catch (AmazonClientException e) {
-                                getLogger().info("Failure initiating upload flowfile={} bucket={} key={} reason={}",
-                                        new Object[]{ffFilename, bucket, key, e.getMessage()});
-                                throw (e);
-                            }
+                // load or create persistent state
+                //------------------------------------------------------------
+                MultipartState currentState;
+                try {
+                    currentState = getLocalStateIfInS3(s3, bucket, cacheKey);
+                    if (currentState != null) {
+                        if (currentState.getPartETags().size() > 0) {
+                            final PartETag lastETag = currentState.getPartETags().get(
+                                    currentState.getPartETags().size() - 1);
+                            getLogger().info("Resuming upload for flowfile='{}' bucket='{}' key='{}' " +
+                                            "uploadID='{}' filePosition='{}' partSize='{}' storageClass='{}' " +
+                                            "contentLength='{}' partsLoaded={} lastPart={}/{}",
+                                    ffFilename, bucket, key, currentState.getUploadId(),
+                                    currentState.getFilePosition(), currentState.getPartSize(),
+                                    currentState.getStorageClass().toString(),
+                                    currentState.getContentLength(),
+                                    currentState.getPartETags().size(),
+                                    Integer.toString(lastETag.getPartNumber()),
+                                    lastETag.getETag());
                         } else {
-                            if (currentState.getFilePosition() > 0) {
-                                try {
-                                    final long skipped = in.skip(currentState.getFilePosition());
-                                    if (skipped != currentState.getFilePosition()) {
-                                        getLogger().info("Failure skipping to resume upload flowfile={} " +
-                                                        "bucket={} key={} position={} skipped={}",
-                                                new Object[]{ffFilename, bucket, key,
-                                                        currentState.getFilePosition(), skipped});
-                                    }
-                                } catch (Exception e) {
-                                    getLogger().info("Failure skipping to resume upload flowfile={} bucket={} " +
-                                                    "key={} position={} reason={}",
-                                            new Object[]{ffFilename, bucket, key, currentState.getFilePosition(),
-                                                    e.getMessage()});
-                                    throw (new ProcessException(e));
-                                }
-                            }
+                            getLogger().info("Resuming upload for flowfile='{}' bucket='{}' key='{}' " +
+                                            "uploadID='{}' filePosition='{}' partSize='{}' storageClass='{}' " +
+                                            "contentLength='{}' no partsLoaded",
+                                    ffFilename, bucket, key, currentState.getUploadId(),
+                                    currentState.getFilePosition(), currentState.getPartSize(),
+                                    currentState.getStorageClass().toString(),
+                                    currentState.getContentLength());
                         }
+                    } else {
+                        currentState = new MultipartState();
+                        currentState.setPartSize(multipartPartSize);
+                        currentState.setStorageClass(
+                                StorageClass.valueOf(context.getProperty(STORAGE_CLASS).getValue()));
+                        currentState.setContentLength(ff.getSize());
+                        persistLocalState(cacheKey, currentState);
+                        getLogger().info("Starting new upload for flowfile='{}' bucket='{}' key='{}'",
+                                ffFilename, bucket, key);
+                    }
+                } catch (IOException e) {
+                    getLogger().error("IOException initiating cache state while processing flow files: " +
+                            e.getMessage());
+                    throw (e);
+                }
 
-                        // upload parts
-                        //------------------------------------------------------------
-                        long thisPartSize;
-                        boolean isLastPart;
-                        for (int part = currentState.getPartETags().size() + 1;
-                             currentState.getFilePosition() < currentState.getContentLength(); part++) {
-                            if (!PutS3Object.this.isScheduled()) {
-                                throw new IOException(S3_PROCESS_UNSCHEDULED_MESSAGE + " flowfile=" + ffFilename +
-                                        " part=" + part + " uploadId=" + currentState.getUploadId());
-                            }
-                            thisPartSize = Math.min(currentState.getPartSize(),
-                                    (currentState.getContentLength() - currentState.getFilePosition()));
-                            isLastPart = currentState.getContentLength() == currentState.getFilePosition() + thisPartSize;
-                            UploadPartRequest uploadRequest = new UploadPartRequest()
-                                    .withBucketName(bucket)
-                                    .withKey(key)
-                                    .withUploadId(currentState.getUploadId())
-                                    .withInputStream(in)
-                                    .withPartNumber(part)
-                                    .withPartSize(thisPartSize)
-                                    .withLastPart(isLastPart);
-                            if (encryptionService != null) {
-                                encryptionService.configureUploadPartRequest(uploadRequest, objectMetadata);
-                            }
-                            try {
-                                UploadPartResult uploadPartResult = s3.uploadPart(uploadRequest);
-                                currentState.addPartETag(uploadPartResult.getPartETag());
-                                currentState.setFilePosition(currentState.getFilePosition() + thisPartSize);
-                                try {
-                                    persistLocalState(cacheKey, currentState);
-                                } catch (Exception e) {
-                                    getLogger().info("Exception saving cache state processing flow file: " +
-                                            e.getMessage());
-                                }
-                                int available = 0;
-                                try {
-                                    available = in.available();
-                                } catch (IOException e) {
-                                    // in case of the last part, the stream is already closed
-                                }
-                                getLogger().info("Success uploading part flowfile={} part={} available={} " +
-                                        "etag={} uploadId={}", new Object[]{ffFilename, part, available,
-                                        uploadPartResult.getETag(), currentState.getUploadId()});
-                            } catch (AmazonClientException e) {
-                                getLogger().info("Failure uploading part flowfile={} part={} bucket={} key={} " +
-                                        "reason={}", new Object[]{ffFilename, part, bucket, key, e.getMessage()});
-                                throw (e);
-                            }
-                        }
+                // initiate multipart upload or find position in file
+                //------------------------------------------------------------
+                if (currentState.getUploadId().isEmpty()) {
+                    final InitiateMultipartUploadRequest initiateRequest = new InitiateMultipartUploadRequest(bucket, key, objectMetadata);
+                    if (encryptionService != null) {
+                        encryptionService.configureInitiateMultipartUploadRequest(initiateRequest, objectMetadata);
+                        attributes.put(S3_ENCRYPTION_STRATEGY, encryptionService.getStrategyName());
+                    }
+                    initiateRequest.setStorageClass(currentState.getStorageClass());
 
-                        // complete multipart upload
-                        //------------------------------------------------------------
-                        CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
-                                bucket, key, currentState.getUploadId(), currentState.getPartETags());
+                    final AccessControlList acl = createACL(context, ff);
+                    if (acl != null) {
+                        initiateRequest.setAccessControlList(acl);
+                    }
+                    final CannedAccessControlList cannedAcl = createCannedACL(context, ff);
+                    if (cannedAcl != null) {
+                        initiateRequest.withCannedACL(cannedAcl);
+                    }
 
-                        // No call to an encryption service is needed for a CompleteMultipartUploadRequest.
+                    if (context.getProperty(OBJECT_TAGS_PREFIX).isSet()) {
+                        initiateRequest.setTagging(new ObjectTagging(getObjectTags(context, flowFileCopy)));
+                    }
+
+                    try {
+                        final InitiateMultipartUploadResult initiateResult =
+                                s3.initiateMultipartUpload(initiateRequest);
+                        currentState.setUploadId(initiateResult.getUploadId());
+                        currentState.getPartETags().clear();
                         try {
-                            CompleteMultipartUploadResult completeResult =
-                                    s3.completeMultipartUpload(completeRequest);
-                            getLogger().info("Success completing upload flowfile={} etag={} uploadId={}",
-                                    new Object[]{ffFilename, completeResult.getETag(), currentState.getUploadId()});
-                            if (completeResult.getVersionId() != null) {
-                                attributes.put(S3_VERSION_ATTR_KEY, completeResult.getVersionId());
+                            persistLocalState(cacheKey, currentState);
+                        } catch (Exception e) {
+                            getLogger().info("Exception saving cache state while processing flow file: " +
+                                    e.getMessage());
+                            throw (new ProcessException("Exception saving cache state", e));
+                        }
+                        getLogger().info("Success initiating upload flowfile={} available={} position={} " +
+                                        "length={} bucket={} key={} uploadId={}",
+                                new Object[]{ffFilename, in.available(), currentState.getFilePosition(),
+                                        currentState.getContentLength(), bucket, key,
+                                        currentState.getUploadId()});
+                        if (initiateResult.getUploadId() != null) {
+                            attributes.put(S3_UPLOAD_ID_ATTR_KEY, initiateResult.getUploadId());
+                        }
+                    } catch (AmazonClientException e) {
+                        getLogger().info("Failure initiating upload flowfile={} bucket={} key={} reason={}",
+                                new Object[]{ffFilename, bucket, key, e.getMessage()});
+                        throw (e);
+                    }
+                } else {
+                    if (currentState.getFilePosition() > 0) {
+                        try {
+                            final long skipped = in.skip(currentState.getFilePosition());
+                            if (skipped != currentState.getFilePosition()) {
+                                getLogger().info("Failure skipping to resume upload flowfile={} " +
+                                                "bucket={} key={} position={} skipped={}",
+                                        new Object[]{ffFilename, bucket, key,
+                                                currentState.getFilePosition(), skipped});
                             }
-                            if (completeResult.getETag() != null) {
-                                attributes.put(S3_ETAG_ATTR_KEY, completeResult.getETag());
-                            }
-                            if (completeResult.getExpirationTime() != null) {
-                                attributes.put(S3_EXPIRATION_ATTR_KEY,
-                                        completeResult.getExpirationTime().toString());
-                            }
-                            if (currentState.getStorageClass() != null) {
-                                attributes.put(S3_STORAGECLASS_ATTR_KEY, currentState.getStorageClass().toString());
-                            }
-                            if (userMetadata.size() > 0) {
-                                StringBuilder userMetaBldr = new StringBuilder();
-                                for (String userKey : userMetadata.keySet()) {
-                                    userMetaBldr.append(userKey).append("=").append(userMetadata.get(userKey));
-                                }
-                                attributes.put(S3_USERMETA_ATTR_KEY, userMetaBldr.toString());
-                            }
-                            attributes.put(S3_API_METHOD_ATTR_KEY, S3_API_METHOD_MULTIPARTUPLOAD);
-                        } catch (AmazonClientException e) {
-                            getLogger().info("Failure completing upload flowfile={} bucket={} key={} reason={}",
-                                    new Object[]{ffFilename, bucket, key, e.getMessage()});
-                            throw (e);
+                        } catch (Exception e) {
+                            getLogger().info("Failure skipping to resume upload flowfile={} bucket={} " +
+                                            "key={} position={} reason={}",
+                                    new Object[]{ffFilename, bucket, key, currentState.getFilePosition(),
+                                            e.getMessage()});
+                            throw (new ProcessException(e));
                         }
                     }
                 }
-            });
+
+                // upload parts
+                //------------------------------------------------------------
+                long thisPartSize;
+                boolean isLastPart;
+                for (int part = currentState.getPartETags().size() + 1;
+                     currentState.getFilePosition() < currentState.getContentLength(); part++) {
+                    if (!PutS3Object.this.isScheduled()) {
+                        throw new IOException(S3_PROCESS_UNSCHEDULED_MESSAGE + " flowfile=" + ffFilename +
+                                " part=" + part + " uploadId=" + currentState.getUploadId());
+                    }
+                    thisPartSize = Math.min(currentState.getPartSize(),
+                            (currentState.getContentLength() - currentState.getFilePosition()));
+                    isLastPart = currentState.getContentLength() == currentState.getFilePosition() + thisPartSize;
+                    UploadPartRequest uploadRequest = new UploadPartRequest()
+                            .withBucketName(bucket)
+                            .withKey(key)
+                            .withUploadId(currentState.getUploadId())
+                            .withInputStream(in)
+                            .withPartNumber(part)
+                            .withPartSize(thisPartSize)
+                            .withLastPart(isLastPart);
+                    if (encryptionService != null) {
+                        encryptionService.configureUploadPartRequest(uploadRequest, objectMetadata);
+                    }
+                    try {
+                        UploadPartResult uploadPartResult = s3.uploadPart(uploadRequest);
+                        currentState.addPartETag(uploadPartResult.getPartETag());
+                        currentState.setFilePosition(currentState.getFilePosition() + thisPartSize);
+                        try {
+                            persistLocalState(cacheKey, currentState);
+                        } catch (Exception e) {
+                            getLogger().info("Exception saving cache state processing flow file: " +
+                                    e.getMessage());
+                        }
+                        int available = 0;
+                        try {
+                            available = in.available();
+                        } catch (IOException e) {
+                            // in case of the last part, the stream is already closed
+                        }
+                        getLogger().info("Success uploading part flowfile={} part={} available={} " +
+                                "etag={} uploadId={}", new Object[]{ffFilename, part, available,
+                                uploadPartResult.getETag(), currentState.getUploadId()});
+                    } catch (AmazonClientException e) {
+                        getLogger().info("Failure uploading part flowfile={} part={} bucket={} key={} " +
+                                "reason={}", new Object[]{ffFilename, part, bucket, key, e.getMessage()});
+                        throw (e);
+                    }
+                }
+
+                // complete multipart upload
+                //------------------------------------------------------------
+                CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+                        bucket, key, currentState.getUploadId(), currentState.getPartETags());
+
+                // No call to an encryption service is needed for a CompleteMultipartUploadRequest.
+                try {
+                    CompleteMultipartUploadResult completeResult =
+                            s3.completeMultipartUpload(completeRequest);
+                    getLogger().info("Success completing upload flowfile={} etag={} uploadId={}",
+                            new Object[]{ffFilename, completeResult.getETag(), currentState.getUploadId()});
+                    if (completeResult.getVersionId() != null) {
+                        attributes.put(S3_VERSION_ATTR_KEY, completeResult.getVersionId());
+                    }
+                    if (completeResult.getETag() != null) {
+                        attributes.put(S3_ETAG_ATTR_KEY, completeResult.getETag());
+                    }
+                    if (completeResult.getExpirationTime() != null) {
+                        attributes.put(S3_EXPIRATION_ATTR_KEY,
+                                completeResult.getExpirationTime().toString());
+                    }
+                    if (currentState.getStorageClass() != null) {
+                        attributes.put(S3_STORAGECLASS_ATTR_KEY, currentState.getStorageClass().toString());
+                    }
+                    if (userMetadata.size() > 0) {
+                        StringBuilder userMetaBldr = new StringBuilder();
+                        for (String userKey : userMetadata.keySet()) {
+                            userMetaBldr.append(userKey).append("=").append(userMetadata.get(userKey));
+                        }
+                        attributes.put(S3_USERMETA_ATTR_KEY, userMetaBldr.toString());
+                    }
+                    attributes.put(S3_API_METHOD_ATTR_KEY, S3_API_METHOD_MULTIPARTUPLOAD);
+                } catch (AmazonClientException e) {
+                    getLogger().info("Failure completing upload flowfile={} bucket={} key={} reason={}",
+                            new Object[]{ffFilename, bucket, key, e.getMessage()});
+                    throw (e);
+                }
+            }
 
             if (!attributes.isEmpty()) {
                 flowFile = session.putAllAttributes(flowFile, attributes);
@@ -852,25 +858,27 @@ public class PutS3Object extends AbstractS3Processor {
             final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
             session.getProvenanceReporter().send(flowFile, url, millis);
 
-            getLogger().info("Successfully put {} to Amazon S3 in {} milliseconds", new Object[] {ff, millis});
+            getLogger().info("Successfully put {} to Amazon S3 in {} milliseconds", new Object[]{ff, millis});
             try {
                 removeLocalState(cacheKey);
             } catch (IOException e) {
                 getLogger().info("Error trying to delete key {} from cache: {}",
                         new Object[]{cacheKey, e.getMessage()});
             }
-        } catch (final ProcessException | AmazonClientException pe) {
+
+        } catch (final ProcessException | AmazonClientException | IOException pe) {
             extractExceptionDetails(pe, session, flowFile);
             if (pe.getMessage().contains(S3_PROCESS_UNSCHEDULED_MESSAGE)) {
                 getLogger().info(pe.getMessage());
                 session.rollback();
             } else {
-                getLogger().error("Failed to put {} to Amazon S3 due to {}", new Object[]{flowFile, pe});
+                getLogger().error("Failed to put {} to Amazon S3 due to {}", flowFile, pe);
                 flowFile = session.penalize(flowFile);
                 session.transfer(flowFile, REL_FAILURE);
             }
+        } finally {
+            session.remove(flowFileCopy);
         }
-
     }
 
     private final Lock s3BucketLock = new ReentrantLock();

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -527,328 +527,333 @@ public class PutS3Object extends AbstractS3Processor {
         /*
          * Then
          */
-        final FlowFile flowFileCopy = session.clone(flowFile);
-        Optional<FileResource> optFileResource = getFileResource(resourceTransferSource, context, flowFile.getAttributes());
-        try (InputStream in = optFileResource
-                .map(FileResource::getInputStream)
-                .orElseGet(() -> session.read(flowFileCopy))) {
-            final ObjectMetadata objectMetadata = new ObjectMetadata();
-            objectMetadata.setContentLength(optFileResource.map(FileResource::getSize).orElseGet(ff::getSize));
+        try {
+            final FlowFile flowFileCopy = flowFile;
+            Optional<FileResource> optFileResource = getFileResource(resourceTransferSource, context, flowFile.getAttributes());
+            try (InputStream in = optFileResource
+                    .map(FileResource::getInputStream)
+                    .orElseGet(() -> session.read(flowFileCopy))) {
+                final ObjectMetadata objectMetadata = new ObjectMetadata();
+                objectMetadata.setContentLength(optFileResource.map(FileResource::getSize).orElseGet(ff::getSize));
 
-            final String contentType = context.getProperty(CONTENT_TYPE)
-                    .evaluateAttributeExpressions(ff).getValue();
-            if (contentType != null) {
-                objectMetadata.setContentType(contentType);
-                attributes.put(S3_CONTENT_TYPE, contentType);
-            }
-
-            final String cacheControl = context.getProperty(CACHE_CONTROL)
-                    .evaluateAttributeExpressions(ff).getValue();
-            if (cacheControl != null) {
-                objectMetadata.setCacheControl(cacheControl);
-                attributes.put(S3_CACHE_CONTROL, cacheControl);
-            }
-
-            final String contentDisposition = context.getProperty(CONTENT_DISPOSITION).getValue();
-            String fileName = URLEncoder.encode(ff.getAttribute(CoreAttributes.FILENAME.key()), StandardCharsets.UTF_8);
-            if (contentDisposition != null && contentDisposition.equals(CONTENT_DISPOSITION_INLINE)) {
-                objectMetadata.setContentDisposition(CONTENT_DISPOSITION_INLINE);
-                attributes.put(S3_CONTENT_DISPOSITION, CONTENT_DISPOSITION_INLINE);
-            } else if (contentDisposition != null && contentDisposition.equals(CONTENT_DISPOSITION_ATTACHMENT)) {
-                String contentDispositionValue = CONTENT_DISPOSITION_ATTACHMENT + "; filename=\"" + fileName + "\"";
-                objectMetadata.setContentDisposition(contentDispositionValue);
-                attributes.put(S3_CONTENT_DISPOSITION, contentDispositionValue);
-            } else {
-                objectMetadata.setContentDisposition(fileName);
-            }
-
-            final String expirationRule = context.getProperty(EXPIRATION_RULE_ID)
-                    .evaluateAttributeExpressions(ff).getValue();
-            if (expirationRule != null) {
-                objectMetadata.setExpirationTimeRuleId(expirationRule);
-            }
-
-            final Map<String, String> userMetadata = new HashMap<>();
-            for (final Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
-                if (entry.getKey().isDynamic()) {
-                    final String value = context.getProperty(
-                            entry.getKey()).evaluateAttributeExpressions(ff).getValue();
-                    userMetadata.put(entry.getKey().getName(), value);
-                }
-            }
-
-            final String serverSideEncryption = context.getProperty(SERVER_SIDE_ENCRYPTION).getValue();
-            AmazonS3EncryptionService encryptionService = null;
-
-            if (!serverSideEncryption.equals(NO_SERVER_SIDE_ENCRYPTION)) {
-                objectMetadata.setSSEAlgorithm(serverSideEncryption);
-                attributes.put(S3_SSE_ALGORITHM, serverSideEncryption);
-            } else {
-                encryptionService = context.getProperty(ENCRYPTION_SERVICE).asControllerService(AmazonS3EncryptionService.class);
-            }
-
-            if (!userMetadata.isEmpty()) {
-                objectMetadata.setUserMetadata(userMetadata);
-            }
-
-            if (ff.getSize() <= multipartThreshold) {
-                //----------------------------------------
-                // single part upload
-                //----------------------------------------
-                final PutObjectRequest request = new PutObjectRequest(bucket, key, in, objectMetadata);
-                if (encryptionService != null) {
-                    encryptionService.configurePutObjectRequest(request, objectMetadata);
-                    attributes.put(S3_ENCRYPTION_STRATEGY, encryptionService.getStrategyName());
+                final String contentType = context.getProperty(CONTENT_TYPE)
+                        .evaluateAttributeExpressions(ff).getValue();
+                if (contentType != null) {
+                    objectMetadata.setContentType(contentType);
+                    attributes.put(S3_CONTENT_TYPE, contentType);
                 }
 
-                request.setStorageClass(StorageClass.valueOf(context.getProperty(STORAGE_CLASS).getValue()));
-                final AccessControlList acl = createACL(context, ff);
-                if (acl != null) {
-                    request.setAccessControlList(acl);
+                final String cacheControl = context.getProperty(CACHE_CONTROL)
+                        .evaluateAttributeExpressions(ff).getValue();
+                if (cacheControl != null) {
+                    objectMetadata.setCacheControl(cacheControl);
+                    attributes.put(S3_CACHE_CONTROL, cacheControl);
                 }
 
-                final CannedAccessControlList cannedAcl = createCannedACL(context, ff);
-                if (cannedAcl != null) {
-                    request.withCannedAcl(cannedAcl);
+                final String contentDisposition = context.getProperty(CONTENT_DISPOSITION).getValue();
+                String fileName = URLEncoder.encode(ff.getAttribute(CoreAttributes.FILENAME.key()), StandardCharsets.UTF_8);
+                if (contentDisposition != null && contentDisposition.equals(CONTENT_DISPOSITION_INLINE)) {
+                    objectMetadata.setContentDisposition(CONTENT_DISPOSITION_INLINE);
+                    attributes.put(S3_CONTENT_DISPOSITION, CONTENT_DISPOSITION_INLINE);
+                } else if (contentDisposition != null && contentDisposition.equals(CONTENT_DISPOSITION_ATTACHMENT)) {
+                    String contentDispositionValue = CONTENT_DISPOSITION_ATTACHMENT + "; filename=\"" + fileName + "\"";
+                    objectMetadata.setContentDisposition(contentDispositionValue);
+                    attributes.put(S3_CONTENT_DISPOSITION, contentDispositionValue);
+                } else {
+                    objectMetadata.setContentDisposition(fileName);
                 }
 
-                if (context.getProperty(OBJECT_TAGS_PREFIX).isSet()) {
-                    request.setTagging(new ObjectTagging(getObjectTags(context, flowFileCopy)));
+                final String expirationRule = context.getProperty(EXPIRATION_RULE_ID)
+                        .evaluateAttributeExpressions(ff).getValue();
+                if (expirationRule != null) {
+                    objectMetadata.setExpirationTimeRuleId(expirationRule);
                 }
 
-                try {
-                    final PutObjectResult result = s3.putObject(request);
-                    if (result.getVersionId() != null) {
-                        attributes.put(S3_VERSION_ATTR_KEY, result.getVersionId());
+                final Map<String, String> userMetadata = new HashMap<>();
+                for (final Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
+                    if (entry.getKey().isDynamic()) {
+                        final String value = context.getProperty(
+                                entry.getKey()).evaluateAttributeExpressions(ff).getValue();
+                        userMetadata.put(entry.getKey().getName(), value);
                     }
-                    if (result.getETag() != null) {
-                        attributes.put(S3_ETAG_ATTR_KEY, result.getETag());
-                    }
-                    if (result.getExpirationTime() != null) {
-                        attributes.put(S3_EXPIRATION_ATTR_KEY, result.getExpirationTime().toString());
-                    }
-                    if (result.getMetadata().getStorageClass() != null) {
-                        attributes.put(S3_STORAGECLASS_ATTR_KEY, result.getMetadata().getStorageClass());
-                    } else {
-                        attributes.put(S3_STORAGECLASS_ATTR_KEY, StorageClass.Standard.toString());
-                    }
-                    if (userMetadata.size() > 0) {
-                        StringBuilder userMetaBldr = new StringBuilder();
-                        for (String userKey : userMetadata.keySet()) {
-                            userMetaBldr.append(userKey).append("=").append(userMetadata.get(userKey));
-                        }
-                        attributes.put(S3_USERMETA_ATTR_KEY, userMetaBldr.toString());
-                    }
-                    attributes.put(S3_API_METHOD_ATTR_KEY, S3_API_METHOD_PUTOBJECT);
-                } catch (AmazonClientException e) {
-                    getLogger().info("Failure completing upload flowfile={} bucket={} key={} reason={}",
-                            ffFilename, bucket, key, e.getMessage());
-                    throw (e);
-                }
-            } else {
-                //----------------------------------------
-                // multipart upload
-                //----------------------------------------
-
-                // load or create persistent state
-                //------------------------------------------------------------
-                MultipartState currentState;
-                try {
-                    currentState = getLocalStateIfInS3(s3, bucket, cacheKey);
-                    if (currentState != null) {
-                        if (currentState.getPartETags().size() > 0) {
-                            final PartETag lastETag = currentState.getPartETags().get(
-                                    currentState.getPartETags().size() - 1);
-                            getLogger().info("Resuming upload for flowfile='{}' bucket='{}' key='{}' " +
-                                            "uploadID='{}' filePosition='{}' partSize='{}' storageClass='{}' " +
-                                            "contentLength='{}' partsLoaded={} lastPart={}/{}",
-                                    ffFilename, bucket, key, currentState.getUploadId(),
-                                    currentState.getFilePosition(), currentState.getPartSize(),
-                                    currentState.getStorageClass().toString(),
-                                    currentState.getContentLength(),
-                                    currentState.getPartETags().size(),
-                                    Integer.toString(lastETag.getPartNumber()),
-                                    lastETag.getETag());
-                        } else {
-                            getLogger().info("Resuming upload for flowfile='{}' bucket='{}' key='{}' " +
-                                            "uploadID='{}' filePosition='{}' partSize='{}' storageClass='{}' " +
-                                            "contentLength='{}' no partsLoaded",
-                                    ffFilename, bucket, key, currentState.getUploadId(),
-                                    currentState.getFilePosition(), currentState.getPartSize(),
-                                    currentState.getStorageClass().toString(),
-                                    currentState.getContentLength());
-                        }
-                    } else {
-                        currentState = new MultipartState();
-                        currentState.setPartSize(multipartPartSize);
-                        currentState.setStorageClass(
-                                StorageClass.valueOf(context.getProperty(STORAGE_CLASS).getValue()));
-                        currentState.setContentLength(ff.getSize());
-                        persistLocalState(cacheKey, currentState);
-                        getLogger().info("Starting new upload for flowfile='{}' bucket='{}' key='{}'",
-                                ffFilename, bucket, key);
-                    }
-                } catch (IOException e) {
-                    getLogger().error("IOException initiating cache state while processing flow files: " +
-                            e.getMessage());
-                    throw (e);
                 }
 
-                // initiate multipart upload or find position in file
-                //------------------------------------------------------------
-                if (currentState.getUploadId().isEmpty()) {
-                    final InitiateMultipartUploadRequest initiateRequest = new InitiateMultipartUploadRequest(bucket, key, objectMetadata);
+                final String serverSideEncryption = context.getProperty(SERVER_SIDE_ENCRYPTION).getValue();
+                AmazonS3EncryptionService encryptionService = null;
+
+                if (!serverSideEncryption.equals(NO_SERVER_SIDE_ENCRYPTION)) {
+                    objectMetadata.setSSEAlgorithm(serverSideEncryption);
+                    attributes.put(S3_SSE_ALGORITHM, serverSideEncryption);
+                } else {
+                    encryptionService = context.getProperty(ENCRYPTION_SERVICE).asControllerService(AmazonS3EncryptionService.class);
+                }
+
+                if (!userMetadata.isEmpty()) {
+                    objectMetadata.setUserMetadata(userMetadata);
+                }
+
+                if (ff.getSize() <= multipartThreshold) {
+                    //----------------------------------------
+                    // single part upload
+                    //----------------------------------------
+                    final PutObjectRequest request = new PutObjectRequest(bucket, key, in, objectMetadata);
                     if (encryptionService != null) {
-                        encryptionService.configureInitiateMultipartUploadRequest(initiateRequest, objectMetadata);
+                        encryptionService.configurePutObjectRequest(request, objectMetadata);
                         attributes.put(S3_ENCRYPTION_STRATEGY, encryptionService.getStrategyName());
                     }
-                    initiateRequest.setStorageClass(currentState.getStorageClass());
 
+                    request.setStorageClass(StorageClass.valueOf(context.getProperty(STORAGE_CLASS).getValue()));
                     final AccessControlList acl = createACL(context, ff);
                     if (acl != null) {
-                        initiateRequest.setAccessControlList(acl);
+                        request.setAccessControlList(acl);
                     }
+
                     final CannedAccessControlList cannedAcl = createCannedACL(context, ff);
                     if (cannedAcl != null) {
-                        initiateRequest.withCannedACL(cannedAcl);
+                        request.withCannedAcl(cannedAcl);
                     }
 
                     if (context.getProperty(OBJECT_TAGS_PREFIX).isSet()) {
-                        initiateRequest.setTagging(new ObjectTagging(getObjectTags(context, flowFileCopy)));
+                        request.setTagging(new ObjectTagging(getObjectTags(context, flowFileCopy)));
                     }
 
                     try {
-                        final InitiateMultipartUploadResult initiateResult =
-                                s3.initiateMultipartUpload(initiateRequest);
-                        currentState.setUploadId(initiateResult.getUploadId());
-                        currentState.getPartETags().clear();
-                        try {
-                            persistLocalState(cacheKey, currentState);
-                        } catch (Exception e) {
-                            getLogger().info("Exception saving cache state while processing flow file: " +
-                                    e.getMessage());
-                            throw (new ProcessException("Exception saving cache state", e));
+                        final PutObjectResult result = s3.putObject(request);
+                        if (result.getVersionId() != null) {
+                            attributes.put(S3_VERSION_ATTR_KEY, result.getVersionId());
                         }
-                        getLogger().info("Success initiating upload flowfile={} available={} position={} " +
-                                        "length={} bucket={} key={} uploadId={}",
-                                new Object[]{ffFilename, in.available(), currentState.getFilePosition(),
-                                        currentState.getContentLength(), bucket, key,
-                                        currentState.getUploadId()});
-                        if (initiateResult.getUploadId() != null) {
-                            attributes.put(S3_UPLOAD_ID_ATTR_KEY, initiateResult.getUploadId());
+                        if (result.getETag() != null) {
+                            attributes.put(S3_ETAG_ATTR_KEY, result.getETag());
                         }
+                        if (result.getExpirationTime() != null) {
+                            attributes.put(S3_EXPIRATION_ATTR_KEY, result.getExpirationTime().toString());
+                        }
+                        if (result.getMetadata().getStorageClass() != null) {
+                            attributes.put(S3_STORAGECLASS_ATTR_KEY, result.getMetadata().getStorageClass());
+                        } else {
+                            attributes.put(S3_STORAGECLASS_ATTR_KEY, StorageClass.Standard.toString());
+                        }
+                        if (userMetadata.size() > 0) {
+                            StringBuilder userMetaBldr = new StringBuilder();
+                            for (String userKey : userMetadata.keySet()) {
+                                userMetaBldr.append(userKey).append("=").append(userMetadata.get(userKey));
+                            }
+                            attributes.put(S3_USERMETA_ATTR_KEY, userMetaBldr.toString());
+                        }
+                        attributes.put(S3_API_METHOD_ATTR_KEY, S3_API_METHOD_PUTOBJECT);
                     } catch (AmazonClientException e) {
-                        getLogger().info("Failure initiating upload flowfile={} bucket={} key={} reason={}",
-                                new Object[]{ffFilename, bucket, key, e.getMessage()});
+                        getLogger().info("Failure completing upload flowfile={} bucket={} key={} reason={}",
+                                ffFilename, bucket, key, e.getMessage());
                         throw (e);
                     }
                 } else {
-                    if (currentState.getFilePosition() > 0) {
-                        try {
-                            final long skipped = in.skip(currentState.getFilePosition());
-                            if (skipped != currentState.getFilePosition()) {
-                                getLogger().info("Failure skipping to resume upload flowfile={} " +
-                                                "bucket={} key={} position={} skipped={}",
-                                        new Object[]{ffFilename, bucket, key,
-                                                currentState.getFilePosition(), skipped});
-                            }
-                        } catch (Exception e) {
-                            getLogger().info("Failure skipping to resume upload flowfile={} bucket={} " +
-                                            "key={} position={} reason={}",
-                                    new Object[]{ffFilename, bucket, key, currentState.getFilePosition(),
-                                            e.getMessage()});
-                            throw (new ProcessException(e));
-                        }
-                    }
-                }
+                    //----------------------------------------
+                    // multipart upload
+                    //----------------------------------------
 
-                // upload parts
-                //------------------------------------------------------------
-                long thisPartSize;
-                boolean isLastPart;
-                for (int part = currentState.getPartETags().size() + 1;
-                     currentState.getFilePosition() < currentState.getContentLength(); part++) {
-                    if (!PutS3Object.this.isScheduled()) {
-                        throw new IOException(S3_PROCESS_UNSCHEDULED_MESSAGE + " flowfile=" + ffFilename +
-                                " part=" + part + " uploadId=" + currentState.getUploadId());
-                    }
-                    thisPartSize = Math.min(currentState.getPartSize(),
-                            (currentState.getContentLength() - currentState.getFilePosition()));
-                    isLastPart = currentState.getContentLength() == currentState.getFilePosition() + thisPartSize;
-                    UploadPartRequest uploadRequest = new UploadPartRequest()
-                            .withBucketName(bucket)
-                            .withKey(key)
-                            .withUploadId(currentState.getUploadId())
-                            .withInputStream(in)
-                            .withPartNumber(part)
-                            .withPartSize(thisPartSize)
-                            .withLastPart(isLastPart);
-                    if (encryptionService != null) {
-                        encryptionService.configureUploadPartRequest(uploadRequest, objectMetadata);
-                    }
+                    // load or create persistent state
+                    //------------------------------------------------------------
+                    MultipartState currentState;
                     try {
-                        UploadPartResult uploadPartResult = s3.uploadPart(uploadRequest);
-                        currentState.addPartETag(uploadPartResult.getPartETag());
-                        currentState.setFilePosition(currentState.getFilePosition() + thisPartSize);
-                        try {
+                        currentState = getLocalStateIfInS3(s3, bucket, cacheKey);
+                        if (currentState != null) {
+                            if (currentState.getPartETags().size() > 0) {
+                                final PartETag lastETag = currentState.getPartETags().get(
+                                        currentState.getPartETags().size() - 1);
+                                getLogger().info("Resuming upload for flowfile='{}' bucket='{}' key='{}' " +
+                                                "uploadID='{}' filePosition='{}' partSize='{}' storageClass='{}' " +
+                                                "contentLength='{}' partsLoaded={} lastPart={}/{}",
+                                        ffFilename, bucket, key, currentState.getUploadId(),
+                                        currentState.getFilePosition(), currentState.getPartSize(),
+                                        currentState.getStorageClass().toString(),
+                                        currentState.getContentLength(),
+                                        currentState.getPartETags().size(),
+                                        Integer.toString(lastETag.getPartNumber()),
+                                        lastETag.getETag());
+                            } else {
+                                getLogger().info("Resuming upload for flowfile='{}' bucket='{}' key='{}' " +
+                                                "uploadID='{}' filePosition='{}' partSize='{}' storageClass='{}' " +
+                                                "contentLength='{}' no partsLoaded",
+                                        ffFilename, bucket, key, currentState.getUploadId(),
+                                        currentState.getFilePosition(), currentState.getPartSize(),
+                                        currentState.getStorageClass().toString(),
+                                        currentState.getContentLength());
+                            }
+                        } else {
+                            currentState = new MultipartState();
+                            currentState.setPartSize(multipartPartSize);
+                            currentState.setStorageClass(
+                                    StorageClass.valueOf(context.getProperty(STORAGE_CLASS).getValue()));
+                            currentState.setContentLength(ff.getSize());
                             persistLocalState(cacheKey, currentState);
-                        } catch (Exception e) {
-                            getLogger().info("Exception saving cache state processing flow file: " +
-                                    e.getMessage());
+                            getLogger().info("Starting new upload for flowfile='{}' bucket='{}' key='{}'",
+                                    ffFilename, bucket, key);
                         }
-                        int available = 0;
+                    } catch (IOException e) {
+                        getLogger().error("IOException initiating cache state while processing flow files: " +
+                                e.getMessage());
+                        throw (e);
+                    }
+
+                    // initiate multipart upload or find position in file
+                    //------------------------------------------------------------
+                    if (currentState.getUploadId().isEmpty()) {
+                        final InitiateMultipartUploadRequest initiateRequest = new InitiateMultipartUploadRequest(bucket, key, objectMetadata);
+                        if (encryptionService != null) {
+                            encryptionService.configureInitiateMultipartUploadRequest(initiateRequest, objectMetadata);
+                            attributes.put(S3_ENCRYPTION_STRATEGY, encryptionService.getStrategyName());
+                        }
+                        initiateRequest.setStorageClass(currentState.getStorageClass());
+
+                        final AccessControlList acl = createACL(context, ff);
+                        if (acl != null) {
+                            initiateRequest.setAccessControlList(acl);
+                        }
+                        final CannedAccessControlList cannedAcl = createCannedACL(context, ff);
+                        if (cannedAcl != null) {
+                            initiateRequest.withCannedACL(cannedAcl);
+                        }
+
+                        if (context.getProperty(OBJECT_TAGS_PREFIX).isSet()) {
+                            initiateRequest.setTagging(new ObjectTagging(getObjectTags(context, flowFileCopy)));
+                        }
+
                         try {
-                            available = in.available();
-                        } catch (IOException e) {
-                            // in case of the last part, the stream is already closed
+                            final InitiateMultipartUploadResult initiateResult =
+                                    s3.initiateMultipartUpload(initiateRequest);
+                            currentState.setUploadId(initiateResult.getUploadId());
+                            currentState.getPartETags().clear();
+                            try {
+                                persistLocalState(cacheKey, currentState);
+                            } catch (Exception e) {
+                                getLogger().info("Exception saving cache state while processing flow file: " +
+                                        e.getMessage());
+                                throw (new ProcessException("Exception saving cache state", e));
+                            }
+                            getLogger().info("Success initiating upload flowfile={} available={} position={} " +
+                                            "length={} bucket={} key={} uploadId={}",
+                                    new Object[]{ffFilename, in.available(), currentState.getFilePosition(),
+                                            currentState.getContentLength(), bucket, key,
+                                            currentState.getUploadId()});
+                            if (initiateResult.getUploadId() != null) {
+                                attributes.put(S3_UPLOAD_ID_ATTR_KEY, initiateResult.getUploadId());
+                            }
+                        } catch (AmazonClientException e) {
+                            getLogger().info("Failure initiating upload flowfile={} bucket={} key={} reason={}",
+                                    new Object[]{ffFilename, bucket, key, e.getMessage()});
+                            throw (e);
                         }
-                        getLogger().info("Success uploading part flowfile={} part={} available={} " +
-                                "etag={} uploadId={}", new Object[]{ffFilename, part, available,
-                                uploadPartResult.getETag(), currentState.getUploadId()});
+                    } else {
+                        if (currentState.getFilePosition() > 0) {
+                            try {
+                                final long skipped = in.skip(currentState.getFilePosition());
+                                if (skipped != currentState.getFilePosition()) {
+                                    getLogger().info("Failure skipping to resume upload flowfile={} " +
+                                                    "bucket={} key={} position={} skipped={}",
+                                            new Object[]{ffFilename, bucket, key,
+                                                    currentState.getFilePosition(), skipped});
+                                }
+                            } catch (Exception e) {
+                                getLogger().info("Failure skipping to resume upload flowfile={} bucket={} " +
+                                                "key={} position={} reason={}",
+                                        new Object[]{ffFilename, bucket, key, currentState.getFilePosition(),
+                                                e.getMessage()});
+                                throw (new ProcessException(e));
+                            }
+                        }
+                    }
+
+                    // upload parts
+                    //------------------------------------------------------------
+                    long thisPartSize;
+                    boolean isLastPart;
+                    for (int part = currentState.getPartETags().size() + 1;
+                         currentState.getFilePosition() < currentState.getContentLength(); part++) {
+                        if (!PutS3Object.this.isScheduled()) {
+                            throw new IOException(S3_PROCESS_UNSCHEDULED_MESSAGE + " flowfile=" + ffFilename +
+                                    " part=" + part + " uploadId=" + currentState.getUploadId());
+                        }
+                        thisPartSize = Math.min(currentState.getPartSize(),
+                                (currentState.getContentLength() - currentState.getFilePosition()));
+                        isLastPart = currentState.getContentLength() == currentState.getFilePosition() + thisPartSize;
+                        UploadPartRequest uploadRequest = new UploadPartRequest()
+                                .withBucketName(bucket)
+                                .withKey(key)
+                                .withUploadId(currentState.getUploadId())
+                                .withInputStream(in)
+                                .withPartNumber(part)
+                                .withPartSize(thisPartSize)
+                                .withLastPart(isLastPart);
+                        if (encryptionService != null) {
+                            encryptionService.configureUploadPartRequest(uploadRequest, objectMetadata);
+                        }
+                        try {
+                            UploadPartResult uploadPartResult = s3.uploadPart(uploadRequest);
+                            currentState.addPartETag(uploadPartResult.getPartETag());
+                            currentState.setFilePosition(currentState.getFilePosition() + thisPartSize);
+                            try {
+                                persistLocalState(cacheKey, currentState);
+                            } catch (Exception e) {
+                                getLogger().info("Exception saving cache state processing flow file: " +
+                                        e.getMessage());
+                            }
+                            int available = 0;
+                            try {
+                                available = in.available();
+                            } catch (IOException e) {
+                                // in case of the last part, the stream is already closed
+                            }
+                            getLogger().info("Success uploading part flowfile={} part={} available={} " +
+                                    "etag={} uploadId={}", new Object[]{ffFilename, part, available,
+                                    uploadPartResult.getETag(), currentState.getUploadId()});
+                        } catch (AmazonClientException e) {
+                            getLogger().info("Failure uploading part flowfile={} part={} bucket={} key={} " +
+                                    "reason={}", new Object[]{ffFilename, part, bucket, key, e.getMessage()});
+                            throw (e);
+                        }
+                    }
+
+                    // complete multipart upload
+                    //------------------------------------------------------------
+                    CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
+                            bucket, key, currentState.getUploadId(), currentState.getPartETags());
+
+                    // No call to an encryption service is needed for a CompleteMultipartUploadRequest.
+                    try {
+                        CompleteMultipartUploadResult completeResult =
+                                s3.completeMultipartUpload(completeRequest);
+                        getLogger().info("Success completing upload flowfile={} etag={} uploadId={}",
+                                new Object[]{ffFilename, completeResult.getETag(), currentState.getUploadId()});
+                        if (completeResult.getVersionId() != null) {
+                            attributes.put(S3_VERSION_ATTR_KEY, completeResult.getVersionId());
+                        }
+                        if (completeResult.getETag() != null) {
+                            attributes.put(S3_ETAG_ATTR_KEY, completeResult.getETag());
+                        }
+                        if (completeResult.getExpirationTime() != null) {
+                            attributes.put(S3_EXPIRATION_ATTR_KEY,
+                                    completeResult.getExpirationTime().toString());
+                        }
+                        if (currentState.getStorageClass() != null) {
+                            attributes.put(S3_STORAGECLASS_ATTR_KEY, currentState.getStorageClass().toString());
+                        }
+                        if (userMetadata.size() > 0) {
+                            StringBuilder userMetaBldr = new StringBuilder();
+                            for (String userKey : userMetadata.keySet()) {
+                                userMetaBldr.append(userKey).append("=").append(userMetadata.get(userKey));
+                            }
+                            attributes.put(S3_USERMETA_ATTR_KEY, userMetaBldr.toString());
+                        }
+                        attributes.put(S3_API_METHOD_ATTR_KEY, S3_API_METHOD_MULTIPARTUPLOAD);
                     } catch (AmazonClientException e) {
-                        getLogger().info("Failure uploading part flowfile={} part={} bucket={} key={} " +
-                                "reason={}", new Object[]{ffFilename, part, bucket, key, e.getMessage()});
+                        getLogger().info("Failure completing upload flowfile={} bucket={} key={} reason={}",
+                                new Object[]{ffFilename, bucket, key, e.getMessage()});
                         throw (e);
                     }
                 }
-
-                // complete multipart upload
-                //------------------------------------------------------------
-                CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
-                        bucket, key, currentState.getUploadId(), currentState.getPartETags());
-
-                // No call to an encryption service is needed for a CompleteMultipartUploadRequest.
-                try {
-                    CompleteMultipartUploadResult completeResult =
-                            s3.completeMultipartUpload(completeRequest);
-                    getLogger().info("Success completing upload flowfile={} etag={} uploadId={}",
-                            new Object[]{ffFilename, completeResult.getETag(), currentState.getUploadId()});
-                    if (completeResult.getVersionId() != null) {
-                        attributes.put(S3_VERSION_ATTR_KEY, completeResult.getVersionId());
-                    }
-                    if (completeResult.getETag() != null) {
-                        attributes.put(S3_ETAG_ATTR_KEY, completeResult.getETag());
-                    }
-                    if (completeResult.getExpirationTime() != null) {
-                        attributes.put(S3_EXPIRATION_ATTR_KEY,
-                                completeResult.getExpirationTime().toString());
-                    }
-                    if (currentState.getStorageClass() != null) {
-                        attributes.put(S3_STORAGECLASS_ATTR_KEY, currentState.getStorageClass().toString());
-                    }
-                    if (userMetadata.size() > 0) {
-                        StringBuilder userMetaBldr = new StringBuilder();
-                        for (String userKey : userMetadata.keySet()) {
-                            userMetaBldr.append(userKey).append("=").append(userMetadata.get(userKey));
-                        }
-                        attributes.put(S3_USERMETA_ATTR_KEY, userMetaBldr.toString());
-                    }
-                    attributes.put(S3_API_METHOD_ATTR_KEY, S3_API_METHOD_MULTIPARTUPLOAD);
-                } catch (AmazonClientException e) {
-                    getLogger().info("Failure completing upload flowfile={} bucket={} key={} reason={}",
-                            new Object[]{ffFilename, bucket, key, e.getMessage()});
-                    throw (e);
-                }
+            } catch (IOException e) {
+                getLogger().error("Error during upload of flow files: " + e.getMessage());
+                throw e;
             }
 
             if (!attributes.isEmpty()) {
@@ -878,8 +883,6 @@ public class PutS3Object extends AbstractS3Processor {
                 flowFile = session.penalize(flowFile);
                 session.transfer(flowFile, REL_FAILURE);
             }
-        } finally {
-            session.remove(flowFileCopy);
         }
     }
 

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -866,7 +866,7 @@ public class PutS3Object extends AbstractS3Processor {
                         new Object[]{cacheKey, e.getMessage()});
             }
 
-        } catch (final ProcessException | AmazonClientException | IOException pe) {
+        } catch (final ProcessException | AmazonClientException | IOException e) {
             extractExceptionDetails(pe, session, flowFile);
             if (pe.getMessage().contains(S3_PROCESS_UNSCHEDULED_MESSAGE)) {
                 getLogger().info(pe.getMessage());

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
@@ -17,7 +17,6 @@
 package org.apache.nifi.processors.aws.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.GetObjectTaggingRequest;
 import com.amazonaws.services.s3.model.GetObjectTaggingResult;
 import com.amazonaws.services.s3.model.ListMultipartUploadsRequest;
@@ -41,7 +40,6 @@ import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -98,19 +96,6 @@ public class ITPutS3Object extends AbstractS3IT {
 
         randomKeyMaterial = Base64.encodeBase64String(keyRawBytes);
         kmsKeyId = getKMSKey();
-    }
-
-    @AfterEach
-    public void tearDown() {
-        // clear bucket content
-        AmazonS3 client = getClient();
-        List<S3ObjectSummary> objectSummaries = client.listObjects(BUCKET_NAME).getObjectSummaries();
-        if (!objectSummaries.isEmpty()) {
-            client.deleteObjects(new DeleteObjectsRequest(BUCKET_NAME)
-                    .withKeys(objectSummaries.stream()
-                            .map(S3ObjectSummary::getKey)
-                            .toArray(String[]::new)));
-        }
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
@@ -63,6 +63,7 @@ import static org.apache.nifi.processors.transfer.ResourceTransferProperties.FIL
 import static org.apache.nifi.processors.transfer.ResourceTransferProperties.RESOURCE_TRANSFER_SOURCE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -139,6 +140,7 @@ public class ITPutS3Object extends AbstractS3IT {
         List<S3ObjectSummary> objectSummaries = getClient().listObjects(BUCKET_NAME).getObjectSummaries();
         assertThat(objectSummaries, hasSize(1));
         assertEquals(objectSummaries.getFirst().getKey(), resourcePath.getFileName().toString());
+        assertThat(objectSummaries.getFirst().getSize(), greaterThan(0L));
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
@@ -37,10 +37,13 @@ import com.amazonaws.services.s3.model.StorageClass;
 import com.amazonaws.services.s3.model.Tag;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.fileresource.service.api.FileResource;
+import org.apache.nifi.fileresource.service.api.FileResourceService;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processors.aws.signer.AwsSignerType;
 import org.apache.nifi.processors.aws.testutil.AuthUtils;
+import org.apache.nifi.processors.transfer.ResourceTransferSource;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -50,6 +53,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.File;
+import java.io.InputStream;
 import java.net.URLEncoder;
 import java.util.Date;
 import java.util.HashMap;
@@ -57,11 +61,16 @@ import java.util.List;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.nifi.processors.transfer.ResourceTransferProperties.FILE_RESOURCE_SERVICE;
+import static org.apache.nifi.processors.transfer.ResourceTransferProperties.RESOURCE_TRANSFER_SOURCE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 
 public class TestPutS3Object {
@@ -88,6 +97,30 @@ public class TestPutS3Object {
     }
 
     @Test
+    public void testPutSinglePartFromLocalFileSource() throws Exception {
+        prepareTest();
+
+        String serviceId = "fileresource";
+        FileResourceService service = mock(FileResourceService.class);
+        InputStream localFileInputStream = mock(InputStream.class);
+        doReturn(serviceId).when(service).getIdentifier();
+        doReturn(new FileResource(localFileInputStream, 10)).when(service).getFileResource(anyMap());
+
+        runner.addControllerService(serviceId, service);
+        runner.enableControllerService(service);
+        runner.setProperty(RESOURCE_TRANSFER_SOURCE, ResourceTransferSource.FILE_RESOURCE_SERVICE.getValue());
+        runner.setProperty(FILE_RESOURCE_SERVICE, serviceId);
+
+        runner.run();
+
+        ArgumentCaptor<PutObjectRequest> captureRequest = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(mockS3Client).putObject(captureRequest.capture());
+        assertEquals(localFileInputStream, captureRequest.getValue().getInputStream());
+
+        runner.assertAllFlowFilesTransferred(PutS3Object.REL_SUCCESS, 1);
+    }
+
+    @Test
     public void testPutSinglePart() {
         runner.setProperty("x-custom-prop", "hello");
         prepareTest();
@@ -95,7 +128,7 @@ public class TestPutS3Object {
         runner.run(1);
 
         ArgumentCaptor<PutObjectRequest> captureRequest = ArgumentCaptor.forClass(PutObjectRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).putObject(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).putObject(captureRequest.capture());
         PutObjectRequest request = captureRequest.getValue();
         assertEquals("test-bucket", request.getBucketName());
 
@@ -105,6 +138,7 @@ public class TestPutS3Object {
         MockFlowFile ff0 = flowFiles.get(0);
 
         ff0.assertAttributeEquals(CoreAttributes.FILENAME.key(), "testfile.txt");
+        ff0.assertContentEquals("Test Content");
         ff0.assertAttributeEquals(PutS3Object.S3_ETAG_ATTR_KEY, "test-etag");
         ff0.assertAttributeEquals(PutS3Object.S3_VERSION_ATTR_KEY, "test-version");
     }
@@ -150,7 +184,7 @@ public class TestPutS3Object {
         runner.run(1);
 
         ArgumentCaptor<PutObjectRequest> captureRequest = ArgumentCaptor.forClass(PutObjectRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).putObject(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).putObject(captureRequest.capture());
         PutObjectRequest request = captureRequest.getValue();
 
         List<Tag> tagSet = request.getTagging().getTagSet();
@@ -169,7 +203,7 @@ public class TestPutS3Object {
             runner.run(1);
 
             ArgumentCaptor<PutObjectRequest> captureRequest = ArgumentCaptor.forClass(PutObjectRequest.class);
-            Mockito.verify(mockS3Client, Mockito.times(1)).putObject(captureRequest.capture());
+            verify(mockS3Client, Mockito.times(1)).putObject(captureRequest.capture());
             PutObjectRequest request = captureRequest.getValue();
 
             assertEquals(storageClass.toString(), request.getStorageClass());
@@ -185,7 +219,7 @@ public class TestPutS3Object {
         runner.run(1);
 
         ArgumentCaptor<PutObjectRequest> captureRequest = ArgumentCaptor.forClass(PutObjectRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).putObject(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).putObject(captureRequest.capture());
         PutObjectRequest request = captureRequest.getValue();
 
         ObjectMetadata objectMetadata = request.getMetadata();


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary
Added support to upload content directly from local file's inputstream (by-passing the content repository) inside the PutS3Object processor. The default behaviour is upload from flowfile content to be backward compatible. This can be overridden if the RESOURCE_TRANSFER_SOURCE property value is set to FILE_RESOURCE_SERVICE, and a FileResourceService controller service is registered.

[NIFI-12642](https://issues.apache.org/jira/browse/NIFI-12642)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
