### PR TITLE
NIFI-12854: Add S3 user metadata via flowfile attributes

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
@@ -819,6 +819,29 @@ public class ITPutS3Object extends AbstractS3IT {
     }
 
     @Test
+    public void testObjectUserMetadata() throws IOException {
+        TestRunner runner = initTestRunner();
+
+        runner.setProperty(PutS3Object.OBJECT_METADATA_PREFIX, "metadataS3");
+        runner.setProperty(PutS3Object.REMOVE_METADATA_PREFIX, "true");
+
+        final Map<String, String> attrs = new HashMap<>();
+        attrs.put("filename", "tag-test.txt");
+        attrs.put("metadataS3PII", "true");
+        runner.enqueue(getResourcePath(SAMPLE_FILE_RESOURCE_NAME), attrs);
+
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutS3Object.REL_SUCCESS, 1);
+
+        Map<String,String> result = getClient().getObjectMetadata(BUCKET_NAME, "tag-test.txt").getUserMetadata();
+        assertEquals(1, result.size());
+
+        Map.Entry<String, String> entry = result.entrySet().iterator().next();
+        assertEquals("PII", entry.getKey());
+        assertEquals("true", entry.getValue());
+    }
+
+    @Test
     public void testEncryptionServiceWithServerSideS3EncryptionStrategyUsingSingleUpload() throws IOException, InitializationException {
         byte[] smallData = Files.readAllBytes(getResourcePath(SAMPLE_FILE_RESOURCE_NAME));
         testEncryptionServiceWithServerSideS3EncryptionStrategy(smallData);

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestPutS3Object.java
@@ -199,6 +199,27 @@ public class TestPutS3Object {
     }
 
     @Test
+    public void testObjectUserMetadata() {
+        runner.setProperty(PutS3Object.OBJECT_METADATA_PREFIX, "metadataS3");
+        runner.setProperty(PutS3Object.REMOVE_METADATA_PREFIX, "false");
+        prepareTest();
+
+        runner.run(1);
+
+        ArgumentCaptor<PutObjectRequest> captureRequest = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(mockS3Client, Mockito.times(1)).putObject(captureRequest.capture());
+        PutObjectRequest request = captureRequest.getValue();
+
+        Map<String,String> userMetadata = request.getMetadata().getUserMetadata();
+
+        assertEquals(1, userMetadata.size());
+
+        Map.Entry<String, String> entry = userMetadata.entrySet().iterator().next();
+        assertEquals("metadataS3PII", entry.getKey());
+        assertEquals("true", entry.getValue());
+    }
+
+    @Test
     public void testStorageClasses() {
         for (StorageClass storageClass : StorageClass.values()) {
             runner.setProperty(PutS3Object.STORAGE_CLASS, storageClass.name());
@@ -253,6 +274,7 @@ public class TestPutS3Object {
         Map<String, String> ffAttributes = new HashMap<>();
         ffAttributes.put("filename", filename);
         ffAttributes.put("tagS3PII", "true");
+        ffAttributes.put("metadataS3PII", "true");
         runner.enqueue("Test Content", ffAttributes);
 
         initMocks();


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12854](https://issues.apache.org/jira/browse/NIFI-12854) The PutS3Object processor currently supports adding user metadata to objects via dynamic properties.  This PR adds support for using FlowFile attributes to generate S3 user metadata.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
- [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
