### PR TITLE
NIFI-12232 Corrected Group Component ID Handling for Clustered Flows

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/connectable/StandardConnection.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/connectable/StandardConnection.java
@@ -307,7 +307,7 @@ public final class StandardConnection implements Connection, ConnectionEventList
         }
 
         if (previousDestination.isRunning() && !(previousDestination instanceof Funnel || previousDestination instanceof LocalPort)) {
-            throw new IllegalStateException("Cannot change destination of Connection because the current destination is running");
+            throw new IllegalStateException(String.format("Cannot change destination of Connection because the current destination ([%s]) is running", previousDestination));
         }
 
         if (getFlowFileQueue().isUnacknowledgedFlowFile()) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -3485,10 +3485,12 @@ public final class StandardProcessGroup implements ProcessGroup {
 
             if (currentId == null) {
                 versionedComponentId.set(componentId);
+                LOG.info("Set Versioned Component ID of {} to {}", this, componentId);
             } else if (currentId.equals(componentId)) {
                 return;
             } else if (componentId == null) {
                 versionedComponentId.set(null);
+                LOG.info("Cleared Versioned Component ID for {}", this);
             } else {
                 throw new IllegalStateException(this + " is already under version control with a different Versioned Component ID");
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -2504,8 +2504,17 @@ public class FlowController implements ReportingTaskProvider, Authorizable, Node
     }
 
     public void onClusterDisconnect() {
-        leaderElectionManager.unregister(ClusterRoles.PRIMARY_NODE);
-        leaderElectionManager.unregister(ClusterRoles.CLUSTER_COORDINATOR);
+        try {
+            leaderElectionManager.unregister(ClusterRoles.PRIMARY_NODE);
+        } catch (final Exception e) {
+            LOG.warn("Failed to unregister this node as a Primary Node candidate", e);
+        }
+
+        try {
+            leaderElectionManager.unregister(ClusterRoles.CLUSTER_COORDINATOR);
+        } catch (final Exception e) {
+            LOG.warn("Failed to unregister this node as a Cluster Coordinator candidate", e);
+        }
     }
 
     public LeaderElectionManager getLeaderElectionManager() {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/leader/election/CuratorLeaderElectionManager.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/leader/election/CuratorLeaderElectionManager.java
@@ -182,7 +182,14 @@ public class CuratorLeaderElectionManager implements LeaderElectionManager {
 
         leaderRole.getElectionListener().disable();
 
-        leaderSelector.close();
+        try {
+            leaderSelector.close();
+        } catch (final Exception e) {
+            // LeaderSelector will throw an IllegalStateException if it is not in the STARTED state.
+            // However, it exposes no method to check its state, so we have to catch the exception and ignore it.
+            logger.debug("Failed to close Leader Selector when unregistering for Role '{}'", roleName, e);
+        }
+
         logger.info("This node is no longer registered to be elected as the Leader for Role '{}'", roleName);
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -902,8 +902,8 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
                     if (flowService != null && flowService.isRunning()) {
                         flowService.stop(false);
                     }
-                    logger.error("Unable to load flow due to: " + e, e);
-                    throw new Exception("Unable to load flow due to: " + e); // cannot wrap the exception as they are not defined in a classloader accessible to the caller
+                    logger.error("Failed to start Flow Service", e);
+                    throw new Exception("Failed to start Flow Service: " + e); // cannot wrap the exception as they are not defined in a classloader accessible to the caller
                 }
             }
 
@@ -1062,7 +1062,7 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
     private void startUpFailure(Throwable t) {
         System.err.println("Failed to start web server: " + t.getMessage());
         System.err.println("Shutting down...");
-        logger.warn("Failed to start web server... shutting down.", t);
+        logger.error("Failed to start web server... shutting down.", t);
         System.exit(1);
     }
 


### PR DESCRIPTION
Ensured that if a Process Group doesn't have a Versioned Component ID we use the ComponentIdLookup to create one based on its Instance ID in the same way that is done when serializing the flow; this ensures matching ID's when we synchronize flows across the cluster. Also included some code cleanup around failure handling on startup

This closes #8406

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
