### PR TITLE
NIFI-12695 Enable PKCE Support for OIDC Integration

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -518,6 +518,9 @@ The implementation supports the Authorization Code Grant Type as described in
 link:https://www.rfc-editor.org/rfc/rfc6749#section-4.1[RFC 6749 Section 4.1^] and
 link:https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps[OpenID Connect Core Section 3.1.1^].
 
+The Authorization Code Grant Type implementation supports link:https://www.rfc-editor.org/rfc/rfc7636[RFC 7636] Proof
+Key for Code Exchange as part of the authentication process. PKCE support uses the `S256` code challenge method.
+
 After successful authentication with the Authorization Server, NiFi generates an application Bearer Token with an
 expiration based on the OAuth2 Access Token expiration. NiFi stores authorized tokens using the local State
 Provider and encrypts serialized information using the application Sensitive Properties Key.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/client/web/StandardOAuth2AuthorizationRequestResolver.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/client/web/StandardOAuth2AuthorizationRequestResolver.java
@@ -19,7 +19,7 @@ package org.apache.nifi.web.security.oidc.client.web;
 import org.apache.nifi.web.util.RequestUriBuilder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestCustomizers;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -27,6 +27,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.util.Objects;
+
+import static org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
 
 /**
  * Authorization Request Resolver supports handling of headers from reverse proxy servers
@@ -41,7 +43,10 @@ public class StandardOAuth2AuthorizationRequestResolver implements OAuth2Authori
      */
     public StandardOAuth2AuthorizationRequestResolver(final ClientRegistrationRepository clientRegistrationRepository) {
         Objects.requireNonNull(clientRegistrationRepository, "Repository required");
-        resolver = new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository, OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI);
+        final DefaultOAuth2AuthorizationRequestResolver requestResolver = new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository, DEFAULT_AUTHORIZATION_REQUEST_BASE_URI);
+        // Enable RFC 7636 Proof Key for Code Exchange on Requests
+        requestResolver.setAuthorizationRequestCustomizer(OAuth2AuthorizationRequestCustomizers.withPkce());
+        resolver = requestResolver;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/oidc/client/web/StandardOAuth2AuthorizationRequestResolverTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/oidc/client/web/StandardOAuth2AuthorizationRequestResolverTest.java
@@ -30,11 +30,15 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
 import jakarta.servlet.ServletContext;
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
+
 import java.net.URI;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -99,6 +103,7 @@ class StandardOAuth2AuthorizationRequestResolverTest {
 
         assertNotNull(authorizationRequest);
         assertEquals(REDIRECT_URI, authorizationRequest.getRedirectUri());
+        assertPkceParametersFound(authorizationRequest);
     }
 
     @Test
@@ -119,6 +124,15 @@ class StandardOAuth2AuthorizationRequestResolverTest {
 
         assertNotNull(authorizationRequest);
         assertEquals(FORWARDED_REDIRECT_URI, authorizationRequest.getRedirectUri());
+        assertPkceParametersFound(authorizationRequest);
+    }
+
+    private void assertPkceParametersFound(final OAuth2AuthorizationRequest authorizationRequest) {
+        assertNotNull(authorizationRequest.getAttribute(PkceParameterNames.CODE_VERIFIER));
+
+        final Map<String, Object> additionalParameters = authorizationRequest.getAdditionalParameters();
+        assertTrue(additionalParameters.containsKey(PkceParameterNames.CODE_CHALLENGE));
+        assertTrue(additionalParameters.containsKey(PkceParameterNames.CODE_CHALLENGE_METHOD));
     }
 
     ClientRegistration getClientRegistration() {


### PR DESCRIPTION
# Summary

[NIFI-12695](https://issues.apache.org/jira/browse/NIFI-12695) Adds Proof Key for Code Exchange support to the NiFi framework OpenID Connect implementation as described in [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636).

PKCE support is an optional extension for OAuth 2.0, but it is required in [OAuth 2.1](https://oauth.net/2.1/) for all clients using the authorization code flow.

Authorization Servers that do not support PKCE will continue to function in the same way, ignoring the additional query parameters as described in [RFC 7636 Section 5](https://www.rfc-editor.org/rfc/rfc7636#section-5).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
