### PR TITLE
NIFI-12785 Refactored the code to avoid double encoding.

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -203,7 +203,8 @@ public class InvokeHTTP extends AbstractProcessor {
 
     public static final PropertyDescriptor HTTP_URL = new PropertyDescriptor.Builder()
             .name("HTTP URL")
-            .description("HTTP remote URL including a scheme of http or https, as well as a hostname or IP address with optional port and path elements.")
+            .description("HTTP remote URL including a scheme of http or https, as well as a hostname or IP address with optional port and path elements." +
+                    " Any encoding of the URL must be done by the user.")
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .addValidator(StandardValidators.URL_VALIDATOR)
@@ -852,19 +853,18 @@ public class InvokeHTTP extends AbstractProcessor {
         FlowFile responseFlowFile = null;
         try {
             final String urlProperty = trimToEmpty(context.getProperty(HTTP_URL).evaluateAttributeExpressions(requestFlowFile).getValue());
-            final URL url = URLValidator.createURL(urlProperty);
 
-            Request httpRequest = configureRequest(context, session, requestFlowFile, url);
+            Request httpRequest = configureRequest(context, session, requestFlowFile, urlProperty);
             logRequest(logger, httpRequest);
 
             if (httpRequest.body() != null) {
-                session.getProvenanceReporter().send(requestFlowFile, url.toExternalForm(), true);
+                session.getProvenanceReporter().send(requestFlowFile, urlProperty, true);
             }
 
             final long startNanos = System.nanoTime();
 
             try (Response responseHttp = okHttpClient.newCall(httpRequest).execute()) {
-                logResponse(logger, url, responseHttp);
+                logResponse(logger, urlProperty, responseHttp);
 
                 // store the status code and message
                 int statusCode = responseHttp.code();
@@ -874,7 +874,7 @@ public class InvokeHTTP extends AbstractProcessor {
                 Map<String, String> statusAttributes = new HashMap<>();
                 statusAttributes.put(STATUS_CODE, String.valueOf(statusCode));
                 statusAttributes.put(STATUS_MESSAGE, statusMessage);
-                statusAttributes.put(REQUEST_URL, url.toExternalForm());
+                statusAttributes.put(REQUEST_URL, urlProperty);
                 statusAttributes.put(REQUEST_DURATION, Long.toString(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos)));
                 statusAttributes.put(RESPONSE_URL, responseHttp.request().url().toString());
                 statusAttributes.put(TRANSACTION_ID, txId.toString());
@@ -927,6 +927,7 @@ public class InvokeHTTP extends AbstractProcessor {
 
                         // update FlowFile's filename attribute with an extracted value from the remote URL
                         if (FlowFileNamingStrategy.URL_PATH.equals(getFlowFileNamingStrategy(context)) && HttpMethod.GET.name().equals(httpRequest.method())) {
+                            final URL url = URLValidator.createURL(urlProperty);
                             String fileName = getFileNameFromUrl(url);
                             if (fileName != null) {
                                 responseFlowFile = session.putAttribute(responseFlowFile, CoreAttributes.FILENAME.key(), fileName);
@@ -950,9 +951,9 @@ public class InvokeHTTP extends AbstractProcessor {
                             // emit provenance event
                             final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
                             if (requestFlowFile != null) {
-                                session.getProvenanceReporter().fetch(responseFlowFile, url.toExternalForm(), millis);
+                                session.getProvenanceReporter().fetch(responseFlowFile, urlProperty, millis);
                             } else {
-                                session.getProvenanceReporter().receive(responseFlowFile, url.toExternalForm(), millis);
+                                session.getProvenanceReporter().receive(responseFlowFile, urlProperty, millis);
                             }
                         }
                     }
@@ -1012,7 +1013,7 @@ public class InvokeHTTP extends AbstractProcessor {
         }
     }
 
-    private Request configureRequest(final ProcessContext context, final ProcessSession session, final FlowFile requestFlowFile, URL url) {
+    private Request configureRequest(final ProcessContext context, final ProcessSession session, final FlowFile requestFlowFile, String url) {
         final Request.Builder requestBuilder = new Request.Builder();
 
         requestBuilder.url(url);
@@ -1231,10 +1232,10 @@ public class InvokeHTTP extends AbstractProcessor {
         }
     }
 
-    private void logResponse(ComponentLog logger, URL url, Response response) {
+    private void logResponse(ComponentLog logger, String url, Response response) {
         if (logger.isDebugEnabled()) {
             logger.debug("\nResponse from remote service:\n\t{}\n{}",
-                    url.toExternalForm(), getLogString(response.headers().toMultimap()));
+                    url, getLogString(response.headers().toMultimap()));
         }
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12785](https://issues.apache.org/jira/browse/NIFI-12785)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
