### PR TITLE
NIFI-13014 Remove unused Avatica versions from code-coverage

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -28,8 +28,6 @@
 
     <properties>
         <ant.version>1.10.14</ant.version>
-        <calcite.avatica.version>1.6.0</calcite.avatica.version>
-        <avatica.version>1.24.0</avatica.version>
         <org.apache.sshd.version>2.12.0</org.apache.sshd.version>
         <mime4j.version>0.8.11</mime4j.version>
     </properties>
@@ -63,17 +61,6 @@
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant-antlr</artifactId>
                 <version>${ant.version}</version>
-            </dependency>
-            <!-- Calcite Avatica referenced in Hive -->
-            <dependency>
-                <groupId>org.apache.calcite</groupId>
-                <artifactId>calcite-avatica</artifactId>
-                <version>${calcite.avatica.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.calcite.avatica</groupId>
-                <artifactId>avatica</artifactId>
-                <version>${avatica.version}</version>
             </dependency>
             <!-- Commons Compiler 3.1.9 from calcite-core -->
             <dependency>


### PR DESCRIPTION
# Summary

[NIFI-13014](https://issues.apache.org/jira/browse/NIFI-13014) Removes unused Calcite Avatica version references from `nifi-code-coverage` dependency declarations, which are no longer needed following the removal of Hive 3 components.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
