### PR TITLE
NIFI-12900 Avoid unnecessary directory listing in PutSFTP

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
@@ -708,8 +708,6 @@ public class SFTPTransfer implements FileTransfer {
             }
         }
 
-        // Previously JSCH would perform a listing on the full path (path + filename) and would get an exception when it wasn't
-        // a file and then return null, so to preserve that behavior we return null if the matchingEntry is a directory
         if (fileAttributes == null || isDirectory(fileAttributes)) {
             return null;
         } else {

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
@@ -111,8 +111,14 @@ public class SFTPTransfer implements FileTransfer {
     }
 
     private static String buildFullPath(String path, String filename) {
-        if (path == null) return filename;
-        if (path.endsWith("/")) return path + filename;
+        if (path == null) {
+             return filename;
+        }
+        
+        if (path.endsWith("/")) { 
+            return path + filename;
+        }
+         
         return path + "/" + filename;
     }
 

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
@@ -114,11 +114,11 @@ public class SFTPTransfer implements FileTransfer {
         if (path == null) {
              return filename;
         }
-        
-        if (path.endsWith("/")) { 
+
+        if (path.endsWith("/")) {
             return path + filename;
         }
-         
+
         return path + "/" + filename;
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Adjusts `SFTPTransfer` to avoid listing whole target directory before upload in `PutSFTP`. 

[NIFI-12900](https://issues.apache.org/jira/browse/NIFI-12900)

I'd appreciate if we could backport these changes to 1.x as well. Please let me know if I should open a separate pull-request for that.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
