### PR TITLE
NIFI-12853 Refactor FlowFilePrioritizer using updated Java APIs

### DIFF
--- a/nifi-framework-api/src/main/java/org/apache/nifi/flowfile/FlowFilePrioritizer.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/flowfile/FlowFilePrioritizer.java
@@ -19,11 +19,10 @@ package org.apache.nifi.flowfile;
 import java.util.Comparator;
 
 /**
- * Provides a mechanism to prioritize flow file objects based on their
- * attributes. The actual flow file content will not be available for comparison
- * so if features of that content are necessary for prioritization it should be
- * extracted to be used as an attribute of the flow file.
- *
+ * Provides a mechanism to prioritize flow file objects based on their attributes.
+ * The actual flow file content will not be available for comparison.
+ * If features of that content are necessary for prioritization,
+ * it should be extracted to be used as an attribute of the flow file.
  */
 public interface FlowFilePrioritizer extends Comparator<FlowFile> {
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/main/java/org/apache/nifi/prioritizer/FirstInFirstOutPrioritizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/main/java/org/apache/nifi/prioritizer/FirstInFirstOutPrioritizer.java
@@ -19,24 +19,18 @@ package org.apache.nifi.prioritizer;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.FlowFilePrioritizer;
 
-public class FirstInFirstOutPrioritizer implements FlowFilePrioritizer {
+import java.util.Comparator;
+
+    public class FirstInFirstOutPrioritizer implements FlowFilePrioritizer {
+
+    private static final Comparator<FlowFile> composedComparator = Comparator.nullsLast(
+            Comparator
+                    .comparingLong(FlowFile::getLastQueueDate)
+                    .thenComparingLong(FlowFile::getQueueDateIndex)
+    );
 
     @Override
     public int compare(final FlowFile o1, final FlowFile o2) {
-        if (o1 == null && o2 == null) {
-            return 0;
-        } else if (o2 == null) {
-            return -1;
-        } else if (o1 == null) {
-            return 1;
-        }
-
-        final int dateComparison = o1.getLastQueueDate().compareTo(o2.getLastQueueDate());
-        if (dateComparison != 0) {
-            return dateComparison;
-        }
-
-        return Long.compare(o1.getQueueDateIndex(), o2.getQueueDateIndex());
+        return composedComparator.compare(o1, o2);
     }
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/main/java/org/apache/nifi/prioritizer/NewestFlowFileFirstPrioritizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/main/java/org/apache/nifi/prioritizer/NewestFlowFileFirstPrioritizer.java
@@ -19,24 +19,19 @@ package org.apache.nifi.prioritizer;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.FlowFilePrioritizer;
 
+import java.util.Comparator;
+
 public class NewestFlowFileFirstPrioritizer implements FlowFilePrioritizer {
+
+    private static final Comparator<FlowFile> composedComparator = Comparator.nullsLast(
+            Comparator
+                    .comparingLong(FlowFile::getLineageStartDate)
+                    .thenComparingLong(FlowFile::getLineageStartIndex)
+                    .reversed()
+    );
 
     @Override
     public int compare(final FlowFile o1, final FlowFile o2) {
-        if (o1 == null && o2 == null) {
-            return 0;
-        } else if (o2 == null) {
-            return -1;
-        } else if (o1 == null) {
-            return 1;
-        }
-
-        final int lineageDateCompare = Long.compare(o2.getLineageStartDate(), o1.getLineageStartDate());
-        if (lineageDateCompare != 0) {
-            return lineageDateCompare;
-        }
-
-        return Long.compare(o2.getLineageStartIndex(), o1.getLineageStartIndex());
+        return composedComparator.compare(o1, o2);
     }
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/main/java/org/apache/nifi/prioritizer/OldestFlowFileFirstPrioritizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/main/java/org/apache/nifi/prioritizer/OldestFlowFileFirstPrioritizer.java
@@ -19,24 +19,18 @@ package org.apache.nifi.prioritizer;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.FlowFilePrioritizer;
 
+import java.util.Comparator;
+
 public class OldestFlowFileFirstPrioritizer implements FlowFilePrioritizer {
+
+    private static final Comparator<FlowFile> composedComparator = Comparator.nullsLast(
+            Comparator
+                    .comparingLong(FlowFile::getLineageStartDate)
+                    .thenComparingLong(FlowFile::getLineageStartIndex)
+    );
 
     @Override
     public int compare(final FlowFile o1, final FlowFile o2) {
-        if (o1 == null && o2 == null) {
-            return 0;
-        } else if (o2 == null) {
-            return -1;
-        } else if (o1 == null) {
-            return 1;
-        }
-
-        final int lineageDateCompare = Long.compare(o1.getLineageStartDate(), o2.getLineageStartDate());
-        if (lineageDateCompare != 0) {
-            return lineageDateCompare;
-        }
-
-        return Long.compare(o1.getLineageStartIndex(), o2.getLineageStartIndex());
+        return composedComparator.compare(o1, o2);
     }
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/test/java/org/apache/nifi/prioritizer/FirstInFirstOutPrioritizerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/test/java/org/apache/nifi/prioritizer/FirstInFirstOutPrioritizerTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.nifi.prioritizer;
 
-import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.FlowFilePrioritizer;
+import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.NoOpProcessor;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -26,16 +26,17 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("EqualsWithItself")
-public class NewestFirstPrioritizerTest {
+public class FirstInFirstOutPrioritizerTest {
 
     private final TestRunner testRunner = TestRunners.newTestRunner(NoOpProcessor.class);
-    private final FlowFilePrioritizer prioritizer = new NewestFlowFileFirstPrioritizer();
+    private final FlowFilePrioritizer prioritizer = new FirstInFirstOutPrioritizer();
 
     @Test
-    public void testPrioritizer() throws InterruptedException {
-        final FlowFile flowFile1 = testRunner.enqueue("flowFile1");
-        Thread.sleep(2); // guarantee the FlowFile entryDate for flowFile2 is different than flowFile1
-        final FlowFile flowFile2 = testRunner.enqueue("flowFile1");
+    public void testPrioritizer() {
+        MockFlowFile flowFile1 = testRunner.enqueue("created first but 'enqueued' later");
+        flowFile1.setLastEnqueuedDate(830822400000L);
+        MockFlowFile flowFile2 = testRunner.enqueue("created second but 'enqueued' earlier");
+        flowFile2.setLastEnqueuedDate(795916800000L);
 
         assertEquals(0, prioritizer.compare(null, null));
         assertEquals(-1, prioritizer.compare(flowFile1, null));

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/test/java/org/apache/nifi/prioritizer/OldestFirstPrioritizerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/test/java/org/apache/nifi/prioritizer/OldestFirstPrioritizerTest.java
@@ -16,37 +16,27 @@
  */
 package org.apache.nifi.prioritizer;
 
-import org.apache.nifi.processor.AbstractProcessor;
-import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.Processor;
-import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.util.MockFlowFile;
-import org.apache.nifi.util.MockProcessSession;
-import org.apache.nifi.util.SharedSessionState;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.FlowFilePrioritizer;
+import org.apache.nifi.util.NoOpProcessor;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SuppressWarnings("EqualsWithItself")
 public class OldestFirstPrioritizerTest {
 
+    private final TestRunner testRunner = TestRunners.newTestRunner(NoOpProcessor.class);
+    private final FlowFilePrioritizer prioritizer = new OldestFlowFileFirstPrioritizer();
+
     @Test
-    public void testPrioritizer() {
-        final Processor processor = new SimpleProcessor();
-        final AtomicLong idGenerator = new AtomicLong(0L);
-        final MockProcessSession session = new MockProcessSession(new SharedSessionState(processor, idGenerator), Mockito.mock(Processor.class));
+    public void testPrioritizer() throws InterruptedException {
+        final FlowFile flowFile1 = testRunner.enqueue("flowFile1");
+        Thread.sleep(2); // guarantee the FlowFile entryDate for flowFile2 is different than flowFile1
+        final FlowFile flowFile2 = testRunner.enqueue("flowFile2");
 
-        final MockFlowFile flowFile1 = session.create();
-        try {
-            Thread.sleep(2); // guarantee the FlowFile entryDate for flowFile2 is different than flowFile1
-        } catch (final InterruptedException e) {
-        }
-        final MockFlowFile flowFile2 = session.create();
-
-        final OldestFlowFileFirstPrioritizer prioritizer = new OldestFlowFileFirstPrioritizer();
         assertEquals(0, prioritizer.compare(null, null));
         assertEquals(-1, prioritizer.compare(flowFile1, null));
         assertEquals(1, prioritizer.compare(null, flowFile1));
@@ -55,13 +45,4 @@ public class OldestFirstPrioritizerTest {
         assertEquals(-1, prioritizer.compare(flowFile1, flowFile2));
         assertEquals(1, prioritizer.compare(flowFile2, flowFile1));
     }
-
-    public class SimpleProcessor extends AbstractProcessor {
-
-        @Override
-        public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
-        }
-
-    }
-
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/test/java/org/apache/nifi/prioritizer/PriorityAttributePrioritizerTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-standard-prioritizers/src/test/java/org/apache/nifi/prioritizer/PriorityAttributePrioritizerTest.java
@@ -16,102 +16,64 @@
  */
 package org.apache.nifi.prioritizer;
 
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.FlowFilePrioritizer;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
-import org.apache.nifi.processor.AbstractProcessor;
-import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.Processor;
-import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.util.MockFlowFile;
-import org.apache.nifi.util.MockProcessSession;
-import org.apache.nifi.util.SharedSessionState;
-import org.junit.jupiter.api.BeforeAll;
+import org.apache.nifi.util.NoOpProcessor;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SuppressWarnings("EqualsWithItself")
 public class PriorityAttributePrioritizerTest {
 
-    static Map<String, String> attrsPri1 = new HashMap<>();
-    static Map<String, String> attrsPri2 = new HashMap<>();
-    static Map<String, String> attrsPrin1 = new HashMap<>();
-    static Map<String, String> attrsPriA = new HashMap<>();
-    static Map<String, String> attrsPriB = new HashMap<>();
-    static Map<String, String> attrsPriLP = new HashMap<>();
-    static Map<String, String> attrsPriLN = new HashMap<>();
-
-    @BeforeAll
-    public static void init() {
-        attrsPri1.put(CoreAttributes.PRIORITY.key(), "1");
-        attrsPri2.put(CoreAttributes.PRIORITY.key(), "2");
-        attrsPrin1.put(CoreAttributes.PRIORITY.key(), "-1");
-        attrsPriA.put(CoreAttributes.PRIORITY.key(), "A");
-        attrsPriB.put(CoreAttributes.PRIORITY.key(), "B");
-        attrsPriLP.put(CoreAttributes.PRIORITY.key(), "5432123456789");
-        attrsPriLN.put(CoreAttributes.PRIORITY.key(), "-5432123456789");
-    }
+    private final TestRunner testRunner = TestRunners.newTestRunner(NoOpProcessor.class);
+    private final FlowFilePrioritizer prioritizer = new PriorityAttributePrioritizer();
 
     @Test
     public void testPrioritizer() {
-        final Processor processor = new SimpleProcessor();
-        final AtomicLong idGenerator = new AtomicLong(0L);
-        final MockProcessSession session = new MockProcessSession(new SharedSessionState(processor, idGenerator), Mockito.mock(Processor.class));
+        final FlowFile ffWithoutPriority = testRunner.enqueue("data");
+        final FlowFile ffWithPriority1 = enqueueWithPriority("1");
+        final FlowFile ffWithPriority2 = enqueueWithPriority("2");
+        final FlowFile ffWithPriorityNegative1 = enqueueWithPriority("-1");
+        final FlowFile ffWithPriorityA = enqueueWithPriority("A");
+        final FlowFile ffWithPriorityB = enqueueWithPriority("B");
+        final FlowFile ffWithLongPriority = enqueueWithPriority("5432123456789");
+        final FlowFile ffWithNegativeLongPriority = enqueueWithPriority("-5432123456789");
 
-        final MockFlowFile ffNoPriority = session.create();
-        final MockFlowFile ffPri1 = session.create();
-        ffPri1.putAttributes(attrsPri1);
-        final MockFlowFile ffPri2 = session.create();
-        ffPri2.putAttributes(attrsPri2);
-        final MockFlowFile ffPrin1 = session.create();
-        ffPrin1.putAttributes(attrsPrin1);
-        final MockFlowFile ffPriA = session.create();
-        ffPriA.putAttributes(attrsPriA);
-        final MockFlowFile ffPriB = session.create();
-        ffPriB.putAttributes(attrsPriB);
-        final MockFlowFile ffPriLP = session.create();
-        ffPriLP.putAttributes(attrsPriLP);
-        final MockFlowFile ffPriLN = session.create();
-        ffPriLN.putAttributes(attrsPriLN);
-
-        final PriorityAttributePrioritizer prioritizer = new PriorityAttributePrioritizer();
         assertEquals(0, prioritizer.compare(null, null));
-        assertEquals(-1, prioritizer.compare(ffNoPriority, null));
-        assertEquals(1, prioritizer.compare(null, ffNoPriority));
+        assertEquals(-1, prioritizer.compare(ffWithoutPriority, null));
+        assertEquals(1, prioritizer.compare(null, ffWithoutPriority));
 
-        assertEquals(0, prioritizer.compare(ffNoPriority, ffNoPriority));
-        assertEquals(-1, prioritizer.compare(ffPri1, ffNoPriority));
-        assertEquals(1, prioritizer.compare(ffNoPriority, ffPri1));
+        assertEquals(0, prioritizer.compare(ffWithoutPriority, ffWithoutPriority));
+        assertEquals(-1, prioritizer.compare(ffWithPriority1, ffWithoutPriority));
+        assertEquals(1, prioritizer.compare(ffWithoutPriority, ffWithPriority1));
 
-        assertEquals(0, prioritizer.compare(ffPri1, ffPri1));
-        assertEquals(-1, prioritizer.compare(ffPri1, ffPri2));
-        assertEquals(1, prioritizer.compare(ffPri2, ffPri1));
-        assertEquals(-1, prioritizer.compare(ffPrin1, ffPri1));
-        assertEquals(1, prioritizer.compare(ffPri1, ffPrin1));
+        assertEquals(0, prioritizer.compare(ffWithPriority1, ffWithPriority1));
+        assertEquals(-1, prioritizer.compare(ffWithPriority1, ffWithPriority2));
+        assertEquals(1, prioritizer.compare(ffWithPriority2, ffWithPriority1));
+        assertEquals(-1, prioritizer.compare(ffWithPriorityNegative1, ffWithPriority1));
+        assertEquals(1, prioritizer.compare(ffWithPriority1, ffWithPriorityNegative1));
 
-        assertEquals(-1, prioritizer.compare(ffPri1, ffPriA));
-        assertEquals(1, prioritizer.compare(ffPriA, ffPri1));
+        assertEquals(-1, prioritizer.compare(ffWithPriority1, ffWithPriorityA));
+        assertEquals(1, prioritizer.compare(ffWithPriorityA, ffWithPriority1));
 
-        assertEquals(0, prioritizer.compare(ffPriA, ffPriA));
-        assertEquals(-1, prioritizer.compare(ffPriA, ffPriB));
-        assertEquals(1, prioritizer.compare(ffPriB, ffPriA));
+        assertEquals(0, prioritizer.compare(ffWithPriorityA, ffWithPriorityA));
+        assertEquals(-1, prioritizer.compare(ffWithPriorityA, ffWithPriorityB));
+        assertEquals(1, prioritizer.compare(ffWithPriorityB, ffWithPriorityA));
 
-        assertEquals(1, prioritizer.compare(ffPriLP, ffPri1));
-        assertEquals(-1, prioritizer.compare(ffPri1, ffPriLP));
-        assertEquals(-1, prioritizer.compare(ffPriLN, ffPri1));
-        assertEquals(1, prioritizer.compare(ffPri1, ffPriLN));
+        assertEquals(1, prioritizer.compare(ffWithLongPriority, ffWithPriority1));
+        assertEquals(-1, prioritizer.compare(ffWithPriority1, ffWithLongPriority));
+        assertEquals(-1, prioritizer.compare(ffWithNegativeLongPriority, ffWithPriority1));
+        assertEquals(1, prioritizer.compare(ffWithPriority1, ffWithNegativeLongPriority));
     }
 
-    public class SimpleProcessor extends AbstractProcessor {
-
-        @Override
-        public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
-        }
-
+    private MockFlowFile enqueueWithPriority(String priority) {
+        return testRunner.enqueue("data", Map.of(CoreAttributes.PRIORITY.key(), priority));
     }
-
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12853](https://issues.apache.org/jira/browse/NIFI-12853)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
