### PR TITLE
NIFI-12889: Retry Kerberos login on auth failure in HDFS processors

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
@@ -65,6 +65,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -719,7 +720,7 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
                 .findFirst();
     }
 
-    protected boolean handleAuthErrors(Throwable t, ProcessSession session, ProcessContext context) {
+    protected boolean handleAuthErrors(Throwable t, ProcessSession session, ProcessContext context, BiConsumer<ProcessSession, ProcessContext> sessionHandler) {
         Optional<GSSException> causeOptional = findCause(t, GSSException.class, gsse -> GSSException.NO_CRED == gsse.getMajor());
         if (causeOptional.isPresent()) {
 
@@ -729,8 +730,7 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
             } catch (IOException ioe) {
                 getLogger().error("An error occurred resetting HDFS resources, you may need to restart the processor.");
             }
-            session.rollback(false);
-            context.yield();
+            sessionHandler.accept(session, context);
             return true;
         }
         return false;

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
@@ -202,8 +202,12 @@ public class DeleteHDFS extends AbstractHadoopProcessor {
                     session.remove(flowFile);
                 }
             } catch (IOException e) {
-                getLogger().error("Error processing delete for flowfile {} due to {}", flowFile, e.getMessage(), e);
-                session.transfer(flowFile, getFailureRelationship());
+                if (handleAuthErrors(e, session, context)) {
+                    return null;
+                } else {
+                    getLogger().error("Error processing delete for flowfile {} due to {}", flowFile, e.getMessage(), e);
+                    session.transfer(flowFile, getFailureRelationship());
+                }
             }
 
             return null;

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
@@ -39,6 +39,7 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.hadoop.util.GSSExceptionRollbackYieldSessionHandler;
 
 import java.io.IOException;
 import java.security.PrivilegedAction;
