### PR TITLE
NIFI-12704 Support record root reference in function arguments

### DIFF
--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/paths/RecordPathCompiler.java
@@ -130,6 +130,10 @@ public class RecordPathCompiler {
                 return new RootPath();
             }
             case CHILD_REFERENCE: {
+                if (tree.getChildCount() == 0) {
+                    return new RootPath();
+                }
+
                 final Tree childTree = tree.getChild(0);
                 if (childTree == null) {
                     return new RootPath();

--- a/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
+++ b/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
@@ -2161,6 +2161,17 @@ public class TestRecordPath {
         assertEquals(48, fieldValues.get(0).getValue());
     }
 
+    @Test
+    public void testRecordRootReferenceInFunction() {
+        final Record record = createSimpleRecord();
+
+        final FieldValue singleArgumentFieldValue = evaluateSingleFieldValue("escapeJson(/)", record);
+        assertEquals("{\"id\":48,\"name\":\"John Doe\",\"missing\":null}", singleArgumentFieldValue.getValue());
+        final FieldValue multipleArgumentsFieldValue = evaluateSingleFieldValue("mapOf(\"copy\",/)", record);
+        assertInstanceOf(MapRecord.class, multipleArgumentsFieldValue.getValue());
+        assertEquals(record.toString(), ((MapRecord) multipleArgumentsFieldValue.getValue()).getValue("copy"));
+    }
+
     private List<RecordField> getDefaultFields() {
         final List<RecordField> fields = new ArrayList<>();
         fields.add(new RecordField("id", RecordFieldType.INT.getDataType()));
@@ -2198,4 +2209,11 @@ public class TestRecordPath {
         return new MapRecord(schema, values);
     }
 
+    private static FieldValue evaluateSingleFieldValue(RecordPath recordPath, Record record) {
+        return recordPath.evaluate(record).getSelectedFields().findFirst().get();
+    }
+
+    private static FieldValue evaluateSingleFieldValue(String path, Record record) {
+        return evaluateSingleFieldValue(RecordPath.compile(path), record);
+    }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Add support for references to the record root in functions.

[NIFI-12704](https://issues.apache.org/jira/browse/NIFI-12704)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
