### PR TITLE
NIFI-12962 Upgrade Spring Framework from 6.0.18 to 6.1.5

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
@@ -37,6 +37,14 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- Enable parameters for AspectJ Around annotation argument name resolution -->
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -35,7 +35,6 @@
         <module>nifi-registry-docker-maven</module>
     </modules>
     <properties>
-        <spring.version>6.1.5</spring.version>
         <spring.boot.version>3.2.3</spring.boot.version>
         <flyway.version>9.22.3</flyway.version>
         <flyway.tests.version>9.5.0</flyway.tests.version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <snakeyaml.version>2.2</snakeyaml.version>
         <netty.4.version>4.1.106.Final</netty.4.version>
         <servlet-api.version>6.0.0</servlet-api.version>
-        <spring.version>6.0.18</spring.version>
+        <spring.version>6.1.5</spring.version>
         <spring.security.version>6.2.3</spring.security.version>
         <swagger.annotations.version>2.2.20</swagger.annotations.version>
         <h2.version>2.2.224</h2.version>


### PR DESCRIPTION
# Summary

[NIFI-12962](https://issues.apache.org/jira/browse/NIFI-12962) Upgrades Spring Framework dependencies from 6.0.18 to [6.1.5](https://github.com/spring-projects/spring-framework/releases/tag/v6.1.5) aligning the project root version with the current version used in NiFi Registry.

This upgrade required enabling the [parameters](https://docs.oracle.com/en/java/javase/21/docs/specs/man/javac.html#option-parameters) option for the Java compiler in the `nifi-web-api` module. Enabling parameters supports runtime reflection and parameter name determination, which supports existing AspectJ Around expressions that require mapping expression arguments to method arguments. This approach follows the recommendation of the Spring Framework documentation for [explicit argument names](https://docs.spring.io/spring-framework/reference/core/aop/ataspectj/advice.html#aop-ataspectj-advice-params-names-explicit) and avoids the need to define and repeat the argument names in the annotations.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
