### PR TITLE
NIFI-12671 Added AwsFileResourceService

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/util/RegionUtilV1.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/util/RegionUtilV1.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.util;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.context.PropertyContext;
+import org.apache.nifi.processor.exception.ProcessException;
+
+import java.util.Map;
+
+import static org.apache.nifi.processors.aws.s3.AbstractS3Processor.S3_REGION;
+
+/**
+ * Utility class for AWS region methods. This class uses AWS SDK v1.
+ *
+ */
+public abstract class RegionUtilV1 {
+
+    public static final String S3_REGION_ATTRIBUTE = "s3.region" ;
+    static final AllowableValue ATTRIBUTE_DEFINED_REGION = new AllowableValue("attribute-defined-region",
+            "Use '" + S3_REGION_ATTRIBUTE + "' Attribute",
+            "Uses '" + S3_REGION_ATTRIBUTE + "' FlowFile attribute as region.");
+
+    public static Region parseRegionValue(String regionValue) {
+        if (regionValue == null) {
+            throw new ProcessException(String.format("[%s] was selected as region source but [%s] attribute does not exist", ATTRIBUTE_DEFINED_REGION, S3_REGION_ATTRIBUTE));
+        }
+
+        try {
+            return Region.getRegion(Regions.fromName(regionValue));
+        } catch (Exception e) {
+            throw new ProcessException(String.format("The [%s] attribute contains an invalid region value [%s]", S3_REGION_ATTRIBUTE, regionValue), e);
+        }
+    }
+
+    public static Region resolveRegion(final PropertyContext context, final Map<String, String> attributes) {
+        String regionValue = context.getProperty(S3_REGION).getValue();
+
+        if (ATTRIBUTE_DEFINED_REGION.getValue().equals(regionValue)) {
+            regionValue = attributes.get(S3_REGION_ATTRIBUTE);
+        }
+
+        return parseRegionValue(regionValue);
+    }
+}

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsProcessor.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsProcessor.java
@@ -109,8 +109,8 @@ public abstract class AbstractAwsProcessor<T extends SdkClient> extends Abstract
     public static final PropertyDescriptor REGION = new PropertyDescriptor.Builder()
             .name("Region")
             .required(true)
-            .allowableValues(RegionUtil.getAvailableRegions())
-            .defaultValue(RegionUtil.createAllowableValue(Region.US_WEST_2).getValue())
+            .allowableValues(RegionUtilV2.getAvailableRegions())
+            .defaultValue(RegionUtilV2.createAllowableValue(Region.US_WEST_2).getValue())
             .build();
 
     public static final PropertyDescriptor TIMEOUT = new PropertyDescriptor.Builder()

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/RegionUtilV2.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/RegionUtilV2.java
@@ -25,10 +25,10 @@ import java.util.Comparator;
 import java.util.List;
 
 /**
- * Utility class for AWS region methods.
+ * Utility class for AWS region methods. This class uses AWS SDK v2.
  *
  */
