### PR TITLE
NIFI-12811 Upgrade Spring Framework from 6.0.16 to 6.0.17

### DIFF
--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -35,7 +35,7 @@
         <module>nifi-registry-docker-maven</module>
     </modules>
     <properties>
-        <spring.version>6.1.3</spring.version>
+        <spring.version>6.1.4</spring.version>
         <spring.boot.version>3.2.2</spring.boot.version>
         <flyway.version>9.22.3</flyway.version>
         <flyway.tests.version>9.5.0</flyway.tests.version>

--- a/pom.xml
+++ b/pom.xml
@@ -152,8 +152,8 @@
         <snakeyaml.version>2.2</snakeyaml.version>
         <netty.4.version>4.1.106.Final</netty.4.version>
         <servlet-api.version>6.0.0</servlet-api.version>
-        <spring.version>6.0.16</spring.version>
-        <spring.security.version>6.2.0</spring.security.version>
+        <spring.version>6.0.17</spring.version>
+        <spring.security.version>6.2.2</spring.security.version>
         <swagger.annotations.version>2.2.20</swagger.annotations.version>
         <h2.version>2.2.224</h2.version>
         <zookeeper.version>3.9.1</zookeeper.version>


### PR DESCRIPTION
# Summary

[NIFI-12811](https://issues.apache.org/jira/browse/NIFI-12811) Upgrades Spring Framework dependencies from 6.0.16 to [6.0.17](https://github.com/spring-projects/spring-framework/releases/tag/v6.0.17) and Spring Security dependencies from 6.2.0 to [6.2.2](https://github.com/spring-projects/spring-security/releases/tag/6.2.2).

Additional changes include upgrading Registry's version of Spring Framework from 6.1.3 to [6.1.4](https://github.com/spring-projects/spring-framework/releases/tag/v6.1.4).

Testing Spring Framework 6.1.4 with NiFi continues to exhibit problems with AOP parameter resolution in Auditor classes, which is the reason for the version differences between NiFi and Registry for now.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
