### PR TITLE
NIFI-12868 Upgrade Commons DBCP from 2.11.0 to 2.12.0

### DIFF
--- a/nifi-nar-bundles/pom.xml
+++ b/nifi-nar-bundles/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>nifi-nar-bundles</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <commons.dbcp2.version>2.11.0</commons.dbcp2.version>
+        <commons.dbcp2.version>2.12.0</commons.dbcp2.version>
     </properties>
     <modules>
         <module>nifi-framework-bundle</module>


### PR DESCRIPTION
# Summary

[NIFI-12868](https://issues.apache.org/jira/browse/NIFI-12868) Upgrades Apache Commons DBCP dependencies from 2.11.0 to [2.12.0](https://commons.apache.org/proper/commons-dbcp/changes-report.html#a2.12.0) incorporating several minor bug fixes and improvements.

This change is compatible with Java 8 and should be backported to the support branch.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
