### PR TITLE
NIFI-12957 Upgrade Azure SDK BOM from 1.2.19 to 1.2.21

### DIFF
--- a/nifi-commons/nifi-property-protection-azure/pom.xml
+++ b/nifi-commons/nifi-property-protection-azure/pom.xml
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.19</version>
+                <version>1.2.21</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -85,15 +85,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Override oauth2-oidc-sdk 9.35 from msal4j -->
-        <dependency>
-            <groupId>com.nimbusds</groupId>
-            <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>9.43.3</version>
-        </dependency>
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core-http-okhttp</artifactId>
+        </dependency>
+        <!-- Override MSAL4J 1.14.0 from azure-identity -->
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>msal4j</artifactId>
+            <version>1.14.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -27,8 +27,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <azure.sdk.bom.version>1.2.19</azure.sdk.bom.version>
-        <msal4j.version>1.14.2</msal4j.version>
+        <azure.sdk.bom.version>1.2.21</azure.sdk.bom.version>
+        <msal4j.version>1.14.3</msal4j.version>
         <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>
 
@@ -67,12 +67,6 @@
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.37.3</version>
-            </dependency>
-            <!-- Override Reactor Netty client 1.0.34 from Azure Identity -->
-            <dependency>
-                <groupId>io.projectreactor.netty</groupId>
-                <artifactId>reactor-netty-http</artifactId>
-                <version>1.0.39</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-12957](https://issues.apache.org/jira/browse/NIFI-12957) Upgrades the Azure SDK BOM from 1.2.19 to [1.2.21](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/boms/azure-sdk-bom/CHANGELOG.md) incorporating recent dependencies. The upgrade also removes the need for several custom overrides now that the transitive dependency versions have also been upgraded.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
