### PR TITLE
NIFI-12739 - Import ProcessPoolExecutor to fix bug in python 3.9+

### DIFF
--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/Controller.py
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/Controller.py
@@ -1,3 +1,5 @@
+
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,18 +17,19 @@
 
 import logging
 import os
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 
 from py4j.java_gateway import JavaGateway, CallbackServerParameters, GatewayParameters
 
 import ExtensionManager
 
-# We do not use ThreadPoolExecutor, but it must be kept here. Python introduced a bug in 3.9 that causes Exceptions to be raised
+# We do not use ThreadPoolExecutor or ProcessPoolExecutor, but they must be kept here. Python introduced a bug in 3.9 that causes Exceptions to be raised
 # incorrectly in multi-threaded applications (https://bugs.python.org/issue42647). This works around the bug.
-# What is actually necessary is to import ThreadPoolExecutor.
+# What is actually necessary is to import ThreadPoolExecutor and ProcessPoolExecutor.
 # Unfortunately, IntelliJ often likes to cleanup the unused import. So we assign a bogus variable just so
-# that we have some reference to ThreadPoolExecutor in order to prevent the IDE from cleaning up the import
+# that we have some reference to ThreadPoolExecutor and ProcessPoolExecutor in order to prevent the IDE from cleaning up the import
 threadpool_attrs = dir(ThreadPoolExecutor)
+processpool_attrs = dir(ProcessPoolExecutor)
 
 
 # Initialize logging

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/Controller.py
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/Controller.py
@@ -1,5 +1,3 @@
-
-
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.


### PR DESCRIPTION
Python 3.0 incorrectly raises an exception in multi-threaded applications (https://bugs.python.org/issue42647).

This applies a fix for importing ProcessPoolExecutor that is similar to a previous fix for importing ThreadPoolExecutor.



<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12739](https://issues.apache.org/jira/browse/NIFI-12739)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

NiFi was recompiled and manually deployed and tested to verify that the `RuntimeError: can't register atexit after shutdown` is no longer thrown when importing `ProcessPoolExecutor`

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21
