### PR TITLE
NIFI-12755 - Upgrade Jetty to 12.0.6

### DIFF
--- a/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketServer.java
+++ b/nifi-nar-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketServer.java
@@ -90,19 +90,7 @@ public class TestJettyWebSocketServer {
         final AtomicBoolean connected = new AtomicBoolean();
 
         final WebSocketClient client = new WebSocketClient();
-        final Session.Listener.AutoDemanding adapter = new AbstractAutoDemanding() {
-            @Override
-            public void onWebSocketOpen(Session session) {
-                super.onWebSocketOpen(session);
-                connected.set(true);
-            }
-
-            @Override
-            public void onWebSocketText(final String message) {
-
-            }
-        };
-
+        final Session.Listener.AutoDemanding adapter = new TrackedAutoDemandingListener(connected);
 
         try {
             client.start();
@@ -122,5 +110,24 @@ public class TestJettyWebSocketServer {
 
     private URI getWebSocketUri(final int port) {
         return URI.create(String.format("ws://localhost:%d", port));
+    }
+
+    public static class TrackedAutoDemandingListener extends AbstractAutoDemanding {
+        private final AtomicBoolean connected;
+
+        public TrackedAutoDemandingListener(final AtomicBoolean connected) {
+            this.connected = connected;
+        }
+
+        @Override
+        public void onWebSocketOpen(Session session) {
+            super.onWebSocketOpen(session);
+            connected.set(true);
+        }
+
+        @Override
+        public void onWebSocketText(final String message) {
+
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <derby.version>10.17.1.0</derby.version>
         <ranger.version>2.4.0</ranger.version>
-        <jetty.version>12.0.5</jetty.version>
+        <jetty.version>12.0.6</jetty.version>
         <jackson.bom.version>2.16.1</jackson.bom.version>
         <avro.version>1.11.3</avro.version>
         <jaxb.runtime.version>4.0.4</jaxb.runtime.version>


### PR DESCRIPTION
# Summary

[NIFI-12755](https://issues.apache.org/jira/browse/NIFI-12755) - Upgrade Jetty to 12.0.6

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
