### PR TITLE
NIFI-12760 Flow sensitive properties encryption support in toolkit

### DIFF
--- a/minifi/minifi-commons/minifi-commons-framework/src/main/java/org/apache/nifi/minifi/commons/service/StandardFlowPropertyEncryptor.java
+++ b/minifi/minifi-commons/minifi-commons-framework/src/main/java/org/apache/nifi/minifi/commons/service/StandardFlowPropertyEncryptor.java
@@ -93,7 +93,9 @@ public class StandardFlowPropertyEncryptor implements FlowPropertyEncryptor {
     }
 
     private Map<String, Set<String>> runtimeManifestSensitiveProperties() {
-        return ofNullable(runTimeManifest.getBundles()).orElse(List.of())
+        return ofNullable(runTimeManifest)
+            .map(RuntimeManifest::getBundles)
+            .orElse(List.of())
             .stream()
             .flatMap(bundle -> Stream.of(
                 ofNullable(bundle.getComponentManifest().getProcessors()).orElse(List.of()),

--- a/minifi/minifi-toolkit/minifi-toolkit-assembly/README.md
+++ b/minifi/minifi-toolkit/minifi-toolkit-assembly/README.md
@@ -64,7 +64,7 @@ It's not guaranteed in all circumstances that the migration will result in a cor
 # <a id="encrypt-sensitive-properties-in-bootstrapconf" href="#encrypt-sensitive-properties-in-bootstrapconf">Encrypting Sensitive Properties in bootstrap.conf</a>
 
 ## MiNiFi Encrypt-Config Tool
-The encrypt-config command line tool (invoked in minifi-toolkit as ./bin/encrypt-config.sh or bin\encrypt-config.bat) reads from a bootstrap.conf file with plaintext sensitive configuration values and encrypts each value using a random encryption key. It replaces the plain values with the protected value in the same file, or writes to a new bootstrap.conf file if specified.
+The encrypt-config command line tool (invoked in minifi-toolkit as ./bin/encrypt-config.sh or bin\encrypt-config.bat) reads from a bootstrap.conf file with plaintext sensitive configuration values and encrypts each value using a random encryption key. It replaces the plain values with the protected value in the same file, or writes to a new bootstrap.conf file if specified. Additionally it can be used to encrypt the unencrypted sensitive properties (if any) in the flow.json.raw. For using this functionality `nifi.minifi.sensitive.props.key` and `nifi.minifi.sensitive.props.algorithm` has to be provided in bootstrap.conf. 
 
 The supported encryption algorithm utilized is AES/GCM 256-bit.
 
@@ -78,9 +78,12 @@ To show help:
 The following are the available options:
 * -b, --bootstrapConf <bootstrapConfPath> Path to file containing Bootstrap Configuration [bootstrap.conf]
 * -B, --outputBootstrapConf <outputBootstrapConf> Path to output file for Bootstrap Configuration [bootstrap.conf] with root key configured
+* -x, --encryptRawFlowJsonOnly Process Raw Flow Configuration [flow.json.raw] sensitive property values without modifying other configuration files
+* -f, --rawFlowJson <flowConfigurationPath> Path to file containing Raw Flow Configuration [flow.json.raw] that will be updated unless the output argument is provided
+* -g, --outputRawFlowJson <outputFlowConfigurationPath> ath to output file for Raw Flow Configuration [flow.json.raw] with property protection applied
 * -h, --help          Show help message and exit.
 
-### Example
+### Example 1
 As an example of how the tool works with the following existing values in the bootstrap.conf file:
 ```
 nifi.sensitive.props.key=thisIsABadSensitiveKeyPassword
@@ -141,6 +144,18 @@ Sensitive configuration values are encrypted by the tool by default, however you
 
 If the bootstrap.conf file already has valid protected values, those property values are not modified by the tool.
 
+### Example 2
+An example to encrypt non encrypted sensitive properties in flow.json.raw
+```
+nifi.sensitive.props.key=sensitivePropsKey
+nifi.sensitive.props.algorithm=NIFI_PBKDF2_AES_GCM_256
+```
+Enter the following arguments when using the tool:
+```
+encrypt-config.sh -x -f flow.json.raw
+```
+As a result, the flow.json.raw file is overwritten with encrypted sensitive properties
+The algorithm uses the property descriptors in the flow.json.raw to determine if a property is sensitive or not. If that information is missing, no properties will be encrypted even if it is defined sensitive in the agent manifest.
 
 ## Getting Help
 If you have questions, you can reach out to our mailing list: dev@nifi.apache.org

--- a/minifi/minifi-toolkit/minifi-toolkit-encrypt-config/pom.xml
+++ b/minifi/minifi-toolkit/minifi-toolkit-encrypt-config/pom.xml
@@ -52,6 +52,18 @@
         <dependency>
             <groupId>org.apache.nifi.minifi</groupId>
             <artifactId>minifi-commons-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi.minifi</groupId>
+            <artifactId>minifi-commons-framework</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-framework-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/minifi/minifi-toolkit/minifi-toolkit-encrypt-config/src/main/java/org/apache/nifi/minifi/toolkit/config/command/MiNiFiEncryptConfig.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-encrypt-config/src/main/java/org/apache/nifi/minifi/toolkit/config/command/MiNiFiEncryptConfig.java
@@ -14,7 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.nifi.minifi.toolkit.config.command;
+
+import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.Files.write;
+import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.StringUtils.isAnyBlank;
+import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.NIFI_MINIFI_SENSITIVE_PROPS_ALGORITHM;
+import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.NIFI_MINIFI_SENSITIVE_PROPS_KEY;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -24,8 +32,13 @@ import java.nio.file.StandardCopyOption;
 import java.security.SecureRandom;
 import java.util.HashSet;
 import java.util.HexFormat;
-import java.util.Optional;
 import java.util.Set;
+import org.apache.nifi.controller.flow.VersionedDataflow;
+import org.apache.nifi.encrypt.PropertyEncryptorBuilder;
+import org.apache.nifi.minifi.commons.service.FlowPropertyEncryptor;
+import org.apache.nifi.minifi.commons.service.FlowSerDeService;
+import org.apache.nifi.minifi.commons.service.StandardFlowPropertyEncryptor;
+import org.apache.nifi.minifi.commons.service.StandardFlowSerDeService;
 import org.apache.nifi.minifi.properties.BootstrapProperties;
 import org.apache.nifi.minifi.properties.BootstrapPropertiesLoader;
 import org.apache.nifi.minifi.properties.ProtectedBootstrapProperties;
@@ -40,23 +53,23 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 /**
- * Shared Encrypt Configuration for NiFi and NiFi Registry
+ * Encrypt Configuration for MiNiFi
  */
 @Command(
-        name = "encrypt-config",
-        sortOptions = false,
-        mixinStandardHelpOptions = true,
-        usageHelpWidth = 160,
-        separator = " ",
-        version = {
-                "Java ${java.version} (${java.vendor} ${java.vm.name} ${java.vm.version})"
-        },
-        descriptionHeading = "Description: ",
-        description = {
-                "encrypt-config supports protection of sensitive values in Apache MiNiFi"
-        }
+    name = "encrypt-config",
+    sortOptions = false,
+    mixinStandardHelpOptions = true,
+    usageHelpWidth = 160,
+    separator = " ",
+    version = {
+        "Java ${java.version} (${java.vendor} ${java.vm.name} ${java.vm.version})"
+    },
+    descriptionHeading = "Description: ",
+    description = {
+        "encrypt-config supports protection of sensitive values in Apache MiNiFi"
+    }
 )
-public class MiNiFiEncryptConfig implements Runnable{
+public class MiNiFiEncryptConfig implements Runnable {
 
     static final String BOOTSTRAP_ROOT_KEY_PROPERTY = "minifi.bootstrap.sensitive.key";
 
@@ -64,30 +77,52 @@ public class MiNiFiEncryptConfig implements Runnable{
     private static final int KEY_LENGTH = 32;
 
     @Option(
-            names = {"-b", "--bootstrapConf"},
-            description = "Path to file containing Bootstrap Configuration [bootstrap.conf] for optional root key and property protection scheme settings"
+        names = {"-b", "--bootstrapConf"},
+        description = "Path to file containing Bootstrap Configuration [bootstrap.conf] for optional root key and property protection scheme settings"
     )
     Path bootstrapConfPath;
 
     @Option(
-            names = {"-B", "--outputBootstrapConf"},
-            description = "Path to output file for Bootstrap Configuration [bootstrap.conf] with root key configured"
+        names = {"-B", "--outputBootstrapConf"},
+        description = "Path to output file for Bootstrap Configuration [bootstrap.conf] with root key configured"
     )
     Path outputBootstrapConf;
+
+    @Option(
+        names = {"-x", "--encryptRawFlowJsonOnly"},
+        description = "Process Raw Flow Configuration [flow.json.raw] sensitive property values without modifying other configuration files"
+    )
+    boolean flowConfigurationRequested;
+
+    @Option(
+        names = {"-f", "--rawFlowJson"},
+        description = "Path to file containing Raw Flow Configuration [flow.json.raw] that will be updated unless the output argument is provided"
+    )
+    Path flowConfigurationPath;
+
+    @Option(
+        names = {"-g", "--outputRawFlowJson"},
+        description = "Path to output file for Raw Flow Configuration [flow.json.raw] with property protection applied"
+    )
+    Path outputFlowConfigurationPath;
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public void run() {
-        processBootstrapConf();
+        BootstrapProperties unprotectedProperties = BootstrapPropertiesLoader.load(bootstrapConfPath.toFile());
+        processBootstrapConf(unprotectedProperties);
+        processFlowConfiguration(unprotectedProperties);
     }
 
     /**
      * Process bootstrap.conf writing new Root Key to specified Root Key Property when bootstrap.conf is specified
-     *
      */
-    protected void processBootstrapConf() {
-        BootstrapProperties unprotectedProperties = BootstrapPropertiesLoader.load(bootstrapConfPath.toFile());
+    protected void processBootstrapConf(BootstrapProperties unprotectedProperties) {
+        if (flowConfigurationRequested) {
+            logger.info("Bootstrap Configuration [bootstrap.conf] not modified based on provided arguments");
+            return;
+        }
 
         logger.info("Started processing Bootstrap Configuration [{}]", bootstrapConfPath);
 
@@ -98,7 +133,7 @@ public class MiNiFiEncryptConfig implements Runnable{
         runFileTransformer(fileTransformer2, bootstrapConfPath, outputBootstrapConf);
 
         FileTransformer fileTransformer = new BootstrapConfigurationFileTransformer(BOOTSTRAP_ROOT_KEY_PROPERTY, newRootKey);
-        runFileTransformer(fileTransformer, Optional.ofNullable(outputBootstrapConf).orElse(bootstrapConfPath), outputBootstrapConf);
+        runFileTransformer(fileTransformer, ofNullable(outputBootstrapConf).orElse(bootstrapConfPath), outputBootstrapConf);
         logger.info("Completed processing Bootstrap Configuration [{}]", bootstrapConfPath);
     }
 
@@ -113,8 +148,8 @@ public class MiNiFiEncryptConfig implements Runnable{
      * Run File Transformer using working path based on output path
      *
      * @param fileTransformer File Transformer to be invoked
-     * @param inputPath Input path of file to be transformed
-     * @param outputPath Output path for transformed file that defaults to the input path when not specified
+     * @param inputPath       Input path of file to be transformed
+     * @param outputPath      Output path for transformed file that defaults to the input path when not specified
      */
     protected void runFileTransformer(FileTransformer fileTransformer, Path inputPath, Path outputPath) {
         Path configuredOutputPath = outputPath == null ? inputPath : outputPath;
@@ -142,5 +177,46 @@ public class MiNiFiEncryptConfig implements Runnable{
         Path fileName = resourcePath.getFileName();
         String workingFileName = String.format(WORKING_FILE_NAME_FORMAT, fileName, System.currentTimeMillis());
         return resourcePath.resolveSibling(workingFileName);
+    }
+
+    private void processFlowConfiguration(BootstrapProperties unprotectedProperties) {
+        if (flowConfigurationPath == null) {
+            logger.info("Flow Configuration not specified");
+            return;
+        }
+        String sensitivePropertiesKey = unprotectedProperties.getProperty(NIFI_MINIFI_SENSITIVE_PROPS_KEY.getKey());
+        String sensitivePropertiesAlgorithm = unprotectedProperties.getProperty(NIFI_MINIFI_SENSITIVE_PROPS_ALGORITHM.getKey());
+        if (isAnyBlank(sensitivePropertiesKey, sensitivePropertiesAlgorithm)) {
+            logger.info("Sensitive Properties Key or Sensitive Properties Algorithm is not provided");
+            return;
+        }
+
+        logger.info("Started processing Flow Configuration [{}]", flowConfigurationPath);
+
+        byte[] flowAsBytes;
+        try {
+            flowAsBytes = readAllBytes(flowConfigurationPath);
+        } catch (IOException e) {
+            logger.error("Unable to load Flow Configuration [{}]", flowConfigurationPath);
+            return;
+        }
+
+        FlowSerDeService flowSerDeService = StandardFlowSerDeService.defaultInstance();
+        FlowPropertyEncryptor flowPropertyEncryptor = new StandardFlowPropertyEncryptor(
+            new PropertyEncryptorBuilder(sensitivePropertiesKey).setAlgorithm(sensitivePropertiesAlgorithm).build(), null);
+
+        VersionedDataflow flow = flowSerDeService.deserialize(flowAsBytes);
+        VersionedDataflow encryptedFlow = flowPropertyEncryptor.encryptSensitiveProperties(flow);
+        byte[] encryptedFlowAsBytes = flowSerDeService.serialize(encryptedFlow);
+
+        Path targetPath = ofNullable(outputFlowConfigurationPath).orElse(flowConfigurationPath);
+        try {
+            write(targetPath, encryptedFlowAsBytes);
+        } catch (IOException e) {
+            logger.error("Unable to write Flow Configuration [{}]", targetPath);
+            return;
+        }
+
+        logger.info("Completed processing Flow Configuration [{}]", flowConfigurationPath);
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12760](https://issues.apache.org/jira/browse/NIFI-12760)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
