### PR TITLE
NIFI-12796 - PutDatabaseRecord statement type should support u/c/d for Debezium

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -183,7 +183,8 @@ public class PutDatabaseRecord extends AbstractProcessor {
     static final PropertyDescriptor STATEMENT_TYPE_RECORD_PATH = new Builder()
         .name("Statement Type Record Path")
         .displayName("Statement Type Record Path")
-        .description("Specifies a RecordPath to evaluate against each Record in order to determine the Statement Type. The RecordPath should equate to either INSERT, UPDATE, UPSERT, or DELETE.")
+        .description("Specifies a RecordPath to evaluate against each Record in order to determine the Statement Type. The RecordPath should equate to either INSERT, UPDATE, UPSERT, or DELETE. "
+                + "(Debezium style operation types are also supported: \"r\" and \"c\" for INSERT, \"u\" for UPDATE, and \"d\" for DELETE)")
         .required(true)
         .addValidator(new RecordPathValidator())
         .expressionLanguageSupported(NONE)
@@ -1555,6 +1556,13 @@ public class PutDatabaseRecord extends AbstractProcessor {
                 case DELETE_TYPE:
                 case UPSERT_TYPE:
                     return resultValue;
+                case "C":
+                case "R":
+                    return INSERT_TYPE;
+                case "U":
+                    return UPDATE_TYPE;
+                case "D":
+                    return DELETE_TYPE;
             }
 
             throw new ProcessException("Evaluated RecordPath " + recordPath.getPath() + " against Record to determine Statement Type but found invalid value: " + resultValue);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordTest.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/PutDatabaseRecordTest.java
@@ -1311,9 +1311,10 @@ public class PutDatabaseRecordTest {
         // CREATE, CREATE, CREATE, DELETE, UPDATE
         parser.addRecord("INSERT", new MapRecord(dataSchema, createValues(1, "John Doe", 55)));
         parser.addRecord("INSERT", new MapRecord(dataSchema, createValues(2, "Jane Doe", 44)));
-        parser.addRecord("INSERT", new MapRecord(dataSchema, createValues(3, "Jim Doe", 2)));
+        parser.addRecord("c", new MapRecord(dataSchema, createValues(3, "Jim Doe", 2)));
         parser.addRecord("DELETE", new MapRecord(dataSchema, createValues(2, "Jane Doe", 44)));
         parser.addRecord("UPDATE", new MapRecord(dataSchema, createValues(1, "John Doe", 201)));
+        parser.addRecord("u", new MapRecord(dataSchema, createValues(3, "Jim Doe", 20)));
 
         runner.setProperty(PutDatabaseRecord.RECORD_READER_FACTORY, "parser");
         runner.setProperty(PutDatabaseRecord.STATEMENT_TYPE, PutDatabaseRecord.USE_RECORD_PATH);
@@ -1337,7 +1338,7 @@ public class PutDatabaseRecordTest {
         assertTrue(rs.next());
         assertEquals(3, rs.getInt(1));
         assertEquals("Jim Doe", rs.getString(2));
-        assertEquals(2, rs.getInt(3));
+        assertEquals(20, rs.getInt(3));
         assertFalse(rs.next());
 
         stmt.close();


### PR DESCRIPTION
# Summary

[NIFI-12796](https://issues.apache.org/jira/browse/NIFI-12796) - PutDatabaseRecord statement type should support u/c/d for Debezium

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
