### PR TITLE
NIFI-12764 Removed Commons Codec and Lang3 from security-utils

### DIFF
--- a/nifi-commons/nifi-security-utils/pom.xml
+++ b/nifi-commons/nifi-security-utils/pom.xml
@@ -45,14 +45,6 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
         </dependency>

--- a/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/StandardTlsConfiguration.java
+++ b/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/StandardTlsConfiguration.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.security.util;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.util.NiFiProperties;
 
 import java.io.File;
@@ -267,7 +266,7 @@ public class StandardTlsConfiguration implements TlsConfiguration {
      */
     @Override
     public String getFunctionalKeyPassword() {
-        return StringUtils.isNotBlank(keyPassword) ? keyPassword : keystorePassword;
+        return isNotBlank(keyPassword) ? keyPassword : keystorePassword;
     }
 
     /**
@@ -346,7 +345,7 @@ public class StandardTlsConfiguration implements TlsConfiguration {
     public boolean isKeystoreValid() {
         if (isStoreValid(keystorePath, keystorePassword, keystoreType, StoreType.KEY_STORE)) {
             return true;
-        } else if (StringUtils.isNotBlank(keyPassword) && !keyPassword.equals(keystorePassword)) {
+        } else if (isNotBlank(keyPassword) && !keyPassword.equals(keystorePassword)) {
             return isKeystorePopulated()
                     && KeyStoreUtils.isKeyPasswordCorrect(getFileUrl(keystorePath), keystoreType, keystorePassword.toCharArray(),
                     getFunctionalKeyPassword().toCharArray());
@@ -464,20 +463,20 @@ public class StandardTlsConfiguration implements TlsConfiguration {
     }
 
     private static String maskPasswordForLog(String password) {
-        return StringUtils.isNotBlank(password) ? MASKED_PASSWORD_LOG : NULL_LOG;
+        return isNotBlank(password) ? MASKED_PASSWORD_LOG : NULL_LOG;
     }
 
     private boolean isAnyPopulated(String path, String password, KeystoreType type) {
-        return StringUtils.isNotBlank(path) || StringUtils.isNotBlank(password) || type != null;
+        return isNotBlank(path) || isNotBlank(password) || type != null;
     }
 
     private boolean isStorePopulated(final String path, final String password, final KeystoreType type, final StoreType storeType) {
         boolean populated;
 
         // Legacy trust stores such as JKS can be populated without a password; only check the path and type
-        populated = StringUtils.isNotBlank(path) && type != null;
+        populated = isNotBlank(path) && type != null;
         if (StoreType.KEY_STORE == storeType) {
-            populated = populated && StringUtils.isNotBlank(password);
+            populated = populated && isNotBlank(password);
         }
 
         return populated;
@@ -493,6 +492,10 @@ public class StandardTlsConfiguration implements TlsConfiguration {
         } catch (final MalformedURLException e) {
             throw new IllegalArgumentException(String.format("File Path [%s] URL conversion failed", path), e);
         }
+    }
+
+    private static boolean isNotBlank(final String string) {
+        return string != null && !string.isBlank();
     }
 
     private enum StoreType {

--- a/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/crypto/HashAlgorithm.java
+++ b/nifi-commons/nifi-security-utils/src/main/java/org/apache/nifi/security/util/crypto/HashAlgorithm.java
@@ -18,10 +18,6 @@ package org.apache.nifi.security.util.crypto;
 
 import java.util.Arrays;
 import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-
 
 /**
  * Enumeration capturing information about the cryptographic hash algorithms
@@ -113,12 +109,7 @@ public enum HashAlgorithm {
 
     @Override
     public String toString() {
-        final ToStringBuilder builder = new ToStringBuilder(this);
-        ToStringBuilder.setDefaultStyle(ToStringStyle.SHORT_PREFIX_STYLE);
-        builder.append("Algorithm Name", name);
-        builder.append("Digest Length", digestBytesLength + " bytes");
-        builder.append("Description", description);
-        return builder.toString();
+        return "HashAlgorithm[Name=%s,Digest Length=%d bytes,Description=%s".formatted(name, digestBytesLength, description);
     }
 
     /**
@@ -137,7 +128,7 @@ public enum HashAlgorithm {
         if (!isStrongAlgorithm()) {
             sb.append(" [WARNING -- Cryptographically broken]");
         }
-        if (StringUtils.isNotBlank(description)) {
+        if (description != null && !description.isBlank()) {
             sb.append(" ").append(description);
         }
         return sb.toString();

--- a/nifi-commons/nifi-security-utils/src/test/java/org/apache/nifi/security/util/KeyStoreUtilsTest.java
+++ b/nifi-commons/nifi-security-utils/src/test/java/org/apache/nifi/security/util/KeyStoreUtilsTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.nifi.security.util;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.security.cert.builder.StandardCertificateBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -56,6 +55,7 @@ public class KeyStoreUtilsTest {
     private static final String SECRET_KEY_ALGORITHM = "AES";
     private static final String KEY_PROTECTION_ALGORITHM = "PBEWithHmacSHA256AndAES_256";
     private static final String HYPHEN_SEPARATOR = "-";
+    private static final String EMPTY = "";
 
     private static KeyPair keyPair;
     private static X509Certificate certificate;
@@ -65,7 +65,7 @@ public class KeyStoreUtilsTest {
     public static void generateKeysAndCertificates() throws NoSuchAlgorithmException {
         keyPair = KeyPairGenerator.getInstance(KEY_ALGORITHM).generateKeyPair();
         certificate = new StandardCertificateBuilder(keyPair, new X500Principal(SUBJECT_DN), Duration.ofDays(DURATION_DAYS)).build();
-        final byte[] encodedKey = StringUtils.remove(UUID.randomUUID().toString(), HYPHEN_SEPARATOR).getBytes(StandardCharsets.UTF_8);
+        final byte[] encodedKey = UUID.randomUUID().toString().replaceAll(HYPHEN_SEPARATOR, EMPTY).getBytes(StandardCharsets.UTF_8);
         secretKey = new SecretKeySpec(encodedKey, SECRET_KEY_ALGORITHM);
     }
 

--- a/nifi-commons/nifi-security-utils/src/test/java/org/apache/nifi/security/util/SslSocketFactoryTest.java
+++ b/nifi-commons/nifi-security-utils/src/test/java/org/apache/nifi/security/util/SslSocketFactoryTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.security.util;
 
-import org.apache.nifi.util.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SslSocketFactoryTest {
+    private static final String EMPTY = "";
+
     private static TlsConfiguration tlsConfiguration;
 
     @BeforeAll
@@ -53,7 +54,7 @@ public class SslSocketFactoryTest {
         final TlsConfiguration customTlsConfiguration = new StandardTlsConfiguration(
                 tlsConfiguration.getKeystorePath(),
                 tlsConfiguration.getKeystorePassword(),
-                StringUtils.EMPTY,
+                EMPTY,
                 tlsConfiguration.getKeystoreType(),
                 tlsConfiguration.getTruststorePath(),
                 tlsConfiguration.getTruststorePassword(),
@@ -68,7 +69,7 @@ public class SslSocketFactoryTest {
     @Test
     public void testCreateSslContextEmptyTrustStorePasswordJks() throws TlsException {
         final TlsConfiguration customTlsConfiguration = new TemporaryKeyStoreBuilder()
-                .trustStorePassword(StringUtils.EMPTY)
+                .trustStorePassword(EMPTY)
                 .trustStoreType(KeystoreType.JKS.getType())
                 .build();
         final SSLContext sslContext = SslContextFactory.createSslContext(customTlsConfiguration);

--- a/nifi-commons/nifi-security-utils/src/test/java/org/apache/nifi/security/util/crypto/HashServiceTest.java
+++ b/nifi-commons/nifi-security-utils/src/test/java/org/apache/nifi/security/util/crypto/HashServiceTest.java
@@ -92,18 +92,13 @@ public class HashServiceTest {
     /**
      * This test ensures that the service properly handles UTF-16 encoded data to return it without
      * the Big Endian Byte Order Mark (BOM). Java treats UTF-16 encoded data without a BOM as Big Endian by default on decoding, but when <em>encoding</em>, it inserts a BE BOM in the data.
-     *
      * Examples:
-     *
      * "apachenifi"
-     *
      * *     UTF-8: 0x61 0x70 0x61 0x63 0x68 0x65 0x6E 0x69 0x66 0x69
      * *    UTF-16: 0xFE 0xFF 0x00 0x61 0x00 0x70 0x00 0x61 0x00 0x63 0x00 0x68 0x00 0x65 0x00 0x6E 0x00 0x69 0x00 0x66 0x00 0x69
      * *  UTF-16LE: 0x61 0x00 0x70 0x00 0x61 0x00 0x63 0x00 0x68 0x00 0x65 0x00 0x6E 0x00 0x69 0x00 0x66 0x00 0x69 0x00
      * *  UTF-16BE: 0x00 0x61 0x00 0x70 0x00 0x61 0x00 0x63 0x00 0x68 0x00 0x65 0x00 0x6E 0x00 0x69 0x00 0x66 0x00 0x69
-     *
      * The result of "UTF-16" decoding should have the 0xFE 0xFF stripped on return by encoding in UTF-16BE directly, which will not insert a BOM.
-     *
      * See also: <a href="https://unicode.org/faq/utf_bom.html#bom10">https://unicode.org/faq/utf_bom.html#bom10</a>
      */
     @Test
@@ -191,7 +186,7 @@ public class HashServiceTest {
     }
 
     @Test
-    void testShouldHashConstantValue() throws Exception {
+    void testShouldHashConstantValue() {
         // Arrange
         final List<HashAlgorithm> algorithms = List.of(HashAlgorithm.values());
 
@@ -232,7 +227,7 @@ public class HashServiceTest {
     }
 
     @Test
-    void testShouldHashEmptyValue() throws Exception {
+    void testShouldHashEmptyValue() {
         // Arrange
         final List<HashAlgorithm> algorithms = List.of(HashAlgorithm.values());
         final String EMPTY_VALUE = "";
@@ -274,7 +269,7 @@ public class HashServiceTest {
     }
 
     @Test
-    void testShouldBuildHashAlgorithmAllowableValues() throws Exception {
+    void testShouldBuildHashAlgorithmAllowableValues() {
         // Arrange
         final List<HashAlgorithm> EXPECTED_ALGORITHMS = List.of(HashAlgorithm.values());
 
@@ -298,7 +293,7 @@ public class HashServiceTest {
     }
 
     @Test
-    void testShouldBuildCharacterSetAllowableValues() throws Exception {
+    void testShouldBuildCharacterSetAllowableValues() {
         // Arrange
         final List<Charset> EXPECTED_CHARACTER_SETS = Arrays.asList(
                 StandardCharsets.US_ASCII,
@@ -336,7 +331,7 @@ public class HashServiceTest {
     }
 
     @Test
-    void testShouldHashValueFromStream() throws Exception {
+    void testShouldHashValueFromStream() {
         // Arrange
 
         // No command-line md2sum tool available

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
@@ -183,6 +183,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Commons Codec required for OpenSAML -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${org.apache.commons.codec.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.security.kerberos</groupId>
             <artifactId>spring-security-kerberos-core</artifactId>

--- a/nifi-system-tests/nifi-system-test-suite/pom.xml
+++ b/nifi-system-tests/nifi-system-test-suite/pom.xml
@@ -190,6 +190,10 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-api</artifactId>
             <version>2.0.0-SNAPSHOT</version>


### PR DESCRIPTION
# Summary

[NIFI-12764](https://issues.apache.org/jira/browse/NIFI-12764) Removes `commons-codec` and `commons-lang3` dependencies from `nifi-security-utils` to reduce the transitive dependencies inherited in other referencing modules.

Changes include replacing Commons Codec Hex with Java [HexFormat](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/HexFormat.html) and replacing `StringUtils` references with simple checks.

Commons Codec is a runtime dependency of OpenSAML, so it is now declared explicitly in `nifi-web-security`, and Commons Lang3 is a runtime dependency of the `nifi-system-test-suite` for dynamic class loading tests.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
