### PR TITLE
NIFI-12749 NiFi Toolkit export-all-flows fails when flow name contain…

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/registry/VersionedFlowSnapshotsResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/registry/VersionedFlowSnapshotsResult.java
@@ -42,6 +42,7 @@ public class VersionedFlowSnapshotsResult implements WritableResult<Iterator<Ver
     private static final String FILE_NAME_PREFIX = "toolkit_registry_export_all";
     private static final String EXPORT_FILE_NAME = "%s/%s_%s_%s_%d";
     private static final String SEPARATOR = "_";
+    private static final String SLASH = "/";
     private static final String REPLACEMENT = "-";
     private final Iterator<VersionedFlowSnapshot> versionedFlowSnapshots;
     private final String exportDirectoryName;
@@ -62,7 +63,9 @@ public class VersionedFlowSnapshotsResult implements WritableResult<Iterator<Ver
             final VersionedFlowSnapshot versionedFlowSnapshot = versionedFlowSnapshots.next();
             if (exportDirectoryName != null) {
                 final String bucketName = versionedFlowSnapshot.getBucket().getName().replaceAll(SEPARATOR, REPLACEMENT);
-                final String flowName = versionedFlowSnapshot.getFlow().getName().replaceAll(SEPARATOR, REPLACEMENT);
+                final String flowName = versionedFlowSnapshot.getFlow().getName()
+                        .replaceAll(SEPARATOR, REPLACEMENT)
+                        .replaceAll(SLASH, REPLACEMENT);
                 final int version = versionedFlowSnapshot.getSnapshotMetadata().getVersion();
                 final String exportFileName = String.format(EXPORT_FILE_NAME, exportDirectoryName, FILE_NAME_PREFIX, bucketName, flowName, version);
                 try (final OutputStream resultOut = Files.newOutputStream(Paths.get(exportFileName))) {


### PR DESCRIPTION
…s '/'

# Summary

The command fails if there are any flows in the registry that has a / character because when exporting the flow, the toolkit assumes / is a path separator as the toolkit will use the versioned flow name and version when creating the exported files.

[NIFI-12749](https://issues.apache.org/jira/browse/NIFI-12749)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
