### PR TITLE
NIFI-12901 Remove time units in description of properties that specify a time period

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/src/main/java/org/apache/nifi/dbcp/utils/DBCPProperties.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-dbcp-base/src/main/java/org/apache/nifi/dbcp/utils/DBCPProperties.java
@@ -136,7 +136,7 @@ public final class DBCPProperties {
     public static final PropertyDescriptor MAX_CONN_LIFETIME = new PropertyDescriptor.Builder()
             .displayName("Max Connection Lifetime")
             .name("dbcp-max-conn-lifetime")
-            .description("The maximum lifetime in milliseconds of a connection. After this time is exceeded the " +
+            .description("The maximum lifetime of a connection. After this time is exceeded the " +
                     "connection will fail the next activation, passivation or validation test. A value of zero or less " +
                     "means the connection has an infinite lifetime.")
             .defaultValue(DefaultDataSourceValues.MAX_CONN_LIFETIME.getValue())
@@ -148,7 +148,7 @@ public final class DBCPProperties {
     public static final PropertyDescriptor EVICTION_RUN_PERIOD = new PropertyDescriptor.Builder()
             .displayName("Time Between Eviction Runs")
             .name("dbcp-time-between-eviction-runs")
-            .description("The number of milliseconds to sleep between runs of the idle connection evictor thread. When " +
+            .description("The time period to sleep between runs of the idle connection evictor thread. When " +
                     "non-positive, no idle connection evictor thread will be run.")
             .defaultValue(DefaultDataSourceValues.EVICTION_RUN_PERIOD.getValue())
             .required(false)

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/dbcp/hive/Hive3ConnectionPool.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/dbcp/hive/Hive3ConnectionPool.java
@@ -198,7 +198,7 @@ public class Hive3ConnectionPool extends AbstractControllerService implements Hi
     public static final PropertyDescriptor MAX_CONN_LIFETIME = new PropertyDescriptor.Builder()
             .displayName("Max Connection Lifetime")
             .name("dbcp-max-conn-lifetime")
-            .description("The maximum lifetime in milliseconds of a connection. After this time is exceeded the " +
+            .description("The maximum lifetime of a connection. After this time is exceeded the " +
                     "connection will fail the next activation, passivation or validation test. A value of zero or less " +
                     "means the connection has an infinite lifetime.")
             .defaultValue(DEFAULT_MAX_CONN_LIFETIME)
@@ -210,7 +210,7 @@ public class Hive3ConnectionPool extends AbstractControllerService implements Hi
     public static final PropertyDescriptor EVICTION_RUN_PERIOD = new PropertyDescriptor.Builder()
             .displayName("Time Between Eviction Runs")
             .name("dbcp-time-between-eviction-runs")
-            .description("The number of milliseconds to sleep between runs of the idle connection evictor thread. When " +
+            .description("The time period to sleep between runs of the idle connection evictor thread. When " +
                     "non-positive, no idle connection evictor thread will be run.")
             .defaultValue(DEFAULT_EVICTION_RUN_PERIOD)
             .required(false)

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
@@ -99,7 +99,7 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
             .build();
     public static final PropertyDescriptor MAPPING_FILE_REFRESH_INTERVAL = new PropertyDescriptor.Builder()
             .name("Mapping File Refresh Interval")
-            .description("The polling interval in seconds to check for updates to the mapping file. The default is 60s.")
+            .description("The polling interval to check for updates to the mapping file. The default is 60s.")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .required(true)
             .defaultValue("60s")

--- a/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/main/java/org/apache/nifi/dbcp/HikariCPConnectionPool.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/main/java/org/apache/nifi/dbcp/HikariCPConnectionPool.java
@@ -179,7 +179,7 @@ public class HikariCPConnectionPool extends AbstractControllerService implements
     public static final PropertyDescriptor MAX_CONN_LIFETIME = new PropertyDescriptor.Builder()
             .name("hikaricp-max-conn-lifetime")
             .displayName("Max Connection Lifetime")
-            .description("The maximum lifetime in milliseconds of a connection. After this time is exceeded the " +
+            .description("The maximum lifetime of a connection. After this time is exceeded the " +
                     "connection will fail the next activation, passivation or validation test. A value of zero or less " +
                     "means the connection has an infinite lifetime.")
             .defaultValue(DEFAULT_MAX_CONN_LIFETIME)

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hadoop-dbcp-service-bundle/nifi-hadoop-dbcp-service/src/main/java/org/apache/nifi/dbcp/HadoopDBCPConnectionPool.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hadoop-dbcp-service-bundle/nifi-hadoop-dbcp-service/src/main/java/org/apache/nifi/dbcp/HadoopDBCPConnectionPool.java
@@ -215,7 +215,7 @@ public class HadoopDBCPConnectionPool extends AbstractControllerService implemen
     public static final PropertyDescriptor MAX_CONN_LIFETIME = new PropertyDescriptor.Builder()
             .displayName("Max Connection Lifetime")
             .name("dbcp-max-conn-lifetime")
-            .description("The maximum lifetime in milliseconds of a connection. After this time is exceeded the " +
+            .description("The maximum lifetime of a connection. After this time is exceeded the " +
                     "connection will fail the next activation, passivation or validation test. A value of zero or less " +
                     "means the connection has an infinite lifetime.")
             .defaultValue(DEFAULT_MAX_CONN_LIFETIME)
@@ -227,7 +227,7 @@ public class HadoopDBCPConnectionPool extends AbstractControllerService implemen
     public static final PropertyDescriptor EVICTION_RUN_PERIOD = new PropertyDescriptor.Builder()
             .displayName("Time Between Eviction Runs")
             .name("dbcp-time-between-eviction-runs")
-            .description("The number of milliseconds to sleep between runs of the idle connection evictor thread. When " +
+            .description("The time period to sleep between runs of the idle connection evictor thread. When " +
                     "non-positive, no idle connection evictor thread will be run.")
             .defaultValue(DEFAULT_EVICTION_RUN_PERIOD)
             .required(false)


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12901](https://issues.apache.org/jira/browse/NIFI-12901)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