-public abstract class RegionUtil {
+public abstract class RegionUtilV2 {
 
     /**
      * Creates an AllowableValue from a Region.

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/AwsFileResourceService.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/AwsFileResourceService.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.s3;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.regions.Region;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.S3Object;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.documentation.UseCase;
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.context.PropertyContext;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.fileresource.service.api.FileResource;
+import org.apache.nifi.fileresource.service.api.FileResourceService;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderService;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.nifi.processors.aws.AbstractAWSCredentialsProviderProcessor.AWS_CREDENTIALS_PROVIDER_SERVICE;
+import static org.apache.nifi.processors.aws.util.RegionUtilV1.resolveRegion;
+import static org.apache.nifi.util.StringUtils.isBlank;
+
+@Tags({"Amazon", "S3", "AWS", "file", "resource"})
+@SeeAlso({FetchS3Object.class})
+@CapabilityDescription("Provides an Amazon Web Services (AWS) S3 file resource for other components.")
+@UseCase(
+        description = "Fetch a specific file from S3. " +
+                "The service provides higher performance compared to fetch processors when the data should be moved between different storages without any transformation.",
+        configuration = """
+                "Bucket" = "${s3.bucket}"
+                "Name" = "${filename}"
+
+                The "Region" property must be set to denote the S3 region that the Bucket resides in.
+                If the flow being built is to be reused elsewhere, it's a good idea to parameterize this property by setting it to something like #{S3_REGION}.
+
+                The "AWS Credentials Provider Service" property should specify an instance of the AWSCredentialsProviderService in order to provide credentials for accessing the bucket.
+                """
+)
+public class AwsFileResourceService extends AbstractControllerService implements FileResourceService {
+
+    public static final PropertyDescriptor BUCKET_WITH_DEFAULT_VALUE = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(AbstractS3Processor.BUCKET_WITH_DEFAULT_VALUE)
+            .build();
+
+    public static final PropertyDescriptor KEY = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(AbstractS3Processor.KEY)
+            .build();
+
+    public static final PropertyDescriptor S3_REGION = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(AbstractS3Processor.S3_REGION)
+            .build();
+
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            BUCKET_WITH_DEFAULT_VALUE,
+            KEY,
+            S3_REGION,
+            AWS_CREDENTIALS_PROVIDER_SERVICE);
+
+    private final Cache<Region, AmazonS3> clientCache = Caffeine.newBuilder().build();
+
+    private volatile PropertyContext context;
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTIES;
+    }
+
+    @OnEnabled
+    public void onEnabled(final ConfigurationContext context) {
+        this.context = context;
+    }
+
+    @OnDisabled
+    public void onDisabled() {
+        this.context = null;
+    }
+
+    @Override
+    public FileResource getFileResource(Map<String, String> attributes) {
+        final AWSCredentialsProviderService awsCredentialsProviderService = context.getProperty(AWS_CREDENTIALS_PROVIDER_SERVICE)
+                .asControllerService(AWSCredentialsProviderService.class);
+        final AmazonS3 client = getS3Client(attributes, awsCredentialsProviderService.getCredentialsProvider());
+
+        try {
+            return fetchObject(client, attributes);
+        } catch (final ProcessException | SdkClientException e) {
+            throw new ProcessException("Failed to fetch s3 object", e);
+        }
+    }
+
+    /**
+     * Fetches s3 object from the provided bucket and returns it as FileResource
+     *
+     * @param client amazon s3 client
+     * @param attributes configuration attributes
+     * @return fetched s3 object as FileResource
+     * @throws ProcessException if the object 'bucketName/key' does not exist
+     */
+    private FileResource fetchObject(final AmazonS3 client, final Map<String, String> attributes) throws ProcessException,
+            SdkClientException {
+        final String bucketName = context.getProperty(BUCKET_WITH_DEFAULT_VALUE).evaluateAttributeExpressions(attributes).getValue();
+        final String key = context.getProperty(KEY).evaluateAttributeExpressions(attributes).getValue();
+
+        if (isBlank(bucketName) || isBlank(key)) {
+            throw new ProcessException("Bucket name or key value is missing");
+        }
+
+        if (!client.doesObjectExist(bucketName, key)) {
+            throw new ProcessException(String.format("Object '%s/%s' does not exist in s3", bucketName, key));
+        }
+
+        final S3Object object = client.getObject(bucketName, key);
+        return new FileResource(object.getObjectContent(), object.getObjectMetadata().getContentLength());
+    }
+
+    protected AmazonS3 getS3Client(Map<String, String> attributes, AWSCredentialsProvider credentialsProvider) {
+        Region region = resolveRegion(context, attributes);
+        return clientCache.get(region, ignored -> AmazonS3Client.builder()
+                .withRegion(region.getName())
+                .withCredentials(credentialsProvider)
+                .build());
+    }
+}

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -15,3 +15,4 @@
 org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService
 
 org.apache.nifi.processors.aws.s3.encryption.StandardS3EncryptionService
+org.apache.nifi.processors.aws.s3.AwsFileResourceService

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/AwsFileResourceServiceTest.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/AwsFileResourceServiceTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.aws.s3;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import org.apache.nifi.fileresource.service.api.FileResource;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService;
+import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderService;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.NoOpProcessor;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.apache.nifi.processors.aws.AbstractAWSCredentialsProviderProcessor.AWS_CREDENTIALS_PROVIDER_SERVICE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AwsFileResourceServiceTest {
+
+    private static final String TEST_NAME = AwsFileResourceServiceTest.class.getSimpleName();
+    private static final String CONTROLLER_SERVICE = "AWSCredentialsService";
+    private static final String BUCKET_NAME = "test-bucket";
+    private static final String KEY = "key";
+    private static final long CONTENT_LENGTH = 10L;
+
+    @Mock
+    private AmazonS3 client;
+
+    @Mock
+    private S3Object s3Object;
+
+    @Mock
+    private ObjectMetadata metadata;
+
+    @Mock
+    private S3ObjectInputStream inputStream;
+
+    @InjectMocks
+    private TestAwsFileResourceService service;
+    private TestRunner runner;
+
+    @BeforeEach
+    public void setup() throws InitializationException {
+        runner = TestRunners.newTestRunner(NoOpProcessor.class);
+        runner.addControllerService(TEST_NAME, service);
+    }
+
+    @Test
+    void testGetFileResourceHappyPath() throws InitializationException {
+        setupS3Client();
+        setupService();
+
+        FileResource fileResource = service.getFileResource(Map.of());
+        assertFileResource(fileResource);
+    }
+
+    @Test
+    void testNonExistingObject() throws InitializationException {
+        when(client.doesObjectExist(BUCKET_NAME, KEY)).thenReturn(false);
+        setupService();
+
+        assertThrows(ProcessException.class, () -> service.getFileResource(Map.of()), "Failed to fetch s3 object");
+        verify(client).doesObjectExist(BUCKET_NAME, KEY);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    void testValidBlobUsingELButMissingAttribute() throws InitializationException {
+        setupService("${s3.bucket}", "${key}");
+
+        assertThrows(ProcessException.class,
+                () -> service.getFileResource(Map.of()), "Bucket name or key value is missing");
+        verifyNoInteractions(client);
+    }
+
+    @Test
+    void testValidBlobUsingEL() throws InitializationException {
+        String bucketProperty = "s3.bucket";
+        String keyProperty = "key";
+        setupService("${" + bucketProperty + "}", "${" + keyProperty + "}");
+        setupS3Client();
+
+        FileResource fileResource = service.getFileResource(Map.of(
+                bucketProperty, BUCKET_NAME,
+                keyProperty, KEY));
+        assertFileResource(fileResource);
+    }
+
+    private void assertFileResource(FileResource fileResource) {
+        assertNotNull(fileResource);
+        assertEquals(fileResource.getInputStream(), inputStream);
+        assertEquals(fileResource.getSize(), CONTENT_LENGTH);
+        verify(client).doesObjectExist(BUCKET_NAME, KEY);
+        verify(client).getObject(BUCKET_NAME, KEY);
+        verify(s3Object).getObjectMetadata();
+        verify(metadata).getContentLength();
+        verify(s3Object).getObjectContent();
+    }
+
+    private void setupService() throws InitializationException {
+        setupService(BUCKET_NAME, KEY);
+    }
+
+    private void setupService(String bucket, String key) throws InitializationException {
+        final AWSCredentialsProviderService credentialsService = new AWSCredentialsProviderControllerService();
+
+        runner.addControllerService(CONTROLLER_SERVICE, credentialsService);
+        runner.enableControllerService(credentialsService);
+
+        runner.setProperty(service, AWS_CREDENTIALS_PROVIDER_SERVICE, CONTROLLER_SERVICE);
+        runner.setProperty(service, AwsFileResourceService.KEY, key);
+        runner.setProperty(service, AwsFileResourceService.BUCKET_WITH_DEFAULT_VALUE, bucket);
+
+        runner.enableControllerService(service);
+    }
+
+    private void setupS3Client() {
+        when(client.doesObjectExist(BUCKET_NAME, KEY)).thenReturn(true);
+        when(client.getObject(BUCKET_NAME, KEY)).thenReturn(s3Object);
+        when(s3Object.getObjectContent()).thenReturn(inputStream);
+        when(s3Object.getObjectMetadata()).thenReturn(metadata);
+        when(metadata.getContentLength()).thenReturn(CONTENT_LENGTH);
+    }
+
+    private static class TestAwsFileResourceService extends AwsFileResourceService {
+
+        private final AmazonS3 client;
+
+        private TestAwsFileResourceService(AmazonS3 client) {
+            this.client = client;
+        }
+
+        @Override
+        protected AmazonS3 getS3Client(Map<String, String> attributes, AWSCredentialsProvider credentialsProvider) {
+            return client;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12671](https://issues.apache.org/jira/browse/NIFI-12671)

Implemented the AWS S3 specific version of FileResourceService to be able to fetch data directly from this service, by-passing the content repository.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
