### PR TITLE
NIFI-12775: Renamed provenance/FileResource to ProvenanceFileResource

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceFileResource.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceFileResource.java
@@ -20,7 +20,7 @@ package org.apache.nifi.provenance;
  * Holds information of a file resource for UPLOAD
  * provenance events.
  */
-public record FileResource(String location, long size) {
+public record ProvenanceFileResource(String location, long size) {
 
     @Override
     public String toString() {

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceFileResource.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceFileResource.java
@@ -24,6 +24,6 @@ public record ProvenanceFileResource(String location, long size) {
 
     @Override
     public String toString() {
-        return "FileResource[location=%s, size=%d]".formatted(location, size);
+        return "ProvenanceFileResource[location=%s, size=%d]".formatted(location, size);
     }
 }

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceReporter.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceReporter.java
@@ -330,7 +330,7 @@ public interface ProvenanceReporter {
      * events to an external Enterprise-wide system that is then able to
      * correlate the SEND and RECEIVE events.
      */
-    void upload(FlowFile flowFile, FileResource fileResource, String transitUri);
+    void upload(FlowFile flowFile, ProvenanceFileResource fileResource, String transitUri);
 
     /**
      * Emits a Provenance Event of type {@link ProvenanceEventType#UPLOAD UPLOAD}
@@ -355,7 +355,7 @@ public interface ProvenanceReporter {
      * ProvenanceReporter is associated is rolled back. Otherwise, the Event
      * will be recorded only on a successful session commit.
      */
-    void upload(FlowFile flowFile, FileResource fileResource, String transitUri, String details, long transmissionMillis, boolean force);
+    void upload(FlowFile flowFile, ProvenanceFileResource fileResource, String transitUri, String details, long transmissionMillis, boolean force);
 
     /**
      * Emits a Provenance Event of type {@link ProvenanceEventType#REMOTE_INVOCATION}

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProvenanceReporter.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProvenanceReporter.java
@@ -24,7 +24,7 @@ import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.provenance.ProvenanceReporter;
 import org.apache.nifi.provenance.StandardProvenanceEventRecord;
-import org.apache.nifi.provenance.FileResource;
+import org.apache.nifi.provenance.ProvenanceFileResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -228,13 +228,13 @@ public class MockProvenanceReporter implements ProvenanceReporter {
     }
 
     @Override
-    public void upload(final FlowFile flowFile, final FileResource fileResource, final String transitUri) {
+    public void upload(final FlowFile flowFile, final ProvenanceFileResource fileResource, final String transitUri) {
         upload(flowFile, fileResource, transitUri, null, -1L, true);
 
     }
 
     @Override
-    public void upload(FlowFile flowFile, FileResource fileResource, String transitUri, String details, long transmissionMillis, boolean force) {
+    public void upload(FlowFile flowFile, ProvenanceFileResource fileResource, String transitUri, String details, long transmissionMillis, boolean force) {
         try {
             final String fileResourceDetails = fileResource.toString();
             final String enrichedDetails = details == null ? fileResourceDetails : details + " " + fileResourceDetails;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProvenanceReporter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProvenanceReporter.java
@@ -24,7 +24,7 @@ import org.apache.nifi.provenance.ProvenanceEventBuilder;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventRepository;
 import org.apache.nifi.provenance.ProvenanceEventType;
-import org.apache.nifi.provenance.FileResource;
+import org.apache.nifi.provenance.ProvenanceFileResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -282,12 +282,12 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
     }
 
     @Override
-    public void upload(final FlowFile flowFile, final FileResource fileResource, final String transitUri) {
+    public void upload(final FlowFile flowFile, final ProvenanceFileResource fileResource, final String transitUri) {
         upload(flowFile, fileResource, transitUri, null, -1L, true);
     }
 
     @Override
-    public void upload(final FlowFile flowFile, final FileResource fileResource, final String transitUri, final String details, final long transmissionMillis, final boolean force) {
+    public void upload(final FlowFile flowFile, final ProvenanceFileResource fileResource, final String transitUri, final String details, final long transmissionMillis, final boolean force) {
         try {
             final String fileResourceDetails = fileResource.toString();
             final String enrichedDetails = details == null ? fileResourceDetails : details + " " + fileResourceDetails;


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12775](https://issues.apache.org/jira/browse/NIFI-12775)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
