### PR TITLE
NIFI-12965 Upgrade Guava from 32.1.2 to 33.1.0

### DIFF
--- a/minifi/pom.xml
+++ b/minifi/pom.xml
@@ -458,7 +458,7 @@ limitations under the License.
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
 
             <!-- Override Commons Compiler 3.1.9 from calcite-core -->

--- a/nifi-commons/nifi-property-protection-gcp/pom.xml
+++ b/nifi-commons/nifi-property-protection-gcp/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>nifi-property-protection-gcp</artifactId>
     <properties>
         <gcp.sdk.version>26.25.0</gcp.sdk.version>
-        <guava.version>32.1.2-jre</guava.version>
+        <guava.version>33.1.0-jre</guava.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-accumulo-bundle/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <accumulo.version>2.1.2</accumulo.version>
-        <guava.version>32.1.2-jre</guava.version>
+        <guava.version>33.1.0-jre</guava.version>
     </properties>
 
     <artifactId>nifi-accumulo-bundle</artifactId>

--- a/nifi-nar-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/pom.xml
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
             <!-- Override Apache Qpid Proton J for Azure EventHubs to resolve PROTON-2347 -->
             <dependency>

--- a/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.1.2-jre</version>
+            <version>33.1.0-jre</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -24,7 +24,7 @@
     <description>NiFi: Framework Bundle</description>
     <properties>
         <curator.version>5.6.0</curator.version>
-        <guava.version>32.1.2-jre</guava.version>
+        <guava.version>33.1.0-jre</guava.version>
         <tika.version>2.9.1</tika.version>
         <org.opensaml.version>4.3.0</org.opensaml.version>
     </properties>

--- a/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-gcp-bundle/pom.xml
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-nar-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <gremlin.version>3.7.1</gremlin.version>
         <janusgraph.version>0.6.3</janusgraph.version>
-        <guava.version>32.1.2-jre</guava.version>
+        <guava.version>33.1.0-jre</guava.version>
         <amqp-client.version>5.20.0</amqp-client.version>
     </properties>
     <dependencyManagement>

--- a/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -114,7 +114,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.hive</groupId>

--- a/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
             <!-- Override Groovy from hive-exec -->
             <dependency>

--- a/nifi-nar-bundles/nifi-opentelemetry-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-opentelemetry-bundle/pom.xml
@@ -44,7 +44,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/pom.xml
@@ -22,7 +22,7 @@
     <artifactId>nifi-sql-reporting-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <guava.version>32.1.2-jre</guava.version>
+        <guava.version>33.1.0-jre</guava.version>
     </properties>
     <modules>
         <module>nifi-sql-reporting-tasks</module>

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -232,7 +232,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.networknt</groupId>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
@@ -78,7 +78,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -114,7 +114,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
+                <version>33.1.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <guava.version>32.1.2-jre</guava.version>
+        <guava.version>33.1.0-jre</guava.version>
         <jline.version>3.25.1</jline.version>
     </properties>
 


### PR DESCRIPTION
# Summary

[NIFI-12965](https://issues.apache.org/jira/browse/NIFI-12965) Upgrades Google Guava dependencies from 32.1.2 to [33.1.0](https://github.com/google/guava/releases/tag/v33.1.0) incorporating bug fixes and improvements.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
