### PR TITLE
NIFI-12693: Moved notification of python process that a Processor was…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessorDAO.java
@@ -589,7 +589,7 @@ public class StandardProcessorDAO extends ComponentDAO implements ProcessorDAO {
         try {
             // attempt remove the processor
             processor.getProcessGroup().removeProcessor(processor);
-        } catch (ComponentLifeCycleException plce) {
+        } catch (final ComponentLifeCycleException plce) {
             throw new NiFiCoreException(plce.getMessage(), plce);
         }
     }

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/StandardPythonBridge.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/StandardPythonBridge.java
@@ -38,11 +38,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -162,18 +162,29 @@ public class StandardPythonBridge implements PythonBridge {
                 return;
             }
 
-            // Find the Python Process that has the Processor, if any, and remove it.
-            // If there are no additional Processors in the Python Process, remove it from our list and shut down the process.
-            final Iterator<PythonProcess> processItr = processes.iterator(); // Use iterator so we can call remove()
-            while (processItr.hasNext()) {
-                final PythonProcess process = processItr.next();
-                final boolean removed = process.removeProcessor(identifier);
-                if (removed && process.getProcessorCount() == 0) {
-                    processItr.remove();
-                    process.shutdown();
-                    break;
+            Thread.ofVirtual().name("Remove Python Processor " + identifier).start(() -> {
+                PythonProcess toRemove = null;
+
+                try {
+                    // Find the Python Process that has the Processor, if any, and remove it.
+                    // If there are no additional Processors in the Python Process, remove it from our list and shut down the process.
+                    // Use iterator so we can call remove()
+                    for (final PythonProcess process : processes) {
+                        final boolean removed = process.removeProcessor(identifier);
+                        if (removed && process.getProcessorCount() == 0) {
+                            toRemove = process;
+                            break;
+                        }
+                    }
+
+                    if (toRemove != null) {
+                        processes.remove(toRemove);
+                        toRemove.shutdown();
+                    }
+                } catch (final Exception e) {
+                    logger.error("Failed to trigger removal of Python Processor with ID {}", identifier, e);
                 }
-            }
+            });
 
             processorCountByType.merge(extensionId, -1, Integer::sum);
         } else {
@@ -198,7 +209,7 @@ public class StandardPythonBridge implements PythonBridge {
         // isolation (which is the case when Extension Manager creates a temp component), or if an existing process
         // consists only of processors that don't prefer isolation. I.e., we don't want to collocate two Processors if
         // they both prefer isolation.
-        final List<PythonProcess> processesForType = processesByProcessorType.computeIfAbsent(extensionId, key -> new ArrayList<>());
+        final List<PythonProcess> processesForType = processesByProcessorType.computeIfAbsent(extensionId, key -> new CopyOnWriteArrayList<>());
         for (final PythonProcess pythonProcess : processesForType) {
             if (!preferIsolatedProcess || !pythonProcess.containsIsolatedProcessor()) {
                 logger.debug("Using {} to create Processor of type {}", pythonProcess, extensionId.type());

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/python/processor/PythonProcessorProxy.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/python/processor/PythonProcessorProxy.java
@@ -126,7 +126,7 @@ public abstract class PythonProcessorProxy extends AbstractProcessor implements 
             return this.cachedPropertyDescriptors;
         }
 
-        if (bridge == null) {
+        if (getState() != LoadState.FINISHED_LOADING) {
             return Collections.emptyList();
         }
 
@@ -202,7 +202,7 @@ public abstract class PythonProcessorProxy extends AbstractProcessor implements 
             return cachedDynamicDescriptors.get(propertyDescriptorName);
         }
 
-        if (bridge == null) {
+        if (getState() != LoadState.FINISHED_LOADING) {
             return null;
         }
 
@@ -221,7 +221,7 @@ public abstract class PythonProcessorProxy extends AbstractProcessor implements 
             return supportsDynamicProperties;
         }
 
-        if (bridge == null) {
+        if (getState() != LoadState.FINISHED_LOADING) {
             return false;
         }
 
@@ -266,7 +266,7 @@ public abstract class PythonProcessorProxy extends AbstractProcessor implements 
     }
 
     private Set<Relationship> fetchRelationshipsFromPythonProcessor() {
-        if (bridge == null) {
+        if (getState() != LoadState.FINISHED_LOADING) {
             return Collections.emptySet();
         }
 


### PR DESCRIPTION
… removed to a background (virtual) thread. Also noted in testing that in one instance a Python Processor never became

valid because it had cached property descriptors before the processor was fully initialized, so updated code to ensure that we do not cache values before initialization is completed.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
