### PR TITLE
NIFI-12645 Fix to correctly invoke onStopped method of scripted code

### DIFF
--- a/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/InvokeScriptedProcessor.java
+++ b/nifi-nar-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/InvokeScriptedProcessor.java
@@ -606,7 +606,7 @@ public class InvokeScriptedProcessor extends AbstractSessionFactoryProcessor {
     @OnStopped
     public void stop(ProcessContext context) {
         // If the script needs to be reloaded at this point, it is because it was empty
-        if (!scriptNeedsReload.get()) {
+        if (scriptRunner != null) {
             invokeScriptedProcessorMethod("onStopped", context);
         }
         scriptingComponentHelper.stop();


### PR DESCRIPTION
NIFI-12645 Fix to correctly invoke onStopped method of scripted processor

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12645](https://issues.apache.org/jira/browse/NIFI-12645)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-12645) issue created

### Pull Request Tracking

- [ X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-12645`
- [ X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-12645`

### Pull Request Formatting

- [ X] Pull Request based on current revision of the `main` branch
- [ X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.
I tested the new code from the NIFI user interface by creating a flow which used InvokeScriptedProcessor. I the scripted processor, I made its onStopped method write a statement to the log. Then a started and stopped the processor andI saw that the log statement wasa succesfully written to the log file. 

### Build

- [ X] Build completed using `mvn clean install -P contrib-check`
  - [X ] JDK 21

### Licensing
No new files added and no new dependencies added.

### Documentation
No documentation changes needed