@@ -177,7 +178,7 @@ public class DeleteHDFS extends AbstractHadoopProcessor {
                             flowFile = session.putAttribute(flowFile, HADOOP_FILE_URL_ATTRIBUTE, qualifiedPath.toString());
                             session.getProvenanceReporter().invokeRemoteProcess(flowFile, qualifiedPath.toString());
                         } catch (IOException ioe) {
-                            if (handleAuthErrors(ioe, session, context)) {
+                            if (handleAuthErrors(ioe, session, context, new GSSExceptionRollbackYieldSessionHandler())) {
                                 return null;
                             } else {
                                 // One possible scenario is that the IOException is permissions based, however it would be impractical to check every possible
@@ -202,7 +203,7 @@ public class DeleteHDFS extends AbstractHadoopProcessor {
                     session.remove(flowFile);
                 }
             } catch (IOException e) {
-                if (handleAuthErrors(e, session, context)) {
+                if (handleAuthErrors(e, session, context, new GSSExceptionRollbackYieldSessionHandler())) {
                     return null;
                 } else {
                     getLogger().error("Error processing delete for flowfile {} due to {}", flowFile, e.getMessage(), e);

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
@@ -39,6 +39,7 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.ietf.jgss.GSSException;
 
 import java.io.IOException;
 import java.security.PrivilegedAction;
@@ -47,6 +48,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -177,16 +179,29 @@ public class DeleteHDFS extends AbstractHadoopProcessor {
                             flowFile = session.putAttribute(flowFile, HADOOP_FILE_URL_ATTRIBUTE, qualifiedPath.toString());
                             session.getProvenanceReporter().invokeRemoteProcess(flowFile, qualifiedPath.toString());
                         } catch (IOException ioe) {
-                            // One possible scenario is that the IOException is permissions based, however it would be impractical to check every possible
-                            // external HDFS authorization tool (Ranger, Sentry, etc). Local ACLs could be checked but the operation would be expensive.
-                            getLogger().warn("Failed to delete file or directory", ioe);
+                            // Catch GSSExceptions and reset the resources
+                            Optional<GSSException> causeOptional = findCause(ioe, GSSException.class, gsse -> GSSException.NO_CRED == gsse.getMajor());
+                            if (causeOptional.isPresent()) {
+                                getLogger().error("Error authenticating when performing file operation, resetting HDFS resources", causeOptional);
+                                try {
+                                    hdfsResources.set(resetHDFSResources(getConfigLocations(context), context));
+                                } catch (IOException resetResourcesException) {
+                                    getLogger().error("An error occurred resetting HDFS resources, you may need to restart the processor.", resetResourcesException);
+                                }
+                                session.rollback();
+                                context.yield();
+                            } else {
+                                // One possible scenario is that the IOException is permissions based, however it would be impractical to check every possible
+                                // external HDFS authorization tool (Ranger, Sentry, etc). Local ACLs could be checked but the operation would be expensive.
+                                getLogger().warn("Failed to delete file or directory", ioe);
 
-                            Map<String, String> attributes = Maps.newHashMapWithExpectedSize(1);
-                            // The error message is helpful in understanding at a flowfile level what caused the IOException (which ACL is denying the operation, e.g.)
-                            attributes.put(getAttributePrefix() + ".error.message", ioe.getMessage());
+                                Map<String, String> attributes = Maps.newHashMapWithExpectedSize(1);
+                                // The error message is helpful in understanding at a flowfile level what caused the IOException (which ACL is denying the operation, e.g.)
+                                attributes.put(getAttributePrefix() + ".error.message", ioe.getMessage());
 
-                            session.transfer(session.putAllAttributes(session.clone(flowFile), attributes), getFailureRelationship());
-                            failedPath++;
+                                session.transfer(session.putAllAttributes(session.clone(flowFile), attributes), getFailureRelationship());
+                                failedPath++;
+                            }
                         }
                     }
                 }

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSSequenceFile.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSSequenceFile.java
@@ -30,7 +30,6 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processors.hadoop.util.GSSExceptionRollbackYieldSessionHandler;
 import org.apache.nifi.processors.hadoop.util.SequenceFileReader;
 import org.apache.nifi.util.StopWatch;
 
@@ -110,9 +109,9 @@ public class GetHDFSSequenceFile extends GetHDFS {
                     logger.warn("Unable to delete path " + file.toString() + " from HDFS.  Will likely be picked up over and over...");
                 }
             } catch (Throwable t) {
-                if (!handleAuthErrors(t, session, context, new GSSExceptionRollbackYieldSessionHandler())) {
-                    logger.error("Error retrieving file {} from HDFS due to {}", file, t);
-                }
+                logger.error("Error retrieving file {} from HDFS due to {}", file, t);
+                session.rollback();
+                context.yield();
             } finally {
                 stopWatch.stop();
                 long totalSize = 0;

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSSequenceFile.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSSequenceFile.java
@@ -30,6 +30,7 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processors.hadoop.util.GSSExceptionRollbackYieldSessionHandler;
 import org.apache.nifi.processors.hadoop.util.SequenceFileReader;
 import org.apache.nifi.util.StopWatch;
 
@@ -109,9 +110,14 @@ public class GetHDFSSequenceFile extends GetHDFS {
                     logger.warn("Unable to delete path " + file.toString() + " from HDFS.  Will likely be picked up over and over...");
                 }
             } catch (Throwable t) {
-                logger.error("Error retrieving file {} from HDFS due to {}", file, t);
-                session.rollback();
-                context.yield();
+                final String errorString = "Error retrieving file {} from HDFS due to {}";
+                if (!handleAuthErrors(t, session, context, new GSSExceptionRollbackYieldSessionHandler())) {
+                    logger.error(errorString, file, t);
+                    session.rollback();
+                    context.yield();
+                } else {
+                    logger.warn(errorString, file, t);
+                }
             } finally {
                 stopWatch.stop();
                 long totalSize = 0;

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
@@ -18,7 +18,6 @@ package org.apache.nifi.processors.hadoop;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.google.common.base.Throwables;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FileStatus;
@@ -54,7 +53,6 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.processor.io.InputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.apache.nifi.util.StopWatch;
@@ -63,7 +61,6 @@ import org.ietf.jgss.GSSException;
 import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.security.PrivilegedAction;
@@ -76,8 +73,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 /**
  * This processor copies FlowFiles to HDFS.
@@ -295,7 +290,7 @@ public class PutHDFS extends AbstractHadoopProcessor {
             return;
         }
 
-        ugi.doAs(new PrivilegedAction<Object>() {
+        ugi.doAs(new PrivilegedAction<>() {
             @Override
             public Object run() {
                 Path tempDotCopyFile = null;
@@ -352,18 +347,18 @@ public class PutHDFS extends AbstractHadoopProcessor {
                             case REPLACE_RESOLUTION:
                                 if (hdfs.delete(copyFile, false)) {
                                     getLogger().info("deleted {} in order to replace with the contents of {}",
-                                            new Object[]{copyFile, putFlowFile});
+                                            copyFile, putFlowFile);
                                 }
                                 break;
                             case IGNORE_RESOLUTION:
                                 session.transfer(putFlowFile, getSuccessRelationship());
                                 getLogger().info("transferring {} to success because file with same name already exists",
-                                        new Object[]{putFlowFile});
+                                        putFlowFile);
                                 return null;
                             case FAIL_RESOLUTION:
                                 session.transfer(session.penalize(putFlowFile), getFailureRelationship());
                                 getLogger().warn("penalizing {} and routing to failure because file with same name already exists",
-                                        new Object[]{putFlowFile});
+                                        putFlowFile);
                                 return null;
                             default:
                                 break;
@@ -372,63 +367,68 @@ public class PutHDFS extends AbstractHadoopProcessor {
 
                     // Write FlowFile to temp file on HDFS
                     final StopWatch stopWatch = new StopWatch(true);
-                    session.read(putFlowFile, new InputStreamCallback() {
+                    session.read(putFlowFile, in -> {
+                        OutputStream fos = null;
+                        Path createdFile = null;
+                        try {
+                            if (conflictResponse.equals(APPEND_RESOLUTION) && destinationExists) {
+                                fos = hdfs.append(copyFile, bufferSize);
+                            } else {
+                                final EnumSet<CreateFlag> cflags = EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE);
 
-                        @Override
-                        public void process(InputStream in) throws IOException {
-                            OutputStream fos = null;
-                            Path createdFile = null;
-                            try {
-                                if (conflictResponse.equals(APPEND_RESOLUTION) && destinationExists) {
-                                    fos = hdfs.append(copyFile, bufferSize);
-                                } else {
-                                    final EnumSet<CreateFlag> cflags = EnumSet.of(CreateFlag.CREATE, CreateFlag.OVERWRITE);
-
-                                    if (shouldIgnoreLocality(context, session)) {
-                                        cflags.add(CreateFlag.IGNORE_CLIENT_LOCALITY);
-                                    }
-
-                                    fos = hdfs.create(actualCopyFile, FsCreateModes.applyUMask(FsPermission.getFileDefault(),
-                                            FsPermission.getUMask(hdfs.getConf())), cflags, bufferSize, replication, blockSize,
-                                            null, null);
+                                if (shouldIgnoreLocality(context, session)) {
+                                    cflags.add(CreateFlag.IGNORE_CLIENT_LOCALITY);
                                 }
 
-                                if (codec != null) {
-                                    fos = codec.createOutputStream(fos);
-                                }
-                                createdFile = actualCopyFile;
-                                BufferedInputStream bis = new BufferedInputStream(in);
-                                StreamUtils.copy(bis, fos);
-                                bis = null;
-                                fos.flush();
-                            } finally {
-                                try {
-                                    if (fos != null) {
-                                        fos.close();
-                                    }
-                                } catch (Throwable t) {
-                                    // when talking to remote HDFS clusters, we don't notice problems until fos.close()
-                                    if (createdFile != null) {
-                                        try {
-                                            hdfs.delete(createdFile, false);
-                                        } catch (Throwable ignore) {
-                                        }
-                                    }
-                                    throw t;
-                                }
-                                fos = null;
+                                fos = hdfs.create(actualCopyFile, FsCreateModes.applyUMask(FsPermission.getFileDefault(),
+                                                FsPermission.getUMask(hdfs.getConf())), cflags, bufferSize, replication, blockSize,
+                                        null, null);
                             }
-                        }
 
+                            if (codec != null) {
+                                fos = codec.createOutputStream(fos);
+                            }
+                            createdFile = actualCopyFile;
+                            BufferedInputStream bis = new BufferedInputStream(in);
+                            StreamUtils.copy(bis, fos);
+                            bis = null;
+                            fos.flush();
+                        } catch (IOException e) {
+                            // Catch GSSExceptions and reset the resources
+                            Optional<GSSException> causeOptional = findCause(e, GSSException.class, gsse -> GSSException.NO_CRED == gsse.getMajor());
+                            if (causeOptional.isPresent()) {
+                                getLogger().error("Error authenticating when performing file operation, resetting HDFS resources", causeOptional);
+                                hdfsResources.set(resetHDFSResources(getConfigLocations(context), context));
+                                throw new ProcessException(causeOptional.get());
+                            } else {
+                                throw new ProcessException(e);
+                            }
+                        } finally {
+                            try {
+                                if (fos != null) {
+                                    fos.close();
+                                }
+                            } catch (Throwable t) {
+                                // when talking to remote HDFS clusters, we don't notice problems until fos.close()
+                                if (createdFile != null) {
+                                    try {
+                                        hdfs.delete(createdFile, false);
+                                    } catch (Throwable ignore) {
+                                    }
+                                }
+                                throw t;
+                            }
+                            fos = null;
+                        }
                     });
                     stopWatch.stop();
                     final String dataRate = stopWatch.calculateDataRate(putFlowFile.getSize());
                     final long millis = stopWatch.getDuration(TimeUnit.MILLISECONDS);
                     tempDotCopyFile = tempCopyFile;
 
-                    if  (
-                        writingStrategy.equals(WRITE_AND_RENAME)
-                        && (!conflictResponse.equals(APPEND_RESOLUTION) || (conflictResponse.equals(APPEND_RESOLUTION) && !destinationExists))
+                    if (
+                            writingStrategy.equals(WRITE_AND_RENAME)
+                                    && (!conflictResponse.equals(APPEND_RESOLUTION) || (conflictResponse.equals(APPEND_RESOLUTION) && !destinationExists))
                     ) {
                         boolean renamed = false;
 
@@ -449,7 +449,7 @@ public class PutHDFS extends AbstractHadoopProcessor {
                     }
 
                     getLogger().info("copied {} to HDFS at {} in {} milliseconds at a rate of {}",
-                            new Object[]{putFlowFile, copyFile, millis, dataRate});
+                            putFlowFile, copyFile, millis, dataRate);
 
                     final String newFilename = copyFile.getName();
                     final String hdfsPath = copyFile.getParent().toString();
@@ -465,10 +465,16 @@ public class PutHDFS extends AbstractHadoopProcessor {
                 } catch (final IOException e) {
                     Optional<GSSException> causeOptional = findCause(e, GSSException.class, gsse -> GSSException.NO_CRED == gsse.getMajor());
                     if (causeOptional.isPresent()) {
-                        getLogger().warn("An error occurred while connecting to HDFS. "
-                                        + "Rolling back session, and penalizing flow file {}",
-                                new Object[] {putFlowFile.getAttribute(CoreAttributes.UUID.key()), causeOptional.get()});
-                        session.rollback(true);
+                        getLogger().error("An error occurred while connecting to HDFS. "
+                                        + "Rolling back session, resetting HDFS resources, and penalizing flow file {}",
+                                putFlowFile.getAttribute(CoreAttributes.UUID.key()), causeOptional.get());
+                        try {
+                            hdfsResources.set(resetHDFSResources(getConfigLocations(context), context));
+                        } catch (IOException ioe) {
+                            getLogger().error("An error occurred resetting HDFS resources, you may need to restart the processor.");
+                        }
+                        session.rollback(false);
+                        context.yield();
                     } else {
                         getLogger().error("Failed to access HDFS due to {}", new Object[]{e});
                         session.transfer(putFlowFile, getFailureRelationship());
@@ -546,21 +552,6 @@ public class PutHDFS extends AbstractHadoopProcessor {
     protected String getGroup(final ProcessContext context, final FlowFile flowFile) {
         final String group = context.getProperty(REMOTE_GROUP).evaluateAttributeExpressions(flowFile).getValue();
         return group == null || group.isEmpty() ? null : group;
-    }
-
-    /**
-     * Returns an optional with the first throwable in the causal chain that is assignable to the provided cause type,
-     * and satisfies the provided cause predicate, {@link Optional#empty()} otherwise.
-     * @param t The throwable to inspect for the cause.
-     * @return Throwable Cause
-     */
-    private <T extends Throwable> Optional<T> findCause(Throwable t, Class<T> expectedCauseType, Predicate<T> causePredicate) {
-        Stream<Throwable> causalChain = Throwables.getCausalChain(t).stream();
-        return causalChain
-                .filter(expectedCauseType::isInstance)
-                .map(expectedCauseType::cast)
-                .filter(causePredicate)
-                .findFirst();
     }
 
     protected void changeOwner(final ProcessContext context, final FileSystem hdfs, final Path name, final FlowFile flowFile) {

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
@@ -54,6 +54,7 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.hadoop.util.GSSExceptionRollbackYieldSessionHandler;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.apache.nifi.util.StopWatch;
 
@@ -451,7 +452,7 @@ public class PutHDFS extends AbstractHadoopProcessor {
                     session.transfer(putFlowFile, getSuccessRelationship());
 
                 } catch (final Throwable t) {
-                    if (handleAuthErrors(t, session, context)) {
+                    if (handleAuthErrors(t, session, context, new GSSExceptionRollbackYieldSessionHandler())) {
                         return null;
                     }
                     if (tempDotCopyFile != null) {

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
@@ -391,8 +391,6 @@ public class PutHDFS extends AbstractHadoopProcessor {
                             StreamUtils.copy(bis, fos);
                             bis = null;
                             fos.flush();
-                        } catch (IOException e) {
-                            throw new ProcessException(e);
                         } finally {
                             try {
                                 if (fos != null) {

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/util/GSSExceptionRollbackYieldSessionHandler.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/util/GSSExceptionRollbackYieldSessionHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.hadoop.util;
+
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+
+import java.util.function.BiConsumer;
+
+public class GSSExceptionRollbackYieldSessionHandler implements BiConsumer<ProcessSession, ProcessContext> {
+    @Override
+    public void accept(ProcessSession processSession, ProcessContext processContext) {
+        processSession.rollback();
+        processContext.yield();
+    }
+}

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
@@ -28,7 +28,6 @@ import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.hadoop.KerberosProperties;
 import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.hadoop.util.MockFileSystem;
@@ -56,7 +55,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -352,15 +350,6 @@ public class PutHDFSTest {
         // assert no flowfiles transferred to outgoing relationships
         runner.assertTransferCount(PutHDFS.REL_SUCCESS, 0);
         runner.assertTransferCount(PutHDFS.REL_FAILURE, 0);
-        // assert the processor's queue is not empty
-        assertFalse(runner.isQueueEmpty());
-        assertEquals(1, runner.getQueueSize().getObjectCount());
-        // assert the input file is back on the queue
-        ProcessSession session = runner.getProcessSessionFactory().createSession();
-        FlowFile queuedFlowFile = session.get();
-        assertNotNull(queuedFlowFile);
-        assertEquals("randombytes-1", queuedFlowFile.getAttribute(CoreAttributes.FILENAME.key()));
-        session.rollback();
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
@@ -17,16 +17,12 @@
 package org.apache.nifi.processors.hadoop;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.AclEntry;
-import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.util.Progressable;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
@@ -35,6 +31,7 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processors.hadoop.util.MockFileSystem;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.util.MockFlowFile;
@@ -47,13 +44,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.security.sasl.SaslException;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -75,7 +68,7 @@ public class PutHDFSTest {
     private final static String FILE_NAME = "randombytes-1";
 
     private KerberosProperties kerberosProperties;
-    private FileSystem mockFileSystem;
+    private MockFileSystem mockFileSystem;
 
     @BeforeEach
     public void setup() {
@@ -359,10 +352,6 @@ public class PutHDFSTest {
         // assert no flowfiles transferred to outgoing relationships
         runner.assertTransferCount(PutHDFS.REL_SUCCESS, 0);
         runner.assertTransferCount(PutHDFS.REL_FAILURE, 0);
-        // assert the input flowfile was penalized
-        List<MockFlowFile> penalizedFlowFiles = runner.getPenalizedFlowFiles();
-        assertEquals(1, penalizedFlowFiles.size());
-        assertEquals("randombytes-1", penalizedFlowFiles.iterator().next().getAttribute(CoreAttributes.FILENAME.key()));
         // assert the processor's queue is not empty
         assertFalse(runner.isQueueEmpty());
         assertEquals(1, runner.getQueueSize().getObjectCount());
@@ -610,8 +599,37 @@ public class PutHDFSTest {
 
     @Test
     public void testPutFileWithCloseException() throws IOException {
-        mockFileSystem = new MockFileSystem(true);
+        mockFileSystem = new MockFileSystem();
+        mockFileSystem.setFailOnClose(true);
         String dirName = "target/testPutFileCloseException";
+        File file = new File(dirName);
+        file.mkdirs();
+        Path p = new Path(dirName).makeQualified(mockFileSystem.getUri(), mockFileSystem.getWorkingDirectory());
+
+        TestRunner runner = TestRunners.newTestRunner(new TestablePutHDFS(kerberosProperties, mockFileSystem));
+        runner.setProperty(PutHDFS.DIRECTORY, dirName);
+        runner.setProperty(PutHDFS.CONFLICT_RESOLUTION, "replace");
+
+        try (FileInputStream fis = new FileInputStream("src/test/resources/testdata/randombytes-1")) {
+            Map<String, String> attributes = new HashMap<>();
+            attributes.put(CoreAttributes.FILENAME.key(), "randombytes-1");
+            runner.enqueue(fis, attributes);
+            runner.run();
+        }
+
+        List<MockFlowFile> failedFlowFiles = runner
+                .getFlowFilesForRelationship(PutHDFS.REL_FAILURE);
+        assertFalse(failedFlowFiles.isEmpty());
+        assertTrue(failedFlowFiles.get(0).isPenalized());
+
+        mockFileSystem.delete(p, true);
+    }
+
+    @Test
+    public void testPutFileWithCreateException() throws IOException {
+        mockFileSystem = new MockFileSystem();
+        mockFileSystem.setFailOnCreate(true);
+        String dirName = "target/testPutFileCreateException";
         File file = new File(dirName);
         file.mkdirs();
         Path p = new Path(dirName).makeQualified(mockFileSystem.getUri(), mockFileSystem.getWorkingDirectory());
@@ -637,8 +655,8 @@ public class PutHDFSTest {
 
     private class TestablePutHDFS extends PutHDFS {
 
-        private KerberosProperties testKerberosProperties;
-        private FileSystem fileSystem;
+        private final KerberosProperties testKerberosProperties;
+        private final FileSystem fileSystem;
 
         TestablePutHDFS(KerberosProperties testKerberosProperties, FileSystem fileSystem) {
             this.testKerberosProperties = testKerberosProperties;
@@ -660,135 +678,5 @@ public class PutHDFSTest {
         protected FileSystem getFileSystem() {
             return fileSystem;
         }
-    }
-
-    private static class MockFileSystem extends FileSystem {
-        private final Map<Path, FileStatus> pathToStatus = new HashMap<>();
-        private final Map<Path, List<AclEntry>> pathToAcl = new HashMap<>();
-        private final boolean failOnClose;
-
-        public MockFileSystem() {
-            failOnClose = false;
-        }
-
-        public MockFileSystem(boolean failOnClose) {
-            this.failOnClose = failOnClose;
-        }
-
-        public void setAcl(final Path path, final List<AclEntry> aclSpec) {
-            pathToAcl.put(path, aclSpec);
-        }
-
-        @Override
-        public AclStatus getAclStatus(final Path path) {
-            return new AclStatus.Builder().addEntries(pathToAcl.getOrDefault(path, new ArrayList<>())).build();
-        }
-
-        @Override
-        public URI getUri() {
-            return URI.create("file:///");
-        }
-
-        @Override
-        public FSDataInputStream open(final Path f, final int bufferSize) {
-            return null;
-        }
-
-        @Override
-        public FSDataOutputStream create(final Path f, final FsPermission permission, final boolean overwrite, final int bufferSize, final short replication,
-                                         final long blockSize, final Progressable progress) {
-            pathToStatus.put(f, newFile(f, permission));
-            if(failOnClose) {
-                return new FSDataOutputStream(new ByteArrayOutputStream(), new Statistics("")) {
-                    @Override
-                    public void close() throws IOException {
-                        super.close();
-                        throw new IOException("Fail on close");
-                    }
-                };
-            } else {
-                return new FSDataOutputStream(new ByteArrayOutputStream(), new Statistics(""));
-            }
-        }
-
-        @Override
-        public FSDataOutputStream append(final Path f, final int bufferSize, final Progressable progress) {
-            return null;
-        }
-
-        @Override
-        public boolean rename(final Path src, final Path dst) {
-            if (pathToStatus.containsKey(src)) {
-                pathToStatus.put(dst, pathToStatus.remove(src));
-            } else {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public boolean delete(final Path f, final boolean recursive) {
-            if (pathToStatus.containsKey(f)) {
-                pathToStatus.remove(f);
-            } else {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public FileStatus[] listStatus(final Path f) {
-            return null;
-        }
-
-        @Override
-        public void setWorkingDirectory(final Path new_dir) {
-
-        }
-
-        @Override
-        public Path getWorkingDirectory() {
-            return new Path(new File(".").getAbsolutePath());
-        }
-
-        @Override
-        public boolean mkdirs(final Path f, final FsPermission permission) {
-            return false;
-        }
-
-        @Override
-        public boolean mkdirs(Path f) {
-            pathToStatus.put(f, newDir(f));
-            return true;
-        }
-
-        @Override
-        public FileStatus getFileStatus(final Path f) throws IOException {
-            final FileStatus fileStatus = pathToStatus.get(f);
-            if (fileStatus == null) throw new FileNotFoundException();
-            return fileStatus;
-        }
-
-        @Override
-        public boolean exists(Path f) {
-            return pathToStatus.containsKey(f);
-        }
-
-        private FileStatus newFile(Path p, FsPermission permission) {
-            return new FileStatus(100L, false, 3, 128 * 1024 * 1024, 1523456000000L, 1523457000000L, permission, "owner", "group", p);
-        }
-
-        private FileStatus newDir(Path p) {
-            return new FileStatus(1L, true, 3, 128 * 1024 * 1024, 1523456000000L, 1523457000000L, perms((short) 0755), "owner", "group", (Path)null, p, true, false, false);
-        }
-
-        @Override
-        public long getDefaultBlockSize(Path f) {
-            return 33554432L;
-        }
-    }
-
-    static FsPermission perms(short p) {
-        return new FsPermission(p);
     }
 }

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestDeleteHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestDeleteHDFS.java
@@ -27,6 +27,7 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.ietf.jgss.GSSException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,13 +46,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestDeleteHDFS {
-    private NiFiProperties mockNiFiProperties;
     private FileSystem mockFileSystem;
     private KerberosProperties kerberosProperties;
 
     @BeforeEach
     public void setup() throws Exception {
-        mockNiFiProperties = mock(NiFiProperties.class);
+        NiFiProperties mockNiFiProperties = mock(NiFiProperties.class);
         when(mockNiFiProperties.getKerberosConfigurationFile()).thenReturn(null);
         kerberosProperties = new KerberosProperties(null);
         mockFileSystem = mock(FileSystem.class);
@@ -104,6 +104,20 @@ public class TestDeleteHDFS {
     public void testIOException() throws Exception {
         Path filePath = new Path("/some/path/to/file.txt");
         when(mockFileSystem.exists(any(Path.class))).thenThrow(new IOException());
+        DeleteHDFS deleteHDFS = new TestableDeleteHDFS(kerberosProperties, mockFileSystem);
+        TestRunner runner = TestRunners.newTestRunner(deleteHDFS);
+        runner.setProperty(DeleteHDFS.FILE_OR_DIRECTORY, "${hdfs.file}");
+        Map<String, String> attributes = Maps.newHashMap();
+        attributes.put("hdfs.file", filePath.toString());
+        runner.enqueue("foo", attributes);
+        runner.run();
+        runner.assertTransferCount(DeleteHDFS.REL_FAILURE, 1);
+    }
+
+    @Test
+    public void testGSSException() throws Exception {
+        Path filePath = new Path("/some/path/to/file.txt");
+        when(mockFileSystem.exists(any(Path.class))).thenThrow(new IOException(new GSSException(13)));
         DeleteHDFS deleteHDFS = new TestableDeleteHDFS(kerberosProperties, mockFileSystem);
         TestRunner runner = TestRunners.newTestRunner(deleteHDFS);
         runner.setProperty(DeleteHDFS.FILE_OR_DIRECTORY, "${hdfs.file}");

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestDeleteHDFS.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestDeleteHDFS.java
@@ -125,7 +125,9 @@ public class TestDeleteHDFS {
         attributes.put("hdfs.file", filePath.toString());
         runner.enqueue("foo", attributes);
         runner.run();
-        runner.assertTransferCount(DeleteHDFS.REL_FAILURE, 1);
+        // GSS Auth exceptions should cause rollback
+        runner.assertTransferCount(DeleteHDFS.REL_SUCCESS, 0);
+        runner.assertTransferCount(DeleteHDFS.REL_FAILURE, 0);
     }
 
     @Test

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/util/MockFileSystem.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/util/MockFileSystem.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.hadoop.util;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.AclEntry;
+import org.apache.hadoop.fs.permission.AclStatus;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.util.Progressable;
+import org.ietf.jgss.GSSException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class MockFileSystem extends FileSystem {
+    private final Map<Path, FileStatus> pathToStatus = new HashMap<>();
+    private final Map<Path, List<AclEntry>> pathToAcl = new HashMap<>();
+    private final Map<Path, Set<FileStatus>> fileStatuses = new HashMap<>();
+
+    private boolean failOnOpen;
+    private boolean failOnClose;
+    private boolean failOnCreate;
+    private boolean failOnFileStatus;
+    private boolean failOnExists;
+
+
+    public void setFailOnClose(final boolean failOnClose) {
+        this.failOnClose = failOnClose;
+    }
+
+    public void setFailOnCreate(final boolean failOnCreate) {
+        this.failOnCreate = failOnCreate;
+    }
+
+    public void setFailOnFileStatus(final boolean failOnFileStatus) {
+        this.failOnFileStatus = failOnFileStatus;
+    }
+
+    public void setFailOnExists(final boolean failOnExists) {
+        this.failOnExists = failOnExists;
+    }
+
+    public void setFailOnOpen(final boolean failOnOpen) {
+        this.failOnOpen = failOnOpen;
+    }
+
+    public void setAcl(final Path path, final List<AclEntry> aclSpec) {
+        pathToAcl.put(path, aclSpec);
+    }
+
+    @Override
+    public AclStatus getAclStatus(final Path path) {
+        return new AclStatus.Builder().addEntries(pathToAcl.getOrDefault(path, new ArrayList<>())).build();
+    }
+
+    @Override
+    public URI getUri() {
+        return URI.create("file:///");
+    }
+
+    @Override
+    public FSDataInputStream open(final Path f, final int bufferSize) throws IOException {
+        if (failOnOpen) {
+            throw new IOException(new GSSException(13));
+        }
+        return null;
+    }
+
+    @Override
+    public FSDataOutputStream create(final Path f, final FsPermission permission, final boolean overwrite, final int bufferSize, final short replication,
+                                     final long blockSize, final Progressable progress) throws IOException {
+        if (failOnCreate) {
+            // Simulate an AuthenticationException wrapped in an IOException
+            throw new IOException(new AuthenticationException("test auth error"));
+        }
+        pathToStatus.put(f, newFile(f, permission));
+        if(failOnClose) {
+            return new FSDataOutputStream(new ByteArrayOutputStream(), new FileSystem.Statistics("")) {
+                @Override
+                public void close() throws IOException {
+                    super.close();
+                    throw new IOException("Fail on close");
+                }
+            };
+        } else {
+            return new FSDataOutputStream(new ByteArrayOutputStream(), new Statistics(""));
+        }
+    }
+
+    @Override
+    public FSDataOutputStream append(final Path f, final int bufferSize, final Progressable progress) {
+        return null;
+    }
+
+    @Override
+    public boolean rename(final Path src, final Path dst) {
+        if (pathToStatus.containsKey(src)) {
+            pathToStatus.put(dst, pathToStatus.remove(src));
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean delete(final Path f, final boolean recursive) {
+        if (pathToStatus.containsKey(f)) {
+            pathToStatus.remove(f);
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void setWorkingDirectory(final Path new_dir) {
+
+    }
+
+    @Override
+    public Path getWorkingDirectory() {
+        return new Path(new File(".").getAbsolutePath());
+    }
+
+    @Override
+    public boolean mkdirs(final Path f, final FsPermission permission) {
+        return false;
+    }
+
+    @Override
+    public boolean mkdirs(Path f) {
+        pathToStatus.put(f, newDir(f));
+        return true;
+    }
+
+    @Override
+    public FileStatus getFileStatus(final Path path) throws IOException {
+        if (failOnFileStatus) {
+            throw new IOException(new GSSException(13));
+        }
+        if (path != null && path.getName().startsWith("exception_")) {
+            final String className = path.getName().substring("exception_".length());
+            final IOException exception;
+            try {
+                exception = (IOException) Class.forName(className).getDeclaredConstructor().newInstance();
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+            throw exception;
+        }
+
+        final FileStatus fileStatus = pathToStatus.get(path);
+        if (fileStatus == null) {
+            throw new FileNotFoundException();
+        }
+        return fileStatus;
+    }
+
+    @Override
+    public boolean exists(Path f) throws IOException {
+        if (failOnExists) {
+            throw new IOException(new GSSException(13));
+        }
+        return pathToStatus.containsKey(f);
+    }
+
+    public FileStatus newFile(Path p, FsPermission permission) {
+        return new FileStatus(100L, false, 3, 128 * 1024 * 1024, 1523456000000L, 1523457000000L, permission, "owner", "group", p);
+    }
+
+    public FileStatus newDir(Path p) {
+        return new FileStatus(1L, true, 3, 128 * 1024 * 1024, 1523456000000L, 1523457000000L, perms((short) 0755), "owner", "group", (Path)null, p, true, false, false);
+    }
+
+    public FileStatus newFile(String p) {
+        return new FileStatus(100L, false, 3, 128*1024*1024, 1523456000000L, 1523457000000L, perms((short)0644), "owner", "group", new Path(p));
+    }
+    public FileStatus newDir(String p) {
+        return new FileStatus(1L, true, 3, 128*1024*1024, 1523456000000L, 1523457000000L, perms((short)0755), "owner", "group", new Path(p));
+    }
+
+    @Override
+    public long getDefaultBlockSize(Path f) {
+        return 33554432L;
+    }
+
+    public void addFileStatus(final FileStatus parent, final FileStatus child) {
+        Set<FileStatus> children = fileStatuses.computeIfAbsent(parent.getPath(), k -> new HashSet<>());
+        if (child != null) {
+            children.add(child);
+            if (child.isDirectory() && !fileStatuses.containsKey(child.getPath())) {
+                fileStatuses.put(child.getPath(), new HashSet<>());
+            }
+        }
+
+        pathToStatus.put(parent.getPath(), parent);
+        pathToStatus.put(child.getPath(), child);
+    }
+
+    @Override
+    public FileStatus[] listStatus(final Path f) throws IOException {
+        if (!fileStatuses.containsKey(f)) {
+            throw new FileNotFoundException();
+        }
+
+        if (f.getName().startsWith("list_exception_")) {
+            final String className = f.getName().substring("list_exception_".length());
+            final IOException exception;
+            try {
+                exception = (IOException) Class.forName(className).getDeclaredConstructor().newInstance();
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+            throw exception;
+        }
+
+        final Set<FileStatus> statuses = fileStatuses.get(f);
+        if (statuses == null) {
+            return new FileStatus[0];
+        }
+
+        for (FileStatus s : statuses) {
+            getFileStatus(s.getPath()); //support exception handling only.
+        }
+
+        return statuses.toArray(new FileStatus[0]);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public long getDefaultBlockSize() {
+        return 1024L;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public short getDefaultReplication() {
+        return 1;
+    }
+
+
+    private static FsPermission perms(short p) {
+        return new FsPermission(p);
+    }
+}


### PR DESCRIPTION

# Summary

[NIFI-12889](https://issues.apache.org/jira/browse/NIFI-12889) This PR resets the HDFS resources upon Kerberos authentication failure so the relogin can happen correctly on the next try.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
