### PR TITLE
NIFI-12773: Added join and anchored RecordPath function

### DIFF
--- a/nifi-commons/nifi-record-path/pom.xml
+++ b/nifi-commons/nifi-record-path/pom.xml
@@ -104,6 +104,10 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-property-utils</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr-runtime</artifactId>
             <version>3.5.3</version>

--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/Anchored.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/Anchored.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.record.path.functions;
+
+import org.apache.nifi.record.path.FieldValue;
+import org.apache.nifi.record.path.RecordPathEvaluationContext;
+import org.apache.nifi.record.path.StandardRecordPathEvaluationContext;
+import org.apache.nifi.record.path.paths.RecordPathSegment;
+import org.apache.nifi.serialization.record.Record;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class Anchored extends RecordPathSegment {
+
+    private final RecordPathSegment anchorPath;
+    private final RecordPathSegment evaluationPath;
+
+    public Anchored(final RecordPathSegment anchorPath, final RecordPathSegment evaluationPath, final boolean absolute) {
+        super("anchored", null, absolute);
+
+        this.anchorPath = anchorPath;
+        this.evaluationPath = evaluationPath;
+    }
+
+
+    @Override
+    public Stream<FieldValue> evaluate(final RecordPathEvaluationContext context) {
+        final Stream<FieldValue> anchoredStream = anchorPath.evaluate(context);
+
+        return anchoredStream.flatMap(fv -> {
+            final Object value = fv.getValue();
+            return evaluate(value);
+        });
+    }
+
+    private Stream<FieldValue> evaluate(final Object value) {
+        if (value == null) {
+            return Stream.of();
+        }
+        if (value instanceof Record) {
+            final RecordPathEvaluationContext recordPathEvaluateContext = new StandardRecordPathEvaluationContext((Record) value);
+            return evaluationPath.evaluate(recordPathEvaluateContext);
+        }
+        if (value instanceof final Record[] array) {
+            return Arrays.stream(array).flatMap(element -> {
+                final RecordPathEvaluationContext recordPathEvaluateContext = new StandardRecordPathEvaluationContext(element);
+                return evaluationPath.evaluate(recordPathEvaluateContext);
+            });
+        }
+        if (value instanceof final Iterable<?> iterable) {
+            return StreamSupport.stream(iterable.spliterator(), false).flatMap(element -> {
+                if (!(element instanceof Record)) {
+                    return Stream.of();
+                }
+
+                final RecordPathEvaluationContext recordPathEvaluateContext = new StandardRecordPathEvaluationContext((Record) element);
+                return evaluationPath.evaluate(recordPathEvaluateContext);
+            });
+        }
+
+        return Stream.of();
+    }
+}

--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/Join.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/Join.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.record.path.functions;
+
+import org.apache.nifi.record.path.FieldValue;
+import org.apache.nifi.record.path.RecordPathEvaluationContext;
+import org.apache.nifi.record.path.StandardFieldValue;
+import org.apache.nifi.record.path.paths.RecordPathSegment;
+import org.apache.nifi.record.path.util.RecordPathUtils;
+import org.apache.nifi.serialization.record.RecordField;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.serialization.record.util.DataTypeUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class Join extends RecordPathSegment {
+    private final RecordPathSegment delimiterPath;
+    private final RecordPathSegment[] valuePaths;
+
+    public Join(final RecordPathSegment delimiterPath, final RecordPathSegment[] valuePaths, final boolean absolute) {
+        super("join", null, absolute);
+        this.delimiterPath = delimiterPath;
+        this.valuePaths = valuePaths;
+    }
+
+    @Override
+    public Stream<FieldValue> evaluate(final RecordPathEvaluationContext context) {
+        String delimiter = RecordPathUtils.getFirstStringValue(delimiterPath, context);
+        if (delimiter == null) {
+            delimiter = "";
+        }
+
+        final List<String> values = new ArrayList<>();
+        for (final RecordPathSegment valuePath : valuePaths) {
+            final Stream<FieldValue> stream = valuePath.evaluate(context);
+
+            stream.forEach(fv -> {
+                final Object value = fv.getValue();
+                addStringValue(value, values);
+            });
+        }
+
+        final String joined = String.join(delimiter, values);
+        final RecordField field = new RecordField("join", RecordFieldType.STRING.getDataType());
+        final FieldValue responseValue = new StandardFieldValue(joined, field, null);
+        return Stream.of(responseValue);
+    }
+
+    private void addStringValue(final Object value, final List<String> values) {
+        if (value == null) {
+            values.add("null");
+            return;
+        }
+
+        if (value instanceof final Object[] array) {
+            for (final Object element : array) {
+                addStringValue(element, values);
+            }
+        } else if (value instanceof final Iterable<?> iterable) {
+            for (final Object element : iterable) {
+                addStringValue(element, values);
+            }
+        } else {
+            values.add(DataTypeUtils.toString(value, null));
+        }
+    }
+}

