### PR TITLE
NIFI-11443 Route Python Framework Logging to SLF4J

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -319,7 +319,6 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String PYTHON_FRAMEWORK_SOURCE_DIRECTORY = "nifi.python.framework.source.directory";
     public static final String PYTHON_EXTENSION_DIRECTORY_PREFIX = "nifi.python.extensions.source.directory.";
     public static final String PYTHON_WORKING_DIRECTORY = "nifi.python.working.directory";
-    public static final String PYTHON_LOGS_DIRECTORY = "nifi.python.logs.directory";
     public static final String PYTHON_MAX_PROCESSES = "nifi.python.max.processes";
     public static final String PYTHON_MAX_PROCESSES_PER_TYPE = "nifi.python.max.processes.per.extension.type";
     public static final String PYTHON_COMMS_TIMEOUT = "nifi.python.comms.timeout";
@@ -327,7 +326,6 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String PYTHON_CONTROLLER_DEBUGPY_ENABLED = "nifi.python.controller.debugpy.enabled";
     public static final String PYTHON_CONTROLLER_DEBUGPY_PORT = "nifi.python.controller.debugpy.port";
     public static final String PYTHON_CONTROLLER_DEBUGPY_HOST = "nifi.python.controller.debugpy.host";
-    public static final String PYTHON_CONTROLLER_DEBUGPY_LOGS_DIR = "nifi.python.controller.debugpy.logs.directory";
 
     // kubernetes properties
     public static final String CLUSTER_LEADER_ELECTION_KUBERNETES_LEASE_PREFIX = "nifi.cluster.leader.election.kubernetes.lease.prefix";

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -247,9 +247,6 @@ located as a sibling of this directory. For example, if the value of this proper
 by default, but multiple Python Extension directories can be added by adding additional properties with the prefix `nifi.python.extensions.source.directory.`.
 | nifi.python.working.directory | ./work/python | The working directory where NiFi should store artifacts, such as any third-party libraries that are downloaded as dependencies
 for the Python Processors.
-| nifi.python.logs.directory | ./logs | The directory where NiFi should store the logs for the Python processes. If Python Processors use the in-built logger, the messages will be logged to the
-app-log. However, if they create their own Python logger, the messages will be written to the Python-specific log file(s). Additionally, the Python framework will write to the Python-specific log
-file(s).
 | nifi.python.max.processes.per.extension.type | 10 | The maximum number of Python processes that should be spawned for any one type of Processor. Because Python does not scale vertically,
 adding many NiFi Processors within the same Python process would yield very poor performance. Instead, NiFi creates a Python process for every Python Processor that is added to the canvas,
 within limits. This property indicates the maximum number of Python processes that can be created for any particular type of Processor. For example, if there are 5 instances of the

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -871,7 +871,6 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
         final File pythonFrameworkSourceDirectory = nifiProperties.getPythonFrameworkSourceDirectory();
         final List<File> pythonExtensionsDirectories = nifiProperties.getPythonExtensionsDirectories();
         final File pythonWorkingDirectory = new File(nifiProperties.getProperty(NiFiProperties.PYTHON_WORKING_DIRECTORY));
-        final File pythonLogsDirectory = new File(nifiProperties.getProperty(NiFiProperties.PYTHON_LOGS_DIRECTORY));
 
         int maxProcesses = nifiProperties.getIntegerProperty(NiFiProperties.PYTHON_MAX_PROCESSES, 20);
         int maxProcessesPerType = nifiProperties.getIntegerProperty(NiFiProperties.PYTHON_MAX_PROCESSES_PER_TYPE, 2);
@@ -879,7 +878,6 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
         final boolean enableControllerDebug = Boolean.parseBoolean(nifiProperties.getProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_ENABLED, "false"));
         final int debugPort = nifiProperties.getIntegerProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_PORT, 5678);
         final String debugHost = nifiProperties.getProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_HOST, "localhost");
