### PR TITLE
NIFI-12752 Update GitHub Workflows to use macos-14

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -97,7 +97,7 @@ jobs:
           # Cache Maven modules using a cache key different from setup-java steps
           key: ${{ runner.os }}-maven-static-analysis-${{ hashFiles('**/pom.xml') }}
       - name: Set up Java 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -145,7 +145,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Set up Java 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '21'
@@ -188,7 +188,7 @@ jobs:
 
   macos-build-jp:
     timeout-minutes: 150
-    runs-on: macos-latest
+    runs-on: macos-14
     name: MacOS Zulu JDK 21 JP
     steps:
       - name: System Information
@@ -207,7 +207,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Set up Java 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -274,7 +274,7 @@ jobs:
             **\node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Set up Java 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '21'

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Set up Java Zulu 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 21

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Set up Java Zulu 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 21

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Set up Java Zulu 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 21

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-14 ]
         version: [ 21 ]
     timeout-minutes: 120
     runs-on: ${{ matrix.os }}
@@ -98,16 +98,16 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Set up Java ${{ env.JAVA_DISTRIBUTION }} ${{ matrix.version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ matrix.version }}
           cache: 'maven'
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Build Dependencies
         env:


### PR DESCRIPTION
# Summary

[NIFI-12752](https://issues.apache.org/jira/browse/NIFI-12752) Updates GitHub `ci-workflow` and `system-tests` automated builds to use `macos-14` for the macOS Runner.

The [macos-14](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/) version provides Apple Silicon M1 processing with the AArch64 architecture. This provides additional differentiation from the Ubuntu Linux and Windows builds, and also exhibits performance improvements over the current macOS runners.

Additional changes include updating the `setup-java` action to version 4 and updating the `setup-python` action to version 5, with Python 3.10 for compatibility with macOS AArch64.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
