### PR TITLE
NIFI-12926 Upgrade Jackson from 2.16.2 to 2.17.0

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/config/JsonContentConversionExceptionMapperTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/config/JsonContentConversionExceptionMapperTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.web.api.config;
 
-import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -32,7 +31,6 @@ import java.util.regex.Pattern;
 import static com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class JsonContentConversionExceptionMapperTest {
@@ -43,7 +41,6 @@ public class JsonContentConversionExceptionMapperTest {
 
     @BeforeEach
     public void setUp() {
-        when(mockParser.getTokenLocation()).thenReturn(new JsonLocation(null, 100, 1, 1));
         jsonCCEM = new JsonContentConversionExceptionMapper();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <derby.version>10.17.1.0</derby.version>
         <jetty.version>12.0.6</jetty.version>
-        <jackson.bom.version>2.16.2</jackson.bom.version>
+        <jackson.bom.version>2.17.0</jackson.bom.version>
         <avro.version>1.11.3</avro.version>
         <jaxb.runtime.version>4.0.4</jaxb.runtime.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>


### PR DESCRIPTION
# Summary

[NIFI-12926](https://issues.apache.org/jira/browse/NIFI-12926) Upgrades Jackson JSON dependencies from 2.16.2 to [2.17.0](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.17/) incorporate a number of minor bug fixes and improvements.

Additional changes include removing a unit test expectation no longer needed as a result of the upgraded version.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
