### PR TITLE
NIFI-12966 Upgrade Netty from 4.1.106 to 4.1.108

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <mockito.version>5.8.0</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <netty.4.version>4.1.106.Final</netty.4.version>
+        <netty.4.version>4.1.108.Final</netty.4.version>
         <servlet-api.version>6.0.0</servlet-api.version>
         <spring.version>6.1.5</spring.version>
         <spring.security.version>6.2.3</spring.security.version>


### PR DESCRIPTION
# Summary

[NIFI-12966](https://issues.apache.org/jira/browse/NIFI-12966) Upgrades Netty from 4.1.106 to [4.1.108](https://netty.io/news/2024/03/21/4-1-108-Final.html) incorporating several improvements as well as a resolution for CVE-2024-29025 related to decoding multipart HTTP POST requests.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
