### PR TITLE
NIFI-12902: Updating packaging to account for new build output

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/pom.xml
@@ -80,7 +80,7 @@
                             <outputDirectory>${project.build.directory}/${project.build.finalName}</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${frontend.working.dir}/dist/nifi</directory>
+                                    <directory>${frontend.working.dir}/dist/nifi/browser</directory>
                                     <filtering>false</filtering>
                                     <includes>
                                         <include>**/*</include>


### PR DESCRIPTION
NIFI-12902:
- Updating packaging to account for new build output.