### PR TITLE
NIFI-12710: Allow for microsecond precision timestamps when pushing t…

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
@@ -21,7 +21,6 @@ import org.apache.nifi.serialization.record.util.IllegalTypeConversionException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Date;

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
@@ -27,30 +27,31 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestObjectLocalDateTimeFieldConverter {
-    private final long MILLIS_TIMESTAMP_LONG = 1707238288351L;
-    private final long MICROS_TIMESTAMP_LONG = 1707238288351567L;
-    private final String MICROS_TIMESTAMP_STRING = Long.toString(MICROS_TIMESTAMP_LONG);
-    private final double MICROS_TIMESTAMP_DOUBLE = ((double) MICROS_TIMESTAMP_LONG) / 1000000D;
-    private final long NANOS_AFTER_SECOND = 351567000L;
-    private final Instant INSTANT_MILLIS_PRECISION = Instant.ofEpochMilli(MILLIS_TIMESTAMP_LONG);
+    private static final String FIELD_NAME = "test";
+    private static final long MILLIS_TIMESTAMP_LONG = 1707238288351L;
+    private static final long MICROS_TIMESTAMP_LONG = 1707238288351567L;
+    private static final String MICROS_TIMESTAMP_STRING = Long.toString(MICROS_TIMESTAMP_LONG);
+    private static final double MICROS_TIMESTAMP_DOUBLE = ((double) MICROS_TIMESTAMP_LONG) / 1000000D;
+    private static final long NANOS_AFTER_SECOND = 351567000L;
+    private static final Instant INSTANT_MILLIS_PRECISION = Instant.ofEpochMilli(MILLIS_TIMESTAMP_LONG);
     // Create an instant to represent the same time as the microsecond precision timestamp. We add nanoseconds after second but then have to subtract the milliseconds after the second that are already
     // present in the MILLIS_TIMESTAMP_LONG value.
-    private final Instant INSTANT_MICROS_PRECISION = Instant.ofEpochMilli(MILLIS_TIMESTAMP_LONG).plusNanos(NANOS_AFTER_SECOND).minusMillis(MILLIS_TIMESTAMP_LONG % 1000);
-    private final LocalDateTime LOCAL_DATE_TIME_MILLIS_PRECISION = LocalDateTime.ofInstant(INSTANT_MILLIS_PRECISION, ZoneId.systemDefault());
-    private final LocalDateTime LOCAL_DATE_TIME_MICROS_PRECISION = LocalDateTime.ofInstant(INSTANT_MICROS_PRECISION, ZoneId.systemDefault());
+    private static final Instant INSTANT_MICROS_PRECISION = Instant.ofEpochMilli(MILLIS_TIMESTAMP_LONG).plusNanos(NANOS_AFTER_SECOND).minusMillis(MILLIS_TIMESTAMP_LONG % 1000);
+    private static final LocalDateTime LOCAL_DATE_TIME_MILLIS_PRECISION = LocalDateTime.ofInstant(INSTANT_MILLIS_PRECISION, ZoneId.systemDefault());
+    private static final LocalDateTime LOCAL_DATE_TIME_MICROS_PRECISION = LocalDateTime.ofInstant(INSTANT_MICROS_PRECISION, ZoneId.systemDefault());
 
     private final ObjectLocalDateTimeFieldConverter converter = new ObjectLocalDateTimeFieldConverter();
 
 
     @Test
     public void testConvertTimestampMillis() {
-        final LocalDateTime result = converter.convertField(MILLIS_TIMESTAMP_LONG, Optional.empty(), "test");
+        final LocalDateTime result = converter.convertField(MILLIS_TIMESTAMP_LONG, Optional.empty(), FIELD_NAME);
         assertEquals(LOCAL_DATE_TIME_MILLIS_PRECISION, result);
     }
 
     @Test
     public void testConvertTimestampMicros() {
-        final LocalDateTime result = converter.convertField(MICROS_TIMESTAMP_LONG, Optional.empty(), "test");
+        final LocalDateTime result = converter.convertField(MICROS_TIMESTAMP_LONG, Optional.empty(), FIELD_NAME);
         assertEquals(MILLIS_TIMESTAMP_LONG, result.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
 
         final Instant resultInstant = result.atZone(ZoneId.systemDefault()).toInstant();
@@ -59,14 +60,14 @@ public class TestObjectLocalDateTimeFieldConverter {
 
     @Test
     public void testDoubleAsEpochSeconds() {
-        final LocalDateTime result = converter.convertField(MICROS_TIMESTAMP_DOUBLE, Optional.empty(), "test");
+        final LocalDateTime result = converter.convertField(MICROS_TIMESTAMP_DOUBLE, Optional.empty(), FIELD_NAME);
         assertEquals(LOCAL_DATE_TIME_MICROS_PRECISION, result);
         assertEquals(NANOS_AFTER_SECOND, result.getNano(), 1D);
     }
 
     @Test
     public void testDoubleAsEpochSecondsAsString() {
-        final LocalDateTime result = converter.convertField(MICROS_TIMESTAMP_STRING, Optional.empty(), "test");
+        final LocalDateTime result = converter.convertField(MICROS_TIMESTAMP_STRING, Optional.empty(), FIELD_NAME);
         assertEquals(LOCAL_DATE_TIME_MICROS_PRECISION, result);
         final double expectedNanos = 351567000L;
         assertEquals(expectedNanos, result.getNano(), 1D);
@@ -75,13 +76,13 @@ public class TestObjectLocalDateTimeFieldConverter {
     @Test
     public void testWithDateFormatMillisPrecision() {
         final long millis = System.currentTimeMillis();
-        final LocalDateTime result = converter.convertField(millis, Optional.of("yyyy-MM-dd'T'HH:mm:ss.SSS"), "test");
+        final LocalDateTime result = converter.convertField(millis, Optional.of("yyyy-MM-dd'T'HH:mm:ss.SSS"), FIELD_NAME);
         assertEquals(LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault()), result);
     }
 
     @Test
     public void testWithDateFormatMicrosecondPrecision() {
-        final LocalDateTime result = converter.convertField(MICROS_TIMESTAMP_LONG, Optional.of("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"), "test");
+        final LocalDateTime result = converter.convertField(MICROS_TIMESTAMP_LONG, Optional.of("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"), FIELD_NAME);
         assertEquals(LOCAL_DATE_TIME_MICROS_PRECISION, result);
     }
 }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/TestObjectLocalDateTimeFieldConverter.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.serialization.record.field;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestObjectLocalDateTimeFieldConverter {
+
+    @Test
+    public void testConvertTimestampMillis() {
+        final ObjectLocalDateTimeFieldConverter converter = new ObjectLocalDateTimeFieldConverter();
+        final long now = System.currentTimeMillis();
+        final Instant instant = Instant.ofEpochMilli(now);
+        final LocalDateTime expected = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+
+        final LocalDateTime result = converter.convertField(now, Optional.empty(), "test");
+        assertEquals(expected, result);
+        assertEquals(now, result.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+    }
+
+    @Test
+    public void testConvertTimestampMicros() {
+        final ObjectLocalDateTimeFieldConverter converter = new ObjectLocalDateTimeFieldConverter();
+        final long now = System.currentTimeMillis();
+        final long withMicros =  now * 1000 + 567;
+
+        final LocalDateTime result = converter.convertField(withMicros, Optional.empty(), "test");
+        assertEquals(now, result.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+        final Instant resultInstant = result.atZone(ZoneId.systemDefault()).toInstant();
+        final long expectedNanos = now % 1000 * 1_000_000 + 567_000;
+        assertEquals(expectedNanos, resultInstant.getNano());
+    }
+
+    @Test
+    public void testDoubleAsEpochSeconds() {
+        final ObjectLocalDateTimeFieldConverter converter = new ObjectLocalDateTimeFieldConverter();
+        final long millis = System.currentTimeMillis();
+        final double seconds = millis / 1000.0;
+        final double withMicros =  seconds + 0.000567;
+
+        final LocalDateTime result = converter.convertField(withMicros, Optional.empty(), "test");
+        assertEquals(LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault()).toLocalDate(), result.toLocalDate());
+        final double expectedNanos = (withMicros - (long) seconds) * 1_000_000_000;
+        assertEquals(expectedNanos, result.getNano(), 1000D);
+    }
+
+    @Test
+    public void testDoubleAsEpochSecondsAsString() {
+        final ObjectLocalDateTimeFieldConverter converter = new ObjectLocalDateTimeFieldConverter();
+        final long millis = System.currentTimeMillis();
+        final double seconds = millis / 1000.0;
+        final double withMicros =  seconds + 0.000567;
+
+        final LocalDateTime result = converter.convertField(Double.toString(withMicros), Optional.empty(), "test");
+        assertEquals(LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault()).toLocalDate(), result.toLocalDate());
+        final double expectedNanos = (withMicros - (long) seconds) * 1_000_000_000;
+        assertEquals(expectedNanos, result.getNano(), 1000D);
+    }
+
+    @Test
+    public void testWithDateFormatMillisPrecision() {
+        final ObjectLocalDateTimeFieldConverter converter = new ObjectLocalDateTimeFieldConverter();
+        final long millis = System.currentTimeMillis();
+        final LocalDateTime result = converter.convertField(millis, Optional.of("yyyy-MM-dd'T'HH:mm:ss.SSS"), "test");
+        assertEquals(LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault()), result);
+    }
+
+    @Test
+    public void testWIthDateFormatMicrosecondPrecision() {
+        final ObjectLocalDateTimeFieldConverter converter = new ObjectLocalDateTimeFieldConverter();
+        final long millis = System.currentTimeMillis();
+        final long micros = millis * 1000 + 567;
+        final LocalDateTime result = converter.convertField(micros, Optional.of("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"), "test");
+        assertEquals(LocalDateTime.ofInstant(Instant.ofEpochMilli(millis).plusNanos(567_000), ZoneId.systemDefault()), result);
+    }
+}

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/text/RegexDateTimeMatcher.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/text/RegexDateTimeMatcher.java
@@ -359,7 +359,7 @@ public class RegexDateTimeMatcher implements DateTimeMatcher {
                     addSecondInMinute();
                     break;
                 case 'S':
-                    addMillisecond();
+                    addSubsecond();
                     break;
                 case 'z':
                     addGeneralTimeZone();
@@ -468,9 +468,9 @@ public class RegexDateTimeMatcher implements DateTimeMatcher {
             range = range.plus(1, 2);
         }
 
-        private void addMillisecond() {
-            patterns.add("\\d{1,3}");
-            range = range.plus(1, 3);
+        private void addSubsecond() {
+            patterns.add("\\d{1," + charCount + "}");
+            range = range.plus(1, charCount);
         }
 
         private void addGeneralTimeZone() {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -776,6 +776,7 @@
                         <exclude>src/test/resources/TestXml/xml-bundle-1</exclude>
                         <exclude>src/test/resources/xxe_from_report.xml</exclude>
                         <exclude>src/test/resources/xxe_template.xml</exclude>
+                        <exclude>src/test/resources/PutDatabaseRecordIT/create-person-table.sql</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -488,6 +488,36 @@
             <artifactId>nifi-json-schema-shared</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
+
+        <!-- Test Dependencies for database processors -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.19.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-dbcp-service</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-kerberos-credentials-service-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-kerberos-user-service-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordIT.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordIT.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.dbcp.DBCPConnectionPool;
+import org.apache.nifi.dbcp.utils.DBCPProperties;
+import org.apache.nifi.json.JsonTreeReader;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.serialization.DateTimeUtils;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("resource")
+public class PutDatabaseRecordIT {
+
+    private static PostgreSQLContainer<?> postgres;
+    private TestRunner runner;
+
+
+    @BeforeAll
+    public static void startPostgres() {
+        postgres = new PostgreSQLContainer<>("postgres:9.6.12")
+            .withInitScript("PutDatabaseRecordIT/create-person-table.sql");
+        postgres.start();
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        if (postgres != null) {
+            postgres.close();
+            postgres = null;
+        }
+    }
+
+    @BeforeEach
+    public void setup() throws InitializationException, SQLException {
+        truncateTable();
+
+        runner = TestRunners.newTestRunner(PutDatabaseRecord.class);
+        final DBCPConnectionPool connectionPool = new DBCPConnectionPool();
+        runner.addControllerService("connectionPool", connectionPool);
+        runner.setProperty(connectionPool, DBCPProperties.DATABASE_URL, postgres.getJdbcUrl());
+        runner.setProperty(connectionPool, DBCPProperties.DB_USER, postgres.getUsername());
+        runner.setProperty(connectionPool, DBCPProperties.DB_PASSWORD, postgres.getPassword());
+        runner.setProperty(connectionPool, DBCPProperties.DB_DRIVERNAME, postgres.getDriverClassName());
+        runner.enableControllerService(connectionPool);
+
+        final JsonTreeReader jsonReader = new JsonTreeReader();
+        runner.addControllerService("json-reader", jsonReader);
+        runner.setProperty(jsonReader, DateTimeUtils.DATE_FORMAT, "yyyy-MM-dd");
+        runner.setProperty(jsonReader, DateTimeUtils.TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss.SSSSSS");
+        runner.enableControllerService(jsonReader);
+
+        runner.setProperty(PutDatabaseRecord.RECORD_READER_FACTORY, "json-reader");
+        runner.setProperty(PutDatabaseRecord.DBCP_SERVICE, "connectionPool");
+
+        runner.setProperty(PutDatabaseRecord.TABLE_NAME, "person");
+        runner.setProperty(PutDatabaseRecord.DB_TYPE, "PostgreSQL");
+        runner.setProperty(PutDatabaseRecord.STATEMENT_TYPE, "INSERT");
+    }
+
+
+    @Test
+    public void testSimplePut() throws SQLException {
+        runner.enqueue("""
+            {
+              "name": "John Doe",
+              "age": 50,
+              "favorite_color": "blue"
+            }
+            """);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutDatabaseRecord.REL_SUCCESS, 1);
+
+        final Map<String, Object> results = getResults();
+        assertEquals("John Doe", results.get("name"));
+        assertEquals(50, results.get("age"));
+        assertEquals("blue", results.get("favorite_color"));
+    }
+
+    @Test
+    public void testWithDate() throws SQLException {
+        runner.enqueue("""
+            {
+              "name": "John Doe",
+              "age": 50,
+              "dob": "1975-01-01"
+            }
+            """);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutDatabaseRecord.REL_SUCCESS, 1);
+
+
+        final Map<String, Object> results = getResults();
+        assertEquals("John Doe", results.get("name"));
+        assertEquals(50, results.get("age"));
+        final Date dob = (Date) results.get("dob");
+        assertEquals(1975, dob.toLocalDate().getYear());
+        assertEquals(Month.JANUARY, dob.toLocalDate().getMonth());
+        assertEquals(1, dob.toLocalDate().getDayOfMonth());
+    }
+
+    @Test
+    public void testWithTimestampUsingMillis() throws SQLException {
+        final long now = System.currentTimeMillis();
+        runner.enqueue("""
+            {
+              "name": "John Doe",
+              "age": 50,
+              "lastTransactionTime": %s
+            }
+            """.formatted(now));
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutDatabaseRecord.REL_SUCCESS, 1);
+
+        final Map<String, Object> results = getResults();
+        assertEquals(new Timestamp(now), results.get("lasttransactiontime"));
+    }
+
+    @Test
+    public void testWithTimestampUsingMillisAsString() throws SQLException {
+        final long now = System.currentTimeMillis();
+        runner.enqueue("""
+            {
+              "name": "John Doe",
+              "age": 50,
+              "lastTransactionTime": "%s"
+            }
+            """.formatted(now));
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutDatabaseRecord.REL_SUCCESS, 1);
+
+        final Map<String, Object> results = getResults();
+        assertEquals(new Timestamp(now), results.get("lasttransactiontime"));
+    }
+
+    @Test
+    public void testWithStringTimestampUsingMicros() throws SQLException {
+        runner.enqueue("""
+            {
+              "name": "John Doe",
+              "age": 50,
+              "lastTransactionTime": "2024-01-02 08:41:12.123456"
+            }
+            """);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutDatabaseRecord.REL_SUCCESS, 1);
+
+        final LocalDateTime localDateTime = LocalDateTime.now();
+
+        final Map<String, Object> results = getResults();
+        assertEquals("John Doe", results.get("name"));
+        assertEquals(50, results.get("age"));
+        final Timestamp lastTransactionTime = (Timestamp) results.get("lasttransactiontime");
+        final LocalDateTime transactionLocalTime = lastTransactionTime.toLocalDateTime();
+        assertEquals(2024, transactionLocalTime.getYear());
+        assertEquals(Month.JANUARY, transactionLocalTime.getMonth());
+        assertEquals(2, transactionLocalTime.getDayOfMonth());
+        assertEquals(8, transactionLocalTime.getHour());
+        assertEquals(41, transactionLocalTime.getMinute());
+        assertEquals(12, transactionLocalTime.getSecond());
+        assertEquals(123456000, transactionLocalTime.getNano());
+    }
+
+    @Test
+    public void testWithNumericTimestampUsingMicros() throws SQLException {
+        final Instant now = Instant.now();
+        final long epochSecond = now.getEpochSecond();
+        final long epochMicros = (epochSecond * 1_000_000L) + (now.getNano() / 1000);
+
+        runner.enqueue("""
+            {
+              "name": "John Doe",
+              "age": 50,
+              "lastTransactionTime": %s
+            }
+            """.formatted(epochMicros));
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutDatabaseRecord.REL_SUCCESS, 1);
+
+        final Map<String, Object> results = getResults();
+        assertEquals("John Doe", results.get("name"));
+        assertEquals(50, results.get("age"));
+        final Timestamp lastTransactionTime = (Timestamp) results.get("lasttransactiontime");
+        assertEquals(now, lastTransactionTime.toInstant());
+    }
+
+    @Test
+    public void testWithDecimalTimestampUsingMicros() throws SQLException {
+        final Instant now = Instant.now();
+        final long epochSecond = now.getEpochSecond();
+        final long microsPastSecond = now.getNano() / 1000;
+
+        runner.enqueue("""
+            {
+              "name": "John Doe",
+              "age": 50,
+              "lastTransactionTime": %s.%s
+            }
+            """.formatted(epochSecond, microsPastSecond));
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutDatabaseRecord.REL_SUCCESS, 1);
+
+        final Map<String, Object> results = getResults();
+        assertEquals("John Doe", results.get("name"));
+        assertEquals(50, results.get("age"));
+        final Timestamp lastTransactionTime = (Timestamp) results.get("lasttransactiontime");
+        assertEquals(now, lastTransactionTime.toInstant());
+    }
+
+    @Test
+    public void testWithDecimalTimestampUsingMicrosAsString() throws SQLException {
+        final Instant now = Instant.now();
+        final long epochSecond = now.getEpochSecond();
+        final long microsPastSecond = now.getNano() / 1000;
+
+        runner.enqueue("""
+            {
+              "name": "John Doe",
+              "age": 50,
+              "lastTransactionTime": "%s.%s"
+            }
+            """.formatted(epochSecond, microsPastSecond));
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutDatabaseRecord.REL_SUCCESS, 1);
+
+        final Map<String, Object> results = getResults();
+        assertEquals("John Doe", results.get("name"));
+        assertEquals(50, results.get("age"));
+        final Timestamp lastTransactionTime = (Timestamp) results.get("lasttransactiontime");
+        assertEquals(now, lastTransactionTime.toInstant());
+    }
+
+
+    private static void truncateTable() throws SQLException {
+        try (final Connection connection = DriverManager.getConnection(postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())) {
+            final String sqlQuery = "TRUNCATE TABLE person";
+            try (final PreparedStatement preparedStatement = connection.prepareStatement(sqlQuery)) {
+                preparedStatement.execute();
+            }
+        }
+    }
+
+    private Map<String, Object> getResults() throws SQLException {
+        try (final Connection connection = DriverManager.getConnection(postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())) {
+            final String sqlQuery = "SELECT * FROM person";
+            final Map<String, Object> resultsMap = new HashMap<>();
+
+            try (final PreparedStatement preparedStatement = connection.prepareStatement(sqlQuery);
+                 final ResultSet resultSet = preparedStatement.executeQuery()) {
+
+                final ResultSetMetaData metaData = resultSet.getMetaData();
+                final int columnCount = metaData.getColumnCount();
+
+                while (resultSet.next()) {
+                    for (int i = 1; i <= columnCount; i++) {
+                        final String columnName = metaData.getColumnName(i);
+                        final Object columnValue = resultSet.getObject(i);
+                        resultsMap.put(columnName, columnValue);
+                    }
+                }
+            }
+
+            return resultsMap;
+        }
+    }
+
+}

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordIT.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordIT.java
@@ -41,6 +41,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -200,7 +201,7 @@ public class PutDatabaseRecordIT {
 
     @Test
     public void testWithNumericTimestampUsingMicros() throws SQLException {
-        final Instant now = Instant.now();
+        final Instant now = nowWithMicrosPrecision();
         final long epochSecond = now.getEpochSecond();
         final long epochMicros = (epochSecond * 1_000_000L) + (now.getNano() / 1000);
 
@@ -221,9 +222,16 @@ public class PutDatabaseRecordIT {
         assertEquals(now, lastTransactionTime.toInstant());
     }
 
+    // Depending on the operating system, the precision of Instant.now() may be microsecond precision, or it may be nanosecond precision.
+    // If nanosecond precision, the result that we retrieve from database will be inaccurate because it will be rounded down to microsecond precision.
+    // To adjust for this, we will use Instant.now().truncatedTo(ChronoUnit.MICROS) to ensure that the Instant is microsecond precision.
+    private Instant nowWithMicrosPrecision() {
+        return Instant.now().truncatedTo(ChronoUnit.MICROS);
+    }
+
     @Test
     public void testWithDecimalTimestampUsingMicros() throws SQLException {
-        final Instant now = Instant.now();
+        final Instant now = nowWithMicrosPrecision();
         final long epochSecond = now.getEpochSecond();
         final long microsPastSecond = now.getNano() / 1000;
 
@@ -246,7 +254,7 @@ public class PutDatabaseRecordIT {
 
     @Test
     public void testWithDecimalTimestampUsingMicrosAsString() throws SQLException {
-        final Instant now = Instant.now();
+        final Instant now = nowWithMicrosPrecision();
         final long epochSecond = now.getEpochSecond();
         final long microsPastSecond = now.getNano() / 1000;
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/PutDatabaseRecordIT/create-person-table.sql
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/PutDatabaseRecordIT/create-person-table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE person (
+    name VARCHAR(255) NOT NULL,
+    age INT,
+    favorite_color VARCHAR(255),
+    dob DATE,
+    lastTransactionTime TIMESTAMP WITH TIME ZONE
+);


### PR DESCRIPTION
…o database

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
