### PR TITLE
NIFI-12887 Additional ways for handling Strings as binary in PutDatabaseRecord

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -246,21 +246,21 @@ public class PutDatabaseRecord extends AbstractProcessor {
     );
 
     static final AllowableValue BINARY_STRING_FORMAT_HEX_STRING = new AllowableValue(
-            "Hex String",
-            "Hex String",
+            "Hexadecimal",
+            "Hexadecimal",
             "String values for binary columns contain the original value in hexadecimal format"
     );
 
     static final AllowableValue BINARY_STRING_FORMAT_BASE64 = new AllowableValue(
-            "Base64-encoded String",
-            "Base64-encoded String",
+            "Base64",
+            "Base64",
             "String values for binary columns contain the original value in Base64 encoded format"
     );
 
     static final PropertyDescriptor BINARY_STRING_FORMAT = new Builder()
             .name("put-db-record-binary-format")
             .displayName("Binary String Format")
-            .description("How to interpret string data for binary columns.")
+            .description("The format to be applied when decoding string values to binary.")
             .required(false)
             .expressionLanguageSupported(FLOWFILE_ATTRIBUTES)
             .allowableValues(BINARY_STRING_FORMAT_UTF8, BINARY_STRING_FORMAT_HEX_STRING, BINARY_STRING_FORMAT_BASE64)

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -18,7 +18,6 @@ package org.apache.nifi.processors.standard;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.google.common.io.BaseEncoding;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -803,7 +803,7 @@ public class PutDatabaseRecord extends AbstractProcessor {
                                             if (BINARY_STRING_FORMAT_BASE64.getValue().equals(binaryStringFormat)) {
                                                 currentValue = Base64.getDecoder().decode(stringValue);
                                             } else if (BINARY_STRING_FORMAT_HEX_STRING.getValue().equals(binaryStringFormat)) {
-                                                currentValue = HexFormat.of().parseHex(stringValue.toUpperCase());
+                                                currentValue = HexFormat.of().parseHex(stringValue);
                                             } else {
                                                 currentValue = stringValue.getBytes(StandardCharsets.UTF_8);
                                             }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -262,7 +262,7 @@ public class PutDatabaseRecord extends AbstractProcessor {
             .name("put-db-record-binary-format")
             .displayName("Binary String Format")
             .description("The format to be applied when decoding string values to binary.")
-            .required(false)
+            .required(true)
             .expressionLanguageSupported(FLOWFILE_ATTRIBUTES)
             .allowableValues(BINARY_STRING_FORMAT_UTF8, BINARY_STRING_FORMAT_HEX_STRING, BINARY_STRING_FORMAT_BASE64)
             .defaultValue(BINARY_STRING_FORMAT_UTF8.getValue())

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -78,10 +78,12 @@ import java.sql.SQLTransientException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -799,9 +801,9 @@ public class PutDatabaseRecord extends AbstractProcessor {
                                             final String stringValue = (String) currentValue;
 
                                             if (BINARY_STRING_FORMAT_BASE64.getValue().equals(binaryStringFormat)) {
-                                                currentValue = BaseEncoding.base64().decode(stringValue);
+                                                currentValue = Base64.getDecoder().decode(stringValue);
                                             } else if (BINARY_STRING_FORMAT_HEX_STRING.getValue().equals(binaryStringFormat)) {
-                                                currentValue = BaseEncoding.base16().decode(stringValue.toUpperCase());
+                                                currentValue = HexFormat.of().parseHex(stringValue.toUpperCase());
                                             } else {
                                                 currentValue = stringValue.getBytes(StandardCharsets.UTF_8);
                                             }


### PR DESCRIPTION
Add option to treat Strings as hexadecimal character sequences or base64-encoded binary data when inserting into a binary type column.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12887](https://issues.apache.org/jira/browse/NIFI-12887)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