--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
@@ -35,6 +35,7 @@ import org.apache.nifi.record.path.filter.NotEqualsFilter;
 import org.apache.nifi.record.path.filter.NotFilter;
 import org.apache.nifi.record.path.filter.RecordPathFilter;
 import org.apache.nifi.record.path.filter.StartsWith;
+import org.apache.nifi.record.path.functions.Anchored;
 import org.apache.nifi.record.path.functions.Base64Decode;
 import org.apache.nifi.record.path.functions.Base64Encode;
 import org.apache.nifi.record.path.functions.Coalesce;
@@ -45,6 +46,7 @@ import org.apache.nifi.record.path.functions.FieldName;
 import org.apache.nifi.record.path.functions.FilterFunction;
 import org.apache.nifi.record.path.functions.Format;
 import org.apache.nifi.record.path.functions.Hash;
+import org.apache.nifi.record.path.functions.Join;
 import org.apache.nifi.record.path.functions.MapOf;
 import org.apache.nifi.record.path.functions.PadLeft;
 import org.apache.nifi.record.path.functions.PadRight;
@@ -129,6 +131,10 @@ public class RecordPathCompiler {
             }
             case CHILD_REFERENCE: {
                 final Tree childTree = tree.getChild(0);
+                if (childTree == null) {
+                    return new RootPath();
+                }
+
                 final int childTreeType = childTree.getType();
                 if (childTreeType == FIELD_NAME) {
                     final String childName = childTree.getChild(0).getText();
@@ -403,6 +409,24 @@ public class RecordPathCompiler {
                     case "count": {
                         final RecordPathSegment[] args = getArgPaths(argumentListTree, 1, functionName, absolute);
                         return new Count(args[0], absolute);
+                    }
+                    case "join": {
+                        final int numArgs = argumentListTree.getChildCount();
+                        if (numArgs < 2) {
+                            throw new RecordPathException("Invalid number of arguments: " + functionName + " function takes 2 or more arguments but got " + numArgs);
+                        }
+
+                        final RecordPathSegment[] joinPaths = new RecordPathSegment[numArgs - 1];
+                        for (int i = 0; i < numArgs - 1; i++) {
+                            joinPaths[i] = buildPath(argumentListTree.getChild(i+ 1), null, absolute);
+                        }
+
+                        final RecordPathSegment delimiterPath = buildPath(argumentListTree.getChild(0), null, absolute);
+                        return new Join(delimiterPath, joinPaths, absolute);
+                    }
+                    case "anchored": {
+                        final RecordPathSegment[] args = getArgPaths(argumentListTree, 2, functionName, absolute);
+                        return new Anchored(args[0], args[1], absolute);
                     }
                     case "not":
                     case "contains":

--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
@@ -418,7 +418,7 @@ public class RecordPathCompiler {
 
                         final RecordPathSegment[] joinPaths = new RecordPathSegment[numArgs - 1];
                         for (int i = 0; i < numArgs - 1; i++) {
-                            joinPaths[i] = buildPath(argumentListTree.getChild(i+ 1), null, absolute);
+                            joinPaths[i] = buildPath(argumentListTree.getChild(i + 1), null, absolute);
                         }
 
                         final RecordPathSegment delimiterPath = buildPath(argumentListTree.getChild(0), null, absolute);

--- a/nifi-docs/src/main/asciidoc/record-path-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/record-path-guide.adoc
@@ -456,6 +456,48 @@ Concatenates all the arguments together.
 |==========================================================
 
 
+=== join
+
+Joins together multiple values with a separator.
+
+|==========================================================
+| RecordPath | Return value
+| `join(', ', /workAddress/* )` | 123, 5th Avenue, New York, NY, 10020
+|==========================================================
+
+
+=== anchored
+
+Allows evaluating a RecordPath while anchoring the root context to a child record.
+
+|==========================================================
+| RecordPath | Return value
+| `anchored(/homeAddress, /city)` | Jersey City
+|==========================================================
+
+Additionally, this can be used in conjunction with arrays. For example, if we have the following record:
+----
+{
+    "id": "1234",
+    "elements": [{
+        "name": "book",
+        "color": "red"
+    }, {
+        "name": "computer",
+        "color": "black"
+    }]
+}
+----
+
+We can evaluate hte following Record paths:
+
+|==========================================================
+| RecordPath | Return value
+| `anchored(/elements, /name)` | The array containing `book` and `computer`
+| `anchored(/elements, concat(/name, ': ', /color))` | The array containing `book: red` and `computer: black`
+|==========================================================
+
+
 === fieldName
 
 Normally, when a path is given to a particular field in a Record, what is returned is the value of that field. It


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
