### PR TITLE
NIFI-12855: Add more information to provenance events to facilitate full graph traversal

### DIFF
--- a/minifi/minifi-nar-bundles/minifi-provenance-repository-bundle/minifi-provenance-repositories/src/main/java/org/apache/nifi/provenance/NoOpProvenanceRepository.java
+++ b/minifi/minifi-nar-bundles/minifi-provenance-repository-bundle/minifi-provenance-repositories/src/main/java/org/apache/nifi/provenance/NoOpProvenanceRepository.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static java.util.Collections.EMPTY_SET;
 import static java.util.Collections.emptyList;
 
 /**
@@ -37,12 +36,12 @@ import static java.util.Collections.emptyList;
  * store events.
  *
  */
-public class NoOpProvenanceRepository implements ProvenanceRepository {
+public class NoOpProvenanceRepository extends AbstractProvenanceRepository {
 
   @Override
   public void initialize(EventReporter eventReporter, Authorizer authorizer,
-      ProvenanceAuthorizableFactory factory, IdentifierLookup identifierLookup)
-      throws IOException {
+                         ProvenanceAuthorizableFactory factory, IdentifierLookup identifierLookup)
+          throws IOException {
 
   }
 
@@ -68,13 +67,13 @@ public class NoOpProvenanceRepository implements ProvenanceRepository {
 
   @Override
   public List<ProvenanceEventRecord> getEvents(long firstRecordId, int maxRecords)
-      throws IOException {
+          throws IOException {
     return emptyList();
   }
 
   @Override
   public List<ProvenanceEventRecord> getEvents(long firstRecordId,
-      int maxRecords, NiFiUser niFiUser) throws IOException {
+                                               int maxRecords, NiFiUser niFiUser) throws IOException {
     return emptyList();
   }
 
@@ -135,7 +134,7 @@ public class NoOpProvenanceRepository implements ProvenanceRepository {
 
   @Override
   public Set<String> getContainerNames() {
-    return EMPTY_SET;
+    return Set.of();
   }
 
   @Override
@@ -155,7 +154,7 @@ public class NoOpProvenanceRepository implements ProvenanceRepository {
 
   @Override
   public AsyncLineageSubmission retrieveLineageSubmission(final String lineageIdentifier,
-      final NiFiUser user) {
+                                                          final NiFiUser user) {
     return null;
   }
 

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventBuilder.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventBuilder.java
@@ -273,7 +273,7 @@ public interface ProvenanceEventBuilder {
     ProvenanceEventBuilder setDetails(String details);
 
     /**
-     * Sets the to which the FlowFile was routed for
+     * Sets the relationship to which the FlowFile was routed for
      * {@link ProvenanceEventType#ROUTE} events. This is valid only for
      * {@link ProvenanceEventType#ROUTE} events and will be ignored for any
      * other event types.
@@ -282,6 +282,13 @@ public interface ProvenanceEventBuilder {
      * @return the builder
      */
     ProvenanceEventBuilder setRelationship(Relationship relationship);
+
+    /**
+     * Sets the IDs for the event that happened previously to this event for the given FlowFile
+     * @param previousEventIds The previous event IDs (usually one except for JOIN events and such)
+     * @return the builder
+     */
+    ProvenanceEventBuilder setPreviousEventIds(List<Long> previousEventIds);
 
     /**
      * Populates the builder with as much information as it can from the given
@@ -297,7 +304,7 @@ public interface ProvenanceEventBuilder {
      * {@link ProvenanceEventRecord#getEventId()} on the
      * {@link ProvenanceEventRecord} that is returned will yield
      * <code>-1</code>. This is because the implementation of the Event may
-     * depend on the {@link ProvevenanceEventRepository} to generate the unique
+     * depend on the {@link ProvenanceEventRepository} to generate the unique
      * identifier.
      *
      * @return the event

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventRecord.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventRecord.java
@@ -35,6 +35,12 @@ public interface ProvenanceEventRecord {
     long getEventId();
 
     /**
+     * @return a unique ID for the "parent" Provenance Event, namely the one that came directly before this event
+     * for the given FlowFile. For source events such as CREATE, this value should be set to -1
+     */
+    List<Long> getPreviousEventIds();
+
+    /**
      * @return the time at which this Provenance Event was created, as the
      * number of milliseconds since epoch
      */
@@ -149,14 +155,14 @@ public interface ProvenanceEventRecord {
     /**
      * @return the UUID's of all Parent FlowFiles. This is applicable only when
      * the {@link ProvenanceEventType} is of type
-     * {@link ProvenanceEventType#SPAWN SPAWN}
+     * {@link ProvenanceEventType#JOIN JOIN}
      */
     List<String> getParentUuids();
 
     /**
      * @return the UUID's of all Child FlowFiles. This is applicable only when
      * the {@link ProvenanceEventType} is of type
-     * {@link ProvenanceEventType#SPAWN SPAWN}
+     * {@link ProvenanceEventType#FORK FORK}
      */
     List<String> getChildUuids();
 

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventRepository.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventRepository.java
@@ -93,5 +93,19 @@ public interface ProvenanceEventRepository {
      */
     void close() throws IOException;
 
+    /**
+     * Returns the previous provenance event IDs for the given FlowFile
+     * @param flowFileUUID the UUID of the FlowFile
+     * @return the previous event IDs for the given FlowFile
+     */
+    List<Long> getPreviousEventIds(String flowFileUUID);
+
+    /**
+     * Updates the previous provenance event IDs for the given event
+     *
+     * @param record The record for which to update the previous event IDs
+     * @param previousIds the list of previous event IDs to set for the record, or null to remove
+     */
+    void updatePreviousEventIds(ProvenanceEventRecord record, List<Long> previousIds);
 
 }

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/UpdateableProvenanceEventRecord.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/UpdateableProvenanceEventRecord.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.provenance;
+
+import java.util.List;
+
+public interface UpdateableProvenanceEventRecord extends ProvenanceEventRecord {
+
+    void setEventId(final long eventId);
+    void setPreviousEventIds(List<Long> previousEventIds);
+}

--- a/nifi-commons/nifi-data-provenance-utils/src/main/java/org/apache/nifi/provenance/PlaceholderProvenanceEvent.java
+++ b/nifi-commons/nifi-data-provenance-utils/src/main/java/org/apache/nifi/provenance/PlaceholderProvenanceEvent.java
@@ -25,15 +25,17 @@ import java.util.Map;
  * A Provenance Event that is used to replace another Provenance Event when authorizations
  * are not granted for the original Provenance Event
  */
-public class PlaceholderProvenanceEvent implements ProvenanceEventRecord {
+public class PlaceholderProvenanceEvent implements UpdateableProvenanceEventRecord {
     private final String componentId;
-    private final long eventId;
+    private long eventId;
+    private List<Long> previousEventIds;
     private final long eventTime;
     private final String flowFileUuid;
 
     public PlaceholderProvenanceEvent(final ProvenanceEventRecord original) {
         this.componentId = original.getComponentId();
         this.eventId = original.getEventId();
+        this.previousEventIds = original.getPreviousEventIds();
         this.eventTime = original.getEventTime();
         this.flowFileUuid = original.getFlowFileUuid();
     }
@@ -41,6 +43,21 @@ public class PlaceholderProvenanceEvent implements ProvenanceEventRecord {
     @Override
     public long getEventId() {
         return eventId;
+    }
+
+    @Override
+    public void setEventId(long eventId) {
+        this.eventId = eventId;
+    }
+
+    @Override
+    public List<Long> getPreviousEventIds() {
+        return previousEventIds;
+    }
+
+    @Override
+    public void setPreviousEventIds(List<Long> previousEventIds) {
+        this.previousEventIds = previousEventIds;
     }
 
     @Override

--- a/nifi-commons/nifi-data-provenance-utils/src/main/java/org/apache/nifi/provenance/SearchableFields.java
+++ b/nifi-commons/nifi-data-provenance-utils/src/main/java/org/apache/nifi/provenance/SearchableFields.java
@@ -57,6 +57,9 @@ public class SearchableFields {
     public static final SearchableField SourceQueueIdentifier
             = new NamedSearchableField("SourceQueueIdentifier", "sourceQueueIdentifier", "Source Queue Identifier", false, SearchableFieldType.STRING);
 
+    public static final SearchableField PreviousEventIdentifiers
+            = new NamedSearchableField("PreviousEventIdentifiers", "previousEventIdentifiers", "Previous Event Identifiers", false, SearchableFieldType.LONG);
+
     private static final Map<String, SearchableField> standardFields;
 
     static {
@@ -64,7 +67,7 @@ public class SearchableFields {
             EventTime, FlowFileUUID, Filename, EventType, TransitURI,
             ComponentID, AlternateIdentifierURI, FileSize, Relationship, Details,
             LineageStartDate, LineageIdentifier, ContentClaimSection, ContentClaimContainer, ContentClaimIdentifier,
-            ContentClaimOffset, SourceQueueIdentifier};
+            ContentClaimOffset, SourceQueueIdentifier, PreviousEventIdentifiers};
 
         final Map<String, SearchableField> fields = new HashMap<>();
         for (final SearchableField field : searchableFields) {

--- a/nifi-framework-api/src/main/java/org/apache/nifi/provenance/AbstractProvenanceRepository.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/provenance/AbstractProvenanceRepository.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.provenance;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractProvenanceRepository implements ProvenanceRepository {
+
+    protected final Map<String, List<Long>> previousEventIdsMap = new HashMap<>();
+
+    @Override
+    public List<Long> getPreviousEventIds(String flowFileUUID) {
+        return previousEventIdsMap.get(flowFileUUID);
+    }
+
+    @Override
+    public void updatePreviousEventIds(ProvenanceEventRecord record, List<Long> previousIds) {
+        if (previousIds == null) {
+            previousEventIdsMap.remove(record.getFlowFileUuid());
+        } else {
+            previousEventIdsMap.put(record.getFlowFileUuid(), previousIds);
+        }
+    }
+}

--- a/nifi-mock/src/main/java/org/apache/nifi/provenance/MockProvenanceEvent.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/provenance/MockProvenanceEvent.java
@@ -65,6 +65,8 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
 
     private volatile long eventId = -1L;
 
+    private volatile List<Long> previousEventIds;
+
     private MockProvenanceEvent(final Builder builder) {
         this.eventTime = builder.eventTime;
         this.entryDate = builder.entryDate;
@@ -102,6 +104,8 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
         if (builder.eventId != null) {
             eventId = builder.eventId;
         }
+
+        previousEventIds = builder.previousEventIds;
     }
 
 
@@ -113,6 +117,16 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
     public long getEventId() {
         return eventId;
     }
+
+    @Override
+    public List<Long> getPreviousEventIds() {
+        return previousEventIds;
+    }
+
+    public void setPreviousEventIds(List<Long> previousEventIds) {
+        this.previousEventIds = previousEventIds;
+    }
+
 
     @Override
     public long getEventTime() {
@@ -441,6 +455,8 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
         private long eventDuration = -1L;
         private Long eventId = eventIdGenerator.getAndIncrement();
 
+        private List<Long> previousEventIds;
+
         private String contentClaimSection;
         private String contentClaimContainer;
         private String contentClaimIdentifier;
@@ -492,6 +508,8 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
 
             sourceQueueIdentifier = event.getSourceQueueIdentifier();
 
+            previousEventIds = event.getPreviousEventIds();
+
             return this;
         }
 
@@ -542,6 +560,10 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
             copy.previousSize = previousSize;
 
             copy.sourceQueueIdentifier = sourceQueueIdentifier;
+
+            if (previousEventIds != null) {
+                copy.previousEventIds = previousEventIds;
+            }
 
             return copy;
         }
@@ -672,6 +694,12 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
         @Override
         public Builder setDetails(String details) {
             this.details = details;
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setPreviousEventIds(List<Long> previousEventIds) {
+            this.previousEventIds = previousEventIds;
             return this;
         }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -259,7 +259,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             if (relationship == null) {
                 final String createdThisSession = record.getOriginalQueue() == null ? "was created" : "was not created";
                 throw new FlowFileHandlingException(record.getCurrent() + " transfer relationship not specified. This FlowFile " + createdThisSession + " in this session and was not transferred " +
-                    "to any Relationship via ProcessSession.transfer()");
+                        "to any Relationship via ProcessSession.transfer()");
             }
 
             final Collection<Connection> destinations = context.getConnections(relationship);
@@ -450,9 +450,9 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         // Adjust for any state that has been updated for the Record that is no longer relevant.
         final String uuid = record.getCurrent().getAttribute(CoreAttributes.UUID.key());
         final FlowFileRecord updatedFlowFile = new StandardFlowFileRecord.Builder()
-            .fromFlowFile(record.getOriginal())
-            .addAttribute(retryAttribute, String.valueOf(currentRetries + 1))
-            .build();
+                .fromFlowFile(record.getOriginal())
+                .addAttribute(retryAttribute, String.valueOf(currentRetries + 1))
+                .build();
 
         if (original == null) {
             record.markForDelete();
@@ -922,7 +922,8 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
             final boolean newFlowFile = repoRecord.getOriginal() == null;
             if (contentChanged && !newFlowFile) {
-                recordsToSubmit.add(provenanceReporter.build(curFlowFile, ProvenanceEventType.CONTENT_MODIFIED).build());
+                ProvenanceEventRecord record = provenanceReporter.generateModifyContentEvent(curFlowFile, "Session detected change in content");
+                recordsToSubmit.add(record);
                 addEventType(eventTypesPerFlowFileId, flowFileId, ProvenanceEventType.CONTENT_MODIFIED);
                 eventAdded = true;
             }
@@ -932,18 +933,18 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
                 boolean creationEventRegistered = false;
                 if (registeredTypes != null) {
                     if (registeredTypes.get(ProvenanceEventType.CREATE.ordinal())
-                        || registeredTypes.get(ProvenanceEventType.FORK.ordinal())
-                        || registeredTypes.get(ProvenanceEventType.CLONE.ordinal())
-                        || registeredTypes.get(ProvenanceEventType.JOIN.ordinal())
-                        || registeredTypes.get(ProvenanceEventType.RECEIVE.ordinal())
-                        || registeredTypes.get(ProvenanceEventType.FETCH.ordinal())) {
+                            || registeredTypes.get(ProvenanceEventType.FORK.ordinal())
+                            || registeredTypes.get(ProvenanceEventType.CLONE.ordinal())
+                            || registeredTypes.get(ProvenanceEventType.JOIN.ordinal())
+                            || registeredTypes.get(ProvenanceEventType.RECEIVE.ordinal())
+                            || registeredTypes.get(ProvenanceEventType.FETCH.ordinal())) {
 
                         creationEventRegistered = true;
                     }
                 }
 
                 if (!creationEventRegistered) {
-                    recordsToSubmit.add(provenanceReporter.build(curFlowFile, ProvenanceEventType.CREATE).build());
+                    recordsToSubmit.add(provenanceReporter.generateCreateEvent(curFlowFile, "Session detected no CREATE event present, auto-generating a CREATE event"));
                     eventAdded = true;
                 }
             }
@@ -955,7 +956,9 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
                 // event is redundant if another already exists.
                 // We don't generate ATTRIBUTES_MODIFIED event for retry.
                 if (!eventTypesPerFlowFileId.containsKey(flowFileId)) {
-                    recordsToSubmit.add(provenanceReporter.build(curFlowFile, ProvenanceEventType.ATTRIBUTES_MODIFIED).build());
+                    recordsToSubmit.add(
+                            provenanceReporter.generateModifyAttributesEvent(curFlowFile, "Session detected no provenance event created, auto-generating an ATTRIBUTES_MODIFIED event")
+                    );
                     addEventType(eventTypesPerFlowFileId, flowFileId, ProvenanceEventType.ATTRIBUTES_MODIFIED);
                 }
             }
@@ -1031,11 +1034,11 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         } else {
             final ResourceClaim resourceClaim = originalClaim.getResourceClaim();
             builder.setCurrentContentClaim(
-                resourceClaim.getContainer(), resourceClaim.getSection(), resourceClaim.getId(),
-                repoRecord.getOriginal().getContentClaimOffset() + originalClaim.getOffset(), repoRecord.getOriginal().getSize());
+                    resourceClaim.getContainer(), resourceClaim.getSection(), resourceClaim.getId(),
+                    repoRecord.getOriginal().getContentClaimOffset() + originalClaim.getOffset(), repoRecord.getOriginal().getSize());
             builder.setPreviousContentClaim(
-                resourceClaim.getContainer(), resourceClaim.getSection(), resourceClaim.getId(),
-                repoRecord.getOriginal().getContentClaimOffset() + originalClaim.getOffset(), repoRecord.getOriginal().getSize());
+                    resourceClaim.getContainer(), resourceClaim.getSection(), resourceClaim.getId(),
+                    repoRecord.getOriginal().getContentClaimOffset() + originalClaim.getOffset(), repoRecord.getOriginal().getSize());
         }
     }
 
@@ -1080,8 +1083,8 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
     }
 
     private ProvenanceEventRecord enrich(
-        final ProvenanceEventRecord rawEvent, final Map<String, FlowFileRecord> flowFileRecordMap, final Map<Long, StandardRepositoryRecord> records,
-        final boolean updateAttributes, final long commitNanos) {
+            final ProvenanceEventRecord rawEvent, final Map<String, FlowFileRecord> flowFileRecordMap, final Map<Long, StandardRepositoryRecord> records,
+            final boolean updateAttributes, final long commitNanos) {
         final ProvenanceEventBuilder recordBuilder = context.createProvenanceEventBuilder().fromEvent(rawEvent);
         final FlowFileRecord eventFlowFile = flowFileRecordMap.get(rawEvent.getFlowFileUuid());
         if (eventFlowFile != null) {
@@ -1273,8 +1276,8 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
         // If we have transient claims that need to be cleaned up, do so.
         final List<ContentClaim> transientClaims = recordsToHandle.stream()
-            .flatMap(record -> record.getTransientClaims().stream())
-            .collect(Collectors.toList());
+                .flatMap(record -> record.getTransientClaims().stream())
+                .collect(Collectors.toList());
 
         if (!transientClaims.isEmpty()) {
             final RepositoryRecord repoRecord = new TransientClaimRepositoryRecord(transientClaims);
@@ -1491,12 +1494,12 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             for (final FlowFile flowFile : flowFiles) {
                 if (openInputStreams.containsKey(flowFile)) {
                     throw new IllegalStateException(flowFile + " cannot be migrated to a new Process Session because this session currently "
-                        + "has an open InputStream for the FlowFile, created by calling ProcessSession.read(FlowFile)");
+                            + "has an open InputStream for the FlowFile, created by calling ProcessSession.read(FlowFile)");
                 }
 
                 if (openOutputStreams.containsKey(flowFile)) {
                     throw new IllegalStateException(flowFile + " cannot be migrated to a new Process Session because this session currently "
-                        + "has an open OutputStream for the FlowFile, created by calling ProcessSession.write(FlowFile)");
+                            + "has an open OutputStream for the FlowFile, created by calling ProcessSession.write(FlowFile)");
                 }
 
                 if (readRecursionSet.containsKey(flowFile)) {
@@ -1517,8 +1520,8 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             // ProcessSession is committed, claiming to have created FlowFiles from the parent, which is no longer even in
             // the flow. This would be very confusing when looking at the provenance for the FlowFile, so it is best to avoid this.
             final Set<String> flowFileIds = flowFiles.stream()
-                .map(ff -> ff.getAttribute(CoreAttributes.UUID.key()))
-                .collect(Collectors.toSet());
+                    .map(ff -> ff.getAttribute(CoreAttributes.UUID.key()))
+                    .collect(Collectors.toSet());
 
             for (final Map.Entry<FlowFile, ProvenanceEventBuilder> entry : forkEventBuilders.entrySet()) {
                 final FlowFile eventFlowFile = entry.getKey();
@@ -1527,7 +1530,8 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
                     for (final String childId : eventBuilder.getChildFlowFileIds()) {
                         if (!flowFileIds.contains(childId)) {
                             throw new FlowFileHandlingException("Cannot migrate " + eventFlowFile + " to a new session because it was forked to create " + eventBuilder.getChildFlowFileIds().size()
-                                + " children and not all children are being migrated. If any FlowFile is forked, all of its children must also be migrated at the same time as the forked FlowFile");
+                                    + " children and not all children are being migrated. If any FlowFile is forked, all of its children must also be migrated "
+                                    + "at the same time as the forked FlowFile");
                         }
                     }
                 } else {
@@ -1535,7 +1539,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
                     for (final String childId : eventBuilder.getChildFlowFileIds()) {
                         if (flowFileIds.contains(childId)) {
                             throw new FlowFileHandlingException("Cannot migrate " + eventFlowFile + " to a new session because it was forked from a Parent FlowFile, " +
-                                "but the parent is not being migrated. If any FlowFile is forked, the parent and all children must be migrated at the same time.");
+                                    "but the parent is not being migrated. If any FlowFile is forked, the parent and all children must be migrated at the same time.");
                         }
                     }
                 }
@@ -1702,7 +1706,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
         final StringBuilder sb = new StringBuilder(512);
         if (!LOG.isDebugEnabled() && (largestTransferSetSize > VERBOSE_LOG_THRESHOLD
-            || numModified > VERBOSE_LOG_THRESHOLD || numCreated > VERBOSE_LOG_THRESHOLD || numRemoved > VERBOSE_LOG_THRESHOLD)) {
+                || numModified > VERBOSE_LOG_THRESHOLD || numCreated > VERBOSE_LOG_THRESHOLD || numRemoved > VERBOSE_LOG_THRESHOLD)) {
             if (numCreated > 0) {
                 sb.append("created ").append(numCreated).append(" FlowFiles, ");
             }
@@ -1832,12 +1836,12 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         }
 
         LOG.error("Attempted to pull {} from {} but the Session already has a FlowFile with the same ID ({}): {}, which was pulled from {}. This means that the system has two FlowFiles with the" +
-            " same ID, which should not happen.", flowFile, connection, flowFile.getId(), conflict.getCurrent(), conflict.getOriginalQueue());
+                " same ID, which should not happen.", flowFile, connection, flowFile.getId(), conflict.getCurrent(), conflict.getOriginalQueue());
         connection.getFlowFileQueue().put(flowFile);
 
         rollback(true, false);
         throw new FlowFileAccessException("Attempted to pull a FlowFile with ID " + flowFile.getId() + " from Connection "
-            + connection + " but a FlowFile with that ID already exists in the session");
+                + connection + " but a FlowFile with that ID already exists in the session");
     }
 
     @Override
@@ -2052,8 +2056,8 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             final String key = entry.getKey();
             final String value = entry.getValue();
             if (CoreAttributes.ALTERNATE_IDENTIFIER.key().equals(key)
-                || CoreAttributes.DISCARD_REASON.key().equals(key)
-                || CoreAttributes.UUID.key().equals(key)) {
+                    || CoreAttributes.DISCARD_REASON.key().equals(key)
+                    || CoreAttributes.UUID.key().equals(key)) {
                 continue;
             }
             newAttributes.put(key, value);
@@ -2109,9 +2113,9 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         newAttributes.put(CoreAttributes.UUID.key(), uuid);
 
         final FlowFileRecord fFile = new StandardFlowFileRecord.Builder().id(context.getNextFlowFileSequence())
-            .addAttributes(newAttributes)
-            .lineageStart(lineageStartDate, lineageStartIndex)
-            .build();
+                .addAttributes(newAttributes)
+                .lineageStart(lineageStartDate, lineageStartIndex)
+                .build();
 
         final StandardRepositoryRecord record = new StandardRepositoryRecord((FlowFileQueue) null);
         record.setWorking(fFile, newAttributes, false);
@@ -2561,9 +2565,9 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
                             if (claim != null) {
                                 final ResourceClaim resourceClaim = claim.getResourceClaim();
                                 enriched.setCurrentContentClaim(resourceClaim.getContainer(), resourceClaim.getSection(), resourceClaim.getId(),
-                                    record.getContentClaimOffset() + claim.getOffset(), record.getSize());
+                                        record.getContentClaimOffset() + claim.getOffset(), record.getSize());
                                 enriched.setPreviousContentClaim(resourceClaim.getContainer(), resourceClaim.getSection(), resourceClaim.getId(),
-                                    record.getContentClaimOffset() + claim.getOffset(), record.getSize());
+                                        record.getContentClaimOffset() + claim.getOffset(), record.getSize());
                             }
 
                             enriched.setAttributes(record.getAttributes(), Collections.<String, String> emptyMap());
@@ -2610,7 +2614,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
                         final InputStream limitingInputStream = new LimitingInputStream(new DisableOnCloseInputStream(currentReadClaimStream), flowFile.getSize());
                         final ContentClaimInputStream contentClaimInputStream = new ContentClaimInputStream(context.getContentRepository(), claim,
-                            contentClaimOffset, limitingInputStream, performanceTracker);
+                                contentClaimOffset, limitingInputStream, performanceTracker);
                         return contentClaimInputStream;
                     }
                 }
