### PR TITLE
NIFI-12731:  Ensure state is updated in GetHBase whenever the session is committed

### DIFF
--- a/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/GetHBase.java
+++ b/nifi-nar-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/GetHBase.java
@@ -140,7 +140,7 @@ public class GetHBase extends AbstractProcessor implements VisibilityFetchSuppor
             .build();
 
     private final AtomicReference<ScanResult> lastResult = new AtomicReference<>();
-    private volatile List<Column> columns = new ArrayList<>();
+    private final List<Column> columns = new ArrayList<>();
     private volatile String previousTable = null;
 
     @Override
@@ -201,11 +201,11 @@ public class GetHBase extends AbstractProcessor implements VisibilityFetchSuppor
         for (final String column : columns) {
             if (column.contains(":"))  {
                 final String[] parts = column.split(":");
-                final byte[] cf = parts[0].getBytes(Charset.forName("UTF-8"));
-                final byte[] cq = parts[1].getBytes(Charset.forName("UTF-8"));
+                final byte[] cf = parts[0].getBytes(StandardCharsets.UTF_8);
+                final byte[] cq = parts[1].getBytes(StandardCharsets.UTF_8);
                 this.columns.add(new Column(cf, cq));
             } else {
-                final byte[] cf = column.getBytes(Charset.forName("UTF-8"));
+                final byte[] cf = column.getBytes(StandardCharsets.UTF_8);
                 this.columns.add(new Column(cf, null));
             }
         }
@@ -307,11 +307,7 @@ public class GetHBase extends AbstractProcessor implements VisibilityFetchSuppor
                             final byte[] cellValue = Arrays.copyOfRange(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength() + cell.getValueOffset());
 
                             final String rowHash = new String(rowValue, StandardCharsets.UTF_8);
-                            Set<String> cellHashes = cellsMatchingTimestamp.get(rowHash);
-                            if (cellHashes == null) {
-                                cellHashes = new HashSet<>();
-                                cellsMatchingTimestamp.put(rowHash, cellHashes);
-                            }
+                            Set<String> cellHashes = cellsMatchingTimestamp.computeIfAbsent(rowHash, k -> new HashSet<>());
                             cellHashes.add(new String(cellValue, StandardCharsets.UTF_8));
                         }
                     }
@@ -336,40 +332,11 @@ public class GetHBase extends AbstractProcessor implements VisibilityFetchSuppor
                 rowsPulledHolder.set(++rowsPulled);
 
                 if (++rowsPulled % getBatchSize() == 0) {
-                    session.commitAsync();
+                    updateStateAndCommit(session, latestTimestampHolder.get(), cellsMatchingTimestamp);
                 }
             });
 
