### PR TITLE
NIFI-12675: Fixed bug that caused custom Relationships not to work on…

### DIFF
--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -420,6 +420,11 @@ public class StandardProcessorTestRunner implements TestRunner {
     }
 
     @Override
+    public boolean isValid() {
+        return context.isValid();
+    }
+
+    @Override
     public void assertNotValid() {
         Assertions.assertFalse(context.isValid(), "Processor appears to be valid but expected it to be invalid");
     }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
@@ -394,6 +394,8 @@ public interface TestRunner {
      */
     void assertValid();
 
+    boolean isValid();
+
     /**
      * Assert that the currently configured set of properties/annotation data
      * are NOT valid

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
@@ -19,13 +19,11 @@ package org.apache.nifi.py4j;
 
 import org.apache.nifi.components.AsyncLoadedProcessor;
 import org.apache.nifi.components.AsyncLoadedProcessor.LoadState;
-import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.json.JsonRecordSetWriter;
 import org.apache.nifi.json.JsonTreeReader;
 import org.apache.nifi.mock.MockProcessorInitializationContext;
-import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
@@ -41,7 +39,6 @@ import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.util.MockFlowFile;
-import org.apache.nifi.util.MockPropertyValue;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.AfterAll;
@@ -49,9 +46,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -74,8 +68,6 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 public class PythonControllerInteractionIT {
     private static PythonBridge bridge;

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
@@ -28,6 +28,7 @@ import org.apache.nifi.mock.MockProcessorInitializationContext;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.python.ControllerServiceTypeLookup;
 import org.apache.nifi.python.PythonBridge;
 import org.apache.nifi.python.PythonBridgeInitializationContext;
@@ -66,6 +67,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -256,6 +258,7 @@ public class PythonControllerInteractionIT {
         runner.enqueue("name, number\nJohn Doe, 500");
 
         // Trigger the processor
+        waitForValid(runner);
         runner.run();
         runner.assertTransferCount("original", 1);
         runner.assertTransferCount("success", 1);
@@ -284,6 +287,7 @@ public class PythonControllerInteractionIT {
         runner.enqueue("");
 
         // Trigger the processor
+        waitForValid(runner);
         runner.run();
         runner.assertTransferCount("original", 1);
         runner.assertTransferCount("success", 1);
@@ -365,6 +369,7 @@ public class PythonControllerInteractionIT {
         runner.enqueue("");
 
         // Trigger the processor
+        waitForValid(runner);
         runner.run();
         runner.assertTransferCount("original", 1);
         runner.assertTransferCount("success", 1);
@@ -432,6 +437,7 @@ public class PythonControllerInteractionIT {
         runnerV1.enqueue("");
 
         // Trigger the processor
+        waitForValid(runnerV1);
         runnerV1.run();
         runnerV1.assertTransferCount("success", 1);
         runnerV1.assertTransferCount("original", 1);
@@ -443,10 +449,27 @@ public class PythonControllerInteractionIT {
         runnerV2.enqueue("");
 
         // Trigger the processor
+        waitForValid(runnerV2);
         runnerV2.run();
         runnerV2.assertTransferCount("success", 1);
         runnerV2.assertTransferCount("original", 1);
         runnerV2.getFlowFilesForRelationship("success").get(0).assertContentEquals("Hello, World 2");
+    }
+
+    private void waitForValid(final TestRunner runner) {
+        final long maxTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60L);
+        while (System.currentTimeMillis() < maxTime) {
+            if (runner.isValid()) {
+                return;
+            }
+
+            try {
+                Thread.sleep(10L);
+            } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for processor to be valid");
+            }
+        }
     }
 
     @Test
@@ -469,22 +492,6 @@ public class PythonControllerInteractionIT {
             [{"name":"Jane Doe","number":"8"}]""");
     }
 
-    private ProcessContext createContext(final Map<PropertyDescriptor, String> propertyValues) {
-        final ProcessContext context = Mockito.mock(ProcessContext.class);
-
-        when(context.getProperties()).thenReturn(propertyValues);
-        when(context.getProperty(any(String.class))).thenAnswer(new Answer<>() {
-            @Override
-            public Object answer(final InvocationOnMock invocationOnMock) {
-                final String name = invocationOnMock.getArgument(0, String.class);
-                final PropertyDescriptor descriptor = new PropertyDescriptor.Builder().name(name).build();
-                final String stringValue = propertyValues.get(descriptor);
-                return new MockPropertyValue(stringValue);
-            }
-        });
-
-        return context;
-    }
 
     private TestRunner createRecordTransformRunner(final String type) throws InitializationException {
         final Processor processor = createProcessor("SetRecordField");
@@ -521,6 +528,29 @@ public class PythonControllerInteractionIT {
         final MockFlowFile out = runner.getFlowFilesForRelationship("success").get(0);
         out.assertContentEquals("""
             [{"name":"Jane Doe","father":{"name":"John Doe"}}]""");
+    }
+
+
+    @Test
+    public void testCustomRelationships() {
+        final FlowFileTransformProxy processor = createFlowFileTransform("RouteFlowFile");
+        final TestRunner runner = TestRunners.newTestRunner(processor);
+
+        final Set<Relationship> relationships = runner.getProcessor().getRelationships();
+        assertEquals(4, relationships.size());
+        assertTrue(relationships.stream().anyMatch(rel -> rel.getName().equals("small")));
+        assertTrue(relationships.stream().anyMatch(rel -> rel.getName().equals("large")));
+        assertTrue(relationships.stream().anyMatch(rel -> rel.getName().equals("original")));
+        assertTrue(relationships.stream().anyMatch(rel -> rel.getName().equals("failure")));
+
+        runner.enqueue(new byte[25]);
+        runner.enqueue(new byte[75 * 1024]);
+        runner.run(2);
+
+        runner.assertTransferCount("original", 2);
+        runner.assertTransferCount("small", 1);
+        runner.assertTransferCount("large", 1);
+        runner.assertTransferCount("failure", 0);
     }
 
 

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-extension-api/src/main/python/src/nifiapi/relationship.py
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-extension-api/src/main/python/src/nifiapi/relationship.py
@@ -19,7 +19,7 @@ class Relationship:
         self.description = description
         self.auto_terminated = auto_terminated
 
-    def to_java_descriptor(self, gateway):
+    def to_java_relationship(self, gateway):
         return gateway.jvm.org.apache.nifi.processor.Relationship.Builder() \
             .name(self.name) \
             .description(self.description) \

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-test-extensions/src/main/resources/extensions/RouteFlowFile.py
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-test-extensions/src/main/resources/extensions/RouteFlowFile.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nifiapi.flowfiletransform import FlowFileTransform, FlowFileTransformResult
+from nifiapi.relationship import Relationship
+
+class RouteFlowFile(FlowFileTransform):
+    class Java:
+        implements = ['org.apache.nifi.python.processor.FlowFileTransform']
+    class ProcessorDetails:
+        version = '0.0.1-SNAPSHOT'
+        description = "Routes a FlowFile to 'small' or 'large' based on whether the size of the flowfile exceeds 50 KB"
+
+    REL_SMALL = Relationship(name="small", description="FlowFiles smaller than 50 KB")
+    REL_LARGE = Relationship(name="large", description="FlowFiles larger than 50 KB")
+
+    def __init__(self, **kwargs):
+        pass
+
+    def transform(self, context, flowFile):
+        size = flowFile.getSize()
+        if size > 50000:
+            return FlowFileTransformResult(relationship = "large")
+        else:
+            return FlowFileTransformResult(relationship = "small")
+
+    def getRelationships(self):
+        return [self.REL_SMALL, self.REL_LARGE]


### PR DESCRIPTION
… Python Processors. Added unit test to verify. Also addressed issue in PythonControllerInteractionIT where it did not wait for Processors to become valid (originally this wasn't necessary but when we refactored Processors to initialize in the background this was overlooked).

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
