### PR TITLE
NIFI-12820 Upgrade Email Processors to Jakarta Mail 2

### DIFF
--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>nifi-email-processors</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <spring.integration.version>5.5.20</spring.integration.version>
+        <spring.integration.version>6.2.1</spring.integration.version>
         <poi.version>5.2.5</poi.version>
     </properties>
 
@@ -37,103 +37,95 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-security-cert</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-oauth2-provider-api</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-            <version>1.4.7</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-email</artifactId>
-            <version>1.6.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.mail</groupId>
-                    <artifactId>javax.mail</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>1.6.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.subethamail</groupId>
-            <artifactId>subethasmtp</artifactId>
-            <version>3.1.7</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>jsr305</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.mail</groupId>
-                    <artifactId>mail</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.github.stephenc.findbugs</groupId>
-            <artifactId>findbugs-annotations</artifactId>
-            <version>1.3.9-1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-ssl-context-service-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-oauth2-provider-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
+            <version>2.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>angus-mail</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.davidmoten</groupId>
+            <artifactId>subethasmtp</artifactId>
+            <version>7.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-mail</artifactId>
             <version>${spring.integration.version}</version>
             <exclusions>
+                <!-- Exclude Spring libraries not required for IMAP and POP3 -->
                 <exclusion>
                     <groupId>org.springframework.retry</groupId>
                     <artifactId>spring-retry</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-aop</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-tx</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context-support</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.projectreactor</groupId>
