### PR TITLE
NIFI-12677 Removed documentation of example of a non-existent strategy.

### DIFF
--- a/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/resources/docs/org.apache.nifi.excel.ExcelReader/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/resources/docs/org.apache.nifi.excel.ExcelReader/additionalDetails.html
@@ -302,18 +302,5 @@ first customer!"<br />
     			</tr>
     		</body>
     	</table>
-
-
-
-    	<h3>Example 2 - Schema with Excel Header Line</h3>
-
-    	<p>
-    		When  data consists of a header line whose columns are indicative of all the datatypes of those columns in the rest of the Excel spreadsheet, the reader provides
-    		a couple of different properties for configuring how to handle these column names. The
-    		"Schema Access Strategy" property as well as the associated properties ("Schema Registry," "Schema Text," and
-    		"Schema Name" properties) can be used to specify how to obtain the schema. If the "Schema Access Strategy" is set
-    		to "Use Fields From Header" then the header line of the first chosen Excel sheet will be used to determine the schema. Otherwise,
-    		a schema will be referenced elsewhere and the column names specified in those schemas will be used instead of the cell numbers.
-    	</p>
     </body>
 </html>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12677](https://issues.apache.org/jira/browse/NIFI-12677)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
