### PR TITLE
NIFI-12928 Added Simple Write strategy in PutAzureDataLakeStorage

### DIFF
--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
@@ -40,6 +40,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.azure.AbstractAzureDataLakeStorageProcessor;
 import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils.DirectoryValidator;
+import org.apache.nifi.processors.azure.storage.utils.WritingStrategy;
 import org.apache.nifi.processors.transfer.ResourceTransferSource;
 import org.apache.nifi.util.StringUtils;
 
@@ -99,6 +100,15 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
             .allowableValues(FAIL_RESOLUTION, REPLACE_RESOLUTION, IGNORE_RESOLUTION)
             .build();
 
+    protected static final PropertyDescriptor WRITING_STRATEGY = new PropertyDescriptor.Builder()
+            .name("writing-strategy")
+            .displayName("Writing Strategy")
+            .description("Defines the approach for writing the Azure file.")
+            .required(true)
+            .allowableValues(WritingStrategy.class)
+            .defaultValue(WritingStrategy.WRITE_AND_RENAME)
+            .build();
+
     public static final PropertyDescriptor BASE_TEMPORARY_PATH = new PropertyDescriptor.Builder()
             .name("base-temporary-path")
             .displayName("Base Temporary Path")
@@ -108,6 +118,7 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
             .defaultValue("")
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .addValidator(new DirectoryValidator("Base Temporary Path"))
+            .dependsOn(WRITING_STRATEGY, WritingStrategy.WRITE_AND_RENAME)
             .build();
 
     private static final List<PropertyDescriptor> PROPERTIES = List.of(
@@ -115,6 +126,7 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
             FILESYSTEM,
             DIRECTORY,
             FILE,
+            WRITING_STRATEGY,
             BASE_TEMPORARY_PATH,
             CONFLICT_RESOLUTION,
             RESOURCE_TRANSFER_SOURCE,
@@ -137,41 +149,44 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
         final long startNanos = System.nanoTime();
         try {
             final String fileSystem = evaluateFileSystemProperty(FILESYSTEM, context, flowFile);
-            final String originalDirectory = evaluateDirectoryProperty(DIRECTORY, context, flowFile);
-            final String tempPath = evaluateDirectoryProperty(BASE_TEMPORARY_PATH, context, flowFile);
-            final String tempDirectory = createPath(tempPath, TEMP_FILE_DIRECTORY);
+            final String directory = evaluateDirectoryProperty(DIRECTORY, context, flowFile);
             final String fileName = evaluateFileProperty(context, flowFile);
 
             final DataLakeFileSystemClient fileSystemClient = getFileSystemClient(context, flowFile, fileSystem);
-            final DataLakeDirectoryClient directoryClient = fileSystemClient.getDirectoryClient(originalDirectory);
+            final DataLakeDirectoryClient directoryClient = fileSystemClient.getDirectoryClient(directory);
 
-            final String tempFilePrefix = UUID.randomUUID().toString();
-            final DataLakeDirectoryClient tempDirectoryClient = fileSystemClient.getDirectoryClient(tempDirectory);
+            final WritingStrategy writingStrategy = context.getProperty(WRITING_STRATEGY).asAllowableValue(WritingStrategy.class);
             final String conflictResolution = context.getProperty(CONFLICT_RESOLUTION).getValue();
             final ResourceTransferSource resourceTransferSource = ResourceTransferSource.valueOf(context.getProperty(RESOURCE_TRANSFER_SOURCE).getValue());
             final Optional<FileResource> fileResourceFound = getFileResource(resourceTransferSource, context, flowFile.getAttributes());
             final long transferSize = fileResourceFound.map(FileResource::getSize).orElse(flowFile.getSize());
 
-            final DataLakeFileClient tempFileClient = tempDirectoryClient.createFile(tempFilePrefix + fileName, true);
-            if (transferSize > 0) {
-                final FlowFile sourceFlowFile = flowFile;
-                try (
-                        final InputStream inputStream = new BufferedInputStream(
-                                fileResourceFound.map(FileResource::getInputStream)
-                                        .orElseGet(() -> session.read(sourceFlowFile))
-                        )
-                ) {
-                    uploadContent(tempFileClient, inputStream, transferSize);
-                } catch (final Exception e) {
-                    removeTempFile(tempFileClient);
-                    throw e;
+            final DataLakeFileClient fileClient;
+
+            if (writingStrategy == WritingStrategy.WRITE_AND_RENAME) {
+                final String tempPath = evaluateDirectoryProperty(BASE_TEMPORARY_PATH, context, flowFile);
+                final String tempDirectory = createPath(tempPath, TEMP_FILE_DIRECTORY);
+                final String tempFilePrefix = UUID.randomUUID().toString();
+
+                final DataLakeDirectoryClient tempDirectoryClient = fileSystemClient.getDirectoryClient(tempDirectory);
+                final DataLakeFileClient tempFileClient = tempDirectoryClient.createFile(tempFilePrefix + fileName, true);
+
+                uploadFile(session, flowFile, fileResourceFound, transferSize, tempFileClient);
+
+                createDirectoryIfNotExists(directoryClient);
+
+                fileClient = renameFile(tempFileClient, directoryClient.getDirectoryPath(), fileName, conflictResolution);
+            } else {
+                fileClient = createFile(directoryClient, fileName, conflictResolution);
+
+                if (fileClient != null) {
+                    uploadFile(session, flowFile, fileResourceFound, transferSize, fileClient);
                 }
             }
-            createDirectoryIfNotExists(directoryClient);
 
-            final String fileUrl = renameFile(tempFileClient, directoryClient.getDirectoryPath(), fileName, conflictResolution);
-            if (fileUrl != null) {
-                final Map<String, String> attributes = createAttributeMap(fileSystem, originalDirectory, fileName, fileUrl, transferSize);
+            if (fileClient != null) {
+                final String fileUrl = fileClient.getFileUrl();
+                final Map<String, String> attributes = createAttributeMap(fileSystem, directory, fileName, fileUrl, transferSize);
                 flowFile = session.putAllAttributes(flowFile, attributes);
 
                 final long transferMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
@@ -186,12 +201,12 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
         }
     }
 
-    private DataLakeFileSystemClient getFileSystemClient(ProcessContext context, FlowFile flowFile, String fileSystem) {
+    private DataLakeFileSystemClient getFileSystemClient(final ProcessContext context, final FlowFile flowFile, final String fileSystem) {
         final DataLakeServiceClient storageClient = getStorageClient(context, flowFile);
         return storageClient.getFileSystemClient(fileSystem);
     }
 
-    private Map<String, String> createAttributeMap(String fileSystem, String originalDirectory, String fileName, String fileUrl, long length) {
+    private Map<String, String> createAttributeMap(final String fileSystem, final String originalDirectory, final String fileName, final String fileUrl, final long length) {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put(ATTR_NAME_FILESYSTEM, fileSystem);
         attributes.put(ATTR_NAME_DIRECTORY, originalDirectory);
@@ -201,14 +216,29 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
         return attributes;
     }
 
-    private void createDirectoryIfNotExists(DataLakeDirectoryClient directoryClient) {
+    private void createDirectoryIfNotExists(final DataLakeDirectoryClient directoryClient) {
         if (!directoryClient.getDirectoryPath().isEmpty() && !directoryClient.exists()) {
             directoryClient.create();
         }
     }
 
+    private void uploadFile(final ProcessSession session, final FlowFile flowFile, final Optional<FileResource> fileResourceFound,
+                            final long transferSize, final DataLakeFileClient fileClient) throws Exception {
+        if (transferSize > 0) {
+            try (final InputStream inputStream = new BufferedInputStream(
+                    fileResourceFound.map(FileResource::getInputStream)
+                            .orElseGet(() -> session.read(flowFile)))
+            ) {
+                uploadContent(fileClient, inputStream, transferSize);
+            } catch (final Exception e) {
+                removeFile(fileClient);
+                throw e;
+            }
+        }
+    }
+
     //Visible for testing
-    static void uploadContent(DataLakeFileClient fileClient, InputStream in, long length) {
+    static void uploadContent(final DataLakeFileClient fileClient, final InputStream in, final long length) {
         long chunkStart = 0;
         long chunkSize;
 
@@ -229,19 +259,41 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
     }
 
     /**
-     * This method serves as a "commit" for the upload process. Upon upload, a 0-byte file is created, then the payload is appended to it.
-     * Because of that, a work-in-progress file is available for readers before the upload is complete. It is not an efficient approach in
-     * case of conflicts because FlowFiles are uploaded unnecessarily, but it is a calculated risk because consistency is more important.
+     * Creates the file on Azure for 'Simple Write' strategy. Upon upload, a 0-byte file is created, then the payload is appended to it.
+     * Because of that, a work-in-progress file is available for readers before the upload is complete.
+     *
+     * @param directoryClient directory client of the uploaded file's parent directory
+     * @param fileName name of the uploaded file
+     * @param conflictResolution conflict resolution strategy
+     * @return the file client of the uploaded file or {@code null} if the file already exists and conflict resolution strategy is 'ignore'
+     * @throws ProcessException if the file already exists and the conflict resolution strategy is 'fail'; also in case of other errors
+     */
+    DataLakeFileClient createFile(DataLakeDirectoryClient directoryClient, final String fileName, final String conflictResolution) {
+        final String destinationPath = createPath(directoryClient.getDirectoryPath(), fileName);
+
+        try {
+            final boolean overwrite = conflictResolution.equals(REPLACE_RESOLUTION);
+            return directoryClient.createFile(fileName, overwrite);
+        } catch (DataLakeStorageException dataLakeStorageException) {
+            return handleDataLakeStorageException(dataLakeStorageException, destinationPath, conflictResolution);
+        }
+    }
+
+    /**
+     * This method serves as a "commit" for the upload process in case of 'Write and Rename' strategy. In order to prevent work-in-progress files from being available for readers,
+     * a temporary file is written first, and then renamed/moved to its final destination. It is not an efficient approach in case of conflicts because FlowFiles are uploaded unnecessarily,
+     * but it is a calculated risk because consistency is more important for 'Write and Rename' strategy.
      * <p>
      * Visible for testing
      *
-     * @param sourceFileClient client of the temporary file
+     * @param sourceFileClient file client of the temporary file
      * @param destinationDirectory final location of the uploaded file
      * @param destinationFileName final name of the uploaded file
      * @param conflictResolution conflict resolution strategy
-     * @return URL of the uploaded file
+     * @return the file client of the uploaded file or {@code null} if the file already exists and conflict resolution strategy is 'ignore'
+     * @throws ProcessException if the file already exists and the conflict resolution strategy is 'fail'; also in case of other errors
      */
-    String renameFile(final DataLakeFileClient sourceFileClient, final String destinationDirectory, final String destinationFileName, final String conflictResolution) {
+    DataLakeFileClient renameFile(final DataLakeFileClient sourceFileClient, final String destinationDirectory, final String destinationFileName, final String conflictResolution) {
         final String destinationPath = createPath(destinationDirectory, destinationFileName);
 
         try {
@@ -249,18 +301,23 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
             if (!conflictResolution.equals(REPLACE_RESOLUTION)) {
                 destinationCondition.setIfNoneMatch("*");
             }
-            return sourceFileClient.renameWithResponse(null, destinationPath, null, destinationCondition, null, null).getValue().getFileUrl();
+            return sourceFileClient.renameWithResponse(null, destinationPath, null, destinationCondition, null, null).getValue();
         } catch (DataLakeStorageException dataLakeStorageException) {
-            removeTempFile(sourceFileClient);
-            if (dataLakeStorageException.getStatusCode() == 409 && conflictResolution.equals(IGNORE_RESOLUTION)) {
-                getLogger().info("File [{}] already exists. Remote file not modified due to {} being set to '{}'.",
-                        destinationPath, CONFLICT_RESOLUTION.getDisplayName(), conflictResolution);
-                return null;
-            } else if (dataLakeStorageException.getStatusCode() == 409 && conflictResolution.equals(FAIL_RESOLUTION)) {
-                throw new ProcessException(String.format("File [%s] already exists.", destinationPath), dataLakeStorageException);
-            } else {
-                throw new ProcessException(String.format("Renaming File [%s] failed", destinationPath), dataLakeStorageException);
-            }
+            removeFile(sourceFileClient);
+
+            return handleDataLakeStorageException(dataLakeStorageException, destinationPath, conflictResolution);
+        }
+    }
+
+    private DataLakeFileClient handleDataLakeStorageException(final DataLakeStorageException dataLakeStorageException, final String destinationPath, final String conflictResolution) {
+        if (dataLakeStorageException.getStatusCode() == 409 && conflictResolution.equals(IGNORE_RESOLUTION)) {
+            getLogger().info("File [{}] already exists. Remote file not modified due to {} being set to '{}'.",
+                    destinationPath, CONFLICT_RESOLUTION.getDisplayName(), conflictResolution);
+            return null;
+        } else if (dataLakeStorageException.getStatusCode() == 409 && conflictResolution.equals(FAIL_RESOLUTION)) {
+            throw new ProcessException(String.format("File [%s] already exists.", destinationPath), dataLakeStorageException);
+        } else {
+            throw new ProcessException(String.format("File operation failed [%s]", destinationPath), dataLakeStorageException);
         }
     }
 
@@ -270,7 +327,7 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
                 : path;
     }
 
-    private void removeTempFile(final DataLakeFileClient fileClient) {
+    private void removeFile(final DataLakeFileClient fileClient) {
         try {
             fileClient.delete();
         } catch (Exception e) {

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/WritingStrategy.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/utils/WritingStrategy.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.azure.storage.utils;
+
+import org.apache.nifi.components.DescribedValue;
+
+public enum WritingStrategy implements DescribedValue {
+
+    WRITE_AND_RENAME("Write and Rename", "The processor writes the Azure file into a temporary directory and then renames/moves it to the final destination." +
+            " This prevents other processes from reading partially written files."),
+    SIMPLE_WRITE("Simple Write", "The processor writes the Azure file directly to the destination. This might cause reading partially written files.");
+
+    private final String displayName;
+    private final String description;
+
+    WritingStrategy(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/docs/org.apache.nifi.processors.azure.storage.PutAzureDataLakeStorage/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/resources/docs/org.apache.nifi.processors.azure.storage.PutAzureDataLakeStorage/additionalDetails.html
@@ -26,31 +26,57 @@
     This processor is responsible for uploading files to Azure Data Lake Storage Gen2.
 </p>
 
-<h3>File uploading and cleanup process</h3>
+<h3>File uploading and cleanup process in case of "Write and Rename" strategy</h3>
 
 <h4>New file upload</h4>
 
 <ol>
     <li>A temporary file is created with random prefix under the given path in '_nifitempdirectory'.</li>
     <li>Content is appended to temp file.</li>
-    <li>Temp file is renamed to its original name, the original file is overwritten.</li>
-    <li>In case of appending or renaming failure the temp file is deleted, the original file remains intact.</li>
-    <li>In case of temporary file deletion failure both temp file and original file remain on the server.</li>
+    <li>Temp file is moved to the final destination directory and renamed to its original name.</li>
+    <li>In case of appending or renaming failure, the temp file is deleted.</li>
+    <li>In case of temporary file deletion failure, the temp file remains on the server.</li>
 </ol>
 
 <h4>Existing file upload</h4>
 
 <ul>
-    <li>Processors with "fail" conflict resolution strategy will be directed to "Failure" relationship.</li>
-    <li>Processors with "ignore" conflict resolution strategy will be directed to "Success" relationship.</li>
+    <li>Processors with "fail" conflict resolution strategy will direct the FlowFile to "Failure" relationship.</li>
+    <li>Processors with "ignore" conflict resolution strategy will direct the FlowFile to "Success" relationship.</li>
     <li>Processors with "replace" conflict resolution strategy:</li>
 
     <ol>
         <li>A temporary file is created with random prefix under the given path in '_nifitempdirectory'.</li>
         <li>Content is appended to temp file.</li>
-        <li>Temp file is renamed to its original name, the original file is overwritten.</li>
-        <li>In case of appending or renaming failure the temp file is deleted, the original file remains intact.</li>
-        <li>In case of temporary file deletion failure both temp file and original file remain on the server.</li>
+        <li>Temp file is moved to the final destination directory and renamed to its original name, the original file is overwritten.</li>
+        <li>In case of appending or renaming failure, the temp file is deleted, the original file remains intact.</li>
+        <li>In case of temporary file deletion failure, both temp file and original file remain on the server.</li>
+    </ol>
+</ul>
+
+<h3>File uploading and cleanup process in case of "Simple Write" strategy</h3>
+
+<h4>New file upload</h4>
+
+<ol>
+    <li>An empty file is created at its final destination.</li>
+    <li>Content is appended to the file.</li>
+    <li>In case of appending failure, the file is deleted.</li>
+    <li>In case of file deletion failure, the file remains on the server.</li>
+</ol>
+
+<h4>Existing file upload</h4>
+
+<ul>
+    <li>Processors with "fail" conflict resolution strategy will direct the FlowFile to "Failure" relationship.</li>
+    <li>Processors with "ignore" conflict resolution strategy will direct the FlowFile to "Success" relationship.</li>
+    <li>Processors with "replace" conflict resolution strategy:</li>
+
+    <ol>
+        <li>An empty file is created at its final destination, the original file is overwritten.</li>
+        <li>Content is appended to the file.</li>
+        <li>In case of appending failure, the file is deleted, the original file is not be restored.</li>
+        <li>In case of file deletion failure, the file remains on the server.</li>
     </ol>
 </ul>
 

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureDataLakeStorageIT.java
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/storage/AbstractAzureDataLakeStorageIT.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.processors.azure.storage.utils.AzureStorageUtils;
 import org.apache.nifi.services.azure.storage.ADLSCredentialsControllerService;
 import org.apache.nifi.services.azure.storage.ADLSCredentialsService;
+import org.apache.nifi.services.azure.storage.AzureStorageCredentialsType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -53,6 +54,7 @@ public abstract class AbstractAzureDataLakeStorageIT extends AbstractAzureStorag
     protected void setUpCredentials() throws Exception {
         ADLSCredentialsService service = new ADLSCredentialsControllerService();
         runner.addControllerService("ADLSCredentials", service);
+        runner.setProperty(service, AzureStorageUtils.CREDENTIALS_TYPE, AzureStorageCredentialsType.ACCOUNT_KEY);
         runner.setProperty(service, ADLSCredentialsControllerService.ACCOUNT_NAME, getAccountName());
         runner.setProperty(service, AzureStorageUtils.ACCOUNT_KEY, getAccountKey());
         runner.enableControllerService(service);


### PR DESCRIPTION
# Summary

[NIFI-12928](https://issues.apache.org/jira/browse/NIFI-12928)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
