### PR TITLE
NIFI-12720 BUG - Dark mode skeleton loader styles

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
@@ -196,6 +196,7 @@ $appFontPath: '~roboto-fontface/fonts';
     $canvas-primary-palette-50: mat.get-color-from-palette($canvas-primary-palette, 50);
     $canvas-primary-palette-200: mat.get-color-from-palette($canvas-primary-palette, 200);
     $canvas-primary-palette-400: mat.get-color-from-palette($canvas-primary-palette, 400);
+    $canvas-primary-palette-500: mat.get-color-from-palette($canvas-primary-palette, 500);
     $canvas-primary-palette-900: mat.get-color-from-palette($canvas-primary-palette, 900);
     $canvas-accent-palette-200: mat.get-color-from-palette($canvas-accent-palette, 200);
     $canvas-accent-palette-400: mat.get-color-from-palette($canvas-accent-palette, 400);
@@ -333,6 +334,9 @@ $appFontPath: '~roboto-fontface/fonts';
     .value,
     .refresh-timestamp {
         color: $warn-palette-A400;
+    }
+    .skeleton-loader{
+        background: $canvas-primary-palette-500 !important;
     }
 }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
@@ -196,7 +196,6 @@ $appFontPath: '~roboto-fontface/fonts';
     $canvas-primary-palette-50: mat.get-color-from-palette($canvas-primary-palette, 50);
     $canvas-primary-palette-200: mat.get-color-from-palette($canvas-primary-palette, 200);
     $canvas-primary-palette-400: mat.get-color-from-palette($canvas-primary-palette, 400);
-    $canvas-primary-palette-500: mat.get-color-from-palette($canvas-primary-palette, 500);
     $canvas-primary-palette-900: mat.get-color-from-palette($canvas-primary-palette, 900);
     $canvas-accent-palette-200: mat.get-color-from-palette($canvas-accent-palette, 200);
     $canvas-accent-palette-400: mat.get-color-from-palette($canvas-accent-palette, 400);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
@@ -335,8 +335,9 @@ $appFontPath: '~roboto-fontface/fonts';
     .refresh-timestamp {
         color: $warn-palette-A400;
     }
-    .skeleton-loader{
-        background: $canvas-primary-palette-500 !important;
+
+    ngx-skeleton-loader .skeleton-loader {
+        background: $canvas-primary-palette-400;
     }
 }
 


### PR DESCRIPTION
Set an explicit background color for the skeleton-loader element so there is sufficient contrast to show the animation in both light and dark themes.

## Previous 
![image](https://github.com/apache/nifi/assets/638529/9e5e3111-70c5-40e7-8ddc-419a99bdad6f)

## Updated 
![image](https://github.com/apache/nifi/assets/638529/db2cb694-5371-41ad-8c62-40ced32c402c)




# Summary

[NIFI-12720](https://issues.apache.org/jira/browse/NIFI-12720) BUG - Dark mode skeleton loader styles
