### PR TITLE
NIFI-12813 Correct Username handling in HTTP Request Log

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/log/RequestAuthenticationFilter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/log/RequestAuthenticationFilter.java
@@ -17,7 +17,7 @@
 package org.apache.nifi.web.server.log;
 
 import org.apache.nifi.web.security.log.AuthenticationUserAttribute;
-import org.eclipse.jetty.security.AuthenticationState;
+import org.eclipse.jetty.server.Request.AuthenticationState;
 import org.eclipse.jetty.security.authentication.LoginAuthenticator;
 import org.eclipse.jetty.security.internal.DefaultUserIdentity;
 import org.eclipse.jetty.security.UserIdentity;
@@ -65,7 +65,7 @@ public class RequestAuthenticationFilter extends OncePerRequestFilter {
             final String username = usernameAttribute.toString();
             final Principal principal = new UserPrincipal(username);
             final UserIdentity userIdentity = new DefaultUserIdentity(DEFAULT_SUBJECT, principal, DEFAULT_ROLES);
-            final AuthenticationState.Succeeded authenticationState = new LoginAuthenticator.UserAuthenticationSucceeded(METHOD, userIdentity);
+            final AuthenticationState authenticationState = new LoginAuthenticator.UserAuthenticationSucceeded(METHOD, userIdentity);
             httpServletRequest.setAttribute(AuthenticationState.class.getName(), authenticationState);
         }
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/log/RequestAuthenticationFilterTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/log/RequestAuthenticationFilterTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.server.log;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.nifi.web.security.log.AuthenticationUserAttribute;
+import org.eclipse.jetty.server.Request;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RequestAuthenticationFilterTest {
+
+    private static final String USERNAME = UserPrincipal.class.getSimpleName();
+
+    private static final String AUTHENTICATION_STATE = Request.AuthenticationState.class.getName();
+
+    @Mock
+    HttpServletRequest request;
+
+    @Mock
+    HttpServletResponse response;
+
+    @Mock
+    FilterChain filterChain;
+
+    @Captor
+    ArgumentCaptor<Request.AuthenticationState> authenticationStateCaptor;
+
+    private RequestAuthenticationFilter filter;
+
+    @BeforeEach
+    void setFilter() {
+        filter = new RequestAuthenticationFilter();
+    }
+
+    @Test
+    void testDoFilterInternalUsernameNotFound() throws ServletException, IOException {
+        when(request.getAttribute(eq(AuthenticationUserAttribute.USERNAME.getName()))).thenReturn(null);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(request).getRemoteAddr();
+        verifyNoMoreInteractions(request);
+    }
+
+    @Test
+    void testDoFilterInternalUsernameFound() throws ServletException, IOException {
+        when(request.getAttribute(eq(AuthenticationUserAttribute.USERNAME.getName()))).thenReturn(USERNAME);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(request).setAttribute(eq(AUTHENTICATION_STATE), authenticationStateCaptor.capture());
+
+        final Request.AuthenticationState authenticationState = authenticationStateCaptor.getValue();
+        assertNotNull(authenticationState);
+        final Principal principal = authenticationState.getUserPrincipal();
+        assertNotNull(principal);
+        assertEquals(USERNAME, principal.getName());
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-12813](https://issues.apache.org/jira/browse/NIFI-12813) Corrects username handling in the application HTTP request log written to `nifi-request.log` in the default Logback configuration.

Upgrading to Jetty 12 in NiFi 2.0.0-M2 required changing the filter responsible for setting the authenticated user required for the Jetty `CustomRequestLog`. The initial change referenced the wrong `AuthenticationState` interface, resulting in a failure to retrieve the authenticated user attribute during the logging. This issue does not impact any authentication or authorization behavior and is limited to username logging, which can also be tracked using other loggers in `nifi-user.log`.

Correcting the `AuthenticationState` interface reference resolves the problem, and can be validated by authenticating to NiFi and confirming the presence of the username in the `nifi-request.log`. Additional changes include a new unit test to verify the presence of the expected request attribute name and value.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
