### PR TITLE
NIFI-12732 ListS3 resets its tracking state after configuration change

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/ListS3.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/ListS3.java
@@ -354,8 +354,9 @@ public class ListS3 extends AbstractS3Processor implements VerifiableProcessor {
 
     @OnScheduled
     public void initTrackingStrategy(ProcessContext context) throws IOException {
-        final boolean isTrackingTimestampsStrategy = BY_TIMESTAMPS.getValue().equals(context.getProperty(LISTING_STRATEGY).getValue());
-        final boolean isTrackingEntityStrategy = BY_ENTITIES.getValue().equals(context.getProperty(LISTING_STRATEGY).getValue());
+        final String listingStrategy = context.getProperty(LISTING_STRATEGY).getValue();
+        final boolean isTrackingTimestampsStrategy = BY_TIMESTAMPS.getValue().equals(listingStrategy);
+        final boolean isTrackingEntityStrategy = BY_ENTITIES.getValue().equals(listingStrategy);
 
         if (resetTracking || !isTrackingTimestampsStrategy) {
             context.getStateManager().clear(Scope.CLUSTER);

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestListS3.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestListS3.java
@@ -1,4 +1,4 @@
-    /*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestListS3.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestListS3.java
@@ -32,8 +32,10 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.S3VersionSummary;
 import com.amazonaws.services.s3.model.VersionListing;
 import org.apache.commons.lang3.time.DateUtils;
+import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.state.Scope;
+import org.apache.nifi.distributed.cache.client.DistributedMapCacheClient;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.VerifiableProcessor;
 import org.apache.nifi.processors.aws.testutil.AuthUtils;
@@ -60,25 +62,39 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 public class TestListS3 {
 
-    private TestRunner runner = null;
-    private AmazonS3Client mockS3Client = null;
+    private static final long TEST_TIMESTAMP = 1234567890;
+
+    private TestRunner runner;
+    private ListS3 listS3;
+    private AmazonS3Client mockS3Client;
+    private MockStateManager mockStateManager;
+    private DistributedMapCacheClient mockCache;
 
     @BeforeEach
     public void setUp() {
-        mockS3Client = Mockito.mock(AmazonS3Client.class);
-        final ListS3 mockListS3 = new ListS3() {
+        mockS3Client = mock(AmazonS3Client.class);
+        listS3 = new ListS3() {
             @Override
             protected AmazonS3Client createClient(final ProcessContext context, final AWSCredentialsProvider credentialsProvider, final Region region, final ClientConfiguration config,
                                                   final AwsClientBuilder.EndpointConfiguration endpointConfiguration) {
                 return mockS3Client;
             }
         };
-        runner = TestRunners.newTestRunner(mockListS3);
+        runner = TestRunners.newTestRunner(listS3);
+        mockStateManager = runner.getStateManager();
+        mockCache = mock(DistributedMapCacheClient.class);
         AuthUtils.enableAccessKey(runner, "accessKeyId", "secretKey");
     }
 
@@ -105,16 +121,16 @@ public class TestListS3 {
         objectSummary3.setKey("d/e");
         objectSummary3.setLastModified(lastModified);
         objectListing.getObjectSummaries().add(objectSummary3);
-        Mockito.when(mockS3Client.listObjects(Mockito.any(ListObjectsRequest.class))).thenReturn(objectListing);
+        when(mockS3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(objectListing);
 
         runner.run();
 
         ArgumentCaptor<ListObjectsRequest> captureRequest = ArgumentCaptor.forClass(ListObjectsRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
         ListObjectsRequest request = captureRequest.getValue();
         assertEquals("test-bucket", request.getBucketName());
         assertFalse(request.isRequesterPays());
-        Mockito.verify(mockS3Client, Mockito.never()).listVersions(Mockito.any());
+        verify(mockS3Client, Mockito.never()).listVersions(any());
 
         runner.assertAllFlowFilesTransferred(ListS3.REL_SUCCESS, 3);
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ListS3.REL_SUCCESS);
@@ -162,16 +178,16 @@ public class TestListS3 {
         objectSummary3.setKey("d/e");
         objectSummary3.setLastModified(lastModified);
         objectListing.getObjectSummaries().add(objectSummary3);
-        Mockito.when(mockS3Client.listObjects(Mockito.any(ListObjectsRequest.class))).thenReturn(objectListing);
+        when(mockS3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(objectListing);
 
         runner.run();
 
         ArgumentCaptor<ListObjectsRequest> captureRequest = ArgumentCaptor.forClass(ListObjectsRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
         ListObjectsRequest request = captureRequest.getValue();
         assertEquals("test-bucket", request.getBucketName());
         assertFalse(request.isRequesterPays());
-        Mockito.verify(mockS3Client, Mockito.never()).listVersions(Mockito.any());
+        verify(mockS3Client, Mockito.never()).listVersions(any());
 
         runner.assertAllFlowFilesTransferred(ListS3.REL_SUCCESS, 1);
 
@@ -209,16 +225,16 @@ public class TestListS3 {
         objectSummary3.setKey("d/e");
         objectSummary3.setLastModified(lastModified);
         objectListing.getObjectSummaries().add(objectSummary3);
-        Mockito.when(mockS3Client.listObjects(Mockito.any(ListObjectsRequest.class))).thenReturn(objectListing);
+        when(mockS3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(objectListing);
 
         runner.run();
 
         ArgumentCaptor<ListObjectsRequest> captureRequest = ArgumentCaptor.forClass(ListObjectsRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
         ListObjectsRequest request = captureRequest.getValue();
         assertEquals("test-bucket", request.getBucketName());
         assertTrue(request.isRequesterPays());
-        Mockito.verify(mockS3Client, Mockito.never()).listVersions(Mockito.any());
+        verify(mockS3Client, Mockito.never()).listVersions(any());
 
         runner.assertAllFlowFilesTransferred(ListS3.REL_SUCCESS, 3);
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ListS3.REL_SUCCESS);
@@ -265,16 +281,16 @@ public class TestListS3 {
         objectSummary3.setKey("d/e");
         objectSummary3.setLastModified(lastModified);
         objectListing.getObjectSummaries().add(objectSummary3);
-        Mockito.when(mockS3Client.listObjectsV2(Mockito.any(ListObjectsV2Request.class))).thenReturn(objectListing);
+        when(mockS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(objectListing);
 
         runner.run();
 
         ArgumentCaptor<ListObjectsV2Request> captureRequest = ArgumentCaptor.forClass(ListObjectsV2Request.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).listObjectsV2(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).listObjectsV2(captureRequest.capture());
         ListObjectsV2Request request = captureRequest.getValue();
         assertEquals("test-bucket", request.getBucketName());
         assertFalse(request.isRequesterPays());
-        Mockito.verify(mockS3Client, Mockito.never()).listVersions(Mockito.any());
+        verify(mockS3Client, Mockito.never()).listVersions(any());
 
         runner.assertAllFlowFilesTransferred(ListS3.REL_SUCCESS, 3);
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ListS3.REL_SUCCESS);
@@ -312,16 +328,16 @@ public class TestListS3 {
         objectSummary3.setKey("d/e");
         objectSummary3.setLastModified(lastModified);
         objectListing.getObjectSummaries().add(objectSummary3);
-        Mockito.when(mockS3Client.listObjectsV2(Mockito.any(ListObjectsV2Request.class))).thenReturn(objectListing);
+        when(mockS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(objectListing);
 
         runner.run();
 
         ArgumentCaptor<ListObjectsV2Request> captureRequest = ArgumentCaptor.forClass(ListObjectsV2Request.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).listObjectsV2(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).listObjectsV2(captureRequest.capture());
         ListObjectsV2Request request = captureRequest.getValue();
         assertEquals("test-bucket", request.getBucketName());
         assertTrue(request.isRequesterPays());
-        Mockito.verify(mockS3Client, Mockito.never()).listVersions(Mockito.any());
+        verify(mockS3Client, Mockito.never()).listVersions(any());
 
         runner.assertAllFlowFilesTransferred(ListS3.REL_SUCCESS, 3);
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ListS3.REL_SUCCESS);
@@ -355,15 +371,15 @@ public class TestListS3 {
         versionSummary2.setVersionId("2");
         versionSummary2.setLastModified(lastModified);
         versionListing.getVersionSummaries().add(versionSummary2);
-        Mockito.when(mockS3Client.listVersions(Mockito.any(ListVersionsRequest.class))).thenReturn(versionListing);
+        when(mockS3Client.listVersions(any(ListVersionsRequest.class))).thenReturn(versionListing);
 
         runner.run();
 
         ArgumentCaptor<ListVersionsRequest> captureRequest = ArgumentCaptor.forClass(ListVersionsRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).listVersions(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).listVersions(captureRequest.capture());
         ListVersionsRequest request = captureRequest.getValue();
         assertEquals("test-bucket", request.getBucketName());
-        Mockito.verify(mockS3Client, Mockito.never()).listObjects(Mockito.any(ListObjectsRequest.class));
+        verify(mockS3Client, Mockito.never()).listObjects(any(ListObjectsRequest.class));
 
         runner.assertAllFlowFilesTransferred(ListS3.REL_SUCCESS, 2);
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ListS3.REL_SUCCESS);
@@ -401,15 +417,15 @@ public class TestListS3 {
         objectSummary1.setKey("test-key");
         objectSummary1.setLastModified(objectLastModified);
         objectListing.getObjectSummaries().add(objectSummary1);
-        Mockito.when(mockS3Client.listObjects(Mockito.any(ListObjectsRequest.class))).thenReturn(objectListing);
+        when(mockS3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(objectListing);
 
         runner.run();
 
         ArgumentCaptor<ListObjectsRequest> captureRequest = ArgumentCaptor.forClass(ListObjectsRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
         ListObjectsRequest request = captureRequest.getValue();
         assertEquals("test-bucket", request.getBucketName());
-        Mockito.verify(mockS3Client, Mockito.never()).listVersions(Mockito.any());
+        verify(mockS3Client, Mockito.never()).listVersions(any());
 
         runner.assertAllFlowFilesTransferred(ListS3.REL_SUCCESS, 0);
     }
@@ -440,7 +456,7 @@ public class TestListS3 {
         objectSummary3.setKey("now");
         objectSummary3.setLastModified(lastModifiedNow);
         objectListing.getObjectSummaries().add(objectSummary3);
-        Mockito.when(mockS3Client.listObjects(Mockito.any(ListObjectsRequest.class))).thenReturn(objectListing);
+        when(mockS3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(objectListing);
 
         Map<String,String> stateMap = new HashMap<>();
         String previousTimestamp = String.valueOf(lastModifiedMinus3Hour.getTime());
@@ -451,10 +467,10 @@ public class TestListS3 {
         runner.run();
 
         ArgumentCaptor<ListObjectsRequest> captureRequest = ArgumentCaptor.forClass(ListObjectsRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
         ListObjectsRequest request = captureRequest.getValue();
         assertEquals("test-bucket", request.getBucketName());
-        Mockito.verify(mockS3Client, Mockito.never()).listVersions(Mockito.any());
+        verify(mockS3Client, Mockito.never()).listVersions(any());
 
         runner.assertAllFlowFilesTransferred(ListS3.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ListS3.REL_SUCCESS);
@@ -490,7 +506,7 @@ public class TestListS3 {
         objectSummary3.setKey("now");
         objectSummary3.setLastModified(lastModifiedNow);
         objectListing.getObjectSummaries().add(objectSummary3);
-        Mockito.when(mockS3Client.listObjects(Mockito.any(ListObjectsRequest.class))).thenReturn(objectListing);
+        when(mockS3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(objectListing);
 
         Map<String,String> stateMap = new HashMap<>();
         String previousTimestamp = String.valueOf(lastModifiedMinus3Hour.getTime());
@@ -499,10 +515,10 @@ public class TestListS3 {
         runner.getStateManager().setState(stateMap, Scope.CLUSTER);
         runner.run();
         ArgumentCaptor<ListObjectsRequest> captureRequest = ArgumentCaptor.forClass(ListObjectsRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
         ListObjectsRequest request = captureRequest.getValue();
         assertEquals("test-bucket", request.getBucketName());
-        Mockito.verify(mockS3Client, Mockito.never()).listVersions(Mockito.any());
+        verify(mockS3Client, Mockito.never()).listVersions(any());
 
         runner.assertAllFlowFilesTransferred(ListS3.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ListS3.REL_SUCCESS);
@@ -528,17 +544,17 @@ public class TestListS3 {
         objectSummary1.setLastModified(lastModified);
         objectListing.getObjectSummaries().add(objectSummary1);
 
-        Mockito.when(mockS3Client.listObjects(Mockito.any(ListObjectsRequest.class))).thenReturn(objectListing);
+        when(mockS3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(objectListing);
 
         runner.run();
 
         ArgumentCaptor<GetObjectTaggingRequest> captureRequest = ArgumentCaptor.forClass(GetObjectTaggingRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).getObjectTagging(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).getObjectTagging(captureRequest.capture());
         GetObjectTaggingRequest request = captureRequest.getValue();
 
         assertEquals("test-bucket", request.getBucketName());
         assertEquals("a", request.getKey());
-        Mockito.verify(mockS3Client, Mockito.never()).listVersions(Mockito.any());
+        verify(mockS3Client, Mockito.never()).listVersions(any());
     }
 
     @Test
@@ -555,18 +571,18 @@ public class TestListS3 {
         objectSummary1.setLastModified(lastModified);
         objectListing.getObjectSummaries().add(objectSummary1);
 
-        Mockito.when(mockS3Client.listObjects(Mockito.any(ListObjectsRequest.class))).thenReturn(objectListing);
+        when(mockS3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(objectListing);
 
         runner.run();
 
         ArgumentCaptor<GetObjectMetadataRequest> captureRequest = ArgumentCaptor.forClass(GetObjectMetadataRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).getObjectMetadata(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).getObjectMetadata(captureRequest.capture());
         GetObjectMetadataRequest request = captureRequest.getValue();
 
         assertEquals("test-bucket", request.getBucketName());
         assertEquals("a", request.getKey());
 
-        Mockito.verify(mockS3Client, Mockito.never()).listVersions(Mockito.any());
+        verify(mockS3Client, Mockito.never()).listVersions(any());
     }
 
     @Test
@@ -592,16 +608,16 @@ public class TestListS3 {
         objectSummary3.setKey("d/e");
         objectSummary3.setLastModified(lastModified);
         objectListing.getObjectSummaries().add(objectSummary3);
-        Mockito.when(mockS3Client.listObjects(Mockito.any(ListObjectsRequest.class))).thenReturn(objectListing);
+        when(mockS3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(objectListing);
 
         runner.run();
 
         ArgumentCaptor<ListObjectsRequest> captureRequest = ArgumentCaptor.forClass(ListObjectsRequest.class);
-        Mockito.verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
+        verify(mockS3Client, Mockito.times(1)).listObjects(captureRequest.capture());
         ListObjectsRequest request = captureRequest.getValue();
         assertEquals("test-bucket", request.getBucketName());
         assertFalse(request.isRequesterPays());
-        Mockito.verify(mockS3Client, Mockito.never()).listVersions(Mockito.any());
+        verify(mockS3Client, Mockito.never()).listVersions(any());
 
         runner.assertAllFlowFilesTransferred(ListS3.REL_SUCCESS, 3);
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ListS3.REL_SUCCESS);
@@ -626,5 +642,111 @@ public class TestListS3 {
 
         runner.assertAllFlowFilesTransferred(ListS3.REL_SUCCESS, 3);
         runner.getStateManager().assertStateEquals(ListS3.CURRENT_TIMESTAMP, null, Scope.CLUSTER);
+    }
+
+    @Test
+    void testResetTimestampTrackingWhenPrefixModified() throws Exception {
+        setUpResetTrackingTest(ListS3.BY_TIMESTAMPS);
+
+        assertFalse(listS3.isResetTracking());
+
+        runner.run();
+
+        assertEquals(TEST_TIMESTAMP, listS3.getListingSnapshot().getTimestamp());
+
+        runner.setProperty(ListS3.PREFIX, "prefix2");
+
+        assertTrue(listS3.isResetTracking());
+
+        runner.run();
+
+        assertEquals(0, listS3.getListingSnapshot().getTimestamp());
+        mockStateManager.assertStateEquals(ListS3.CURRENT_TIMESTAMP, "0", Scope.CLUSTER);
+
+        assertFalse(listS3.isResetTracking());
+    }
+
+    @Test
+    void testResetTimestampTrackingWhenStrategyModified() throws Exception {
+        setUpResetTrackingTest(ListS3.BY_TIMESTAMPS);
+
+        assertFalse(listS3.isResetTracking());
+
+        runner.run();
+
+        assertEquals(TEST_TIMESTAMP, listS3.getListingSnapshot().getTimestamp());
+
+        runner.setProperty(ListS3.LISTING_STRATEGY, ListS3.NO_TRACKING);
+
+        assertTrue(listS3.isResetTracking());
+
+        runner.run();
+
+        assertEquals(0, listS3.getListingSnapshot().getTimestamp());
+        mockStateManager.assertStateNotSet(ListS3.CURRENT_TIMESTAMP, Scope.CLUSTER);
+
+        assertFalse(listS3.isResetTracking());
+    }
+
+    @Test
+    void testResetEntityTrackingWhenPrefixModified() throws Exception {
+        setUpResetTrackingTest(ListS3.BY_ENTITIES);
+
+        assertFalse(listS3.isResetTracking());
+
+        runner.run();
+
+        assertNotNull(listS3.getListedEntityTracker());
+
+        runner.setProperty(ListS3.PREFIX, "prefix2");
+
+        assertTrue(listS3.isResetTracking());
+
+        runner.run();
+
+        assertNotNull(listS3.getListedEntityTracker());
+        verify(mockCache).remove(eq("ListedEntities::" + listS3.getIdentifier()), any());
+
+        assertFalse(listS3.isResetTracking());
+    }
+
+    @Test
+    void testResetEntityTrackingWhenStrategyModified() throws Exception {
+        setUpResetTrackingTest(ListS3.BY_ENTITIES);
+
+        assertFalse(listS3.isResetTracking());
+
+        runner.run();
+
+        assertNotNull(listS3.getListedEntityTracker());
+
+        runner.setProperty(ListS3.LISTING_STRATEGY, ListS3.NO_TRACKING);
+
+        assertTrue(listS3.isResetTracking());
+
+        runner.run();
+
+        assertNull(listS3.getListedEntityTracker());
+        verify(mockCache).remove(eq("ListedEntities::" + listS3.getIdentifier()), any());
+
+        assertFalse(listS3.isResetTracking());
+    }
+
+    private void setUpResetTrackingTest(AllowableValue listingStrategy) throws Exception {
+        runner.setProperty(ListS3.BUCKET_WITHOUT_DEFAULT_VALUE, "test-bucket");
+        runner.setProperty(ListS3.LISTING_STRATEGY, listingStrategy);
+        runner.setProperty(ListS3.PREFIX, "prefix1");
+
+        if (listingStrategy == ListS3.BY_TIMESTAMPS) {
+            mockStateManager.setState(Map.of(ListS3.CURRENT_TIMESTAMP, Long.toString(TEST_TIMESTAMP), ListS3.CURRENT_KEY_PREFIX + "0", "file"), Scope.CLUSTER);
+        } else if (listingStrategy == ListS3.BY_ENTITIES) {
+            String serviceId = "DistributedMapCacheClient";
+            when(mockCache.getIdentifier()).thenReturn(serviceId);
+            runner.addControllerService(serviceId, mockCache);
+            runner.enableControllerService(mockCache);
+            runner.setProperty(ListS3.TRACKING_STATE_CACHE, serviceId);
+        }
+
+        when(mockS3Client.listObjects(any(ListObjectsRequest.class))).thenReturn(new ObjectListing());
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-12732](https://issues.apache.org/jira/browse/NIFI-12732)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
