### PR TITLE
NIFI-12987 allow controller service type to be searchable

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/search/attributematchers/ControllerServiceNodeMatcher.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/search/attributematchers/ControllerServiceNodeMatcher.java
@@ -28,6 +28,7 @@ public class ControllerServiceNodeMatcher implements AttributeMatcher<Controller
     private static final String LABEL_VERSION_CONTROL_ID = "Version Control ID";
     private static final String LABEL_NAME = "Name";
     private static final String LABEL_COMMENTS = "Comments";
+    private static final String LABEL_TYPE = "Type";
 
     @Override
     public void match(final ControllerServiceNode component, final SearchQuery query, final List<String> matches) {
@@ -37,5 +38,7 @@ public class ControllerServiceNodeMatcher implements AttributeMatcher<Controller
         addIfMatching(searchTerm, component.getVersionedComponentId().orElse(null), LABEL_VERSION_CONTROL_ID, matches);
         addIfMatching(searchTerm, component.getName(), LABEL_NAME, matches);
         addIfMatching(searchTerm, component.getComments(), LABEL_COMMENTS, matches);
+        addIfMatching(searchTerm, component.getControllerServiceImplementation().getClass().getSimpleName(), LABEL_TYPE, matches);
+        addIfMatching(searchTerm, component.getComponentType(), LABEL_TYPE, matches);
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/search/attributematchers/ControllerServiceNodeMatcherTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/search/attributematchers/ControllerServiceNodeMatcherTest.java
@@ -16,11 +16,18 @@
  */
 package org.apache.nifi.web.search.attributematchers;
 
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.controller.ControllerService;
+import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public class ControllerServiceNodeMatcherTest extends AbstractAttributeMatcherTest {
@@ -37,6 +44,8 @@ public class ControllerServiceNodeMatcherTest extends AbstractAttributeMatcherTe
         Mockito.when(component.getVersionedComponentId()).thenReturn(Optional.of("LoremVersionId"));
         Mockito.when(component.getName()).thenReturn("LoremName");
         Mockito.when(component.getComments()).thenReturn("LoremComment");
+        Mockito.when(component.getControllerServiceImplementation()).thenReturn(new LoremControllerService());
+        Mockito.when(component.getComponentType()).thenReturn("LoremControllerService");
         // when
         testSubject.match(component, searchQuery, matches);
 
@@ -44,6 +53,38 @@ public class ControllerServiceNodeMatcherTest extends AbstractAttributeMatcherTe
         thenMatchConsistsOf("Id: LoremId", //
                 "Version Control ID: LoremVersionId", //
                 "Name: LoremName", //
-                "Comments: LoremComment");
+                "Comments: LoremComment",
+                "Type: LoremControllerService");
+    }
+
+    private static class LoremControllerService implements ControllerService {
+
+        @Override
+        public Collection<ValidationResult> validate(ValidationContext context) {
+            return null;
+        }
+
+        @Override
+        public PropertyDescriptor getPropertyDescriptor(String name) {
+            return null;
+        }
+
+        @Override
+        public void onPropertyModified(PropertyDescriptor descriptor, String oldValue, String newValue) {
+        }
+
+        @Override
+        public List<PropertyDescriptor> getPropertyDescriptors() {
+            return null;
+        }
+
+        @Override
+        public String getIdentifier() {
+            return null;
+        }
+
+        @Override
+        public void initialize(ControllerServiceInitializationContext context) {
+        }
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-12987](https://issues.apache.org/jira/browse/NIFI-12987)
Modeling after the ProcessorMetadataMatcher code which allows searching on processor type, this PR modifies ControllerServiceNodeMatcher to allow searching on controller service type.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [n/a] Documentation formatting appears as expected in rendered files
