### PR TITLE
NIFI-13004 remove include-grpc profile from developer and walkthrough…

### DIFF
--- a/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -2717,7 +2717,7 @@ deprecationLogger.warn(
 
 The following command is used to generate a standard binary distribution of Apache NiFi:
 
-`mvn clean install -Pinclude-grpc,contrib-check`
+`mvn clean install -Pcontrib-check`
 
 == How to contribute to Apache NiFi
 

--- a/nifi-docs/src/main/asciidoc/walkthroughs.adoc
+++ b/nifi-docs/src/main/asciidoc/walkthroughs.adoc
@@ -115,7 +115,7 @@ drwxr-xr-x  14 alopresto  staff   448B Apr  6 15:44 nifi-toolkit/
 -rw-r--r--   1 alopresto  staff    44K Jan 22 15:10 pom.xml
 ----
 . Build the NiFi source using link:https://maven.apache.org/[Apache Maven^] from the source root directory (`nifi-1.11.4/`) using one of the following commands. For more information, see the link:https://cwiki.apache.org/confluence/display/NIFI/Contributor+Guide[NiFi Contributor Guide^]. Estimated build times for each command on a modern professional laptop are listed below; allow additional time for dependency library downloads on first build.
-* `mvn clean install -Pinclude-grpc` -- Builds the application (expected time ~30 minutes)
+* `mvn clean install` -- Builds the application (expected time ~30 minutes)
 * `mvn clean install -T2.0C` -- Builds the application with multiple parallel threads (expected time ~15 minutes)
 * `mvn clean install -T2.0C -DskipTests` -- Builds the application with multiple parallel threads and unit tests disabled (expected time ~6 minutes)
 +


### PR DESCRIPTION
… guides

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Simple update to the Developer and Walkthrough Guides to remove reference to `include-grpc` profile. This applies only to 2.x branch.

Can the website be updated with this change immediately/prior to the next release?

[NIFI-13004](https://issues.apache.org/jira/browse/NIFI-13004)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