-            final ScanResult scanResults = new ScanResult(latestTimestampHolder.get(), cellsMatchingTimestamp);
-
-            final ScanResult latestResult = lastResult.get();
-            if (latestResult == null || scanResults.getTimestamp() > latestResult.getTimestamp()) {
-                session.setState(scanResults.toFlatMap(), Scope.CLUSTER);
-                session.commitAsync(() -> updateScanResultsIfNewer(scanResults));
-            } else if (scanResults.getTimestamp() == latestResult.getTimestamp()) {
-                final Map<String, Set<String>> combinedResults = new HashMap<>(scanResults.getMatchingCells());
-
-                // copy the results of result.getMatchingCells() to combinedResults.
-                // do a deep copy because the Set may be modified below.
-                for (final Map.Entry<String, Set<String>> entry : scanResults.getMatchingCells().entrySet()) {
-                    combinedResults.put(entry.getKey(), new HashSet<>(entry.getValue()));
-                }
-
-                // combined the results from 'lastResult'
-                for (final Map.Entry<String, Set<String>> entry : latestResult.getMatchingCells().entrySet()) {
-                    final Set<String> existing = combinedResults.get(entry.getKey());
-                    if (existing == null) {
-                        combinedResults.put(entry.getKey(), new HashSet<>(entry.getValue()));
-                    } else {
-                        existing.addAll(entry.getValue());
-                    }
-                }
-
-                final ScanResult scanResult = new ScanResult(scanResults.getTimestamp(), combinedResults);
-                session.setState(scanResult.toFlatMap(), Scope.CLUSTER);
-
-                session.commitAsync(() -> updateScanResultsIfNewer(scanResult));
-            }
+            updateStateAndCommit(session, latestTimestampHolder.get(), cellsMatchingTimestamp);
         } catch (final IOException e) {
             getLogger().error("Failed to receive data from HBase due to {}", e);
             session.rollback();
@@ -377,6 +344,39 @@ public class GetHBase extends AbstractProcessor implements VisibilityFetchSuppor
             // if we failed, we want to yield so that we don't hammer hbase. If we succeed, then we have
             // pulled all of the records, so we want to wait a bit before hitting hbase again anyway.
             context.yield();
+        }
+    }
+
+    private void updateStateAndCommit(final ProcessSession session, final long latestTimestamp, final Map<String, Set<String>> cellsMatchingTimestamp) throws IOException {
+        final ScanResult scanResults = new ScanResult(latestTimestamp, cellsMatchingTimestamp);
+
+        final ScanResult latestResult = lastResult.get();
+        if (latestResult == null || scanResults.getTimestamp() > latestResult.getTimestamp()) {
+            session.setState(scanResults.toFlatMap(), Scope.CLUSTER);
+            session.commitAsync(() -> updateScanResultsIfNewer(scanResults));
+        } else if (scanResults.getTimestamp() == latestResult.getTimestamp()) {
+            final Map<String, Set<String>> combinedResults = new HashMap<>(scanResults.getMatchingCells());
+
+            // copy the results of result.getMatchingCells() to combinedResults.
+            // do a deep copy because the Set may be modified below.
+            for (final Map.Entry<String, Set<String>> entry : scanResults.getMatchingCells().entrySet()) {
+                combinedResults.put(entry.getKey(), new HashSet<>(entry.getValue()));
+            }
+
+            // combined the results from 'lastResult'
+            for (final Map.Entry<String, Set<String>> entry : latestResult.getMatchingCells().entrySet()) {
+                final Set<String> existing = combinedResults.get(entry.getKey());
+                if (existing == null) {
+                    combinedResults.put(entry.getKey(), new HashSet<>(entry.getValue()));
+                } else {
+                    existing.addAll(entry.getValue());
+                }
+            }
+
+            final ScanResult scanResult = new ScanResult(scanResults.getTimestamp(), combinedResults);
+            session.setState(scanResult.toFlatMap(), Scope.CLUSTER);
+
+            session.commitAsync(() -> updateScanResultsIfNewer(scanResult));
         }
     }
 
@@ -495,11 +495,7 @@ public class GetHBase extends AbstractProcessor implements VisibilityFetchSuppor
                 final String rowIndex = matcher.group(1);
                 final String cellIndex = matcher.group(3);
 
-                Set<String> cellHashes = rowIndexToMatchingCellHashes.get(rowIndex);
-                if (cellHashes == null) {
-                    cellHashes = new HashSet<>();
-                    rowIndexToMatchingCellHashes.put(rowIndex, cellHashes);
-                }
+                Set<String> cellHashes = rowIndexToMatchingCellHashes.computeIfAbsent(rowIndex, k -> new HashSet<>());
 
                 if (cellIndex == null) {
                     // this provides a Row ID.

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/scan/ResultHandler.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase-client-service-api/src/main/java/org/apache/nifi/hbase/scan/ResultHandler.java
@@ -16,11 +16,13 @@
  */
 package org.apache.nifi.hbase.scan;
 
+import java.io.IOException;
+
 /**
  * Handles a single row from an HBase scan.
  */
 public interface ResultHandler {
 
-    void handle(byte[] row, ResultCell[] resultCells);
+    void handle(byte[] row, ResultCell[] resultCells) throws IOException;
 
 }


### PR DESCRIPTION
# Summary

[NIFI-12731](https://issues.apache.org/jira/browse/NIFI-12731) This PR calls setState() in GetHBase whenever the session is committed, in order to avoid duplicate processing on error.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
