### PR TITLE
NIFI-12939: Retry Kerberos login on authentication failure in Iceberg processors

### DIFF
--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/AbstractIcebergProcessor.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/AbstractIcebergProcessor.java
@@ -68,8 +68,8 @@ public abstract class AbstractIcebergProcessor extends AbstractProcessor impleme
             .description("A FlowFile is routed to this relationship if the operation failed and retrying the operation will also fail, such as an invalid data or schema.")
             .build();
 
-    final protected AtomicReference<KerberosUser> kerberosUserReference = new AtomicReference<>();
-    final protected AtomicReference<UserGroupInformation> ugiReference = new AtomicReference<>();
+    protected final AtomicReference<KerberosUser> kerberosUserReference = new AtomicReference<>();
+    protected final AtomicReference<UserGroupInformation> ugiReference = new AtomicReference<>();
 
     @OnScheduled
     public void onScheduled(final ProcessContext context) {

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/main/java/org/apache/nifi/processors/iceberg/PutIceberg.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/main/java/org/apache/nifi/processors/iceberg/PutIceberg.java
@@ -281,7 +281,8 @@ public class PutIceberg extends AbstractIcebergProcessor {
             if (causeOptional.isPresent()) {
                 getLogger().warn("No valid Kerberos credential found, retrying login", causeOptional.get());
                 initKerberosCredentials(context);
-                session.rollback(true);
+                session.rollback();
+                context.yield();
             } else {
                 getLogger().error("Failed to load table from catalog", e);
                 session.transfer(session.penalize(flowFile), REL_FAILURE);
@@ -313,7 +314,8 @@ public class PutIceberg extends AbstractIcebergProcessor {
             if (causeOptional.isPresent()) {
                 getLogger().warn("No valid Kerberos credential found, retrying login", causeOptional.get());
                 initKerberosCredentials(context);
-                session.rollback(true);
+                session.rollback();
+                context.yield();
             } else {
                 getLogger().error("Exception occurred while writing Iceberg records", e);
                 session.transfer(session.penalize(flowFile), REL_FAILURE);

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/main/java/org/apache/nifi/processors/iceberg/PutIceberg.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/main/java/org/apache/nifi/processors/iceberg/PutIceberg.java
@@ -53,6 +53,7 @@ import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.services.iceberg.IcebergCatalogService;
+import org.ietf.jgss.GSSException;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -61,11 +62,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+import static org.apache.nifi.processors.iceberg.IcebergUtils.findCause;
 import static org.apache.nifi.processors.iceberg.IcebergUtils.getConfigurationFromFiles;
 import static org.apache.nifi.processors.iceberg.IcebergUtils.getDynamicProperties;
 
@@ -274,8 +277,15 @@ public class PutIceberg extends AbstractIcebergProcessor {
         try {
             table = loadTable(context, flowFile);
         } catch (Exception e) {
-            getLogger().error("Failed to load table from catalog", e);
-            session.transfer(session.penalize(flowFile), REL_FAILURE);
+            final Optional<GSSException> causeOptional = findCause(e, GSSException.class, gsse -> GSSException.NO_CRED == gsse.getMajor());
+            if (causeOptional.isPresent()) {
+                getLogger().warn("No valid Kerberos credential found, retrying login", causeOptional.get());
+                initKerberosCredentials(context);
+                session.rollback(true);
+            } else {
+                getLogger().error("Failed to load table from catalog", e);
+                session.transfer(session.penalize(flowFile), REL_FAILURE);
+            }
             return;
         }
 
@@ -299,16 +309,23 @@ public class PutIceberg extends AbstractIcebergProcessor {
             final WriteResult result = taskWriter.complete();
             appendDataFiles(context, flowFile, table, result);
         } catch (Exception e) {
-            getLogger().error("Exception occurred while writing iceberg records. Removing uncommitted data files", e);
+            final Optional<GSSException> causeOptional = findCause(e, GSSException.class, gsse -> GSSException.NO_CRED == gsse.getMajor());
+            if (causeOptional.isPresent()) {
+                getLogger().warn("No valid Kerberos credential found, retrying login", causeOptional.get());
+                initKerberosCredentials(context);
+                session.rollback(true);
+            } else {
+                getLogger().error("Exception occurred while writing Iceberg records", e);
+                session.transfer(session.penalize(flowFile), REL_FAILURE);
+            }
+
             try {
                 if (taskWriter != null) {
                     abort(taskWriter.dataFiles(), table);
                 }
             } catch (Exception ex) {
-                getLogger().error("Failed to abort uncommitted data files", ex);
+                getLogger().warn("Failed to abort uncommitted data files", ex);
             }
-
-            session.transfer(session.penalize(flowFile), REL_FAILURE);
             return;
         }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12939](https://issues.apache.org/jira/browse/NIFI-12939)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
