### PR TITLE
NIFI-12979 Upgrade Kotlin from 1.9.10 to 1.9.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,9 +112,9 @@
         <software.amazon.awssdk.version>2.25.16</software.amazon.awssdk.version>
         <gson.version>2.10.1</gson.version>
         <io.fabric8.kubernetes.client.version>6.10.0</io.fabric8.kubernetes.client.version>
-        <kotlin.version>1.9.10</kotlin.version>
+        <kotlin.version>1.9.23</kotlin.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <okio.version>3.8.0</okio.version>
+        <okio.version>3.9.0</okio.version>
         <org.apache.commons.cli.version>1.6.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.16.1</org.apache.commons.codec.version>
         <org.apache.commons.compress.version>1.26.1</org.apache.commons.compress.version>


### PR DESCRIPTION
# Summary

[NIFI-12979](https://issues.apache.org/jira/browse/NIFI-12979) Upgrades Kotlin dependencies from 1.9.10 to [1.9.23](https://github.com/JetBrains/kotlin/releases/tag/v1.9.23) and Okio from 3.8.0 to [3.9.0](https://github.com/square/okio/blob/master/CHANGELOG.md#version-390). Both of these libraries are transitive dependencies of [OkHttp](https://square.github.io/okhttp/), which is used across framework and extension components.

This upgrade should be applied to both main and support branches.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
