### PR TITLE
NIFI-12676 Fix Servlet Registration in HandleHttpRequest

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
@@ -51,9 +51,8 @@ import org.apache.nifi.scheduling.ExecutionNode;
 import org.apache.nifi.ssl.RestrictedSSLContextService;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.stream.io.StreamUtils;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletContextRequest;
-import org.eclipse.jetty.ee10.servlet.ServletHandler;
-import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -485,8 +484,9 @@ public class HandleHttpRequest extends AbstractProcessor {
                 }
             }
         };
-        final ServletHandler servletHandler = new ServletHandler();
-        servletHandler.addServlet(new ServletHolder(standardServlet));
+        final ServletContextHandler handler = new ServletContextHandler();
+        handler.addServlet(standardServlet, "/");
+        server.setHandler(handler);
 
         this.server = server;
         server.start();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/HandleHttpRequestTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/HandleHttpRequestTest.java
@@ -27,6 +27,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,14 +47,19 @@ class HandleHttpRequestTest {
 
     private static final String MINIMUM_THREADS = "8";
 
+    private static final String URL_FORMAT = "http://127.0.0.1:%d";
+
     @Mock
     HttpContextMap httpContextMap;
 
     TestRunner runner;
 
+    HandleHttpRequest handleHttpRequest;
+
     @BeforeEach
     void setRunner() throws InitializationException {
-        runner = TestRunners.newTestRunner(HandleHttpRequest.class);
+        handleHttpRequest = new HandleHttpRequest();
+        runner = TestRunners.newTestRunner(handleHttpRequest);
 
         when(httpContextMap.getIdentifier()).thenReturn(CONTEXT_MAP_ID);
         runner.addControllerService(CONTEXT_MAP_ID, httpContextMap);
@@ -71,5 +87,48 @@ class HandleHttpRequestTest {
         runner.run();
 
         runner.assertTransferCount(HandleHttpRequest.REL_SUCCESS, 0);
+    }
+
+    @Test
+    void testRunMethodNotAllowed() throws InterruptedException {
+        runner.setProperty(HandleHttpRequest.HTTP_CONTEXT_MAP, CONTEXT_MAP_ID);
+        runner.setProperty(HandleHttpRequest.MAXIMUM_THREADS, MINIMUM_THREADS);
+        runner.setProperty(HandleHttpRequest.PORT, "0");
+        runner.setProperty(HandleHttpRequest.ALLOW_GET, Boolean.FALSE.toString());
+
+        runner.run(1, false);
+        runner.assertTransferCount(HandleHttpRequest.REL_SUCCESS, 0);
+
+        final AtomicInteger responseCodeHolder = new AtomicInteger();
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        final Thread requestThread = Thread.ofVirtual().unstarted(() -> {
+            try {
+                final URL url = getUrl();
+                final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                connection.connect();
+                final int responseCode = connection.getResponseCode();
+                responseCodeHolder.set(responseCode);
+                countDownLatch.countDown();
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        requestThread.start();
+
+        final boolean completed = countDownLatch.await(5, TimeUnit.SECONDS);
+        assertTrue(completed, "HTTP request failed");
+        assertEquals(HttpURLConnection.HTTP_BAD_METHOD, responseCodeHolder.get());
+
+        runner.run(1, true, false);
+    }
+
+    private URL getUrl() {
+        final int port = handleHttpRequest.getPort();
+        final URI uri = URI.create(URL_FORMAT.formatted(port));
+        try {
+            return uri.toURL();
+        } catch (final MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-12676](https://issues.apache.org/jira/browse/NIFI-12676) Corrects Servlet registration in the `HandleHttpRequest` Processor, which was not correctly configured following recent upgrades to Jetty 12.

Changes include a new unit test method to ensure that the configured processing Servlet handles an HTTP request.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
