### PR TITLE
NIFI-12743: Property Table Fixes

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/property-table/editors/nf-editor/nf-editor.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/property-table/editors/nf-editor/nf-editor.component.ts
@@ -163,7 +163,12 @@ export class NfEditor implements OnDestroy {
             mode: this.mode,
             lineNumbers: true,
             matchBrackets: true,
-            extraKeys: { 'Ctrl-Space': 'autocomplete' }
+            extraKeys: {
+                'Ctrl-Space': 'autocomplete',
+                Enter: () => {
+                    this.okClicked();
+                }
+            }
         };
     }
 


### PR DESCRIPTION
NIFI-12743: 
- Updating property editing so that Shift-Enter inserts a new line and Enter commits the edit.
- Fixing bug that prevented deleting a Property and then re-adding a new Property with the same name.