+                    <artifactId>reactor-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-observation</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
+        <!-- poi-scratchpad required for TNEF parsing -->
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-scratchpad</artifactId>
             <version>${poi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-math3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-collections4</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.zaxxer</groupId>
+                    <artifactId>SparseBitSet</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-security-utils</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
-            <version>1.6.15</version>
+            <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeIMAP.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeIMAP.java
@@ -55,16 +55,12 @@ public class ConsumeIMAP extends AbstractEmailProcessor<ImapMailReceiver> {
     static final List<PropertyDescriptor> DESCRIPTORS;
 
     static {
-        List<PropertyDescriptor> _descriptors = new ArrayList<>();
-        _descriptors.addAll(SHARED_DESCRIPTORS);
-        _descriptors.add(SHOULD_MARK_READ);
-        _descriptors.add(USE_SSL);
-        DESCRIPTORS = Collections.unmodifiableList(_descriptors);
+        List<PropertyDescriptor> descriptors = new ArrayList<>(SHARED_DESCRIPTORS);
+        descriptors.add(SHOULD_MARK_READ);
+        descriptors.add(USE_SSL);
+        DESCRIPTORS = Collections.unmodifiableList(descriptors);
     }
 
-    /**
-     *
-     */
     @Override
     protected ImapMailReceiver buildMessageReceiver(ProcessContext processContext) {
         ImapMailReceiver receiver = new ImapMailReceiver(this.buildUrl(processContext));
@@ -74,17 +70,11 @@ public class ConsumeIMAP extends AbstractEmailProcessor<ImapMailReceiver> {
         return receiver;
     }
 
-    /**
-     *
-     */
     @Override
     protected String getProtocol(ProcessContext processContext) {
         return processContext.getProperty(USE_SSL).asBoolean() ? "imaps" : "imap";
     }
 
-    /**
-     *
-     */
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return DESCRIPTORS;

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumePOP3.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumePOP3.java
@@ -16,8 +16,6 @@
  */
 package org.apache.nifi.processors.email;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.nifi.annotation.behavior.InputRequirement;
@@ -34,25 +32,11 @@ import org.springframework.integration.mail.Pop3MailReceiver;
 @Tags({ "Email", "POP3", "Get", "Ingest", "Ingress", "Message", "Consume" })
 public class ConsumePOP3 extends AbstractEmailProcessor<Pop3MailReceiver> {
 
-    static final List<PropertyDescriptor> DESCRIPTORS;
-
-    static {
-        List<PropertyDescriptor> _descriptors = new ArrayList<>();
-        _descriptors.addAll(SHARED_DESCRIPTORS);
-        DESCRIPTORS = Collections.unmodifiableList(_descriptors);
-    }
-
-    /**
-     *
-     */
     @Override
     protected String getProtocol(ProcessContext processContext) {
         return "pop3";
     }
 
-    /**
-     *
-     */
     @Override
     protected Pop3MailReceiver buildMessageReceiver(ProcessContext context) {
         final Pop3MailReceiver receiver = new Pop3MailReceiver(this.buildUrl(context));
@@ -60,11 +44,8 @@ public class ConsumePOP3 extends AbstractEmailProcessor<Pop3MailReceiver> {
         return receiver;
     }
 
-    /**
-     *
-     */
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return SHARED_DESCRIPTORS;
     }
 }

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractTNEFAttachments.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractTNEFAttachments.java
@@ -17,18 +17,12 @@
 package org.apache.nifi.processors.email;
 
 import java.io.BufferedInputStream;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.behavior.SideEffectFree;
@@ -37,7 +31,6 @@ import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
-import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.logging.ComponentLog;
@@ -46,11 +39,8 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.FlowFileHandlingException;
-import org.apache.nifi.processor.io.InputStreamCallback;
-import org.apache.nifi.processor.io.OutputStreamCallback;
 import org.apache.poi.hmef.Attachment;
 import org.apache.poi.hmef.HMEFMessage;
-
 
 @SupportsBatching
 @SideEffectFree
@@ -61,7 +51,6 @@ import org.apache.poi.hmef.HMEFMessage;
         @WritesAttribute(attribute = "filename ", description = "The filename of the attachment"),
         @WritesAttribute(attribute = "email.tnef.attachment.parent.filename ", description = "The filename of the parent FlowFile"),
         @WritesAttribute(attribute = "email.tnef.attachment.parent.uuid", description = "The UUID of the original FlowFile.")})
-
 public class ExtractTNEFAttachments extends AbstractProcessor {
     public static final String ATTACHMENT_ORIGINAL_FILENAME = "email.tnef.attachment.parent.filename";
     public static final String ATTACHMENT_ORIGINAL_UUID = "email.tnef.attachment.parent.uuid";
@@ -79,20 +68,7 @@ public class ExtractTNEFAttachments extends AbstractProcessor {
             .description("Each individual flowfile that could not be parsed will be routed to the failure relationship")
             .build();
 
-    private final static Set<Relationship> RELATIONSHIPS;
-    private final static List<PropertyDescriptor> DESCRIPTORS;
-
-
-    static {
-        final Set<Relationship> _relationships = new HashSet<>();
-        _relationships.add(REL_ATTACHMENTS);
-        _relationships.add(REL_ORIGINAL);
-        _relationships.add(REL_FAILURE);
-        RELATIONSHIPS = Collections.unmodifiableSet(_relationships);
-
-        final List<PropertyDescriptor> _descriptors = new ArrayList<>();
-        DESCRIPTORS = Collections.unmodifiableList(_descriptors);
-    }
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(REL_ATTACHMENTS, REL_ORIGINAL, REL_FAILURE);
 
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) {
@@ -105,66 +81,50 @@ public class ExtractTNEFAttachments extends AbstractProcessor {
         final List<FlowFile> invalidFlowFilesList = new ArrayList<>();
         final List<FlowFile> originalFlowFilesList = new ArrayList<>();
 
-        session.read(originalFlowFile, new InputStreamCallback() {
-            @Override
-            public void process(final InputStream rawIn) throws IOException {
-                try (final InputStream in = new BufferedInputStream(rawIn)) {
-                    Properties props = new Properties();
+        session.read(originalFlowFile, rawIn -> {
+            try (final InputStream in = new BufferedInputStream(rawIn)) {
+                // This will trigger an exception in case content is not a TNEF.
+                final HMEFMessage hmefMessage = new HMEFMessage(in);
 
-                    HMEFMessage hmefMessage = null;
+                // Add original FlowFile (may revert later on in case of errors) //
+                originalFlowFilesList.add(originalFlowFile);
 
-                    // This will trigger an exception in case content is not a TNEF.
-                    hmefMessage = new HMEFMessage(in);
-
-                    // Add otiginal flowfile (may revert later on in case of errors) //
-                    originalFlowFilesList.add(originalFlowFile);
-
-                    if (hmefMessage != null) {
-                        // Attachments isn empty, proceeding.
-                        if (!hmefMessage.getAttachments().isEmpty()) {
-                            final String originalFlowFileName = originalFlowFile.getAttribute(CoreAttributes.FILENAME.key());
-                            try {
-                                for (final Attachment attachment : hmefMessage.getAttachments()) {
-                                    FlowFile split = session.create(originalFlowFile);
-                                    final Map<String, String> attributes = new HashMap<>();
-                                    if (StringUtils.isNotBlank(attachment.getLongFilename())) {
-                                        attributes.put(CoreAttributes.FILENAME.key(), attachment.getFilename());
-                                    }
-
-                                    String parentUuid = originalFlowFile.getAttribute(CoreAttributes.UUID.key());
-                                    attributes.put(ATTACHMENT_ORIGINAL_UUID, parentUuid);
-                                    attributes.put(ATTACHMENT_ORIGINAL_FILENAME, originalFlowFileName);
-
-                                    // TODO: Extract Mime Type (HMEF doesn't seem to be able to get this info.
-
-                                    split = session.append(split, new OutputStreamCallback() {
-                                        @Override
-                                        public void process(OutputStream out) throws IOException {
-                                            out.write(attachment.getContents());
-                                        }
-                                    });
-                                    split = session.putAllAttributes(split, attributes);
-                                    attachmentsList.add(split);
-                                }
-                            } catch (FlowFileHandlingException e) {
-                                // Something went wrong
-                                // Removing splits that may have been created
-                                session.remove(attachmentsList);
-                                // Removing the original flow from its list
-                                originalFlowFilesList.remove(originalFlowFile);
-                                logger.error("Flowfile {} triggered error {} while processing message removing generated FlowFiles from sessions", new Object[]{originalFlowFile, e});
-                                invalidFlowFilesList.add(originalFlowFile);
+                if (!hmefMessage.getAttachments().isEmpty()) {
+                    final String originalFlowFileName = originalFlowFile.getAttribute(CoreAttributes.FILENAME.key());
+                    try {
+                        for (final Attachment attachment : hmefMessage.getAttachments()) {
+                            FlowFile split = session.create(originalFlowFile);
+                            final Map<String, String> attributes = new HashMap<>();
+                            final String attachmentFilename = attachment.getFilename();
+                            if (attachmentFilename != null && !attachmentFilename.isBlank()) {
+                                attributes.put(CoreAttributes.FILENAME.key(), attachmentFilename);
                             }
+
+                            String parentUuid = originalFlowFile.getAttribute(CoreAttributes.UUID.key());
+                            attributes.put(ATTACHMENT_ORIGINAL_UUID, parentUuid);
+                            attributes.put(ATTACHMENT_ORIGINAL_FILENAME, originalFlowFileName);
+
+                            split = session.append(split, out -> out.write(attachment.getContents()));
+                            split = session.putAllAttributes(split, attributes);
+                            attachmentsList.add(split);
                         }
+                    } catch (FlowFileHandlingException e) {
+                        // Something went wrong
+                        // Removing splits that may have been created
+                        session.remove(attachmentsList);
+                        // Removing the original flow from its list
+                        originalFlowFilesList.remove(originalFlowFile);
+                        logger.error("Flowfile {} triggered error {} while processing message removing generated FlowFiles from sessions", originalFlowFile, e);
+                        invalidFlowFilesList.add(originalFlowFile);
                     }
-                } catch (Exception e) {
-                    // Another error hit...
-                    // Removing the original flow from its list
-                    originalFlowFilesList.remove(originalFlowFile);
-                    logger.error("Could not parse the flowfile {} as an email, treating as failure", new Object[]{originalFlowFile, e});
-                    // Message is invalid or triggered an error during parsing
-                    invalidFlowFilesList.add(originalFlowFile);
                 }
+            } catch (Exception e) {
+                // Another error hit...
+                // Removing the original flow from its list
+                originalFlowFilesList.remove(originalFlowFile);
+                logger.error("Could not parse {} as an email, treating as failure", originalFlowFile, e);
+                // Message is invalid or triggered an error during parsing
+                invalidFlowFilesList.add(originalFlowFile);
             }
         });
 
@@ -176,13 +136,13 @@ public class ExtractTNEFAttachments extends AbstractProcessor {
         session.transfer(originalFlowFilesList, REL_ORIGINAL);
 
         // check if attachments have been extracted
-        if (attachmentsList.size() != 0) {
+        if (!attachmentsList.isEmpty()) {
             if (attachmentsList.size() > 10) {
                 // If more than 10, summarise log
-                logger.info("Split {} into {} files", new Object[]{originalFlowFile, attachmentsList.size()});
+                logger.info("Split {} into {} files", originalFlowFile, attachmentsList.size());
             } else {
                 // Otherwise be more verbose and list each individual split
-                logger.info("Split {} into {} files: {}", new Object[]{originalFlowFile, attachmentsList.size(), attachmentsList});
+                logger.info("Split {} into {} files: {}", originalFlowFile, attachmentsList.size(), attachmentsList);
             }
         }
      }
@@ -191,12 +151,5 @@ public class ExtractTNEFAttachments extends AbstractProcessor {
     public Set<Relationship> getRelationships() {
         return RELATIONSHIPS;
     }
-
-    @Override
-    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
-    }
-
-
 }
 

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestConsumeEmail.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestConsumeEmail.java
@@ -28,27 +28,24 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.integration.mail.AbstractMailReceiver;
 
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-import java.lang.reflect.Field;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import java.util.List;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
-public class ITestConsumeEmail {
+public class TestConsumeEmail {
 
     private GreenMail mockIMAP4Server;
     private GreenMail mockPOP3Server;
     private GreenMailUser imapUser;
     private GreenMailUser popUser;
 
-    // Setup mock imap server
     @BeforeEach
     public void setUp() {
         mockIMAP4Server = new GreenMail(ServerSetupTest.IMAP);
@@ -77,7 +74,6 @@ public class ITestConsumeEmail {
         user.deliver(message);
     }
 
-    // Start the testing units
     @Test
     public void testConsumeIMAP4() throws Exception {
 
@@ -157,24 +153,4 @@ public class ITestConsumeEmail {
 
         assertEquals("pop3", consume.getProtocol(runner.getProcessContext()));
     }
-
-    @Test
-    public void validateUrl() throws Exception {
-        Field displayUrlField = AbstractEmailProcessor.class.getDeclaredField("displayUrl");
-        displayUrlField.setAccessible(true);
-
-        AbstractEmailProcessor<? extends AbstractMailReceiver> consume = new ConsumeIMAP();
-        TestRunner runner = TestRunners.newTestRunner(consume);
-        runner.setProperty(ConsumeIMAP.HOST, "foo.bar.com");
-        runner.setProperty(ConsumeIMAP.PORT, "1234");
-        runner.setProperty(ConsumeIMAP.USER, "jon");
-        runner.setProperty(ConsumeIMAP.PASSWORD, "qhgwjgehr");
-        runner.setProperty(ConsumeIMAP.FOLDER, "MYBOX");
-        runner.setProperty(ConsumeIMAP.USE_SSL, "false");
-
-        assertEquals("imap://jon:qhgwjgehr@foo.bar.com:1234/MYBOX", consume.buildUrl(runner.getProcessContext()));
-        assertEquals("imap://jon:[password]@foo.bar.com:1234/MYBOX", displayUrlField.get(consume));
-    }
-
-
 }

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestExtractEmailAttachments.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestExtractEmailAttachments.java
@@ -25,13 +25,10 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
 public class TestExtractEmailAttachments {
-    // Setups the fields to be used...
     String from = "Alice <alice@nifi.apache.org>";
     String to = "bob@nifi.apache.org";
     String subject = "Just a test email";
@@ -40,13 +37,11 @@ public class TestExtractEmailAttachments {
 
     GenerateAttachment attachmentGenerator = new GenerateAttachment(from, to, subject, message, hostName);
 
-
     @Test
-    public void testValidEmailWithAttachments() throws Exception {
+    public void testValidEmailWithAttachments() {
         final TestRunner runner = TestRunners.newTestRunner(new ExtractEmailAttachments());
 
-        // Create the message dynamically
-        byte [] withAttachment = attachmentGenerator.WithAttachments(1);
+        byte [] withAttachment = attachmentGenerator.withAttachments(1);
 
         runner.enqueue(withAttachment);
         runner.run();
@@ -56,17 +51,15 @@ public class TestExtractEmailAttachments {
         runner.assertTransferCount(ExtractEmailAttachments.REL_ATTACHMENTS, 1);
         // Have a look at the attachments...
         final List<MockFlowFile> splits = runner.getFlowFilesForRelationship(ExtractEmailAttachments.REL_ATTACHMENTS);
-        splits.get(0).assertAttributeEquals("filename", "pom.xml1");
+        splits.get(0).assertAttributeEquals("filename", "pom.xml-0");
     }
 
     @Test
-    public void testValidEmailWithMultipleAttachments() throws Exception {
-        Random rnd = new Random() ;
+    public void testValidEmailWithMultipleAttachments() {
         final TestRunner runner = TestRunners.newTestRunner(new ExtractEmailAttachments());
 
-        // Create the message dynamically
-        int amount = rnd.nextInt(10) + 1;
-        byte [] withAttachment = attachmentGenerator.WithAttachments(amount);
+        int amount = 3;
+        byte [] withAttachment = attachmentGenerator.withAttachments(amount);
 
         runner.enqueue(withAttachment);
         runner.run();
@@ -74,23 +67,22 @@ public class TestExtractEmailAttachments {
         runner.assertTransferCount(ExtractEmailAttachments.REL_ORIGINAL, 1);
         runner.assertTransferCount(ExtractEmailAttachments.REL_FAILURE, 0);
         runner.assertTransferCount(ExtractEmailAttachments.REL_ATTACHMENTS, amount);
-        // Have a look at the attachments...
+
         final List<MockFlowFile> splits = runner.getFlowFilesForRelationship(ExtractEmailAttachments.REL_ATTACHMENTS);
 
         List<String> filenames = new ArrayList<>();
         for (int a = 0 ; a < amount ; a++ ) {
-            filenames.add(splits.get(a).getAttribute("filename").toString());
+            filenames.add(splits.get(a).getAttribute("filename"));
         }
 
-        assertTrue(filenames.containsAll(Arrays.asList("pom.xml1", "pom.xml" + amount)));
+        assertTrue(filenames.containsAll(Arrays.asList("pom.xml-0", "pom.xml-1", "pom.xml-2")));
     }
 
     @Test
-    public void testValidEmailWithoutAttachments() throws Exception {
+    public void testValidEmailWithoutAttachments() {
         final TestRunner runner = TestRunners.newTestRunner(new ExtractEmailAttachments());
 
-        // Create the message dynamically
-        byte [] simpleEmail = attachmentGenerator.SimpleEmail();
+        byte [] simpleEmail = attachmentGenerator.simpleMessage();
 
         runner.enqueue(simpleEmail);
         runner.run();
@@ -98,11 +90,10 @@ public class TestExtractEmailAttachments {
         runner.assertTransferCount(ExtractEmailAttachments.REL_ORIGINAL, 1);
         runner.assertTransferCount(ExtractEmailAttachments.REL_FAILURE, 0);
         runner.assertTransferCount(ExtractEmailAttachments.REL_ATTACHMENTS, 0);
-
     }
 
     @Test
-    public void testInvalidEmail() throws Exception {
+    public void testInvalidEmail() {
         final TestRunner runner = TestRunners.newTestRunner(new ExtractEmailAttachments());
         runner.enqueue("test test test chocolate".getBytes());
         runner.run();

--- a/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestListenSMTP.java
+++ b/nifi-nar-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestListenSMTP.java
@@ -30,12 +30,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import javax.net.ssl.SSLContext;
 import java.net.Socket;
 import java.security.GeneralSecurityException;

--- a/pom.xml
+++ b/pom.xml
@@ -1192,7 +1192,6 @@
                                 !AzureGraphUserGroupProviderIT,
                                 !GremlinClientServiceYamlSettingsAndBytecodeIT,
                                 !GremlinClientServiceControllerSettingsIT,
-                                !ITestConsumeEmail#validateUrl,
                                 !PrometheusReportingTaskIT#testNullLabel,
                                 !SnowflakeConnectionPoolIT,
                                 !SnowflakePipeIT,


### PR DESCRIPTION
# Summary

[NIFI-12820](https://issues.apache.org/jira/browse/NIFI-12820) Upgrades Email Processors in the `nifi-email-bundle` to Jakarta Mail 2 along with supporting dependencies.

Dependency upgrades include the following:

- Upgraded from Java Mail 1.4.7 to Jakarta Mail API 2.1.2
- Upgraded Spring Integration from 5.5.20 to 6.2.1
- Upgraded SubEtha SMTP from 3.1.7 to 7.0.1
- Upgraded Greenmail from 1.6.15 to 2.0.1

Additional changes include formatting updates to follow current coding conventions.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
