### PR TITLE
NIFI-7085 add flowFile batching to ConsumeJMS and PublishJMS

### DIFF
--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
@@ -130,7 +130,7 @@ public abstract class AbstractJMSProcessor<T extends JMSWorker> extends Abstract
 
     static final PropertyDescriptor MAX_BATCH_SIZE = new PropertyDescriptor.Builder()
             .name("Maximum Batch Size")
-            .description("The number of messages to publish or consume in a single iteration of the processor.")
+            .description("The maximum number of messages to publish or consume in each invocation of the processor.")
             .required(true)
             .defaultValue("1")
             .addValidator(StandardValidators.createLongValidator(1, 10_000, true))

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/AbstractJMSProcessor.java
@@ -128,6 +128,14 @@ public abstract class AbstractJMSProcessor<T extends JMSWorker> extends Abstract
             .identifiesControllerService(JMSConnectionFactoryProviderDefinition.class)
             .build();
 
+    static final PropertyDescriptor MAX_BATCH_SIZE = new PropertyDescriptor.Builder()
+            .name("Maximum Batch Size")
+            .description("The number of messages to publish or consume in a single iteration of the processor.")
+            .required(true)
+            .defaultValue("1")
+            .addValidator(StandardValidators.createLongValidator(1, 10_000, true))
+            .build();
+
     static final List<PropertyDescriptor> JNDI_JMS_CF_PROPERTIES = Collections.unmodifiableList(
             JndiJmsConnectionFactoryProperties.getPropertyDescriptors().stream()
                     .map(pd -> new PropertyDescriptor.Builder()

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/ConsumeJMS.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/ConsumeJMS.java
@@ -40,6 +40,7 @@ import org.apache.nifi.jms.processors.ioconcept.writer.FlowFileWriter;
 import org.apache.nifi.jms.processors.ioconcept.writer.FlowFileWriterCallback;
 import org.apache.nifi.jms.processors.ioconcept.writer.record.OutputStrategy;
 import org.apache.nifi.jms.processors.ioconcept.writer.record.RecordWriter;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
@@ -252,6 +253,7 @@ public class ConsumeJMS extends AbstractJMSProcessor<JMSConsumer> {
         _propertyDescriptors.add(SHARED_SUBSCRIBER);
         _propertyDescriptors.add(SUBSCRIPTION_NAME);
         _propertyDescriptors.add(TIMEOUT);
+        _propertyDescriptors.add(MAX_BATCH_SIZE);
         _propertyDescriptors.add(ERROR_QUEUE);
 
         _propertyDescriptors.add(RECORD_READER);
@@ -267,6 +269,17 @@ public class ConsumeJMS extends AbstractJMSProcessor<JMSConsumer> {
         _relationships.add(REL_SUCCESS);
         _relationships.add(REL_PARSE_FAILURE);
         relationships = Collections.unmodifiableSet(_relationships);
+    }
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        super.migrateProperties(config);
+
+        if (!config.hasProperty(MAX_BATCH_SIZE)) {
+            if (config.isPropertySet(BASE_RECORD_READER)) {
+                config.setProperty(MAX_BATCH_SIZE, "10000");
+            }
+        }
     }
 
     private static boolean isDurableSubscriber(final ProcessContext context) {
@@ -323,9 +336,9 @@ public class ConsumeJMS extends AbstractJMSProcessor<JMSConsumer> {
 
         try {
             if (context.getProperty(RECORD_READER).isSet()) {
-                processMessageSet(context, processSession, consumer, destinationName, errorQueueName, durable, shared, subscriptionName, messageSelector, charset);
+                processMessagesAsRecords(context, processSession, consumer, destinationName, errorQueueName, durable, shared, subscriptionName, messageSelector, charset);
             } else {
-                processSingleMessage(processSession, consumer, destinationName, errorQueueName, durable, shared, subscriptionName, messageSelector, charset);
+                processMessages(context, processSession, consumer, destinationName, errorQueueName, durable, shared, subscriptionName, messageSelector, charset);
             }
         } catch (Exception e) {
             getLogger().error("Error while trying to process JMS message", e);
@@ -335,26 +348,25 @@ public class ConsumeJMS extends AbstractJMSProcessor<JMSConsumer> {
         }
     }
 
-    private void processSingleMessage(ProcessSession processSession, JMSConsumer consumer, String destinationName, String errorQueueName,
-                                      boolean durable, boolean shared, String subscriptionName, String messageSelector, String charset) {
+    private void processMessages(ProcessContext context, ProcessSession processSession, JMSConsumer consumer, String destinationName, String errorQueueName,
+                                 boolean durable, boolean shared, String subscriptionName, String messageSelector, String charset) {
 
-        consumer.consumeSingleMessage(destinationName, errorQueueName, durable, shared, subscriptionName, messageSelector, charset, response -> {
-            if (response == null) {
-                return;
-            }
+        int batchSize = context.getProperty(MAX_BATCH_SIZE).asInteger();
+        consumer.consumeMessageSet(destinationName, errorQueueName, durable, shared, subscriptionName, messageSelector, charset, batchSize, jmsResponses -> {
+            jmsResponses.forEach(response -> {
+                try {
+                    final FlowFile flowFile = createFlowFileFromMessage(processSession, destinationName, response);
 
-            try {
-                final FlowFile flowFile = createFlowFileFromMessage(processSession, destinationName, response);
-
-                processSession.getProvenanceReporter().receive(flowFile, destinationName);
-                processSession.transfer(flowFile, REL_SUCCESS);
-                processSession.commitAsync(
-                        () -> withLog(() -> acknowledge(response)),
-                        __ -> withLog(() -> response.reject()));
-            } catch (final Throwable t) {
-                response.reject();
-                throw t;
-            }
+                    processSession.getProvenanceReporter().receive(flowFile, destinationName);
+                    processSession.transfer(flowFile, REL_SUCCESS);
+                    processSession.commitAsync(
+                            () -> withLog(() -> acknowledge(response)),
+                            __ -> withLog(() -> response.reject()));
+                } catch (final Throwable t) {
+                    response.reject();
+                    throw t;
+                }
+            });
         });
     }
 
@@ -372,9 +384,10 @@ public class ConsumeJMS extends AbstractJMSProcessor<JMSConsumer> {
         return flowFile;
     }
 
-    private void processMessageSet(ProcessContext context, ProcessSession session, JMSConsumer consumer, String destinationName, String errorQueueName,
-                                   boolean durable, boolean shared, String subscriptionName, String messageSelector, String charset) {
+    private void processMessagesAsRecords(ProcessContext context, ProcessSession session, JMSConsumer consumer, String destinationName, String errorQueueName,
+                                          boolean durable, boolean shared, String subscriptionName, String messageSelector, String charset) {
 
+        int batchSize = context.getProperty(MAX_BATCH_SIZE).asInteger();
         final RecordReaderFactory readerFactory = context.getProperty(RECORD_READER).asControllerService(RecordReaderFactory.class);
         final RecordSetWriterFactory writerFactory = context.getProperty(RECORD_WRITER).asControllerService(RecordSetWriterFactory.class);
         final OutputStrategy outputStrategy = OutputStrategy.valueOf(context.getProperty(OUTPUT_STRATEGY).getValue());
@@ -388,7 +401,7 @@ public class ConsumeJMS extends AbstractJMSProcessor<JMSConsumer> {
                 getLogger()
         );
 
-        consumer.consumeMessageSet(destinationName, errorQueueName, durable, shared, subscriptionName, messageSelector, charset, jmsResponses -> {
+        consumer.consumeMessageSet(destinationName, errorQueueName, durable, shared, subscriptionName, messageSelector, charset, batchSize, jmsResponses -> {
             flowFileWriter.write(session, jmsResponses, new FlowFileWriterCallback<>() {
                 @Override
                 public void onSuccess(FlowFile flowFile, List<JMSResponse> processedMessages, List<JMSResponse> failedMessages) {
@@ -480,7 +493,7 @@ public class ConsumeJMS extends AbstractJMSProcessor<JMSConsumer> {
      * Use provided clientId for non shared durable consumers, if not set
      * always a different value as defined in {@link AbstractJMSProcessor#setClientId(ProcessContext, SingleConnectionFactory)}.
      * </p>
-     * See {@link Session#createDurableConsumer(javax.jms.Topic, String, String, boolean)},
+     * See {@link Session#createDurableConsumer(jakarta.jms.Topic, String, String, boolean)},
      * in special following part: <i>An unshared durable subscription is
      * identified by a name specified by the client and by the client identifier,
      * which must be set. An application which subsequently wishes to create

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSPublisher.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSPublisher.java
@@ -154,7 +154,7 @@ class JMSPublisher extends JMSWorker {
     }
 
     /**
-     * Implementations of this interface use {@link javax.jms.Message} methods to set strongly typed properties.
+     * Implementations of this interface use {@link jakarta.jms.Message} methods to set strongly typed properties.
      */
     public interface JmsPropertySetter {
         void setProperty(final Message message, final String name, final String value) throws JMSException, NumberFormatException;

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
@@ -29,6 +29,7 @@ import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.RequiredPermission;
 import org.apache.nifi.expression.ExpressionLanguageScope;
@@ -199,6 +200,22 @@ public class PublishJMS extends AbstractJMSProcessor<JMSPublisher> {
         relationships = Collections.unmodifiableSet(_relationships);
     }
 
+    volatile Boolean allowIllegalChars;
+    volatile Pattern attributeHeaderPattern;
+    volatile RecordReaderFactory readerFactory;
+    volatile RecordSetWriterFactory writerFactory;
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        allowIllegalChars = context.getProperty(ALLOW_ILLEGAL_HEADER_CHARS).asBoolean();
+
+        final String attributeHeaderRegex = context.getProperty(ATTRIBUTES_AS_HEADERS_REGEX).getValue();
+        attributeHeaderPattern = Pattern.compile(attributeHeaderRegex);
+
+        readerFactory = context.getProperty(RECORD_READER).asControllerService(RecordReaderFactory.class);
+        writerFactory = context.getProperty(RECORD_WRITER).asControllerService(RecordSetWriterFactory.class);
+    }
+
     /**
      * Will construct JMS {@link Message} by extracting its body from the
      * incoming {@link FlowFile}. {@link FlowFile} attributes that represent
@@ -221,15 +238,12 @@ public class PublishJMS extends AbstractJMSProcessor<JMSPublisher> {
             try {
                 final String destinationName = context.getProperty(DESTINATION).evaluateAttributeExpressions(flowFile).getValue();
                 final String charset = context.getProperty(CHARSET).evaluateAttributeExpressions(flowFile).getValue();
-                final Boolean allowIllegalChars = context.getProperty(ALLOW_ILLEGAL_HEADER_CHARS).asBoolean();
-                final String attributeHeaderRegex = context.getProperty(ATTRIBUTES_AS_HEADERS_REGEX).getValue();
 
                 final Map<String, String> attributesToSend = new HashMap<>();
                 // REGEX Attributes
-                final Pattern pattern = Pattern.compile(attributeHeaderRegex);
                 for (final Map.Entry<String, String> entry : flowFile.getAttributes().entrySet()) {
                     final String key = entry.getKey();
-                    if (pattern.matcher(key).matches()) {
+                    if (attributeHeaderPattern.matcher(key).matches()) {
                         if (allowIllegalChars || key.endsWith(".type") || (!key.contains("-") && !key.contains("."))) {
                             attributesToSend.put(key, flowFile.getAttribute(key));
                         }
@@ -237,9 +251,6 @@ public class PublishJMS extends AbstractJMSProcessor<JMSPublisher> {
                 }
 
                 if (context.getProperty(RECORD_READER).isSet()) {
-                    final RecordReaderFactory readerFactory = context.getProperty(RECORD_READER).asControllerService(RecordReaderFactory.class);
-                    final RecordSetWriterFactory writerFactory = context.getProperty(RECORD_WRITER).asControllerService(RecordSetWriterFactory.class);
-
                     final FlowFileReader flowFileReader = new StateTrackingFlowFileReader(
                             getIdentifier(),
                             new RecordSupplier(readerFactory, writerFactory),

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSIT.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSIT.java
@@ -503,6 +503,7 @@ public class ConsumeJMSIT {
             TestRunner testRunner = initializeTestRunner(jmsTemplate.getConnectionFactory(), destination);
             testRunner.setProperty(ConsumeJMS.RECORD_READER, createJsonRecordSetReaderService(testRunner));
             testRunner.setProperty(ConsumeJMS.RECORD_WRITER, createJsonRecordSetWriterService(testRunner));
+            testRunner.setProperty(AbstractJMSProcessor.MAX_BATCH_SIZE, "10");
 
             testRunner.run(1, false);
 
@@ -535,6 +536,7 @@ public class ConsumeJMSIT {
             TestRunner testRunner = initializeTestRunner(jmsTemplate.getConnectionFactory(), destination);
             testRunner.setProperty(ConsumeJMS.RECORD_READER, createJsonRecordSetReaderService(testRunner));
             testRunner.setProperty(ConsumeJMS.RECORD_WRITER, createJsonRecordSetWriterService(testRunner));
+            testRunner.setProperty(AbstractJMSProcessor.MAX_BATCH_SIZE, "10");
             testRunner.setRelationshipAvailable(ConsumeJMS.REL_PARSE_FAILURE);
 
             testRunner.run(1, false);
@@ -568,6 +570,7 @@ public class ConsumeJMSIT {
             TestRunner testRunner = initializeTestRunner(jmsTemplate.getConnectionFactory(), destination);
             testRunner.setProperty(ConsumeJMS.RECORD_READER, createJsonRecordSetReaderService(testRunner));
             testRunner.setProperty(ConsumeJMS.RECORD_WRITER, createJsonRecordSetWriterService(testRunner));
+            testRunner.setProperty(AbstractJMSProcessor.MAX_BATCH_SIZE, "10");
             testRunner.setProperty(ConsumeJMS.OUTPUT_STRATEGY, OutputStrategy.USE_APPENDER.getValue());
 
             testRunner.run(1, false);
@@ -609,6 +612,7 @@ public class ConsumeJMSIT {
             TestRunner testRunner = initializeTestRunner(jmsTemplate.getConnectionFactory(), destination);
             testRunner.setProperty(ConsumeJMS.RECORD_READER, createJsonRecordSetReaderService(testRunner));
             testRunner.setProperty(ConsumeJMS.RECORD_WRITER, createJsonRecordSetWriterService(testRunner));
+            testRunner.setProperty(AbstractJMSProcessor.MAX_BATCH_SIZE, "10");
             testRunner.setProperty(ConsumeJMS.OUTPUT_STRATEGY, OutputStrategy.USE_WRAPPER.getValue());
 
             testRunner.run(1, false);

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/JMSPublisherConsumerIT.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/JMSPublisherConsumerIT.java
@@ -386,7 +386,7 @@ public class JMSPublisherConsumerIT {
                     try {
                         JMSConsumer consumer = new JMSConsumer((CachingConnectionFactory) consumeTemplate.getConnectionFactory(), consumeTemplate, mock(ComponentLog.class));
 
-                        while(msgCounter.get() < totalMessageCount) {
+                        while (msgCounter.get() < totalMessageCount) {
                             consumer.consumeMessageSet(destinationName, null, false, false, null, null, "UTF-8", 5,
                                     responses -> {
                                         responses.forEach( response -> {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFile.java
@@ -184,7 +184,7 @@ public class GetFile extends AbstractProcessor {
             .build();
     public static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
             .name("Batch Size")
-            .description("The maximum number of files to pull in each iteration")
+            .description("The maximum number of files to pull in each invocation of the processor")
             .required(true)
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .defaultValue("10")


### PR DESCRIPTION
# Summary

[NIFI-7085](https://issues.apache.org/jira/browse/NIFI-7085)

This PR adds batching to PublishJMS and ConsumeJMS in the form of a new property. ConsumeJMS can read more than one message from the JMS broker per triggered task. PublishJMS can publish more than one flowFile to the JMS broker per triggered task. This helps get higher message throughput to JMS in busy NiFi environments.

The SupportsBatching annotation was considered, but it is not appropriate for processors that send/receive data from an external source.

The new Maximum Batch Size property has a default value of 1, to match old behavior. ConsumeJMS in record processing mode used to have a 10,000 max batch size which is replaced by this property value. ConsumeJMS will migrate the new Maximum Batch Size property to 10000 if it was not set and it was in record processing mode.

Fixed an bug in JMSConsumer:consumeMessageSet where it could read, but not acknowledge or commit, an extra message when batchCounter = MAX_MESSAGES_PER_FLOW_FILE

Fixed JMSPublisherConsumerIT integration test which didn't account for when consumeMessage() did not read a message.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
