### PR TITLE
NIFI-12828 Add mapping  for BIT SQL Type in DataTypeUtils

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -1917,8 +1917,9 @@ public class DataTypeUtils {
         switch (sqlType) {
             case Types.BIGINT:
                 return RecordFieldType.BIGINT.getDataType();
-            case Types.BOOLEAN:
             case Types.BIT:
+                return RecordFieldType.INT.getDataType();
+            case Types.BOOLEAN:
                 return RecordFieldType.BOOLEAN.getDataType();
             case Types.TINYINT:
                 return RecordFieldType.BYTE.getDataType();

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -1918,6 +1918,7 @@ public class DataTypeUtils {
             case Types.BIGINT:
                 return RecordFieldType.BIGINT.getDataType();
             case Types.BOOLEAN:
+            case Types.BIT:
                 return RecordFieldType.BOOLEAN.getDataType();
             case Types.TINYINT:
                 return RecordFieldType.BYTE.getDataType();

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
@@ -558,6 +558,7 @@ public class TestDataTypeUtils {
     @Test
     public void testGetDataTypeFromSQLTypeValue() {
         assertEquals(RecordFieldType.STRING.getDataType(), DataTypeUtils.getDataTypeFromSQLTypeValue(Types.CLOB));
+        assertEquals(RecordFieldType.BOOLEAN.getDataType(), DataTypeUtils.getDataTypeFromSQLTypeValue(Types.BIT));
         assertEquals(RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType()), DataTypeUtils.getDataTypeFromSQLTypeValue(Types.BLOB));
         assertEquals(RecordFieldType.STRING.getDataType(), DataTypeUtils.getDataTypeFromSQLTypeValue(Types.CHAR));
     }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
@@ -558,7 +558,7 @@ public class TestDataTypeUtils {
     @Test
     public void testGetDataTypeFromSQLTypeValue() {
         assertEquals(RecordFieldType.STRING.getDataType(), DataTypeUtils.getDataTypeFromSQLTypeValue(Types.CLOB));
-        assertEquals(RecordFieldType.BOOLEAN.getDataType(), DataTypeUtils.getDataTypeFromSQLTypeValue(Types.BIT));
+        assertEquals(RecordFieldType.INT.getDataType(), DataTypeUtils.getDataTypeFromSQLTypeValue(Types.BIT));
         assertEquals(RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType()), DataTypeUtils.getDataTypeFromSQLTypeValue(Types.BLOB));
         assertEquals(RecordFieldType.STRING.getDataType(), DataTypeUtils.getDataTypeFromSQLTypeValue(Types.CHAR));
     }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-db-schema-registry-bundle/nifi-db-schema-registry-service/src/main/java/org/apache/nifi/db/schemaregistry/DatabaseTableSchemaRegistry.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-db-schema-registry-bundle/nifi-db-schema-registry-service/src/main/java/org/apache/nifi/db/schemaregistry/DatabaseTableSchemaRegistry.java
@@ -157,7 +157,13 @@ public class DatabaseTableSchemaRegistry extends AbstractControllerService imple
         // COLUMN_DEF must be read first to work around Oracle bug, see NIFI-4279 for details
         final String defaultValue = columnResultSet.getString("COLUMN_DEF");
         final String columnName = columnResultSet.getString("COLUMN_NAME");
-        final int dataType = columnResultSet.getInt("DATA_TYPE");
+        String typeName = columnResultSet.getString("TYPE_NAME");
+        final int dataType;
+        if (typeName.equalsIgnoreCase("bool")) {
+            dataType = 16;
+        } else {
+            dataType = columnResultSet.getInt("DATA_TYPE");
+        }
         final String nullableValue = columnResultSet.getString("IS_NULLABLE");
         final boolean isNullable = "YES".equalsIgnoreCase(nullableValue) || nullableValue.isEmpty();
         return new RecordField(


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12828](https://issues.apache.org/jira/browse/NIFI-12828)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
