### PR TITLE
NIFI-12945 Move Commons Configuration 2.10.1 to shared version

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-test-utils/pom.xml
@@ -64,12 +64,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <!-- Override Guava 27 -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
-            </dependency>
             <!-- Override Jettison from Hive -->
             <dependency>
                 <groupId>org.codehaus.jettison</groupId>

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -110,6 +110,12 @@
                 <artifactId>groovy-all</artifactId>
                 <version>2.4.21</version>
             </dependency>
+            <!-- Override Guava -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.1.2-jre</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-jdbc</artifactId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/pom.xml
@@ -51,13 +51,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.10.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
         <org.apache.commons.cli.version>1.6.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.16.1</org.apache.commons.codec.version>
         <org.apache.commons.compress.version>1.26.1</org.apache.commons.compress.version>
+        <org.apache.commons.configuration.version>2.10.1</org.apache.commons.configuration.version>
         <org.apache.commons.lang3.version>3.14.0</org.apache.commons.lang3.version>
         <org.apache.commons.net.version>3.10.0</org.apache.commons.net.version>
         <org.apache.commons.io.version>2.15.1</org.apache.commons.io.version>
@@ -271,6 +272,17 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>${org.apache.commons.compress.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>${org.apache.commons.configuration.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
# Summary

[NIFI-12945](https://issues.apache.org/jira/browse/NIFI-12945) Moves the Apache Commons Configuration dependency declaration from `nifi-lookup-services` to the root project configuration for shared dependency version management. This change aligns with similar changes for other Apache Commons modules, ensuring that the same version is applied to all extension components.

Additional changes include moving the Google Guava version from the `nifi-hive-test-utils` to the `nifi-hive-bundle` to ensure the same version is applied to all Hive components.

This change applies to the main branch, and a separate pull request will be needed for the support branch to clean up additional references to Commons Configuration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
