### PR TITLE
NIFI-12682 Fix MiNiFi agent manifest hash swaps

### DIFF
--- a/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/c2/client/service/operation/SupportedOperationsProvider.java
+++ b/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/c2/client/service/operation/SupportedOperationsProvider.java
@@ -17,7 +17,10 @@
 
 package org.apache.nifi.c2.client.service.operation;
 
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.nifi.c2.protocol.api.OperandType;
@@ -34,17 +37,26 @@ public class SupportedOperationsProvider {
     public Set<SupportedOperation> getSupportedOperations() {
         return operationHandlers.entrySet()
             .stream()
+            .sorted(Map.Entry.comparingByKey())
             .map(operationEntry -> getSupportedOperation(operationEntry.getKey(), operationEntry.getValue()))
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private SupportedOperation getSupportedOperation(OperationType operationType, Map<OperandType, C2OperationHandler> operands) {
         SupportedOperation supportedOperation = new SupportedOperation();
         supportedOperation.setType(operationType);
 
-        Map<OperandType, Map<String, Object>> properties = operands.values()
+        Map<OperandType, Map<String, Object>> properties = operands.entrySet()
             .stream()
-            .collect(Collectors.toMap(C2OperationHandler::getOperandType, C2OperationHandler::getProperties));
+            .sorted(Map.Entry.comparingByKey())
+            .map(Entry::getValue)
+            .collect(
+                Collectors.toMap(
+                    C2OperationHandler::getOperandType,
+                    C2OperationHandler::getProperties,
+                    (existing, replacement) -> existing,
+                    LinkedHashMap::new
+                ));
 
         supportedOperation.setProperties(properties);
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12682](https://issues.apache.org/jira/browse/NIFI-12682)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
