### PR TITLE
NIFI-12503 Render form-data in swagger.json and RestAPI docs correctly

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
@@ -3825,6 +3825,13 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
     @ApiImplicitParams(
             value = {
                     @ApiImplicitParam(
+                            name = DISCONNECTED_NODE_ACKNOWLEDGED,
+                            value ="Acknowledges that this node is disconnected to allow for mutable requests to proceed.",
+                            required = false,
+                            defaultValue = "false",
+                            type = "boolean",
+                            paramType = "formData"),
+                    @ApiImplicitParam(
                             name = "template",
                             value = "The binary content of the template file being uploaded.",
                             required = true,
@@ -3848,10 +3855,6 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
                     required = true
             )
             @PathParam("id") final String groupId,
-            @ApiParam(
-                    value = "Acknowledges that this node is disconnected to allow for mutable requests to proceed.",
-                    required = false
-            )
             @FormDataParam(DISCONNECTED_NODE_ACKNOWLEDGED) @DefaultValue("false") final Boolean disconnectedNodeAcknowledged,
             @FormDataParam("template") final InputStream in) throws InterruptedException {
 
@@ -4225,6 +4228,47 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
                     @Authorization(value = "Write - /process-groups/{uuid}")
             }
     )
+    @ApiImplicitParams(
+            value = {
+                    @ApiImplicitParam(
+                            name = "groupName",
+                            value = "The process group name.",
+                            required = true,
+                            type = "string",
+                            paramType = "formData"),
+                    @ApiImplicitParam(
+                            name = "positionX",
+                            value = "The process group X position.",
+                            required = true,
+                            type = "number",
+                            paramType = "formData"),
+                    @ApiImplicitParam(
+                            name = "positionY",
+                            value = "The process group Y position.",
+                            required = true,
+                            type = "number",
+                            paramType = "formData"),
+                    @ApiImplicitParam(
+                            name = "clientId",
+                            value = "The client id.",
+                            required = true,
+                            type = "string",
+                            paramType = "formData"),
+                    @ApiImplicitParam(
+                            name = DISCONNECTED_NODE_ACKNOWLEDGED,
+                            value ="Acknowledges that this node is disconnected to allow for mutable requests to proceed.",
+                            required = false,
+                            defaultValue = "false",
+                            type = "boolean",
+                            paramType = "formData"),
+                    @ApiImplicitParam(
+                            name = "file",
+                            value = "The binary content of the versioned flow definition file being uploaded.",
+                            required = true,
+                            type = "file",
+                            paramType = "formData")
+            }
+    )
     @ApiResponses(
             value = {
                     @ApiResponse(code = 400, message = "NiFi was unable to complete the request because it was invalid. The request should not be retried without modification."),
@@ -4240,30 +4284,10 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
                     required = true
             )
             @PathParam("id") final String groupId,
-            @ApiParam(
-                    value = "The process group name.",
-                    required = true
-            )
             @FormDataParam("groupName") final String groupName,
-            @ApiParam(
-                    value = "The process group X position.",
-                    required = true
-            )
             @FormDataParam("positionX") final Double positionX,
-            @ApiParam(
-                    value = "The process group Y position.",
-                    required = true
-            )
             @FormDataParam("positionY") final Double positionY,
-            @ApiParam(
-                    value = "The client id.",
-                    required = true
-            )
             @FormDataParam("clientId") final String clientId,
-            @ApiParam(
-                    value = "Acknowledges that this node is disconnected to allow for mutable requests to proceed.",
-                    required = false
-            )
             @FormDataParam(DISCONNECTED_NODE_ACKNOWLEDGED) @DefaultValue("false") final Boolean disconnectedNodeAcknowledged,
             @FormDataParam("file") final InputStream in) throws InterruptedException {
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Applies the workaround described in [swagger-maven-plugin#352](https://github.com/kongchen/swagger-maven-plugin/issues/352#issuecomment-244225312) to include form-data parameters in the generated swagger.json and the rendered RestAPI documentation for the 1.x branch.

[NIFI-12503](https://issues.apache.org/jira/browse/NIFI-12503)

Due to changes to the OpenAPI spec generation incorporated into the 2.x branch, this workaround seems to no longer be needed there. At least the documentation looks correct already.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
