### PR TITLE
NIFI-12840 Expose REMOTE_POLL_BATCH_SIZE property for ListSFTP (backport for 1.x)

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
@@ -99,6 +99,7 @@ public class ListSFTP extends ListFileTransfer {
         properties.add(SFTPTransfer.FILE_FILTER_REGEX);
         properties.add(SFTPTransfer.PATH_FILTER_REGEX);
         properties.add(SFTPTransfer.IGNORE_DOTTED_FILES);
+        properties.add(SFTPTransfer.REMOTE_POLL_BATCH_SIZE);
         properties.add(SFTPTransfer.STRICT_HOST_KEY_CHECKING);
         properties.add(SFTPTransfer.HOST_KEY_FILE);
         properties.add(SFTPTransfer.CONNECTION_TIMEOUT);

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListSFTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListSFTP.java
@@ -177,6 +177,20 @@ public class TestListSFTP {
 
         runner.assertTransferCount(ListSFTP.REL_SUCCESS, 0);
     }
+    @Test
+    public void testRemotePollBatchSizeEnforced() {
+        runner.setProperty(AbstractListProcessor.LISTING_STRATEGY, AbstractListProcessor.NO_TRACKING);
+        runner.setProperty(SFTPTransfer.REMOTE_POLL_BATCH_SIZE, "1");
+
+        runner.run();
+        // Of 3 items only 1 returned due to batch size
+        runner.assertTransferCount(ListSFTP.REL_SUCCESS, 1);
+
+        runner.setProperty(SFTPTransfer.REMOTE_POLL_BATCH_SIZE, "2");
+
+        runner.run();
+        runner.assertTransferCount(ListSFTP.REL_SUCCESS, 3);
+    }
 
     @Test
     public void testVerificationSuccessful() {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

This is a backport of [NIFI-12772](https://issues.apache.org/jira/browse/NIFI-12772) / #8390 for NiFi 1.x.

[NIFI-12840](https://issues.apache.org/jira/browse/NIFI-12840)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the ~~`main`~~`support/nifi-1.x` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK ~~21~~ 8

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
