### PR TITLE
NIFI-12860 Null exception from ExtensionMetadata caused by NIFI-12113

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/registry/ExtensionMetadataResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/registry/ExtensionMetadataResult.java
@@ -34,7 +34,7 @@ public class ExtensionMetadataResult extends AbstractWritableResult<List<Extensi
 
     public ExtensionMetadataResult(final ResultType resultType, final List<ExtensionMetadata> extensionMetadata) {
         super(resultType);
-        this.extensionMetadata = Objects.requireNonNull(this.extensionMetadata);
+        this.extensionMetadata = Objects.requireNonNull(extensionMetadata);
     }
 
     @Override


### PR DESCRIPTION
# Summary
[NIFI-12860](https://issues.apache.org/jira/browse/NIFI-12860)
This issue is present in all branches from version 1.24 onwards