-        final String debugLogs = nifiProperties.getProperty(NiFiProperties.PYTHON_CONTROLLER_DEBUGPY_LOGS_DIR, "logs");
 
         // Validate configuration for max numbers of processes.
         if (maxProcessesPerType < 1) {
@@ -906,7 +904,6 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
             .pythonCommand(pythonCommand)
             .pythonFrameworkDirectory(pythonFrameworkSourceDirectory)
             .pythonExtensionsDirectories(pythonExtensionsDirectories)
-            .pythonLogsDirectory(pythonLogsDirectory)
             .pythonWorkingDirectory(pythonWorkingDirectory)
             .commsTimeout(commsTimeout == null ? null : Duration.ofMillis(FormatUtils.getTimeDuration(commsTimeout, TimeUnit.MILLISECONDS)))
             .maxPythonProcesses(maxProcesses)
@@ -914,7 +911,6 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
             .enableControllerDebug(enableControllerDebug)
             .debugPort(debugPort)
             .debugHost(debugHost)
-            .debugLogsDirectory(new File(debugLogs))
             .build();
 
         final ControllerServiceTypeLookup serviceTypeLookup = serviceProvider::getControllerServiceType;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -268,7 +268,6 @@
         <nifi.python.working.directory>./work/python</nifi.python.working.directory>
         <nifi.python.max.processes>100</nifi.python.max.processes>
         <nifi.python.max.processes.per.extension.type>10</nifi.python.max.processes.per.extension.type>
-        <nifi.python.logs.dir>./logs</nifi.python.logs.dir>
         
         <nifi.cluster.leader.election.kubernetes.lease.prefix />
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -174,6 +174,9 @@
     <logger name="org.apache.nifi.controller.repository.StandardProcessSession" level="WARN" />
     <logger name="org.apache.parquet.hadoop.InternalParquetRecordReader" level="WARN" />
 
+    <!-- Py4J set to WARN to avoid verbose socket communication messages -->
+    <logger name="py4j" level="WARN" />
+
     <logger name="org.apache.zookeeper.ClientCnxn" level="ERROR" />
     <logger name="org.apache.zookeeper.server.NIOServerCnxn" level="ERROR" />
     <logger name="org.apache.zookeeper.server.NIOServerCnxnFactory" level="ERROR" />

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -49,7 +49,6 @@ nifi.python.extensions.source.directory.default=${nifi.python.extensions.source.
 nifi.python.working.directory=${nifi.python.working.directory}
 nifi.python.max.processes=${nifi.python.max.processes}
 nifi.python.max.processes.per.extension.type=${nifi.python.max.processes.per.extension.type}
-nifi.python.logs.directory=${nifi.python.logs.dir}
 
 ####################
 # State Management #

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/pom.xml
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/pom.xml
@@ -42,6 +42,12 @@
             <artifactId>py4j</artifactId>
             <version>0.10.9.7</version>
         </dependency>
+        <!-- Logback provided dependency for Log Level Change notification -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/PythonProcessLogReader.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/PythonProcessLogReader.java
@@ -22,8 +22,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
@@ -74,16 +74,20 @@ class PythonProcessLogReader implements Runnable {
      */
     @Override
     public void run() {
-        final Queue<ParsedRecord> parsedRecords = new LinkedList<>();
+        final Queue<ParsedRecord> parsedRecords = new ArrayDeque<>();
 
         try {
             String line = processReader.readLine();
             while (line != null) {
-                processLine(line, parsedRecords);
+                try {
+                    processLine(line, parsedRecords);
 
-                if (parsedRecords.size() == 2 || !processReader.ready()) {
-                    final ParsedRecord parsedRecord = parsedRecords.remove();
-                    log(parsedRecord);
+                    if (parsedRecords.size() == 2 || !processReader.ready()) {
+                        final ParsedRecord parsedRecord = parsedRecords.remove();
+                        log(parsedRecord);
+                    }
+                } catch (final Exception e) {
+                    processLogger.error("Failed to handle log from Python Process", e);
                 }
 
                 // Read and block for subsequent lines

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/PythonProcessLogReader.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/PythonProcessLogReader.java
@@ -58,7 +58,7 @@ class PythonProcessLogReader implements Runnable {
                 line = processReader.readLine();
             }
         } catch (final IOException e) {
-            processLogger.error("Read Process output failed", e);
+            processLogger.error("Failed to read output of Python Process", e);
         }
     }
 

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/PythonProcessLogReader.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/PythonProcessLogReader.java
@@ -82,9 +82,18 @@ class PythonProcessLogReader implements Runnable {
                 try {
                     processLine(line, parsedRecords);
 
-                    if (parsedRecords.size() == 2 || !processReader.ready()) {
+                    if (parsedRecords.size() == 2) {
+                        // Log previous record after creating a new record
                         final ParsedRecord parsedRecord = parsedRecords.remove();
                         log(parsedRecord);
+                    }
+
+                    if (!processReader.ready()) {
+                        // Log queued records when Process Reader is not ready
+                        while (!parsedRecords.isEmpty()) {
+                            final ParsedRecord parsedRecord = parsedRecords.poll();
+                            log(parsedRecord);
+                        }
                     }
                 } catch (final Exception e) {
                     processLogger.error("Failed to handle log from Python Process", e);

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/PythonProcessLogReader.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/PythonProcessLogReader.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.py4j;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Runnable Command for reading a line from Process Output Stream and writing to a Logger
+ */
+class PythonProcessLogReader implements Runnable {
+    private static final int LOG_LEVEL_BEGIN_INDEX = 0;
+
+    private static final int LOG_LEVEL_END_INDEX = 2;
+
+    private static final int MESSAGE_BEGIN_INDEX = 3;
+
+    private static final int MINIMUM_LINE_LENGTH = 4;
+
+    private static final char NAME_MESSAGE_SEPARATOR = ':';
+
+    private static final int INDEX_NOT_FOUND = -1;
+
+    private final Logger processLogger = LoggerFactory.getLogger("org.apache.nifi.py4j.ProcessLog");
+
+    private final BufferedReader processReader;
+
+    PythonProcessLogReader(final BufferedReader processReader) {
+        this.processReader = Objects.requireNonNull(processReader, "Reader required");
+    }
+
+    @Override
+    public void run() {
+        try {
+            String line = processReader.readLine();
+            while (line != null) {
+                if (line.length() > MINIMUM_LINE_LENGTH) {
+                    processLine(line);
+                }
+                line = processReader.readLine();
+            }
+        } catch (final IOException e) {
+            processLogger.error("Read Process output failed", e);
+        }
+    }
+
+    private void processLine(final String line) {
+        final String levelNumber = line.substring(LOG_LEVEL_BEGIN_INDEX, LOG_LEVEL_END_INDEX);
+        final LogLevel logLevel = getLogLevel(levelNumber);
+        if (LogLevel.NOTSET == logLevel) {
+            processLogger.info(line);
+        } else {
+            final String message = line.substring(MESSAGE_BEGIN_INDEX);
+            processMessage(logLevel, message);
+        }
+    }
+
+    private void processMessage(final LogLevel logLevel, final String message) {
+        final int nameSeparatorIndex = message.indexOf(NAME_MESSAGE_SEPARATOR);
+        if (INDEX_NOT_FOUND == nameSeparatorIndex) {
+            log(processLogger, logLevel, message);
+        } else {
+            final String loggerName = message.substring(0, nameSeparatorIndex);
+            final Logger messageLogger = LoggerFactory.getLogger(loggerName);
+
+            final int messageBeginIndex = nameSeparatorIndex + 1;
+            final String logMessage = message.substring(messageBeginIndex);
+            log(messageLogger, logLevel, logMessage);
+        }
+    }
+
+    private void log(final Logger logger, final LogLevel logLevel, final String message) {
+        if (LogLevel.DEBUG == logLevel) {
+            logger.debug(message);
+        } else if (LogLevel.INFO == logLevel) {
+            logger.info(message);
+        } else if (LogLevel.WARNING == logLevel) {
+            logger.warn(message);
+        } else if (LogLevel.ERROR == logLevel) {
+            logger.error(message);
+        } else {
+            logger.error(message);
+        }
+    }
+
+    private LogLevel getLogLevel(final String levelNumber) {
+        LogLevel logLevel = LogLevel.NOTSET;
+
+        for (final LogLevel currentLogLevel : LogLevel.values()) {
+            if (currentLogLevel.level.equals(levelNumber)) {
+                logLevel = currentLogLevel;
+                break;
+            }
+        }
+
+        return logLevel;
+    }
+
+    enum LogLevel {
+        NOTSET("0"),
+
+        DEBUG("10"),
+
+        INFO("20"),
+
+        WARNING("30"),
+
+        ERROR("40"),
+
+        CRITICAL("50");
+
+        private final String level;
+
+        LogLevel(final String level) {
+            this.level = level;
+        }
+
+        String getLevel() {
+            return level;
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/StandardPythonBridge.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/StandardPythonBridge.java
@@ -18,6 +18,9 @@
 package org.apache.nifi.py4j;
 
 import org.apache.nifi.components.AsyncLoadedProcessor;
+import org.apache.nifi.py4j.logback.LevelChangeListener;
+import org.apache.nifi.py4j.logging.LogLevelChangeHandler;
+import org.apache.nifi.py4j.logging.StandardLogLevelChangeHandler;
 import org.apache.nifi.python.BoundObjectCounts;
 import org.apache.nifi.python.ControllerServiceTypeLookup;
 import org.apache.nifi.python.PythonBridge;
@@ -71,6 +74,9 @@ public class StandardPythonBridge implements PythonBridge {
         logger.debug("{} launching Python Process", this);
 
         try {
+            final LogLevelChangeHandler logLevelChangeHandler = StandardLogLevelChangeHandler.getHandler();
+            LevelChangeListener.registerLogbackListener(logLevelChangeHandler);
+
             final File envHome = new File(processConfig.getPythonWorkingDirectory(), "controller");
             controllerProcess = new PythonProcess(processConfig, serviceTypeLookup, envHome, "Controller", "Controller");
             controllerProcess.start();

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logback/LevelChangeListener.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logback/LevelChangeListener.java
@@ -47,7 +47,7 @@ public class LevelChangeListener implements LoggerContextListener {
 
     private static final List<Pattern> EXCLUDED_LOGGERS = List.of(
             Pattern.compile("^$"),
-            Pattern.compile("^ROOT|org|com|net$"),
+            Pattern.compile("^org|com|net$"),
             Pattern.compile("^jetbrains.*"),
             Pattern.compile("^org\\.apache.*"),
             Pattern.compile("^org\\.eclipse.*"),
@@ -76,13 +76,13 @@ public class LevelChangeListener implements LoggerContextListener {
     }
 
     /**
-     * Reset Resistant disabled to support persistent behavior when the LoggerContext is changed
+     * Reset Resistant enabled to support persistent behavior when the LoggerContext is changed
      *
-     * @return Reset Resistant disabled
+     * @return Reset Resistant enabled
      */
     @Override
     public boolean isResetResistant() {
-        return false;
+        return true;
     }
 
     /**

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logback/LevelChangeListener.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logback/LevelChangeListener.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.py4j.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggerContextListener;
+import org.apache.nifi.py4j.logging.LogLevelChangeListener;
+import org.apache.nifi.logging.LogLevel;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Logback Listener implementation for tracking Logger Level changes and notifying framework listeners
+ */
+public class LevelChangeListener implements LoggerContextListener {
+    private static final Map<Level, LogLevel> LEVELS = Map.of(
+            Level.ALL, LogLevel.TRACE,
+            Level.TRACE, LogLevel.TRACE,
+            Level.DEBUG, LogLevel.DEBUG,
+            Level.INFO, LogLevel.INFO,
+            Level.WARN, LogLevel.WARN,
+            Level.ERROR, LogLevel.ERROR,
+            Level.OFF, LogLevel.NONE
+    );
+
+    private static final List<Pattern> EXCLUDED_LOGGERS = List.of(
+            Pattern.compile("^$"),
+            Pattern.compile("^ROOT|org|com|net$"),
+            Pattern.compile("^jetbrains.*"),
+            Pattern.compile("^org\\.apache.*"),
+            Pattern.compile("^org\\.eclipse.*"),
+            Pattern.compile("^org\\.glassfish.*"),
+            Pattern.compile("^org\\.springframework.*"),
+            Pattern.compile("^org\\.opensaml.*"),
+            Pattern.compile("^software\\.amazon.*")
+    );
+
+    private final LogLevelChangeListener logLevelChangeListener;
+
+    LevelChangeListener(final LogLevelChangeListener logLevelChangeListener) {
+        this.logLevelChangeListener = Objects.requireNonNull(logLevelChangeListener, "Listener required");
+    }
+
+    /**
+     * Register an instance of Logback LevelChangeListener routing to framework LogLevelChangeListener
+     */
+    public static void registerLogbackListener(final LogLevelChangeListener logLevelChangeListener) {
+        final LevelChangeListener levelChangeListener = new LevelChangeListener(logLevelChangeListener);
+        final ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+        if (loggerFactory instanceof LoggerContext loggerContext) {
+            loggerContext.addListener(levelChangeListener);
+            levelChangeListener.onStart(loggerContext);
+        }
+    }
+
+    /**
+     * Reset Resistant disabled to support persistent behavior when the LoggerContext is changed
+     *
+     * @return Reset Resistant disabled
+     */
+    @Override
+    public boolean isResetResistant() {
+        return false;
+    }
+
+    /**
+     * Set initial Logger Levels from registered loggers when starting
+     *
+     * @param loggerContext Logback Context
+     */
+    @Override
+    public void onStart(final LoggerContext loggerContext) {
+        for (final Logger logger : loggerContext.getLoggerList()) {
+            onLevelChange(logger, logger.getEffectiveLevel());
+        }
+    }
+
+    /**
+     * Set Logger Levels from registered loggers when resetting
+     *
+     * @param loggerContext Logback Context
+     */
+    @Override
+    public void onReset(final LoggerContext loggerContext) {
+        onStart(loggerContext);
+    }
+
+    @Override
+    public void onStop(final LoggerContext loggerContext) {
+
+    }
+
+    /**
+     * Send logger level changes to framework handler for subsequent notification
+     *
+     * @param logger Logback Logger with new level
+     * @param level New level assigned for Logback Logger
+     */
+    @Override
+    public void onLevelChange(final Logger logger, final Level level) {
+        Objects.requireNonNull(level, "Level required");
+
+        final String loggerName = logger.getName();
+        if (isLoggerSupported(loggerName)) {
+            final LogLevel logLevel = LEVELS.getOrDefault(level, LogLevel.WARN);
+            logLevelChangeListener.onLevelChange(loggerName, logLevel);
+        }
+    }
+
+    private boolean isLoggerSupported(final String loggerName) {
+        boolean supported = true;
+
+        for (final Pattern loggerPattern : EXCLUDED_LOGGERS) {
+            final Matcher matcher = loggerPattern.matcher(loggerName);
+            if (matcher.matches()) {
+                supported = false;
+                break;
+            }
+        }
+
+        return supported;
+    }
+}

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logging/LogLevelChangeHandler.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logging/LogLevelChangeHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.py4j.logging;
+
+/**
+ * Handler abstraction for registering Listeners and invoking Listeners on level changes
+ */
+public interface LogLevelChangeHandler extends LogLevelChangeListener {
+    /**
+     * Register Log Level Change Listener with provided identifier
+     *
+     * @param identifier Tracking identifier associated with Log Level Change Listener
+     * @param listener Log Level Change Listener to be registered
+     */
+    void addListener(String identifier, LogLevelChangeListener listener);
+
+    /**
+     * Remove registered listener based on provided identifier
+     *
+     * @param identifier Tracking identifier of registered listener to be removed
+     */
+    void removeListener(String identifier);
+}

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logging/LogLevelChangeListener.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logging/LogLevelChangeListener.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.py4j.logging;
+
+import org.apache.nifi.logging.LogLevel;
+
+/**
+ * Listener abstraction for subscribing to notification of level changes for named loggers
+ */
+public interface LogLevelChangeListener {
+    /**
+     * Handle level change notification for named logger
+     *
+     * @param loggerName Name of logger with updated level
+     * @param logLevel New log level
+     */
+    void onLevelChange(String loggerName, LogLevel logLevel);
+}

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logging/PythonLogLevel.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logging/PythonLogLevel.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.py4j.logging;
+
+import org.apache.nifi.logging.LogLevel;
+
+import java.util.Map;
+
+/**
+ * Python Log Level enumeration with level numbers according to Python logging module documentation
+ */
+public enum PythonLogLevel {
+    NOTSET(0),
+
+    DEBUG(10),
+
+    INFO(20),
+
+    WARNING(30),
+
+    ERROR(40),
+
+    CRITICAL(50);
+
+    private static final Map<LogLevel, PythonLogLevel> FRAMEWORK_LEVELS = Map.of(
+            LogLevel.NONE, NOTSET,
+            LogLevel.DEBUG, DEBUG,
+            LogLevel.INFO, INFO,
+            LogLevel.WARN, WARNING,
+            LogLevel.ERROR, ERROR,
+            LogLevel.FATAL, CRITICAL
+    );
+
+    private final int level;
+
+    PythonLogLevel(final int level) {
+        this.level = level;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    /**
+     * Get Python Log Level equivalent from framework Log Level
+     *
+     * @param logLevel Framework Log Level
+     * @return Python Log Level
+     */
+    public static PythonLogLevel valueOf(LogLevel logLevel) {
+        return FRAMEWORK_LEVELS.getOrDefault(logLevel, WARNING);
+    }
+}

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logging/StandardLogLevelChangeHandler.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/py4j/logging/StandardLogLevelChangeHandler.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.py4j.logging;
+
+import org.apache.nifi.logging.LogLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Standard implementation of Log Level Change Handler with singleton instance for shared collection of listeners
+ */
+public class StandardLogLevelChangeHandler implements LogLevelChangeHandler {
+    private static final StandardLogLevelChangeHandler HANDLER = new StandardLogLevelChangeHandler();
+
+    private static final Logger handlerLogger = LoggerFactory.getLogger(StandardLogLevelChangeHandler.class);
+
+    private final Map<String, LogLevelChangeListener> listeners = new ConcurrentHashMap<>();
+
+    private final Map<String, LogLevel> loggerLevels = new ConcurrentHashMap<>();
+
+    private StandardLogLevelChangeHandler() {
+
+    }
+
+    /**
+     * Get shared reference to Handler for Listener registration and centralized notification
+     *
+     * @return Shared Log Level Change Handler
+     */
+    public static LogLevelChangeHandler getHandler() {
+        return HANDLER;
+    }
+
+    /**
+     * Register Log Level Change Listener with provided identifier
+     *
+     * @param identifier Tracking identifier associated with Log Level Change Listener
+     * @param listener Log Level Change Listener to be registered
+     */
+    @Override
+    public void addListener(final String identifier, final LogLevelChangeListener listener) {
+        Objects.requireNonNull(identifier, "Identifier required");
+        Objects.requireNonNull(listener, "Listener required");
+
+        for (final Map.Entry<String, LogLevel> loggerLevel : loggerLevels.entrySet()) {
+            listener.onLevelChange(loggerLevel.getKey(), loggerLevel.getValue());
+        }
+
+        listeners.put(identifier, listener);
+        handlerLogger.trace("Added Listener [{}]", identifier);
+    }
+
+    /**
+     * Remove registered listener based on provided identifier
+     *
+     * @param identifier Tracking identifier of registered listener to be removed
+     */
+    @Override
+    public void removeListener(String identifier) {
+        Objects.requireNonNull(identifier, "Identifier required");
+        listeners.remove(identifier);
+        handlerLogger.trace("Removed Listener [{}]", identifier);
+    }
+
+    /**
+     * Handle level change notification for named logger and broadcast to registered Listeners
+     *
+     * @param loggerName Name of logger with updated level
+     * @param logLevel New log level
+     */
+    @Override
+    public void onLevelChange(final String loggerName, final LogLevel logLevel) {
+        Objects.requireNonNull(loggerName, "Logger Name required");
+        Objects.requireNonNull(logLevel, "Log Level required");
+        handlerLogger.trace("Logger [{}] Level [{}] changed", loggerName, logLevel);
+
+        loggerLevels.put(loggerName, logLevel);
+        for (final LogLevelChangeListener listener : listeners.values()) {
+            listener.onLevelChange(loggerName, logLevel);
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/PythonProcessLogReaderTest.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/PythonProcessLogReaderTest.java
@@ -30,6 +30,7 @@ import java.io.StringReader;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class PythonProcessLogReaderTest {
@@ -45,6 +46,8 @@ class PythonProcessLogReaderTest {
     private static final String LINE_UNFORMATTED = "Testing message without level or logger";
 
     private static final String LINE_MISSING_SEPARATOR = "%s %s".formatted(PythonProcessLogReader.LogLevel.INFO.getLevel(), LOG_MESSAGE);
+
+    private static final String LINE_EMPTY = "";
 
     @Mock
     private Logger logger;
@@ -108,6 +111,19 @@ class PythonProcessLogReaderTest {
         }
 
         verify(logger).info(eq(LOG_MESSAGE));
+    }
+
+    @Test
+    void testEmpty() {
+        try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+            loggerFactory.when(() -> LoggerFactory.getLogger(eq(PROCESS_LOGGER))).thenReturn(logger);
+
+            final BufferedReader reader = new BufferedReader(new StringReader(LINE_EMPTY));
+            final Runnable command = new PythonProcessLogReader(reader);
+            command.run();
+        }
+
+        verifyNoInteractions(logger);
     }
 
     private void runCommand(final PythonProcessLogReader.LogLevel logLevel) {

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/PythonProcessLogReaderTest.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/PythonProcessLogReaderTest.java
@@ -56,7 +56,7 @@ class PythonProcessLogReaderTest {
 
     private static final String LINE_EMPTY = "";
 
-    private static final String MESSAGE_TRACEBACK = "Command Failed\nTrackback (most recent call last):\n  File: command.py, line 1\nError: name is not defined";
+    private static final String MESSAGE_TRACEBACK = String.format("Command Failed%nTrackback (most recent call last):%n  File: command.py, line 1%nError: name is not defined");
 
     @Mock
     private Logger processLogger;

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/PythonProcessLogReaderTest.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/PythonProcessLogReaderTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.py4j;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PythonProcessLogReaderTest {
+
+    private static final String PROCESS_LOGGER = "org.apache.nifi.py4j.ProcessLog";
+
+    private static final String CONTROLLER_LOGGER = "org.apache.nifi.py4j.Controller";
+
+    private static final String LOG_MESSAGE = "Testing Python Processing";
+
+    private static final String LINE_FORMAT = "%s %s:%s";
+
+    private static final String LINE_UNFORMATTED = "Testing message without level or logger";
+
+    private static final String LINE_MISSING_SEPARATOR = "%s %s".formatted(PythonProcessLogReader.LogLevel.INFO.getLevel(), LOG_MESSAGE);
+
+    @Mock
+    private Logger logger;
+
+    @Test
+    void testDebug() {
+        runCommand(PythonProcessLogReader.LogLevel.DEBUG);
+
+        verify(logger).debug(eq(LOG_MESSAGE));
+    }
+
+    @Test
+    void testInfo() {
+        runCommand(PythonProcessLogReader.LogLevel.INFO);
+
+        verify(logger).info(eq(LOG_MESSAGE));
+    }
+
+    @Test
+    void testWarning() {
+        runCommand(PythonProcessLogReader.LogLevel.WARNING);
+
+        verify(logger).warn(eq(LOG_MESSAGE));
+    }
+
+    @Test
+    void testError() {
+        runCommand(PythonProcessLogReader.LogLevel.ERROR);
+
+        verify(logger).error(eq(LOG_MESSAGE));
+    }
+
+    @Test
+    void testCritical() {
+        runCommand(PythonProcessLogReader.LogLevel.CRITICAL);
+
+        verify(logger).error(eq(LOG_MESSAGE));
+    }
+
+    @Test
+    void testUnformatted() {
+        try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+            loggerFactory.when(() -> LoggerFactory.getLogger(eq(PROCESS_LOGGER))).thenReturn(logger);
+
+            final BufferedReader reader = new BufferedReader(new StringReader(LINE_UNFORMATTED));
+            final Runnable command = new PythonProcessLogReader(reader);
+            command.run();
+        }
+
+        verify(logger).info(eq(LINE_UNFORMATTED));
+    }
+
+    @Test
+    void testMissingSeparator() {
+        try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+            loggerFactory.when(() -> LoggerFactory.getLogger(eq(PROCESS_LOGGER))).thenReturn(logger);
+
+            final BufferedReader reader = new BufferedReader(new StringReader(LINE_MISSING_SEPARATOR));
+            final Runnable command = new PythonProcessLogReader(reader);
+            command.run();
+        }
+
+        verify(logger).info(eq(LOG_MESSAGE));
+    }
+
+    private void runCommand(final PythonProcessLogReader.LogLevel logLevel) {
+        try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+            loggerFactory.when(() -> LoggerFactory.getLogger(eq(CONTROLLER_LOGGER))).thenReturn(logger);
+
+            final String line = getLine(logLevel, CONTROLLER_LOGGER);
+            final BufferedReader reader = new BufferedReader(new StringReader(line));
+            final Runnable command = new PythonProcessLogReader(reader);
+            command.run();
+        }
+    }
+
+    private String getLine(final PythonProcessLogReader.LogLevel logLevel, final String loggerName) {
+        return LINE_FORMAT.formatted(logLevel.getLevel(), loggerName, LOG_MESSAGE);
+    }
+}

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/logback/LevelChangeListenerTest.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/logback/LevelChangeListenerTest.java
@@ -1,0 +1,65 @@
+package org.apache.nifi.py4j.logback;/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import org.apache.nifi.py4j.logging.LogLevelChangeListener;
+import org.apache.nifi.py4j.logging.StandardLogLevelChangeHandler;
+import org.apache.nifi.logging.LogLevel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LevelChangeListenerTest {
+
+    @Mock
+    private Logger logger;
+
+    @Mock
+    private LogLevelChangeListener logLevelChangeListener;
+
+    private LevelChangeListener listener;
+
+    @BeforeEach
+    void setListener() {
+        listener = new LevelChangeListener(StandardLogLevelChangeHandler.getHandler());
+
+        StandardLogLevelChangeHandler.getHandler().addListener(LogLevelChangeListener.class.getSimpleName(), logLevelChangeListener);
+    }
+
+    @AfterEach
+    void removeListener() {
+        StandardLogLevelChangeHandler.getHandler().removeListener(LogLevelChangeListener.class.getSimpleName());
+    }
+
+    @Test
+    void testOnLevelChange() {
+        when(logger.getName()).thenReturn(Logger.ROOT_LOGGER_NAME);
+
+        listener.onLevelChange(logger, Level.INFO);
+
+        verify(logLevelChangeListener).onLevelChange(eq(Logger.ROOT_LOGGER_NAME), eq(LogLevel.INFO));
+    }
+}

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/logback/LevelChangeListenerTest.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/test/java/org/apache/nifi/py4j/logback/LevelChangeListenerTest.java
@@ -34,6 +34,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class LevelChangeListenerTest {
 
+    private static final String LOGGER_NAME = Test.class.getName();
+
     @Mock
     private Logger logger;
 
@@ -56,10 +58,10 @@ class LevelChangeListenerTest {
 
     @Test
     void testOnLevelChange() {
-        when(logger.getName()).thenReturn(Logger.ROOT_LOGGER_NAME);
+        when(logger.getName()).thenReturn(LOGGER_NAME);
 
         listener.onLevelChange(logger, Level.INFO);
 
-        verify(logLevelChangeListener).onLevelChange(eq(Logger.ROOT_LOGGER_NAME), eq(LogLevel.INFO));
+        verify(logLevelChangeListener).onLevelChange(eq(LOGGER_NAME), eq(LogLevel.INFO));
     }
 }

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
@@ -89,7 +89,6 @@ public class PythonControllerInteractionIT {
             .commsTimeout(Duration.ofSeconds(0))
             .maxPythonProcessesPerType(25)
             .maxPythonProcesses(100)
-            .pythonLogsDirectory(logsDir)
             .build();
 
         Files.createDirectories(logsDir.toPath());

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework-api/src/main/java/org/apache/nifi/python/PythonController.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework-api/src/main/java/org/apache/nifi/python/PythonController.java
@@ -99,4 +99,12 @@ public interface PythonController {
      * @return the details that have been discovered
      */
     PythonProcessorDetails getProcessorDetails(String type, String version);
+
+    /**
+     * Set level for specified logger name in Python logging.Logger objects
+     *
+     * @param loggerName Python logger name to be updated
+     * @param level Python log level according to Python logging module documentation
+     */
+    void setLoggerLevel(String loggerName, int level);
 }

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework-api/src/main/java/org/apache/nifi/python/PythonProcessConfig.java
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework-api/src/main/java/org/apache/nifi/python/PythonProcessConfig.java
@@ -30,20 +30,17 @@ public class PythonProcessConfig {
     private final File pythonFrameworkDirectory;
     private final List<File> pythonExtensionsDirectories;
     private final File pythonWorkingDirectory;
-    private final File pythonLogsDirectory;
     private final Duration commsTimeout;
     private final int maxPythonProcesses;
     private final int maxPythonProcessesPerType;
     private final boolean debugController;
     private final String debugHost;
     private final int debugPort;
-    private final File debugLogsDirectory;
 
     private PythonProcessConfig(final Builder builder) {
         this.pythonCommand = builder.pythonCommand;
         this.pythonFrameworkDirectory = builder.pythonFrameworkDirectory;
         this.pythonExtensionsDirectories = builder.pythonExtensionsDirectories;
-        this.pythonLogsDirectory = builder.pythonLogsDirectory;
         this.pythonWorkingDirectory = builder.pythonWorkingDirectory;
         this.commsTimeout = builder.commsTimeout;
         this.maxPythonProcesses = builder.maxProcesses;
@@ -51,7 +48,6 @@ public class PythonProcessConfig {
         this.debugController = builder.debugController;
         this.debugPort = builder.debugPort;
         this.debugHost = builder.debugHost;
-        this.debugLogsDirectory = builder.debugLogsDirectory;
     }
 
     public String getPythonCommand() {
@@ -64,10 +60,6 @@ public class PythonProcessConfig {
 
     public List<File> getPythonExtensionsDirectories() {
         return pythonExtensionsDirectories;
-    }
-
-    public File getPythonLogsDirectory() {
-        return pythonLogsDirectory;
     }
 
     public File getPythonWorkingDirectory() {
@@ -98,15 +90,10 @@ public class PythonProcessConfig {
         return debugPort;
     }
 
-    public File getDebugLogsDirectory() {
-        return debugLogsDirectory;
-    }
-
     public static class Builder {
         private String pythonCommand = "python3";
         private File pythonFrameworkDirectory = new File("python/framework");
         private List<File> pythonExtensionsDirectories = Collections.singletonList(new File("python/extensions"));
-        private File pythonLogsDirectory = new File("./logs");
         private File pythonWorkingDirectory = new File("python");
         private Duration commsTimeout = Duration.ofSeconds(0);
         private int maxProcesses;
@@ -114,8 +101,6 @@ public class PythonProcessConfig {
         private boolean debugController = false;
         private String debugHost = "localhost";
         private int debugPort = 5678;
-        private File debugLogsDirectory = new File("logs/");
-
 
         public Builder pythonCommand(final String command) {
             this.pythonCommand = command;
@@ -164,11 +149,6 @@ public class PythonProcessConfig {
             return this;
         }
 
-        public Builder pythonLogsDirectory(final File logsDirectory) {
-            this.pythonLogsDirectory = logsDirectory;
-            return this;
-        }
-
         public Builder enableControllerDebug(final boolean enableDebug) {
             this.debugController = enableDebug;
             return this;
@@ -181,11 +161,6 @@ public class PythonProcessConfig {
 
         public Builder debugHost(final String debugHost) {
             this.debugHost = debugHost;
-            return this;
-        }
-
-        public Builder debugLogsDirectory(final File debugLogsDirectory) {
-            this.debugLogsDirectory = debugLogsDirectory;
             return this;
         }
 

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/Controller.py
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/Controller.py
@@ -30,18 +30,13 @@ import ExtensionManager
 threadpool_attrs = dir(ThreadPoolExecutor)
 processpool_attrs = dir(ProcessPoolExecutor)
 
-
-# Initialize logging
-logger = logging.getLogger("org.apache.nifi.py4j.Controller")
-logger.setLevel(logging.INFO)
-
-logging.getLogger("py4j").setLevel(logging.WARN)
-
 # Set log format with level number and separator as expected in PythonProcessReaderCommand
-logging.basicConfig(stream=sys.stdout,
-                    format='%(levelno)s %(name)s:%(message)s',
+logging.basicConfig(stream=sys.stderr,
+                    format='PY4JLOG %(levelno)s %(name)s:%(message)s',
                     encoding='utf-8',
                     level=logging.INFO)
+
+logger = logging.getLogger("org.apache.nifi.py4j.Controller")
 
 
 class Controller:
@@ -92,6 +87,9 @@ class Controller:
 
     def setControllerServiceTypeLookup(self, typeLookup):
         self.controllerServiceTypeLookup = typeLookup
+
+    def setLoggerLevel(self, loggerName, level):
+        logging.getLogger(loggerName).setLevel(level)
 
     class Java:
         implements = ["org.apache.nifi.py4j.PythonController"]

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/Controller.py
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/Controller.py
@@ -15,6 +15,7 @@
 
 import logging
 import os
+import sys
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 
 from py4j.java_gateway import JavaGateway, CallbackServerParameters, GatewayParameters
@@ -36,9 +37,9 @@ logger.setLevel(logging.INFO)
 
 logging.getLogger("py4j").setLevel(logging.WARN)
 
-logsDir = os.getenv('LOGS_DIR')
-logging.basicConfig(filename=logsDir + '/nifi-python.log',
-                    format='%(asctime)s %(levelname)s %(name)s %(message)s',
+# Set log format with level number and separator as expected in PythonProcessReaderCommand
+logging.basicConfig(stream=sys.stdout,
+                    format='%(levelno)s %(name)s:%(message)s',
                     encoding='utf-8',
                     level=logging.INFO)
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/nifi.properties
@@ -48,7 +48,6 @@ nifi.python.extensions.source.directory.default=./python/extensions
 nifi.python.working.directory=./work/python
 nifi.python.max.processes=100
 nifi.python.max.processes.per.extension.type=10
-nifi.python.logs.directory=./logs
 
 ####################
 # State Management #

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/nifi.properties
@@ -48,7 +48,6 @@ nifi.python.extensions.source.directory.default=./python/extensions
 nifi.python.working.directory=./work/python
 nifi.python.max.processes=100
 nifi.python.max.processes.per.extension.type=10
-nifi.python.logs.directory=./logs
 
 ####################
 # State Management #

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/nifi.properties
@@ -48,7 +48,6 @@ nifi.python.extensions.source.directory.default=./python/extensions
 nifi.python.working.directory=./work/python
 nifi.python.max.processes=100
 nifi.python.max.processes.per.extension.type=10
-nifi.python.logs.directory=./logs
 
 ####################
 # State Management #

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/logback.xml
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/logback.xml
@@ -115,6 +115,9 @@
     <logger name="org.apache.calcite.runtime.CalciteException" level="OFF" />
     <logger name="deprecation" level="OFF" />
 
+    <!-- Py4J set to WARN to avoid verbose socket communication messages -->
+    <logger name="py4j" level="WARN" />
+
     <logger name="org.apache.curator.framework.recipes.leader.LeaderSelector" level="OFF" />
     <logger name="org.apache.curator.ConnectionState" level="OFF" />
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/nifi.properties
@@ -52,7 +52,6 @@ nifi.python.extensions.source.directory.default=./python/extensions
 nifi.python.working.directory=./work/python
 nifi.python.max.processes=100
 nifi.python.max.processes.per.extension.type=10
-nifi.python.logs.directory=./logs
 
 ####################
 # State Management #


### PR DESCRIPTION
# Summary

[NIFI-11443](https://issues.apache.org/jira/browse/NIFI-11443) Updates Python Process log handling to route messages to SLF4J so that logging levels and appenders can be managed using Logback.

These changes remove the need for separate Python log settings in `nifi.properties` and support translating Python log levels and logger names to Logback.

The implementation changes the Python logging format to use the Python [level numbers](https://docs.python.org/3/library/logging.html#levels) for optimized parsing. The implementation changes Python logging to write messages to the standard output stream, and the `PythonProcess` builder creates a Java Virtual Thread to read lines from the `BufferedReader` containing process output stream messages.

These changes eliminate the dedicated `nifi-python.log` and enable Python logging to be handled along with other framework logging that defaults to the `nifi-app.log` file appender.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
