### PR TITLE
NIFI-12871 Upgrade Commons Compress from 1.25.0 to 1.26.1

### DIFF
--- a/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelRecordReader.java
+++ b/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelRecordReader.java
@@ -25,6 +25,7 @@ import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JRuntimeException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -59,7 +60,8 @@ public class TestExcelRecordReader {
                 .build();
 
         MalformedRecordException mre = assertThrows(MalformedRecordException.class, () -> new ExcelRecordReader(configuration, getInputStream("notExcel.txt"), logger));
-        assertTrue(ExceptionUtils.getStackTrace(mre).contains("this is not a valid OOXML"));
+        final Throwable cause = mre.getCause();
+        assertInstanceOf(OpenXML4JRuntimeException.class, cause);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <okio.version>3.8.0</okio.version>
         <org.apache.commons.cli.version>1.6.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.16.1</org.apache.commons.codec.version>
-        <org.apache.commons.compress.version>1.25.0</org.apache.commons.compress.version>
+        <org.apache.commons.compress.version>1.26.1</org.apache.commons.compress.version>
         <org.apache.commons.lang3.version>3.14.0</org.apache.commons.lang3.version>
         <org.apache.commons.net.version>3.10.0</org.apache.commons.net.version>
         <org.apache.commons.io.version>2.15.1</org.apache.commons.io.version>


### PR DESCRIPTION
# Summary

[NIFI-12871](https://issues.apache.org/jira/browse/NIFI-12871) Upgrades Apache Commons Compress dependencies from 1.25.0 to [1.26.1](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310904&version=12354340). 

This upgrade resolves CVE-2024-26308 related to memory exhaustion for Pack200 files, which are not used directly in NiFi components. Commons Compress 1.26.1 also resolves a transitive dependency issue in version 1.26.0 related to the `TarArchiveOutputStream`.

This version is compatible with Java 8 and should be backported to the support branch.

Additional changes include updating the Excel Reader test to avoid message-based matching on failures, which surfaced when upgraded Commons Compress versions.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
