### PR TITLE
NIFI-12821 Set docker-maven-plugin version to 0.43.4

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -16,7 +16,6 @@
 name: docker-tests
 
 on:
-  # Run every day at 02:00
   schedule:
     - cron: "0 2 * * *"
   push:
@@ -59,7 +58,6 @@ env:
     -ntp
     -ff
 
-# build assemblies (including binaries) for use in Docker Image builds
   MAVEN_BUILD_ARGUMENTS: >-
     -am
     -D skipTests
@@ -82,7 +80,6 @@ env:
     -pl -nifi-toolkit/nifi-toolkit-encrypt-config
     -pl -minifi/minifi-assembly
 
-# build and test Docker Images
   MAVEN_DOCKER_ARGUMENTS: >-
     verify
     -P docker
@@ -100,7 +97,7 @@ permissions:
 
 jobs:
   build_and_test:
-    timeout-minutes: 120
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     name: Ubuntu Java 21
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -884,6 +884,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
+                    <version>0.43.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
# Summary

[NIFI-12821](https://issues.apache.org/jira/browse/NIFI-12821) Set the `docker-maven-plugin` version to 0.43.4 instead of automatically using the latest available version. Recent `docker-tests` workflow executions have failed with automatically resolving version `0.44.0`, so this change sets the plugin version to the one known to be working with current settings.

Additional changes include reducing the workflow timeout from 120 to 60 minutes, as most `docker-tests` workflows finish in less than 40 minutes.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
