### PR TITLE
NIFI-12777 Add support for UUID record field type in QueryRecord processor

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileTable.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/queryrecord/FlowFileTable.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 public class FlowFileTable extends AbstractTable implements QueryableTable, TranslatableTable, Closeable {
 
@@ -229,6 +230,8 @@ public class FlowFileTable extends AbstractTable implements QueryableTable, Tran
                 return typeFactory.createJavaType(BigDecimal.class);
             case ENUM:
                 return typeFactory.createJavaType(Enum.class);
+            case UUID:
+                return typeFactory.createJavaType(UUID.class);
             case CHOICE:
                 final ChoiceDataType choiceDataType = (ChoiceDataType) fieldType;
                 DataType widestDataType = choiceDataType.getPossibleSubTypes().get(0);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestQueryRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestQueryRecord.java
@@ -57,6 +57,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -882,12 +883,15 @@ public class TestQueryRecord {
 
     @Test
     public void testSimple() throws InitializationException {
+        UUID tomId = UUID.randomUUID();
+
         final MockRecordParser parser = new MockRecordParser();
+        parser.addSchemaField("id", RecordFieldType.UUID);
         parser.addSchemaField("name", RecordFieldType.STRING);
         parser.addSchemaField("age", RecordFieldType.INT);
-        parser.addRecord("Tom", 49);
+        parser.addRecord(tomId, "Tom", 49);
 
-        final MockRecordWriter writer = new MockRecordWriter("\"name\",\"points\"");
+        final MockRecordWriter writer = new MockRecordWriter("\"id\",\"name\",\"points\"");
 
         TestRunner runner = getRunner();
         runner.addControllerService("parser", parser);
@@ -895,7 +899,7 @@ public class TestQueryRecord {
         runner.addControllerService("writer", writer);
         runner.enableControllerService(writer);
 
-        runner.setProperty(REL_NAME, "select name, age from FLOWFILE WHERE name <> ''");
+        runner.setProperty(REL_NAME, "select id, name, age from FLOWFILE WHERE name <> ''");
         runner.setProperty(QueryRecord.RECORD_READER_FACTORY, "parser");
         runner.setProperty(QueryRecord.RECORD_WRITER_FACTORY, "writer");
 
@@ -910,8 +914,7 @@ public class TestQueryRecord {
         runner.assertTransferCount(REL_NAME, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(REL_NAME).get(0);
         out.assertAttributeEquals(QueryRecord.ROUTE_ATTRIBUTE_KEY, REL_NAME);
-        System.out.println(new String(out.toByteArray()));
-        out.assertContentEquals("\"name\",\"points\"\n\"Tom\",\"49\"\n");
+        out.assertContentEquals("\"id\",\"name\",\"points\"\n\"" + tomId + "\",\"Tom\",\"49\"\n");
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-12777](https://issues.apache.org/jira/browse/NIFI-12777)

# Tracking

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-12777) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-12777`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-12777`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
- [ ] JDK 21