@@ -2671,9 +2675,9 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         }
 
         try (final InputStream rawIn = getInputStream(source, record.getCurrentClaim(), record.getCurrentClaimOffset(), true);
-            final InputStream limitedIn = new LimitedInputStream(rawIn, source.getSize());
-            final InputStream disableOnCloseIn = new DisableOnCloseInputStream(limitedIn);
-            final ByteCountingInputStream countingStream = new ByteCountingInputStream(disableOnCloseIn, this.bytesRead)) {
+             final InputStream limitedIn = new LimitedInputStream(rawIn, source.getSize());
+             final InputStream disableOnCloseIn = new DisableOnCloseInputStream(limitedIn);
+             final ByteCountingInputStream countingStream = new ByteCountingInputStream(disableOnCloseIn, this.bytesRead)) {
 
             // We want to differentiate between IOExceptions thrown by the repository and IOExceptions thrown from
             // Processor code. As a result, as have the FlowFileAccessInputStream that catches IOException from the repository
@@ -2895,7 +2899,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
         try {
             try (final OutputStream rawOut = contentRepo.write(newClaim);
-                final OutputStream out = new BufferedOutputStream(rawOut)) {
+                 final OutputStream out = new BufferedOutputStream(rawOut)) {
 
                 if (header != null && header.length > 0) {
                     out.write(header);
@@ -2941,11 +2945,11 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
         removeTemporaryClaim(destinationRecord);
         final FlowFileRecord newFile = new StandardFlowFileRecord.Builder()
-            .fromFlowFile(destinationRecord.getCurrent())
-            .contentClaim(newClaim)
-            .contentClaimOffset(0L)
-            .size(writtenCount)
-            .build();
+                .fromFlowFile(destinationRecord.getCurrent())
+                .contentClaim(newClaim)
+                .contentClaimOffset(0L)
+                .size(writtenCount)
+                .build();
         destinationRecord.setWorking(newFile, true);
         return newFile;
     }
@@ -3060,21 +3064,21 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
                     final FlowFileRecord newFile;
                     if (bytesWritten == 0) {
                         newFile = new StandardFlowFileRecord.Builder()
-                            .fromFlowFile(record.getCurrent())
-                            .contentClaim(null)
-                            .contentClaimOffset(0)
-                            .size(bytesWritten)
-                            .build();
+                                .fromFlowFile(record.getCurrent())
+                                .contentClaim(null)
+                                .contentClaimOffset(0)
+                                .size(bytesWritten)
+                                .build();
 
                         context.getContentRepository().decrementClaimantCount(updatedClaim);
                         record.addTransientClaim(updatedClaim);
                     } else {
                         newFile = new StandardFlowFileRecord.Builder()
-                            .fromFlowFile(record.getCurrent())
-                            .contentClaim(updatedClaim)
-                            .contentClaimOffset(Math.max(0, updatedClaim.getLength() - bytesWritten))
-                            .size(bytesWritten)
-                            .build();
+                                .fromFlowFile(record.getCurrent())
+                                .contentClaim(updatedClaim)
+                                .contentClaimOffset(Math.max(0, updatedClaim.getLength() - bytesWritten))
+                                .size(bytesWritten)
+                                .build();
                     }
 
                     record.setWorking(newFile, true);
@@ -3114,9 +3118,9 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
             ensureNotAppending(newClaim);
             try (final OutputStream stream = claimCache.write(newClaim);
-                final NonFlushableOutputStream nonFlushableOutputStream = new NonFlushableOutputStream(stream);
-                final OutputStream disableOnClose = new DisableOnCloseOutputStream(nonFlushableOutputStream);
-                final ByteCountingOutputStream countingOut = new ByteCountingOutputStream(disableOnClose)) {
+                 final NonFlushableOutputStream nonFlushableOutputStream = new NonFlushableOutputStream(stream);
+                 final OutputStream disableOnClose = new DisableOnCloseOutputStream(nonFlushableOutputStream);
+                 final ByteCountingOutputStream countingOut = new ByteCountingOutputStream(disableOnClose)) {
                 try {
                     writeRecursionSet.add(source);
                     final OutputStream ffaos = new FlowFileAccessOutputStream(countingOut, source);
@@ -3146,21 +3150,21 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         final FlowFileRecord newFile;
         if (writtenToFlowFile == 0) {
             newFile = new StandardFlowFileRecord.Builder()
-                .fromFlowFile(record.getCurrent())
-                .contentClaim(null)
-                .contentClaimOffset(0)
-                .size(0)
-                .build();
+                    .fromFlowFile(record.getCurrent())
+                    .contentClaim(null)
+                    .contentClaimOffset(0)
+                    .size(0)
+                    .build();
 
             context.getContentRepository().decrementClaimantCount(newClaim);
             record.addTransientClaim(newClaim);
         } else {
             newFile = new StandardFlowFileRecord.Builder()
-                .fromFlowFile(record.getCurrent())
-                .contentClaim(newClaim)
-                .contentClaimOffset(Math.max(0, newClaim.getLength() - writtenToFlowFile))
-                .size(writtenToFlowFile)
-                .build();
+                    .fromFlowFile(record.getCurrent())
+                    .contentClaim(newClaim)
+                    .contentClaimOffset(Math.max(0, newClaim.getLength() - writtenToFlowFile))
+                    .size(writtenToFlowFile)
+                    .build();
         }
 
         record.setWorking(newFile, true);
@@ -3225,7 +3229,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
                 // Wrap our OutputStreams so that the processor cannot close it
                 try (final OutputStream disableOnClose = new DisableOnCloseOutputStream(nonFlushable);
-                    final OutputStream flowFileAccessOutStream = new FlowFileAccessOutputStream(disableOnClose, source)) {
+                     final OutputStream flowFileAccessOutStream = new FlowFileAccessOutputStream(disableOnClose, source)) {
                     writeRecursionSet.add(source);
                     writer.process(flowFileAccessOutStream);
                 } finally {
@@ -3287,21 +3291,21 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         final FlowFileRecord newFile;
         if (newSize == 0) {
             newFile = new StandardFlowFileRecord.Builder()
-                .fromFlowFile(record.getCurrent())
-                .contentClaim(null)
-                .contentClaimOffset(0)
-                .size(0)
-                .build();
+                    .fromFlowFile(record.getCurrent())
+                    .contentClaim(null)
+                    .contentClaimOffset(0)
+                    .size(0)
+                    .build();
 
             context.getContentRepository().decrementClaimantCount(newClaim);
             record.addTransientClaim(newClaim);
         } else {
             newFile = new StandardFlowFileRecord.Builder()
-                .fromFlowFile(record.getCurrent())
-                .contentClaim(newClaim)
-                .contentClaimOffset(0)
-                .size(newSize)
-                .build();
+                    .fromFlowFile(record.getCurrent())
+                    .contentClaim(newClaim)
+                    .contentClaimOffset(0)
+                    .size(newSize)
+                    .build();
         }
 
         record.setWorking(newFile, true);
@@ -3403,13 +3407,13 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             }
 
             try (final InputStream is = getInputStream(source, currClaim, record.getCurrentClaimOffset(), true);
-                final InputStream limitedIn = new LimitedInputStream(is, source.getSize());
-                final InputStream disableOnCloseIn = new DisableOnCloseInputStream(limitedIn);
-                final ByteCountingInputStream countingIn = new ByteCountingInputStream(disableOnCloseIn, bytesRead);
-                final OutputStream os = claimCache.write(newClaim);
-                final OutputStream nonFlushableOut = new NonFlushableOutputStream(os);
-                final OutputStream disableOnCloseOut = new DisableOnCloseOutputStream(nonFlushableOut);
-                final ByteCountingOutputStream countingOut = new ByteCountingOutputStream(disableOnCloseOut)) {
+                 final InputStream limitedIn = new LimitedInputStream(is, source.getSize());
+                 final InputStream disableOnCloseIn = new DisableOnCloseInputStream(limitedIn);
+                 final ByteCountingInputStream countingIn = new ByteCountingInputStream(disableOnCloseIn, bytesRead);
+                 final OutputStream os = claimCache.write(newClaim);
+                 final OutputStream nonFlushableOut = new NonFlushableOutputStream(os);
+                 final OutputStream disableOnCloseOut = new DisableOnCloseOutputStream(nonFlushableOut);
+                 final ByteCountingOutputStream countingOut = new ByteCountingOutputStream(disableOnCloseOut)) {
 
                 writeRecursionSet.add(source);
 
@@ -3455,21 +3459,21 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
 
         if (writtenToFlowFile == 0) {
             newFile = new StandardFlowFileRecord.Builder()
-                .fromFlowFile(record.getCurrent())
-                .contentClaim(null)
-                .contentClaimOffset(0)
-                .size(0)
-                .build();
+                    .fromFlowFile(record.getCurrent())
+                    .contentClaim(null)
+                    .contentClaimOffset(0)
+                    .size(0)
+                    .build();
 
             context.getContentRepository().decrementClaimantCount(newClaim);
             record.addTransientClaim(newClaim);
         } else {
             newFile = new StandardFlowFileRecord.Builder()
-                .fromFlowFile(record.getCurrent())
-                .contentClaim(newClaim)
-                .contentClaimOffset(Math.max(0L, newClaim.getLength() - writtenToFlowFile))
-                .size(writtenToFlowFile)
-                .build();
+                    .fromFlowFile(record.getCurrent())
+                    .contentClaim(newClaim)
+                    .contentClaimOffset(Math.max(0L, newClaim.getLength() - writtenToFlowFile))
+                    .size(writtenToFlowFile)
+                    .build();
         }
 
         record.setWorking(newFile, true);
@@ -3516,23 +3520,23 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         final FlowFileRecord newFile;
         if (newSize == 0) {
             newFile = new StandardFlowFileRecord.Builder()
-                .fromFlowFile(record.getCurrent())
-                .contentClaim(null)
-                .contentClaimOffset(0)
-                .size(0)
-                .addAttribute(CoreAttributes.FILENAME.key(), source.toFile().getName())
-                .build();
+                    .fromFlowFile(record.getCurrent())
+                    .contentClaim(null)
+                    .contentClaimOffset(0)
+                    .size(0)
+                    .addAttribute(CoreAttributes.FILENAME.key(), source.toFile().getName())
+                    .build();
 
             context.getContentRepository().decrementClaimantCount(newClaim);
             record.addTransientClaim(newClaim);
         } else {
             newFile = new StandardFlowFileRecord.Builder()
-                .fromFlowFile(record.getCurrent())
-                .contentClaim(newClaim)
-                .contentClaimOffset(claimOffset)
-                .size(newSize)
-                .addAttribute(CoreAttributes.FILENAME.key(), source.toFile().getName())
-                .build();
+                    .fromFlowFile(record.getCurrent())
+                    .contentClaim(newClaim)
+                    .contentClaimOffset(claimOffset)
+                    .size(newSize)
+                    .addAttribute(CoreAttributes.FILENAME.key(), source.toFile().getName())
+                    .build();
         }
 
         record.setWorking(newFile, CoreAttributes.FILENAME.key(), source.toFile().getName(), true);
@@ -3576,21 +3580,21 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         final FlowFileRecord newFile;
         if (newSize == 0) {
             newFile = new StandardFlowFileRecord.Builder()
-                .fromFlowFile(record.getCurrent())
-                .contentClaim(null)
-                .contentClaimOffset(0)
-                .size(0)
-                .build();
+                    .fromFlowFile(record.getCurrent())
+                    .contentClaim(null)
+                    .contentClaimOffset(0)
+                    .size(0)
+                    .build();
 
             context.getContentRepository().decrementClaimantCount(newClaim);
             record.addTransientClaim(newClaim);
         } else {
             newFile = new StandardFlowFileRecord.Builder()
-                .fromFlowFile(record.getCurrent())
-                .contentClaim(newClaim)
-                .contentClaimOffset(claimOffset)
-                .size(newSize)
-                .build();
+                    .fromFlowFile(record.getCurrent())
+                    .contentClaim(newClaim)
+                    .contentClaimOffset(claimOffset)
+                    .size(newSize)
+                    .build();
         }
 
         record.setWorking(newFile, true);
@@ -3633,9 +3637,9 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
         }
 
         try (final InputStream rawIn = getInputStream(source, record.getCurrentClaim(), record.getCurrentClaimOffset(), true);
-                final InputStream limitedIn = new LimitedInputStream(rawIn, source.getSize());
-                final InputStream disableOnCloseIn = new DisableOnCloseInputStream(limitedIn);
-                final ByteCountingInputStream countingStream = new ByteCountingInputStream(disableOnCloseIn, this.bytesRead)) {
+             final InputStream limitedIn = new LimitedInputStream(rawIn, source.getSize());
+             final InputStream disableOnCloseIn = new DisableOnCloseInputStream(limitedIn);
+             final ByteCountingInputStream countingStream = new ByteCountingInputStream(disableOnCloseIn, this.bytesRead)) {
 
             // We want to differentiate between IOExceptions thrown by the repository and IOExceptions thrown from
             // Processor code. As a result, as have the FlowFileAccessInputStream that catches IOException from the repository

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProvenanceReporter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProvenanceReporter.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.controller.repository;
 
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.FlowFileHandlingException;
 import org.apache.nifi.provenance.InternalProvenanceReporter;
@@ -27,9 +28,11 @@ import org.apache.nifi.provenance.ProvenanceEventType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -115,7 +118,7 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
     }
 
     /**
-     * Generates a Fork event for the given child and parents but does not register the event. This is useful so that a ProcessSession has the ability to de-dupe events, since one or more events may
+     * Generates a Join event for the given child and parents but does not register the event. This is useful so that a ProcessSession has the ability to de-dupe events, since one or more events may
      * be created by the session itself, as well as by the Processor
      *
      * @param parents parents
@@ -127,16 +130,59 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         final ProvenanceEventBuilder eventBuilder = build(child, ProvenanceEventType.JOIN);
         eventBuilder.addChildFlowFile(child);
 
+        List<Long> parentEventIds = new ArrayList<>(parents.size());
         for (final FlowFile parent : parents) {
             eventBuilder.addParentFlowFile(parent);
+            parentEventIds.addAll(repository.getPreviousEventIds(parent.getAttribute(CoreAttributes.UUID.key())));
         }
+        eventBuilder.setPreviousEventIds(parentEventIds);
 
-        return eventBuilder.build();
+        ProvenanceEventRecord record = eventBuilder.build();
+        repository.updatePreviousEventIds(record, parentEventIds);
+        return record;
     }
 
     @Override
     public ProvenanceEventRecord generateDropEvent(final FlowFile flowFile, final String details) {
-        return build(flowFile, ProvenanceEventType.DROP).setDetails(details).build();
+        final String flowFileUUID = flowFile.getAttribute(CoreAttributes.UUID.key());
+        final ProvenanceEventRecord record =  build(flowFile, ProvenanceEventType.DROP)
+                .setDetails(details)
+                .setPreviousEventIds(repository.getPreviousEventIds(flowFileUUID))
+                .build();
+        repository.updatePreviousEventIds(record, null);
+        return record;
+    }
+
+    @Override
+    public ProvenanceEventRecord generateModifyContentEvent(final FlowFile flowFile, final String details) {
+        final String flowFileUUID = flowFile.getAttribute(CoreAttributes.UUID.key());
+        final ProvenanceEventRecord record =  build(flowFile, ProvenanceEventType.CONTENT_MODIFIED)
+                .setDetails(details)
+                .setPreviousEventIds(repository.getPreviousEventIds(flowFileUUID))
+                .build();
+        repository.updatePreviousEventIds(record, Collections.singletonList(record.getEventId()));
+        return record;
+    }
+
+    @Override
+    public ProvenanceEventRecord generateModifyAttributesEvent(final FlowFile flowFile, final String details) {
+        final String flowFileUUID = flowFile.getAttribute(CoreAttributes.UUID.key());
+        final ProvenanceEventRecord record =  build(flowFile, ProvenanceEventType.ATTRIBUTES_MODIFIED)
+                .setDetails(details)
+                .setPreviousEventIds(repository.getPreviousEventIds(flowFileUUID))
+                .build();
+        repository.updatePreviousEventIds(record, Collections.singletonList(record.getEventId()));
+        return record;
+    }
+
+    @Override
+    public ProvenanceEventRecord generateCreateEvent(final FlowFile flowFile, final String details) {
+        final ProvenanceEventRecord record =  build(flowFile, ProvenanceEventType.CREATE)
+                .setDetails(details)
+                .setPreviousEventIds(Collections.emptyList())
+                .build();
+        repository.updatePreviousEventIds(record, Collections.singletonList(record.getEventId()));
+        return record;
     }
 
     private void verifyFlowFileKnown(final FlowFile flowFile) {
@@ -170,13 +216,15 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
-            final ProvenanceEventBuilder builder = build(flowFile, ProvenanceEventType.RECEIVE);
-            builder.setTransitUri(transitUri);
-            builder.setSourceSystemFlowFileIdentifier(sourceSystemFlowFileIdentifier);
-            builder.setEventDuration(transmissionMillis);
-            builder.setDetails(details);
-            final ProvenanceEventRecord record = builder.build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.RECEIVE)
+                    .setTransitUri(transitUri)
+                    .setSourceSystemFlowFileIdentifier(sourceSystemFlowFileIdentifier)
+                    .setEventDuration(transmissionMillis)
+                    .setDetails(details)
+                    .setPreviousEventIds(Collections.singletonList(-1L))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singletonList(record.getEventId()));
 
             bytesReceived += flowFile.getSize();
             flowFilesReceived++;
@@ -203,13 +251,16 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
+            final String flowFileUUID = flowFile.getAttribute(CoreAttributes.UUID.key());
             final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.FETCH)
                     .setTransitUri(transitUri)
                     .setEventDuration(transmissionMillis)
                     .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFileUUID))
                     .build();
 
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singletonList(record.getEventId()));
 
             bytesFetched += flowFile.getSize();
             flowFilesFetched++;
@@ -259,7 +310,12 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
     @Override
     public void send(final FlowFile flowFile, final String transitUri, final String details, final long transmissionMillis, final boolean force) {
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.SEND).setTransitUri(transitUri).setEventDuration(transmissionMillis).setDetails(details).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.SEND)
+                    .setTransitUri(transitUri)
+                    .setEventDuration(transmissionMillis)
+                    .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             // If the transmissionMillis field has been populated, use zero as the value of commitNanos (the call to System.nanoTime() is expensive but the value will be ignored).
             final long commitNanos = transmissionMillis < 0 ? System.nanoTime() : 0L;
             final ProvenanceEventRecord enriched = eventEnricher == null ? record : eventEnricher.enrich(record, flowFile, commitNanos);
@@ -269,6 +325,7 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
             } else {
                 events.add(enriched);
             }
+            repository.updatePreviousEventIds(enriched, enriched.getPreviousEventIds());
 
             bytesSent += flowFile.getSize();
             flowFilesSent++;
@@ -320,8 +377,12 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
     public void invokeRemoteProcess(FlowFile flowFile, String transitUri, String details) {
         try {
             final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.REMOTE_INVOCATION)
-                    .setTransitUri(transitUri).setDetails(details).build();
+                    .setTransitUri(transitUri)
+                    .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singletonList(record.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);
             if (logger.isDebugEnabled()) {
@@ -347,8 +408,12 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
             }
 
             final String alternateIdentifierUri = trimmedNamespace + ":" + trimmedIdentifier;
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ADDINFO).setAlternateIdentifierUri(alternateIdentifierUri).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ADDINFO)
+                    .setAlternateIdentifierUri(alternateIdentifierUri)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singletonList(record.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);
             if (logger.isDebugEnabled()) {
@@ -364,8 +429,10 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
             if (reason != null) {
                 builder.setDetails("Discard reason: " + reason);
             }
+            builder.setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())));
             final ProvenanceEventRecord record = builder.build();
             events.add(record);
+            repository.updatePreviousEventIds(record, null);
             return record;
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);
@@ -379,8 +446,12 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
     @Override
     public void expire(final FlowFile flowFile, final String details) {
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.EXPIRE).setDetails(details).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.EXPIRE)
+                    .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, null);
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);
             if (logger.isDebugEnabled()) {
@@ -423,7 +494,14 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
                 eventBuilder.setDetails(details);
             }
 
-            events.add(eventBuilder.build());
+            final ProvenanceEventRecord record = eventBuilder.build();
+            events.add(record);
+            for (final FlowFile child : children) {
+                // Add the child FlowFiles to the previous event ID map with the parent's entry in the map
+                repository.updatePreviousEventIds(
+                        record,
+                        repository.getPreviousEventIds(parent.getAttribute(CoreAttributes.UUID.key())));
+            }
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);
             if (logger.isDebugEnabled()) {
@@ -456,11 +534,16 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
             eventBuilder.addChildFlowFile(child);
             eventBuilder.setDetails(details);
 
+            List<Long> parentEventIds = new ArrayList<>(parents.size());
             for (final FlowFile parent : parents) {
                 eventBuilder.addParentFlowFile(parent);
+                parentEventIds.addAll(repository.getPreviousEventIds(parent.getAttribute(CoreAttributes.UUID.key())));
             }
+            eventBuilder.setPreviousEventIds(parentEventIds);
 
-            events.add(eventBuilder.build());
+            final ProvenanceEventRecord record = eventBuilder.build();
+            events.add(record);
+            repository.updatePreviousEventIds(record, parentEventIds);
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);
             if (logger.isDebugEnabled()) {
@@ -482,9 +565,13 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
 
         try {
             final ProvenanceEventBuilder eventBuilder = build(parent, ProvenanceEventType.CLONE);
-            eventBuilder.addChildFlowFile(child);
-            eventBuilder.addParentFlowFile(parent);
-            events.add(eventBuilder.build());
+            final ProvenanceEventRecord event = eventBuilder
+                    .addChildFlowFile(child)
+                    .addParentFlowFile(parent)
+                    .setPreviousEventIds(repository.getPreviousEventIds(parent.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
+            events.add(event);
+            repository.updatePreviousEventIds(event, Collections.singletonList(event.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);
             if (logger.isDebugEnabled()) {
@@ -513,8 +600,13 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.CONTENT_MODIFIED).setEventDuration(processingMillis).setDetails(details).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.CONTENT_MODIFIED)
+                    .setEventDuration(processingMillis)
+                    .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singletonList(record.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);
             if (logger.isDebugEnabled()) {
@@ -533,8 +625,12 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ATTRIBUTES_MODIFIED).setDetails(details).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ATTRIBUTES_MODIFIED)
+                    .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singletonList(record.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);
             if (logger.isDebugEnabled()) {
@@ -563,8 +659,13 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ROUTE).setRelationship(relationship).setDetails(details).setEventDuration(processingDuration).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ROUTE).setRelationship(relationship)
+                    .setDetails(details)
+                    .setEventDuration(processingDuration)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singletonList(record.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);
             if (logger.isDebugEnabled()) {
@@ -583,8 +684,9 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.CREATE).setDetails(details).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.CREATE).setDetails(details).setPreviousEventIds(Collections.emptyList()).build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singletonList(record.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event due to " + e);
             if (logger.isDebugEnabled()) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/provenance/InternalProvenanceReporter.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/provenance/InternalProvenanceReporter.java
@@ -33,6 +33,12 @@ public interface InternalProvenanceReporter extends ProvenanceReporter {
 
     ProvenanceEventRecord generateJoinEvent(Collection<FlowFile> parents, FlowFile child);
 
+    ProvenanceEventRecord generateModifyContentEvent(FlowFile flowFile, String explanation);
+
+    ProvenanceEventRecord generateCreateEvent(FlowFile flowFile, String explanation);
+
+    ProvenanceEventRecord generateModifyAttributesEvent(FlowFile flowFile, String explanation);
+
     void remove(ProvenanceEventRecord event);
 
     void removeEventsForFlowFile(String uuid);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/AbstractFlowFileQueue.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/AbstractFlowFileQueue.java
@@ -426,6 +426,8 @@ public abstract class AbstractFlowFileQueue implements FlowFileQueue {
             builder.setPreviousContentClaim(resourceClaim.getContainer(), resourceClaim.getSection(), resourceClaim.getId(), contentClaim.getOffset(), flowFile.getSize());
         }
 
+        builder.setPreviousEventIds(provRepository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())));
+
         return builder.build();
     }
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/StandardProcessSessionIT.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/StandardProcessSessionIT.java
@@ -1442,10 +1442,11 @@ public class StandardProcessSessionIT {
 
         final FlowFile orig = session.get();
         final FlowFile newFlowFile = session.create(orig);
+        final Relationship a = new Relationship.Builder().name("A").build();
         session.getProvenanceReporter().fork(orig, Collections.singletonList(newFlowFile), 0L);
         session.getProvenanceReporter().fetch(newFlowFile, "nowhere://");
         session.getProvenanceReporter().send(newFlowFile, "nowhere://");
-        session.transfer(newFlowFile, new Relationship.Builder().name("A").build());
+        session.transfer(newFlowFile, a);
         session.commit();
 
         List<ProvenanceEventRecord> events = provenanceRepo.getEvents(0L, 100000);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/provenance/MockProvenanceRepository.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/provenance/MockProvenanceRepository.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.nifi.provenance;
 
 import org.apache.nifi.authorization.Authorizer;
@@ -33,7 +32,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class MockProvenanceRepository implements ProvenanceRepository {
+public class MockProvenanceRepository extends AbstractProvenanceRepository {
+
     private final List<ProvenanceEventRecord> records = new ArrayList<>();
     private final AtomicLong idGenerator = new AtomicLong(0L);
 

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/EventIdFirstSchemaRecordWriter.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/EventIdFirstSchemaRecordWriter.java
@@ -34,6 +34,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -61,6 +62,9 @@ public class EventIdFirstSchemaRecordWriter extends CompressableRecordWriter {
     private static final List<String> eventTypeNames;
 
     private long firstEventId;
+
+    private final Map<String, List<Long>> previousEventIdsMap = new HashMap<>();
+
     private long systemTimeOffset;
 
     static {
@@ -98,6 +102,11 @@ public class EventIdFirstSchemaRecordWriter extends CompressableRecordWriter {
         int totalBytes = 0;
 
         for (final ProvenanceEventRecord event : events) {
+            final long recordIdentifier = event.getEventId() == -1 ? getIdGenerator().getAndIncrement() : event.getEventId();
+            if (event instanceof UpdateableProvenanceEventRecord) {
+                updateEvent((UpdateableProvenanceEventRecord) event, recordIdentifier);
+            }
+
             final byte[] serialized = serializeEvent(event);
             serializedEvents.put(event, serialized);
             totalBytes += serialized.length;
@@ -221,5 +230,46 @@ public class EventIdFirstSchemaRecordWriter extends CompressableRecordWriter {
     @Override
     protected String getSerializationName() {
         return SERIALIZATION_NAME;
+    }
+
+    private void updateEvent(UpdateableProvenanceEventRecord event, long recordIdentifier) {
+        event.setEventId(recordIdentifier);
+        final String flowFileUUID = event.getFlowFileUuid();
+        List<Long> previousEventIds = previousEventIdsMap.get(flowFileUUID);
+        switch (event.getEventType()) {
+            case CREATE:
+            case RECEIVE:
+                event.setPreviousEventIds(Collections.singletonList(-1L));
+                previousEventIdsMap.put(flowFileUUID, Collections.singletonList(recordIdentifier));
+                break;
+            case DROP:
+            case EXPIRE:
+                event.setPreviousEventIds(previousEventIds);
+                previousEventIdsMap.remove(flowFileUUID);
+                break;
+            case FORK:
+            case CLONE:
+            case REPLAY:
+                event.setPreviousEventIds(previousEventIds);
+                for (final String childUUID : event.getChildUuids()) {
+                    // Add the child FlowFiles to the previous event ID map with this event's entry in the map
+                    previousEventIdsMap.put(childUUID, Collections.singletonList(recordIdentifier));
+                }
+                break;
+            case JOIN:
+                List<String> parents = event.getParentUuids();
+                List<Long> parentEventIds = new ArrayList<>(parents.size());
+                for (final String parentUUID : parents) {
+                    parentEventIds.addAll(previousEventIdsMap.get(parentUUID));
+                }
+                event.setPreviousEventIds(parentEventIds);
+                previousEventIdsMap.put(flowFileUUID, Collections.singletonList(recordIdentifier));
+                break;
+
+            default:
+                event.setPreviousEventIds(previousEventIds);
+                previousEventIdsMap.put(flowFileUUID, Collections.singletonList(recordIdentifier));
+                break;
+        }
     }
 }

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/WriteAheadProvenanceRepository.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/WriteAheadProvenanceRepository.java
@@ -88,7 +88,7 @@ import java.util.Set;
  * across disks for far greater performance.
  * </p>
  */
-public class WriteAheadProvenanceRepository implements ProvenanceRepository {
+public class WriteAheadProvenanceRepository extends AbstractProvenanceRepository {
     private static final Logger logger = LoggerFactory.getLogger(WriteAheadProvenanceRepository.class);
     static final int BLOCK_SIZE = 1024 * 32;
     public static final String EVENT_CATEGORY = "Provenance Repository";

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/ConvertEventToLuceneDocument.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/ConvertEventToLuceneDocument.java
@@ -94,6 +94,15 @@ public class ConvertEventToLuceneDocument {
         // be stored so that we know how to lookup the event in the store.
         doc.add(new UnIndexedLongField(SearchableFields.Identifier.getSearchableFieldName(), eventId));
 
+        final List<Long> previousEventIDs = record.getPreviousEventIds();
+        if (previousEventIDs != null) {
+            for (Long previousEventID : previousEventIDs) {
+                doc.add(new StringField(SearchableFields.PreviousEventIdentifiers.getSearchableFieldName(), String.valueOf(previousEventID), Store.YES));
+            }
+        } else {
+            doc.add(new StringField(SearchableFields.PreviousEventIdentifiers.getSearchableFieldName(), "-1", Store.YES));
+        }
+
         // If it's event is a FORK, or JOIN, add the FlowFileUUID for all child/parent UUIDs.
         final ProvenanceEventType eventType = record.getEventType();
         if (eventType == ProvenanceEventType.FORK || eventType == ProvenanceEventType.CLONE || eventType == ProvenanceEventType.REPLAY) {
@@ -141,7 +150,7 @@ public class ConvertEventToLuceneDocument {
 
         public UnIndexedLongField(String name, long value) {
             super(name, TYPE);
-            fieldsData = Long.valueOf(value);
+            fieldsData = value;
         }
     }
 }

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/EventFieldNames.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/EventFieldNames.java
@@ -19,6 +19,7 @@ package org.apache.nifi.provenance.schema;
 
 public class EventFieldNames {
     public static final String EVENT_IDENTIFIER = "Event ID";
+    public static final String PREVIOUS_EVENT_IDENTIFIERS = "Previous Event IDs";
     public static final String EVENT_TYPE = "Event Type";
     public static final String EVENT_TIME = "Event Time";
     public static final String FLOWFILE_ENTRY_DATE = "FlowFile Entry Date";

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/EventRecord.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/EventRecord.java
@@ -111,6 +111,8 @@ public class EventRecord implements Record {
                 return event.getTransitUri();
             case EventFieldNames.UPDATED_ATTRIBUTES:
                 return event.getUpdatedAttributes();
+            case EventFieldNames.PREVIOUS_EVENT_IDENTIFIERS:
+                return event.getPreviousEventIds();
         }
 
         return null;
@@ -165,6 +167,11 @@ public class EventRecord implements Record {
                 (String) previousClaimRecord.getFieldValue(EventFieldNames.CONTENT_CLAIM_IDENTIFIER),
                 (Long) previousClaimRecord.getFieldValue(EventFieldNames.CONTENT_CLAIM_OFFSET),
                 (Long) previousClaimRecord.getFieldValue(EventFieldNames.CONTENT_CLAIM_SIZE));
+        }
+
+        final List<Long> previousEventIDs = (List<Long>) record.getFieldValue(EventFieldNames.PREVIOUS_EVENT_IDENTIFIERS);
+        if (previousEventIDs != null) {
+            builder.setPreviousEventIds(previousEventIDs);
         }
 
         return builder.build();

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventRecord.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventRecord.java
@@ -224,6 +224,8 @@ public class LookupTableEventRecord implements Record {
                 return event.getUpdatedAttributes();
             case EventFieldNames.FLOWFILE_UUID:
                 return event.getAttribute(CoreAttributes.UUID.key());
+            case EventFieldNames.PREVIOUS_EVENT_IDENTIFIERS:
+                return event.getPreviousEventIds();
         }
 
         return null;
@@ -351,6 +353,11 @@ public class LookupTableEventRecord implements Record {
                     (Long) currentClaimRecord.getFieldValue(EventFieldNames.CONTENT_CLAIM_OFFSET),
                     (Long) currentClaimRecord.getFieldValue(EventFieldNames.CONTENT_CLAIM_SIZE));
             }
+        }
+
+        final List<Long> previousEventIDs = (List<Long>) record.getFieldValue(EventFieldNames.PREVIOUS_EVENT_IDENTIFIERS);
+        if (previousEventIDs != null) {
+            builder.setPreviousEventIds(previousEventIDs);
         }
 
         return builder.build();

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventRecordFields.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventRecordFields.java
@@ -33,6 +33,7 @@ public class LookupTableEventRecordFields {
 
     // General Event fields.
     public static final RecordField RECORD_IDENTIFIER_OFFSET = new SimpleRecordField(EventFieldNames.EVENT_IDENTIFIER, FieldType.INT, EXACTLY_ONE);
+    public static final RecordField PREVIOUS_EVENT_IDENTIFIERS = new SimpleRecordField(EventFieldNames.PREVIOUS_EVENT_IDENTIFIERS, FieldType.LONG, ZERO_OR_MORE);
     public static final RecordField EVENT_TYPE_ORDINAL = new SimpleRecordField(EventFieldNames.EVENT_TYPE, FieldType.INT, EXACTLY_ONE);
     public static final RecordField EVENT_TIME_OFFSET = new SimpleRecordField(EventFieldNames.EVENT_TIME, FieldType.INT, EXACTLY_ONE);
     public static final RecordField FLOWFILE_ENTRY_DATE_OFFSET = new SimpleRecordField(EventFieldNames.FLOWFILE_ENTRY_DATE, FieldType.INT, EXACTLY_ONE);

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventSchema.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventSchema.java
@@ -34,6 +34,7 @@ import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.NO_
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.PARENT_UUIDS;
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.PREVIOUS_ATTRIBUTES;
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.PREVIOUS_CONTENT_CLAIM;
+import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.PREVIOUS_EVENT_IDENTIFIERS;
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.RECORD_IDENTIFIER_OFFSET;
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.RELATIONSHIP;
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.SOURCE_QUEUE_ID;
@@ -64,6 +65,7 @@ public class LookupTableEventSchema {
             fields.add(RECORD_IDENTIFIER_OFFSET);
         }
 
+        fields.add(PREVIOUS_EVENT_IDENTIFIERS);
         fields.add(EVENT_TYPE_ORDINAL);
         fields.add(EVENT_TIME_OFFSET);
         fields.add(FLOWFILE_ENTRY_DATE_OFFSET);

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/util/StorageSummaryEvent.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/util/StorageSummaryEvent.java
@@ -21,9 +21,10 @@ import java.util.List;
 import java.util.Map;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.provenance.UpdateableProvenanceEventRecord;
 import org.apache.nifi.provenance.serialization.StorageSummary;
 
-public class StorageSummaryEvent implements ProvenanceEventRecord {
+public class StorageSummaryEvent implements UpdateableProvenanceEventRecord {
     private final ProvenanceEventRecord event;
     private final StorageSummary storageSummary;
 
@@ -37,6 +38,24 @@ public class StorageSummaryEvent implements ProvenanceEventRecord {
         return storageSummary.getEventId();
     }
 
+    @Override
+    public void setEventId(long eventId) {
+        if (event instanceof UpdateableProvenanceEventRecord) {
+            ((UpdateableProvenanceEventRecord) event).setEventId(eventId);
+        }
+    }
+
+    @Override
+    public List<Long> getPreviousEventIds() {
+        return event.getPreviousEventIds();
+    }
+
+    @Override
+    public void setPreviousEventIds(List<Long> previousEventIds) {
+        if (event instanceof UpdateableProvenanceEventRecord) {
+            ((UpdateableProvenanceEventRecord) event).setPreviousEventIds(previousEventIds);
+        }
+    }
     @Override
     public long getEventTime() {
         return event.getEventTime();

--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/main/java/org/apache/nifi/provenance/VolatileProvenanceRepository.java
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/main/java/org/apache/nifi/provenance/VolatileProvenanceRepository.java
@@ -64,7 +64,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
-public class VolatileProvenanceRepository implements ProvenanceRepository {
+public class VolatileProvenanceRepository extends AbstractProvenanceRepository {
 
     // properties
     public static final String BUFFER_SIZE = "nifi.provenance.repository.buffer.size";
@@ -223,6 +223,8 @@ public class VolatileProvenanceRepository implements ProvenanceRepository {
         authorize(event, user);
         return event;
     }
+
+
 
     @Override
     public void close() throws IOException {
@@ -786,7 +788,7 @@ public class VolatileProvenanceRepository implements ProvenanceRepository {
         }
     }
 
-    private static class IdEnrichedProvEvent implements ProvenanceEventRecord {
+    private static class IdEnrichedProvEvent implements UpdateableProvenanceEventRecord {
 
         private final ProvenanceEventRecord record;
         private final long id;
@@ -799,6 +801,25 @@ public class VolatileProvenanceRepository implements ProvenanceRepository {
         @Override
         public long getEventId() {
             return id;
+        }
+
+        @Override
+        public void setEventId(long eventId) {
+            if (record instanceof UpdateableProvenanceEventRecord) {
+                ((UpdateableProvenanceEventRecord) record).setEventId(eventId);
+            }
+        }
+
+        @Override
+        public List<Long> getPreviousEventIds() {
+            return record.getPreviousEventIds();
+        }
+
+        @Override
+        public void setPreviousEventIds(List<Long> previousEventIds) {
+            if (record instanceof UpdateableProvenanceEventRecord) {
+                ((UpdateableProvenanceEventRecord) record).setPreviousEventIds(previousEventIds);
+            }
         }
 
         @Override

--- a/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteProvenanceReportingTask.java
+++ b/nifi-nar-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteProvenanceReportingTask.java
@@ -384,6 +384,15 @@ public class SiteToSiteProvenanceReportingTask extends AbstractSiteToSiteReporti
         addField(builder, "alternateIdentifier", event.getAlternateIdentifierUri(), allowNullValues);
         addField(builder, "platform", platform, allowNullValues);
         addField(builder, "application", applicationName, allowNullValues);
+        List<String> previousEventIdsList = null;
+        List<Long> previousEventIds = event.getPreviousEventIds();
+        if (previousEventIds != null) {
+            previousEventIdsList = new ArrayList<>(previousEventIds.size());
+            for (Long previousEventId : previousEventIds) {
+                previousEventIdsList.add(String.valueOf(previousEventId));
+            }
+        }
+        addField(builder, factory, "previousEventIds", previousEventIdsList, allowNullValues);
 
         return builder.build();
     }

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestQueryNiFiReportingTask.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/test/java/org/apache/nifi/reporting/sql/TestQueryNiFiReportingTask.java
@@ -743,6 +743,7 @@ class TestQueryNiFiReportingTask {
 
     private static class MockProvenanceRepository implements ProvenanceEventRepository {
         private final List<ProvenanceEventRecord> events = new ArrayList<>();
+        protected final Map<String, List<Long>> previousEventIdsMap = new HashMap<>();
 
         @Override
         public ProvenanceEventBuilder eventBuilder() {
@@ -785,6 +786,20 @@ class TestQueryNiFiReportingTask {
 
         @Override
         public void close() {
+        }
+
+        @Override
+        public List<Long> getPreviousEventIds(String flowFileUUID) {
+            return previousEventIdsMap.get(flowFileUUID);
+        }
+
+        @Override
+        public void updatePreviousEventIds(ProvenanceEventRecord record, List<Long> previousIds) {
+            if (previousIds == null) {
+                previousEventIdsMap.remove(record.getFlowFileUuid());
+            } else {
+                previousEventIdsMap.put(record.getFlowFileUuid(), previousIds);
+            }
         }
     }
 }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/repository/StatelessProvenanceRepository.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/repository/StatelessProvenanceRepository.java
@@ -19,6 +19,7 @@ package org.apache.nifi.stateless.repository;
 import org.apache.nifi.authorization.Authorizer;
 import org.apache.nifi.authorization.user.NiFiUser;
 import org.apache.nifi.events.EventReporter;
+import org.apache.nifi.provenance.AbstractProvenanceRepository;
 import org.apache.nifi.provenance.AsyncLineageSubmission;
 import org.apache.nifi.provenance.IdentifierLookup;
 import org.apache.nifi.provenance.ProvenanceAuthorizableFactory;
@@ -26,8 +27,8 @@ import org.apache.nifi.provenance.ProvenanceEventBuilder;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventRepository;
 import org.apache.nifi.provenance.ProvenanceEventType;
-import org.apache.nifi.provenance.ProvenanceRepository;
 import org.apache.nifi.provenance.StandardProvenanceEventRecord;
+import org.apache.nifi.provenance.UpdateableProvenanceEventRecord;
 import org.apache.nifi.provenance.lineage.ComputeLineageSubmission;
 import org.apache.nifi.provenance.search.Query;
 import org.apache.nifi.provenance.search.QuerySubmission;
@@ -42,7 +43,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class StatelessProvenanceRepository implements ProvenanceRepository {
+public class StatelessProvenanceRepository extends AbstractProvenanceRepository {
 
     public static String CONTAINER_NAME = "in-memory";
 
@@ -107,12 +108,7 @@ public class StatelessProvenanceRepository implements ProvenanceRepository {
     }
 
     public ProvenanceEventRecord getEvent(final String identifier) throws IOException {
-        final List<ProvenanceEventRecord> records = ringBuffer.getSelectedElements(new RingBuffer.Filter<ProvenanceEventRecord>() {
-            @Override
-            public boolean select(final ProvenanceEventRecord event) {
-                return identifier.equals(event.getFlowFileUuid());
-            }
-        }, 1);
+        final List<ProvenanceEventRecord> records = ringBuffer.getSelectedElements(event -> identifier.equals(event.getFlowFileUuid()), 1);
         return records.isEmpty() ? null : records.get(0);
     }
 
@@ -208,7 +204,7 @@ public class StatelessProvenanceRepository implements ProvenanceRepository {
         return null;
     }
 
-    private static class IdEnrichedProvEvent implements ProvenanceEventRecord {
+    private static class IdEnrichedProvEvent implements UpdateableProvenanceEventRecord {
 
         private final ProvenanceEventRecord record;
         private final long id;
@@ -221,6 +217,25 @@ public class StatelessProvenanceRepository implements ProvenanceRepository {
         @Override
         public long getEventId() {
             return id;
+        }
+
+        @Override
+        public void setEventId(long eventId) {
+            if (record instanceof UpdateableProvenanceEventRecord) {
+                ((UpdateableProvenanceEventRecord) record).setEventId(eventId);
+            }
+        }
+
+        @Override
+        public List<Long> getPreviousEventIds() {
+            return record.getPreviousEventIds();
+        }
+
+        @Override
+        public void setPreviousEventIds(List<Long> previousEventIds) {
+            if (record instanceof UpdateableProvenanceEventRecord) {
+                ((UpdateableProvenanceEventRecord) record).setPreviousEventIds(previousEventIds);
+            }
         }
 
         @Override


### PR DESCRIPTION
# Summary

[NIFI-12855](https://issues.apache.org/jira/browse/NIFI-12855) This PR augments the provenance capabilities to include the following features:

- A reference in a provenance event to any parent events ("previousEventIds")
- Add methods to GraphClientService to generate queries/statements in popular graph languages such as Tinkerpop/Gremlin, Cypher, and SQL
- Add ArcadeDB service as reference implementation for SQL generation

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
