### PR TITLE
NIFI-12617 Change default nifi.web.https.host to localhost

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -3839,7 +3839,7 @@ For example, to provide two additional network interfaces, a user could also spe
 `nifi.web.http.network.interface.eth1=eth1` +
 +
 Providing three total network interfaces, including  `nifi.web.http.network.interface.default`.
-|`nifi.web.https.host`|The HTTPS host. The default value is `127.0.0.1`.
+|`nifi.web.https.host`|The HTTPS host. The default value is `localhost`.
 |`nifi.web.https.port`|The HTTPS port. The default value is `8443`.
 |`nifi.web.https.port.forwarding`|Same as `nifi.web.http.port.forwarding`, but with HTTPS for secure communication. It is blank by default.
 |`nifi.web.https.ciphersuites.include`|Cipher suites used to initialize the SSLContext of the Jetty HTTPS port.  If unspecified, the runtime SSLContext defaults are used.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -121,7 +121,7 @@
         <nifi.web.http.host />
         <nifi.web.http.port />
         <nifi.web.http.network.interface.default />
-        <nifi.web.https.host>127.0.0.1</nifi.web.https.host>
+        <nifi.web.https.host>localhost</nifi.web.https.host>
         <nifi.web.https.port>8443</nifi.web.https.port>
         <nifi.web.https.network.interface.default />
         <nifi.web.https.application.protocols>h2 http/1.1</nifi.web.https.application.protocols>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

The SNI checks in place when a secured NiFi is used prevent the access of NiFi using the IP address, this includes `127.0.0.1`.
Additionally, the auto-generated TLS certificate does not contain a subject alternative name with the IP address `127.0.0.1`.

However, the default (secure) configuration still declares `127.0.0.1` as `nifi.web.https.host` resulting in the following log output on fresh NiFi installations:

> 2024-03-08 15:23:46,890 INFO [main] org.apache.nifi.web.server.JettyServer Started Server on https://127.0.0.1:8443/nifi

However, accessing that link, users are "greeted" by an `Invalid SNI` error. This might lead to some confusion for new users of NiFi.

This PR changes the default value, see [NIFI-12617](https://issues.apache.org/jira/browse/NIFI-12617).

---

However, accessing NiFi using `127.0.0.1` is still possible and leads to the aforementioned SNI error. 

I thought about including the IP address in the auto-generated certificate and disabling SNI checks whenever "localhost" or "127.0.0.1" is set as host. However, I concluded that this might accidentally weaken security for only a very marginal gain in convenience.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
