### PR TITLE
NIFI-12910 Upgrade Spring Framework from 6.0.17 to 6.0.18

### DIFF
--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -35,8 +35,8 @@
         <module>nifi-registry-docker-maven</module>
     </modules>
     <properties>
-        <spring.version>6.1.4</spring.version>
-        <spring.boot.version>3.2.2</spring.boot.version>
+        <spring.version>6.1.5</spring.version>
+        <spring.boot.version>3.2.3</spring.boot.version>
         <flyway.version>9.22.3</flyway.version>
         <flyway.tests.version>9.5.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <snakeyaml.version>2.2</snakeyaml.version>
         <netty.4.version>4.1.106.Final</netty.4.version>
         <servlet-api.version>6.0.0</servlet-api.version>
-        <spring.version>6.0.17</spring.version>
+        <spring.version>6.0.18</spring.version>
         <spring.security.version>6.2.2</spring.security.version>
         <swagger.annotations.version>2.2.20</swagger.annotations.version>
         <h2.version>2.2.224</h2.version>


### PR DESCRIPTION
# Summary

[NIFI-12910](https://issues.apache.org/jira/browse/NIFI-12910) Upgrades Spring Framework dependencies from 6.0.17 to [6.0.18](https://github.com/spring-projects/spring-framework/releases/tag/v6.0.18) and also upgrade Spring Boot for Registry from 3.2.2 to [3.2.3](https://github.com/spring-projects/spring-boot/releases/tag/v3.2.3).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
