### PR TITLE
NIFI-12865 BUG - Checkboxes are inconsistently styled with primary or accent

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/items/processor/edit-processor/relationship-settings/relationship-settings.component.html
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/items/processor/edit-processor/relationship-settings/relationship-settings.component.html
@@ -37,15 +37,16 @@
                                 name="autoTerminate-{{ i }}"
                                 (change)="handleChanged()"
                                 [disabled]="isDisabled"
-                                >terminate</mat-checkbox
-                            >
+                                >terminate
+                            </mat-checkbox>
                             <mat-checkbox
+                                color="primary"
                                 [(ngModel)]="relationship.retry"
                                 name="retry-{{ i }}"
                                 (change)="handleChanged()"
                                 [disabled]="isDisabled"
-                                >retry</mat-checkbox
-                            >
+                                >retry
+                            </mat-checkbox>
                         </div>
                         @if (hasDescription(relationship)) {
                             <div class="ml-2">{{ relationship.description }}</div>


### PR DESCRIPTION
Updated all the checkboxes to use color="primary" to keep them consistent.

As you can see in the below image, the checkboxes don't match. This PR changes all checkboxes to use the primary theme color.
## Before
![image](https://github.com/apache/nifi/assets/638529/115fa0c0-e7c0-4f5e-aed3-02d2dde6d9ca)

## After
![image](https://github.com/apache/nifi/assets/638529/10226653-6f6d-4001-849d-6d5b26920ac2)


# Summary

[NIFI-12865](https://issues.apache.org/jira/browse/NIFI-12865)
