### PR TITLE
NIFI-12944 Add attribute corresponding to peer address of SNMP TRAP PDUs 

### DIFF
--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/operations/SNMPTrapReceiver.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/operations/SNMPTrapReceiver.java
@@ -47,7 +47,7 @@ public class SNMPTrapReceiver implements CommandResponder {
         final PDU pdu = event.getPDU();
         if (isValidTrapPdu(pdu)) {
             final ProcessSession processSession = processSessionFactory.createSession();
-            final FlowFile flowFile = createFlowFile(processSession, pdu, event.getPeerAddress());
+            final FlowFile flowFile = createFlowFile(processSession,event);
             processSession.getProvenanceReporter().create(flowFile, event.getPeerAddress() + "/" + pdu.getRequestID());
             if (pdu.getErrorStatus() == PDU.noError) {
                 processSession.transfer(flowFile, REL_SUCCESS);
@@ -60,14 +60,16 @@ public class SNMPTrapReceiver implements CommandResponder {
         }
     }
 
-    private FlowFile createFlowFile(final ProcessSession processSession, final PDU pdu, final Address peerAddress) {
+    private FlowFile createFlowFile(final ProcessSession processSession, final  CommandResponderEvent event) {
         FlowFile flowFile = processSession.create();
         final Map<String, String> attributes;
+        final PDU pdu = event.getPDU();
+        final Address peerAddress = event.getPeerAddress();
         if (pdu instanceof PDUv1) {
             attributes = SNMPUtils.getV1TrapPduAttributeMap((PDUv1) pdu);
         } else {
             attributes = SNMPUtils.getPduAttributeMap(pdu);
-        }    
+        }
         if (peerAddress.isValid()) {
             processSession.putAttribute(flowFile, SNMPUtils.SNMP_PROP_PREFIX + "peerAddress", peerAddress.toString());
         }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
@@ -155,8 +155,7 @@ class SNMPTrapReceiverTest {
         when(mockPdu.getErrorStatus()).thenReturn(PDU.badValue);
         
         final Address mockAddress = mock(Address.class);
-        when(mockAddress.toString()).thenReturn("127.0.0.1/62");
-        when(mockAddress.isValid()).thenReturn(true);
+        when(mockAddress.isValid()).thenReturn(false);
        
         final Vector<VariableBinding> vbs = new Vector<>();
         doReturn(vbs).when(mockPdu).getVariableBindings();
@@ -172,6 +171,6 @@ class SNMPTrapReceiverTest {
         final FlowFile flowFile = flowFiles.get(0);
 
         assertEquals(String.valueOf(PDU.badValue), flowFile.getAttribute("snmp$errorStatus"));
-        assertEquals("127.0.0.1/62", flowFile.getAttribute("snmp$peerAddress"));
+        assertEquals(null, flowFile.getAttribute("snmp$peerAddress"));
     }
 }

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
@@ -153,7 +153,7 @@ class SNMPTrapReceiverTest {
 
         when(mockPdu.getType()).thenReturn(PDU.TRAP);
         when(mockPdu.getErrorStatus()).thenReturn(PDU.badValue);
- 
+
         final Address mockAddress = mock(Address.class);
         when(mockAddress.isValid()).thenReturn(false);
 

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
@@ -96,11 +96,11 @@ class SNMPTrapReceiverTest {
         when(mockV1Pdu.getType()).thenReturn(PDU.V1TRAP);
         when(mockV1Pdu.getEnterprise()).thenReturn(new OID("1.3.6.1.2.1.1.1.0"));
         when(mockV1Pdu.getSpecificTrap()).thenReturn(4);
-        
+
         final Address mockAddress = mock(Address.class);
         when(mockAddress.toString()).thenReturn("127.0.0.1/62");
         when(mockAddress.isValid()).thenReturn(true);
-        
+
         final Vector<VariableBinding> vbs = new Vector<>();
         doReturn(vbs).when(mockV1Pdu).getVariableBindings();
         when(mockEvent.getPDU()).thenReturn(mockV1Pdu);
@@ -115,7 +115,7 @@ class SNMPTrapReceiverTest {
         assertEquals("1.3.6.1.2.1.1.1.0", flowFile.getAttribute("snmp$enterprise"));
         assertEquals(String.valueOf(4), flowFile.getAttribute("snmp$specificTrapType"));
         assertEquals("127.0.0.1/62", flowFile.getAttribute("snmp$peerAddress"));
-        
+
     }
 
     @Test
@@ -126,15 +126,15 @@ class SNMPTrapReceiverTest {
         when(mockPdu.getErrorIndex()).thenReturn(123);
         when(mockPdu.getErrorStatusText()).thenReturn("test error status text");
         final Vector<VariableBinding> vbs = new Vector<>();
-        
+
         final Address mockAddress = mock(Address.class);
         when(mockAddress.toString()).thenReturn("127.0.0.1/62");
         when(mockAddress.isValid()).thenReturn(true);
-        
+
         doReturn(vbs).when(mockPdu).getVariableBindings();
         when(mockEvent.getPDU()).thenReturn(mockPdu);
         when(mockEvent.getPeerAddress()).thenReturn(mockAddress);
-        
+
         when(mockProcessSessionFactory.createSession()).thenReturn(mockProcessSession);
 
         snmpTrapReceiver.processPdu(mockEvent);
@@ -153,10 +153,10 @@ class SNMPTrapReceiverTest {
 
         when(mockPdu.getType()).thenReturn(PDU.TRAP);
         when(mockPdu.getErrorStatus()).thenReturn(PDU.badValue);
-        
+ 
         final Address mockAddress = mock(Address.class);
         when(mockAddress.isValid()).thenReturn(false);
-       
+
         final Vector<VariableBinding> vbs = new Vector<>();
         doReturn(vbs).when(mockPdu).getVariableBindings();
         when(mockEvent.getPDU()).thenReturn(mockPdu);

--- a/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
+++ b/nifi-nar-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.snmp4j.CommandResponderEvent;
 import org.snmp4j.PDU;
 import org.snmp4j.PDUv1;
+import org.snmp4j.smi.Address;
 import org.snmp4j.smi.OID;
 import org.snmp4j.smi.VariableBinding;
 
@@ -95,9 +96,15 @@ class SNMPTrapReceiverTest {
         when(mockV1Pdu.getType()).thenReturn(PDU.V1TRAP);
         when(mockV1Pdu.getEnterprise()).thenReturn(new OID("1.3.6.1.2.1.1.1.0"));
         when(mockV1Pdu.getSpecificTrap()).thenReturn(4);
+        
+        final Address mockAddress = mock(Address.class);
+        when(mockAddress.toString()).thenReturn("127.0.0.1/62");
+        when(mockAddress.isValid()).thenReturn(true);
+        
         final Vector<VariableBinding> vbs = new Vector<>();
         doReturn(vbs).when(mockV1Pdu).getVariableBindings();
         when(mockEvent.getPDU()).thenReturn(mockV1Pdu);
+        when(mockEvent.getPeerAddress()).thenReturn(mockAddress);
         when(mockProcessSessionFactory.createSession()).thenReturn(mockProcessSession);
 
         snmpTrapReceiver.processPdu(mockEvent);
@@ -107,6 +114,8 @@ class SNMPTrapReceiverTest {
 
         assertEquals("1.3.6.1.2.1.1.1.0", flowFile.getAttribute("snmp$enterprise"));
         assertEquals(String.valueOf(4), flowFile.getAttribute("snmp$specificTrapType"));
+        assertEquals("127.0.0.1/62", flowFile.getAttribute("snmp$peerAddress"));
+        
     }
 
     @Test
@@ -117,8 +126,15 @@ class SNMPTrapReceiverTest {
         when(mockPdu.getErrorIndex()).thenReturn(123);
         when(mockPdu.getErrorStatusText()).thenReturn("test error status text");
         final Vector<VariableBinding> vbs = new Vector<>();
+        
+        final Address mockAddress = mock(Address.class);
+        when(mockAddress.toString()).thenReturn("127.0.0.1/62");
+        when(mockAddress.isValid()).thenReturn(true);
+        
         doReturn(vbs).when(mockPdu).getVariableBindings();
         when(mockEvent.getPDU()).thenReturn(mockPdu);
+        when(mockEvent.getPeerAddress()).thenReturn(mockAddress);
+        
         when(mockProcessSessionFactory.createSession()).thenReturn(mockProcessSession);
 
         snmpTrapReceiver.processPdu(mockEvent);
@@ -128,6 +144,7 @@ class SNMPTrapReceiverTest {
 
         assertEquals(String.valueOf(123), flowFile.getAttribute("snmp$errorIndex"));
         assertEquals("test error status text", flowFile.getAttribute("snmp$errorStatusText"));
+        assertEquals("127.0.0.1/62", flowFile.getAttribute("snmp$peerAddress"));
     }
 
     @Test
@@ -136,9 +153,15 @@ class SNMPTrapReceiverTest {
 
         when(mockPdu.getType()).thenReturn(PDU.TRAP);
         when(mockPdu.getErrorStatus()).thenReturn(PDU.badValue);
+        
+        final Address mockAddress = mock(Address.class);
+        when(mockAddress.toString()).thenReturn("127.0.0.1/62");
+        when(mockAddress.isValid()).thenReturn(true);
+       
         final Vector<VariableBinding> vbs = new Vector<>();
         doReturn(vbs).when(mockPdu).getVariableBindings();
         when(mockEvent.getPDU()).thenReturn(mockPdu);
+        when(mockEvent.getPeerAddress()).thenReturn(mockAddress);
         when(mockProcessSessionFactory.createSession()).thenReturn(mockProcessSession);
 
         snmpTrapReceiver.processPdu(mockEvent);
@@ -149,5 +172,6 @@ class SNMPTrapReceiverTest {
         final FlowFile flowFile = flowFiles.get(0);
 
         assertEquals(String.valueOf(PDU.badValue), flowFile.getAttribute("snmp$errorStatus"));
+        assertEquals("127.0.0.1/62", flowFile.getAttribute("snmp$peerAddress"));
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12944](https://issues.apache.org/jira/browse/NIFI-12944)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
- [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
