### PR TITLE
NIFI-12680 Fix JAR for DefaultedDynamicClassPathModificationIT on Support Branch

### DIFF
--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/DefaultedDynamicClassPathModificationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/processor/DefaultedDynamicClassPathModificationIT.java
@@ -23,7 +23,9 @@ import org.apache.nifi.web.api.entity.ConnectionEntity;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -86,6 +88,15 @@ class DefaultedDynamicClassPathModificationIT extends NiFiSystemIT {
         defaultedModifyClasspathProcessor = getClientUtil().createProcessor("DefaultedDynamicallyModifyClasspath");
         ProcessorEntity terminateSuccess = getClientUtil().createProcessor("TerminateFlowFile");
         ProcessorEntity terminateFailure = getClientUtil().createProcessor("TerminateFlowFile");
+
+        // Find the commons-lang3 jar that is in the bootstrap directory regardless of version number
+        final File lib = new File(getNiFiInstance().getInstanceDirectory(), "lib");
+        final File bootstrapLib = new File(lib, "bootstrap");
+        final File[] listing = bootstrapLib.listFiles(file -> file.getName().endsWith(".jar") && file.getName().startsWith("commons-lang3"));
+        if (listing != null && listing.length >= 1) {
+            final File lang3Jar = listing[0];
+            defaultedModifyClasspathProcessor = getClientUtil().updateProcessorProperties(defaultedModifyClasspathProcessor, Collections.singletonMap("URLs to Load", lang3Jar.getAbsolutePath()));
+        }
 
         defaultedModifyClasspathInputConnection = getClientUtil().createConnection(generateFlowFileProcessor, defaultedModifyClasspathProcessor, "success");
         successConnection = getClientUtil().createConnection(defaultedModifyClasspathProcessor, terminateSuccess, "success");


### PR DESCRIPTION
# Summary

[NIFI-12680](https://issues.apache.org/jira/browse/NIFI-12680) Corrects the `DefaultedDynamicClassPathModificationIT` system test on the support branch following the same strategy as implemented on the current main branch. The test fails due to a hard-coded default property value referencing commons-lang3 3.13.0. The changes check the `lib/bootstrap` directory for the current available version.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
