### PR TITLE
NIFI-12947 Upgrade MIME4J to 0.8.11

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -31,6 +31,7 @@
         <calcite.avatica.version>1.6.0</calcite.avatica.version>
         <avatica.version>1.24.0</avatica.version>
         <org.apache.sshd.version>2.12.0</org.apache.sshd.version>
+        <mime4j.version>0.8.11</mime4j.version>
     </properties>
 
     <!-- Managed Dependency Versions for referenced modules required based on different parent bundle project -->
@@ -124,6 +125,12 @@
                 <groupId>org.apache.sshd</groupId>
                 <artifactId>sshd-osgi</artifactId>
                 <version>${org.apache.sshd.version}</version>
+            </dependency>
+            <!-- MIME4J from Tika Parsers in media-processors -->
+            <dependency>
+                <groupId>org.apache.james</groupId>
+                <artifactId>apache-mime4j-core</artifactId>
+                <version>${mime4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-media-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-media-bundle/pom.xml
@@ -27,6 +27,7 @@
 
     <properties>
         <poi.version>5.2.5</poi.version>
+        <mime4j.version>0.8.11</mime4j.version>
     </properties>
 
     <modules>
@@ -57,6 +58,11 @@
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi-ooxml</artifactId>
                 <version>${poi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.james</groupId>
+                <artifactId>apache-mime4j-core</artifactId>
+                <version>${mime4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-12947](https://issues.apache.org/jira/browse/NIFI-12947) Upgrades Apache MIME4J from 0.8.9 to [0.8.11](https://github.com/apache/james-mime4j/blob/master/CHANGELOG.md) for the `nifi-media-processors` module and its transitive dependency on Apache Tika Parsers. This upgrade mitigates CVE-2024-21742 related to potential header injection with mail message parsing.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
