### PR TITLE
NIFI-12918 Fix Stateless NullPointerException on versioned sub-process groups

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardVersionControlInformation.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardVersionControlInformation.java
@@ -131,7 +131,7 @@ public class StandardVersionControlInformation implements VersionControlInformat
         }
 
         public StandardVersionControlInformation build() {
-            //Objects.requireNonNull(storageLocation, "Flow Storage (Registry) Location must be specified");
+            Objects.requireNonNull(storageLocation, "Flow Storage (Registry) Location must be specified");
             Objects.requireNonNull(bucketIdentifier, "Bucket ID must be specified");
             Objects.requireNonNull(flowIdentifier, "Flow ID must be specified");
             Objects.requireNonNull(version, "Version must be specified");

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardVersionControlInformation.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardVersionControlInformation.java
@@ -131,7 +131,7 @@ public class StandardVersionControlInformation implements VersionControlInformat
         }
 
         public StandardVersionControlInformation build() {
-            Objects.requireNonNull(storageLocation, "Flow Storage Location must be specified");
+            Objects.requireNonNull(storageLocation, "Flow Storage (Registry) Location must be specified");
             Objects.requireNonNull(bucketIdentifier, "Bucket ID must be specified");
             Objects.requireNonNull(flowIdentifier, "Flow ID must be specified");
             Objects.requireNonNull(version, "Version must be specified");

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardVersionControlInformation.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardVersionControlInformation.java
@@ -131,7 +131,7 @@ public class StandardVersionControlInformation implements VersionControlInformat
         }
 
         public StandardVersionControlInformation build() {
-            Objects.requireNonNull(registryIdentifier, "Registry ID must be specified");
+            Objects.requireNonNull(storageLocation, "Flow Storage Location must be specified");
             Objects.requireNonNull(bucketIdentifier, "Bucket ID must be specified");
             Objects.requireNonNull(flowIdentifier, "Flow ID must be specified");
             Objects.requireNonNull(version, "Version must be specified");

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardVersionControlInformation.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardVersionControlInformation.java
@@ -131,7 +131,7 @@ public class StandardVersionControlInformation implements VersionControlInformat
         }
 
         public StandardVersionControlInformation build() {
-            Objects.requireNonNull(storageLocation, "Flow Storage (Registry) Location must be specified");
+            //Objects.requireNonNull(storageLocation, "Flow Storage (Registry) Location must be specified");
             Objects.requireNonNull(bucketIdentifier, "Bucket ID must be specified");
             Objects.requireNonNull(flowIdentifier, "Flow ID must be specified");
             Objects.requireNonNull(version, "Version must be specified");

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/core/RegistryUtil.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/core/RegistryUtil.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
+import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 public class RegistryUtil {
@@ -130,7 +131,7 @@ public class RegistryUtil {
 
         final VersionedFlowCoordinates coordinates = group.getVersionedFlowCoordinates();
         if (coordinates != null) {
-            final String registryUrl = coordinates.getRegistryUrl();
+            final String registryUrl = coordinates.getRegistryUrl().replace("nifi-registry","");
             final String bucketId = coordinates.getBucketId();
             final String flowId = coordinates.getFlowId();
             final int version = coordinates.getVersion();

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/core/RegistryUtil.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/core/RegistryUtil.java
@@ -130,7 +130,7 @@ public class RegistryUtil {
 
         final VersionedFlowCoordinates coordinates = group.getVersionedFlowCoordinates();
         if (coordinates != null) {
-            final String registryUrl = coordinates.getRegistryUrl().replace("nifi-registry","");
+            final String registryUrl = coordinates.getStorageLocation();
             final String bucketId = coordinates.getBucketId();
             final String flowId = coordinates.getFlowId();
             final int version = coordinates.getVersion();

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/core/RegistryUtil.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/core/RegistryUtil.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
+import java.net.URL;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -130,7 +131,8 @@ public class RegistryUtil {
 
         final VersionedFlowCoordinates coordinates = group.getVersionedFlowCoordinates();
         if (coordinates != null) {
-            final String registryUrl = coordinates.getStorageLocation();
+            URL storageLocation = new URL(coordinates.getStorageLocation());
+            final String registryUrl = storageLocation.getProtocol()+"://"+storageLocation.getAuthority();
             final String bucketId = coordinates.getBucketId();
             final String flowId = coordinates.getFlowId();
             final int version = coordinates.getVersion();

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/core/RegistryUtil.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/core/RegistryUtil.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
-import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 public class RegistryUtil {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12918](https://issues.apache.org/jira/browse/NIFI-12918)

This is the PR for the 2.0 (main) branch: https://github.com/apache/nifi/pull/8536

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-12918) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [-] Pull Request based on current revision of the `main` branch | We need this to be based on support/nifi1.x
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
- [-] JDK 21 | we built this to support nifi version 1.x which is on JDK 11

### Licensing

- [X] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html) - no new dependencies
- [X] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
