### PR TITLE
NIFI-12889: Retry Kerberos login on auth failure in HDFS processors (1.x version)

### DIFF
--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/util/GSSExceptionRollbackYieldSessionHandler.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/util/GSSExceptionRollbackYieldSessionHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.hadoop.util;
+
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+
+import java.util.function.BiConsumer;
+
+public class GSSExceptionRollbackYieldSessionHandler implements BiConsumer<ProcessSession, ProcessContext> {
+    @Override
+    public void accept(ProcessSession processSession, ProcessContext processContext) {
+        processSession.rollback();
+        processContext.yield();
+    }
+}

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/GetHDFSTest.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/GetHDFSTest.java
@@ -31,6 +31,7 @@ import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.ietf.jgss.GSSException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -58,12 +59,11 @@ import static org.mockito.Mockito.when;
 @DisabledOnOs(OS.WINDOWS)
 public class GetHDFSTest {
 
-    private NiFiProperties mockNiFiProperties;
     private KerberosProperties kerberosProperties;
 
     @BeforeEach
     public void setup() {
-        mockNiFiProperties = mock(NiFiProperties.class);
+        NiFiProperties mockNiFiProperties = mock(NiFiProperties.class);
         when(mockNiFiProperties.getKerberosConfigurationFile()).thenReturn(null);
         kerberosProperties = new KerberosProperties(null);
     }
@@ -179,7 +179,7 @@ public class GetHDFSTest {
         assertEquals(1, flowFiles.size());
 
         MockFlowFile flowFile = flowFiles.get(0);
-        assertTrue(flowFile.getAttribute(CoreAttributes.FILENAME.key()).equals("randombytes-1"));
+        assertEquals("randombytes-1", flowFile.getAttribute(CoreAttributes.FILENAME.key()));
         InputStream expected = getClass().getResourceAsStream("/testdata/randombytes-1");
         flowFile.assertContentEquals(expected);
     }
@@ -198,7 +198,7 @@ public class GetHDFSTest {
         assertEquals(1, flowFiles.size());
 
         MockFlowFile flowFile = flowFiles.get(0);
-        assertTrue(flowFile.getAttribute(CoreAttributes.FILENAME.key()).equals("randombytes-1.gz"));
+        assertEquals("randombytes-1.gz", flowFile.getAttribute(CoreAttributes.FILENAME.key()));
         InputStream expected = getClass().getResourceAsStream("/testdata/randombytes-1.gz");
         flowFile.assertContentEquals(expected);
     }
@@ -217,7 +217,7 @@ public class GetHDFSTest {
         assertEquals(1, flowFiles.size());
 
         MockFlowFile flowFile = flowFiles.get(0);
-        assertTrue(flowFile.getAttribute(CoreAttributes.FILENAME.key()).equals("13545423550275052.zip"));
+        assertEquals("13545423550275052.zip", flowFile.getAttribute(CoreAttributes.FILENAME.key()));
         InputStream expected = getClass().getResourceAsStream("/testdata/13545423550275052.zip");
         flowFile.assertContentEquals(expected);
     }
@@ -236,7 +236,7 @@ public class GetHDFSTest {
         assertEquals(1, flowFiles.size());
 
         MockFlowFile flowFile = flowFiles.get(0);
-        assertTrue(flowFile.getAttribute(CoreAttributes.FILENAME.key()).equals("13545423550275052.zip"));
+        assertEquals("13545423550275052.zip", flowFile.getAttribute(CoreAttributes.FILENAME.key()));
         InputStream expected = getClass().getResourceAsStream("/testdata/13545423550275052.zip");
         flowFile.assertContentEquals(expected);
         final List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();
@@ -304,12 +304,12 @@ public class GetHDFSTest {
                 final Object result;
                 if (callCounter == 0) {
                     when(mockFileSystem.exists(any(Path.class))).thenReturn(directoryExists);
-                    result = ((PrivilegedExceptionAction) invocationOnMock.getArgument(0)).run();
+                    result = ((PrivilegedExceptionAction<?>) invocationOnMock.getArgument(0)).run();
                     verify(mockUserGroupInformation, times(callCounter + 1)).doAs(any(PrivilegedExceptionAction.class));
                     verify(mockFileSystem).exists(any(Path.class));
                 } else {
                     when(mockFileSystem.listStatus(any(Path.class))).thenReturn(new FileStatus[0]);
-                    result = ((PrivilegedExceptionAction) invocationOnMock.getArgument(0)).run();
+                    result = ((PrivilegedExceptionAction<?>) invocationOnMock.getArgument(0)).run();
                     verify(mockUserGroupInformation, times(callCounter + 1)).doAs(any(PrivilegedExceptionAction.class));
                     verify(mockFileSystem).listStatus(any(Path.class));
                 }
@@ -322,7 +322,24 @@ public class GetHDFSTest {
 
         // THEN
         verify(mockFileSystem).getUri();
-        verifyNoMoreInteractions(mockFileSystem, mockUserGroupInformation);
+        verifyNoMoreInteractions(mockUserGroupInformation);
+    }
+
+    @Test
+    public void testGSSExceptionOnExists() throws Exception {
+        FileSystem mockFileSystem = mock(FileSystem.class);
+        UserGroupInformation mockUserGroupInformation = mock(UserGroupInformation.class);
+
+        GetHDFS testSubject = new TestableGetHDFSForUGI(kerberosProperties, mockFileSystem, mockUserGroupInformation);
+        TestRunner runner = TestRunners.newTestRunner(testSubject);
+        runner.setProperty(GetHDFS.DIRECTORY, "src/test/resources/testdata");
+        when(mockUserGroupInformation.doAs(any(PrivilegedExceptionAction.class))).thenThrow(new IOException(new GSSException(13)));
+        runner.run();
+
+        // Assert session rollback
+        runner.assertTransferCount(GetHDFS.REL_SUCCESS, 0);
+        // assert that no files were penalized
+        runner.assertPenalizeCount(0);
     }
 
     private static class TestableGetHDFS extends GetHDFS {
@@ -340,8 +357,8 @@ public class GetHDFSTest {
     }
 
     private static class TestableGetHDFSForUGI extends TestableGetHDFS {
-        private FileSystem mockFileSystem;
-        private UserGroupInformation mockUserGroupInformation;
+        private final FileSystem mockFileSystem;
+        private final UserGroupInformation mockUserGroupInformation;
 
         public TestableGetHDFSForUGI(KerberosProperties testKerberosProperties, FileSystem mockFileSystem, UserGroupInformation mockUserGroupInformation) {
             super(testKerberosProperties);

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/PutHDFSTest.java
@@ -17,24 +17,20 @@
 package org.apache.nifi.processors.hadoop;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.AclEntry;
-import org.apache.hadoop.fs.permission.AclStatus;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.util.Progressable;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.hadoop.KerberosProperties;
 import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processors.hadoop.util.MockFileSystem;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.util.MockFlowFile;
@@ -47,13 +43,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.security.sasl.SaslException;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -63,7 +55,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -75,7 +66,7 @@ public class PutHDFSTest {
     private final static String FILE_NAME = "randombytes-1";
 
     private KerberosProperties kerberosProperties;
-    private FileSystem mockFileSystem;
+    private MockFileSystem mockFileSystem;
 
     @BeforeEach
     public void setup() {
@@ -359,19 +350,6 @@ public class PutHDFSTest {
         // assert no flowfiles transferred to outgoing relationships
         runner.assertTransferCount(PutHDFS.REL_SUCCESS, 0);
         runner.assertTransferCount(PutHDFS.REL_FAILURE, 0);
-        // assert the input flowfile was penalized
-        List<MockFlowFile> penalizedFlowFiles = runner.getPenalizedFlowFiles();
-        assertEquals(1, penalizedFlowFiles.size());
-        assertEquals("randombytes-1", penalizedFlowFiles.iterator().next().getAttribute(CoreAttributes.FILENAME.key()));
-        // assert the processor's queue is not empty
-        assertFalse(runner.isQueueEmpty());
-        assertEquals(1, runner.getQueueSize().getObjectCount());
-        // assert the input file is back on the queue
-        ProcessSession session = runner.getProcessSessionFactory().createSession();
-        FlowFile queuedFlowFile = session.get();
-        assertNotNull(queuedFlowFile);
-        assertEquals("randombytes-1", queuedFlowFile.getAttribute(CoreAttributes.FILENAME.key()));
-        session.rollback();
     }
 
     @Test
@@ -610,8 +588,37 @@ public class PutHDFSTest {
 
     @Test
     public void testPutFileWithCloseException() throws IOException {
-        mockFileSystem = new MockFileSystem(true);
+        mockFileSystem = new MockFileSystem();
+        mockFileSystem.setFailOnClose(true);
         String dirName = "target/testPutFileCloseException";
+        File file = new File(dirName);
+        file.mkdirs();
+        Path p = new Path(dirName).makeQualified(mockFileSystem.getUri(), mockFileSystem.getWorkingDirectory());
+
+        TestRunner runner = TestRunners.newTestRunner(new TestablePutHDFS(kerberosProperties, mockFileSystem));
+        runner.setProperty(PutHDFS.DIRECTORY, dirName);
+        runner.setProperty(PutHDFS.CONFLICT_RESOLUTION, "replace");
+
+        try (FileInputStream fis = new FileInputStream("src/test/resources/testdata/randombytes-1")) {
+            Map<String, String> attributes = new HashMap<>();
+            attributes.put(CoreAttributes.FILENAME.key(), "randombytes-1");
+            runner.enqueue(fis, attributes);
+            runner.run();
+        }
+
+        List<MockFlowFile> failedFlowFiles = runner
+                .getFlowFilesForRelationship(PutHDFS.REL_FAILURE);
+        assertFalse(failedFlowFiles.isEmpty());
+        assertTrue(failedFlowFiles.get(0).isPenalized());
+
+        mockFileSystem.delete(p, true);
+    }
+
+    @Test
+    public void testPutFileWithCreateException() throws IOException {
+        mockFileSystem = new MockFileSystem();
+        mockFileSystem.setFailOnCreate(true);
+        String dirName = "target/testPutFileCreateException";
         File file = new File(dirName);
         file.mkdirs();
         Path p = new Path(dirName).makeQualified(mockFileSystem.getUri(), mockFileSystem.getWorkingDirectory());
@@ -637,8 +644,8 @@ public class PutHDFSTest {
 
     private class TestablePutHDFS extends PutHDFS {
 
-        private KerberosProperties testKerberosProperties;
-        private FileSystem fileSystem;
+        private final KerberosProperties testKerberosProperties;
+        private final FileSystem fileSystem;
 
         TestablePutHDFS(KerberosProperties testKerberosProperties, FileSystem fileSystem) {
             this.testKerberosProperties = testKerberosProperties;
@@ -660,135 +667,5 @@ public class PutHDFSTest {
         protected FileSystem getFileSystem() {
             return fileSystem;
         }
-    }
-
-    private static class MockFileSystem extends FileSystem {
-        private final Map<Path, FileStatus> pathToStatus = new HashMap<>();
-        private final Map<Path, List<AclEntry>> pathToAcl = new HashMap<>();
-        private final boolean failOnClose;
-
-        public MockFileSystem() {
-            failOnClose = false;
-        }
-
-        public MockFileSystem(boolean failOnClose) {
-            this.failOnClose = failOnClose;
-        }
-
-        public void setAcl(final Path path, final List<AclEntry> aclSpec) {
-            pathToAcl.put(path, aclSpec);
-        }
-
-        @Override
-        public AclStatus getAclStatus(final Path path) {
-            return new AclStatus.Builder().addEntries(pathToAcl.getOrDefault(path, new ArrayList<>())).build();
-        }
-
-        @Override
-        public URI getUri() {
-            return URI.create("file:///");
-        }
-
-        @Override
-        public FSDataInputStream open(final Path f, final int bufferSize) {
-            return null;
-        }
-
-        @Override
-        public FSDataOutputStream create(final Path f, final FsPermission permission, final boolean overwrite, final int bufferSize, final short replication,
-                                         final long blockSize, final Progressable progress) {
-            pathToStatus.put(f, newFile(f, permission));
-            if(failOnClose) {
-                return new FSDataOutputStream(new ByteArrayOutputStream(), new Statistics("")) {
-                    @Override
-                    public void close() throws IOException {
-                        super.close();
-                        throw new IOException("Fail on close");
-                    }
-                };
-            } else {
-                return new FSDataOutputStream(new ByteArrayOutputStream(), new Statistics(""));
-            }
-        }
-
-        @Override
-        public FSDataOutputStream append(final Path f, final int bufferSize, final Progressable progress) {
-            return null;
-        }
-
-        @Override
-        public boolean rename(final Path src, final Path dst) {
-            if (pathToStatus.containsKey(src)) {
-                pathToStatus.put(dst, pathToStatus.remove(src));
-            } else {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public boolean delete(final Path f, final boolean recursive) {
-            if (pathToStatus.containsKey(f)) {
-                pathToStatus.remove(f);
-            } else {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public FileStatus[] listStatus(final Path f) {
-            return null;
-        }
-
-        @Override
-        public void setWorkingDirectory(final Path new_dir) {
-
-        }
-
-        @Override
-        public Path getWorkingDirectory() {
-            return new Path(new File(".").getAbsolutePath());
-        }
-
-        @Override
-        public boolean mkdirs(final Path f, final FsPermission permission) {
-            return false;
-        }
-
-        @Override
-        public boolean mkdirs(Path f) {
-            pathToStatus.put(f, newDir(f));
-            return true;
-        }
-
-        @Override
-        public FileStatus getFileStatus(final Path f) throws IOException {
-            final FileStatus fileStatus = pathToStatus.get(f);
-            if (fileStatus == null) throw new FileNotFoundException();
-            return fileStatus;
-        }
-
-        @Override
-        public boolean exists(Path f) {
-            return pathToStatus.containsKey(f);
-        }
-
-        private FileStatus newFile(Path p, FsPermission permission) {
-            return new FileStatus(100L, false, 3, 128 * 1024 * 1024, 1523456000000L, 1523457000000L, permission, "owner", "group", p);
-        }
-
-        private FileStatus newDir(Path p) {
-            return new FileStatus(1L, true, 3, 128 * 1024 * 1024, 1523456000000L, 1523457000000L, perms((short) 0755), "owner", "group", (Path)null, p, true, false, false);
-        }
-
-        @Override
-        public long getDefaultBlockSize(Path f) {
-            return 33554432L;
-        }
-    }
-
-    static FsPermission perms(short p) {
-        return new FsPermission(p);
     }
 }

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestGetHDFSFileInfo.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestGetHDFSFileInfo.java
@@ -17,17 +17,23 @@
 package org.apache.nifi.processors.hadoop;
 
 import com.google.common.collect.Maps;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.util.Progressable;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.hadoop.KerberosProperties;
 import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processors.hadoop.util.MockFileSystem;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.NiFiProperties;
@@ -35,21 +41,6 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -255,6 +246,28 @@ public class TestGetHDFSFileInfo {
 
         final MockFlowFile mff = runner.getFlowFilesForRelationship(GetHDFSFileInfo.REL_FAILURE).get(0);
         mff.assertAttributeEquals("hdfs.status", "Failed due to: java.io.InterruptedIOException");
+    }
+
+    @Test
+    public void testWithGSSException() {
+        proc.fileSystem.setFailOnExists(true);
+
+        runner.setIncomingConnection(false);
+        runner.setProperty(GetHDFSFileInfo.FULL_PATH, "/some/home/mydir");
+        runner.setProperty(GetHDFSFileInfo.RECURSE_SUBDIRS, "false");
+        runner.setProperty(GetHDFSFileInfo.IGNORE_DOTTED_DIRS, "true");
+        runner.setProperty(GetHDFSFileInfo.IGNORE_DOTTED_FILES, "true");
+        runner.setProperty(GetHDFSFileInfo.DESTINATION, GetHDFSFileInfo.DESTINATION_CONTENT);
+
+        runner.run();
+
+        // Assert session rollback
+        runner.assertTransferCount(GetHDFSFileInfo.REL_ORIGINAL, 0);
+        runner.assertTransferCount(GetHDFSFileInfo.REL_SUCCESS, 0);
+        runner.assertTransferCount(GetHDFSFileInfo.REL_FAILURE, 0);
+        runner.assertTransferCount(GetHDFSFileInfo.REL_NOT_FOUND, 0);
+
+        proc.fileSystem.setFailOnExists(false);
     }
 
     @Test
@@ -787,137 +800,6 @@ public class TestGetHDFSFileInfo {
         @Override
         protected FileSystem getFileSystem(final Configuration config) throws IOException {
             return fileSystem;
-        }
-    }
-
-    private class MockFileSystem extends FileSystem {
-        private final Map<Path, Set<FileStatus>> fileStatuses = new HashMap<>();
-        private final Map<Path, FileStatus> pathToStatus = new HashMap<>();
-
-        public void addFileStatus(final FileStatus parent, final FileStatus child) {
-            Set<FileStatus> children = fileStatuses.get(parent.getPath());
-            if (children == null) {
-                children = new HashSet<>();
-                fileStatuses.put(parent.getPath(), children);
-            }
-            if (child != null) {
-                children.add(child);
-                if (child.isDirectory() && !fileStatuses.containsKey(child.getPath())) {
-                    fileStatuses.put(child.getPath(), new HashSet<FileStatus>());
-                }
-            }
-
-            pathToStatus.put(parent.getPath(), parent);
-            pathToStatus.put(child.getPath(), child);
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public long getDefaultBlockSize() {
-            return 1024L;
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public short getDefaultReplication() {
-            return 1;
-        }
-
-        @Override
-        public URI getUri() {
-            return null;
-        }
-
-        @Override
-        public FSDataInputStream open(final Path f, final int bufferSize) throws IOException {
-            return null;
-        }
-
-        @Override
-        public FSDataOutputStream create(final Path f, final FsPermission permission, final boolean overwrite, final int bufferSize, final short replication,
-                                         final long blockSize, final Progressable progress) throws IOException {
-            return null;
-        }
-
-        @Override
-        public FSDataOutputStream append(final Path f, final int bufferSize, final Progressable progress) throws IOException {
-            return null;
-        }
-
-        @Override
-        public boolean rename(final Path src, final Path dst) throws IOException {
-            return false;
-        }
-
-        @Override
-        public boolean delete(final Path f, final boolean recursive) throws IOException {
-            return false;
-        }
-
-        @Override
-        public FileStatus[] listStatus(final Path f) throws FileNotFoundException, IOException {
-            if (!fileStatuses.containsKey(f)) {
-                throw new FileNotFoundException();
-            }
-            if (f.getName().startsWith("list_exception_")) {
-                String clzName = f.getName().substring("list_exception_".length(), f.getName().length());
-                IOException exception = null;
-                try {
-                     exception = (IOException)Class.forName(clzName).newInstance();
-                } catch (Throwable t) {
-                    throw new RuntimeException(t);
-                }
-                throw exception;
-            }
-            final Set<FileStatus> statuses = fileStatuses.get(f);
-            if (statuses == null) {
-                return new FileStatus[0];
-            }
-
-            for (FileStatus s : statuses) {
-                getFileStatus(s.getPath()); //support exception handling only.
-            }
-
-            return statuses.toArray(new FileStatus[statuses.size()]);
-        }
-
-        @Override
-        public void setWorkingDirectory(final Path new_dir) {
-
-        }
-
-        @Override
-        public Path getWorkingDirectory() {
-            return new Path(new File(".").getAbsolutePath());
-        }
-
-        @Override
-        public boolean mkdirs(final Path f, final FsPermission permission) throws IOException {
-            return false;
-        }
-
-        @Override
-        public FileStatus getFileStatus(final Path f) throws IOException {
-            if (f!=null && f.getName().startsWith("exception_")) {
-                String clzName = f.getName().substring("exception_".length(), f.getName().length());
-                IOException exception = null;
-                try {
-                     exception = (IOException)Class.forName(clzName).newInstance();
-                } catch (Throwable t) {
-                    throw new RuntimeException(t);
-                }
-                throw exception;
-            }
-            final FileStatus fileStatus = pathToStatus.get(f);
-            if (fileStatus == null) throw new FileNotFoundException();
-            return fileStatus;
-        }
-
-        public FileStatus newFile(String p) {
-            return new FileStatus(100L, false, 3, 128*1024*1024, 1523456000000L, 1523457000000L, perms((short)0644), "owner", "group", new Path(p));
-        }
-        public FileStatus newDir(String p) {
-            return new FileStatus(1L, true, 3, 128*1024*1024, 1523456000000L, 1523457000000L, perms((short)0755), "owner", "group", new Path(p));
         }
     }
 }

--- a/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/util/MockFileSystem.java
+++ b/nifi-nar-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/util/MockFileSystem.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.hadoop.util;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.AclEntry;
+import org.apache.hadoop.fs.permission.AclStatus;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.util.Progressable;
+import org.ietf.jgss.GSSException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class MockFileSystem extends FileSystem {
+    private final Map<Path, FileStatus> pathToStatus = new HashMap<>();
+    private final Map<Path, List<AclEntry>> pathToAcl = new HashMap<>();
+    private final Map<Path, Set<FileStatus>> fileStatuses = new HashMap<>();
+
+    private boolean failOnOpen;
+    private boolean failOnClose;
+    private boolean failOnCreate;
+    private boolean failOnFileStatus;
+    private boolean failOnExists;
+
+
+    public void setFailOnClose(final boolean failOnClose) {
+        this.failOnClose = failOnClose;
+    }
+
+    public void setFailOnCreate(final boolean failOnCreate) {
+        this.failOnCreate = failOnCreate;
+    }
+
+    public void setFailOnFileStatus(final boolean failOnFileStatus) {
+        this.failOnFileStatus = failOnFileStatus;
+    }
+
+    public void setFailOnExists(final boolean failOnExists) {
+        this.failOnExists = failOnExists;
+    }
+
+    public void setFailOnOpen(final boolean failOnOpen) {
+        this.failOnOpen = failOnOpen;
+    }
+
+    public void setAcl(final Path path, final List<AclEntry> aclSpec) {
+        pathToAcl.put(path, aclSpec);
+    }
+
+    @Override
+    public AclStatus getAclStatus(final Path path) {
+        return new AclStatus.Builder().addEntries(pathToAcl.getOrDefault(path, new ArrayList<>())).build();
+    }
+
+    @Override
+    public URI getUri() {
+        return URI.create("file:///");
+    }
+
+    @Override
+    public FSDataInputStream open(final Path f, final int bufferSize) throws IOException {
+        if (failOnOpen) {
+            throw new IOException(new GSSException(13));
+        }
+        return null;
+    }
+
+    @Override
+    public FSDataOutputStream create(final Path f, final FsPermission permission, final boolean overwrite, final int bufferSize, final short replication,
+                                     final long blockSize, final Progressable progress) throws IOException {
+        if (failOnCreate) {
+            // Simulate an AuthenticationException wrapped in an IOException
+            throw new IOException(new AuthenticationException("test auth error"));
+        }
+        pathToStatus.put(f, newFile(f, permission));
+        if(failOnClose) {
+            return new FSDataOutputStream(new ByteArrayOutputStream(), new FileSystem.Statistics("")) {
+                @Override
+                public void close() throws IOException {
+                    super.close();
+                    throw new IOException("Fail on close");
+                }
+            };
+        } else {
+            return new FSDataOutputStream(new ByteArrayOutputStream(), new Statistics(""));
+        }
+    }
+
+    @Override
+    public FSDataOutputStream append(final Path f, final int bufferSize, final Progressable progress) {
+        return null;
+    }
+
+    @Override
+    public boolean rename(final Path src, final Path dst) {
+        if (pathToStatus.containsKey(src)) {
+            pathToStatus.put(dst, pathToStatus.remove(src));
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean delete(final Path f, final boolean recursive) {
+        if (pathToStatus.containsKey(f)) {
+            pathToStatus.remove(f);
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void setWorkingDirectory(final Path new_dir) {
+
+    }
+
+    @Override
+    public Path getWorkingDirectory() {
+        return new Path(new File(".").getAbsolutePath());
+    }
+
+    @Override
+    public boolean mkdirs(final Path f, final FsPermission permission) {
+        return false;
+    }
+
+    @Override
+    public boolean mkdirs(Path f) {
+        pathToStatus.put(f, newDir(f));
+        return true;
+    }
+
+    @Override
+    public FileStatus getFileStatus(final Path path) throws IOException {
+        if (failOnFileStatus) {
+            throw new IOException(new GSSException(13));
+        }
+        if (path != null && path.getName().startsWith("exception_")) {
+            final String className = path.getName().substring("exception_".length());
+            final IOException exception;
+            try {
+                exception = (IOException) Class.forName(className).getDeclaredConstructor().newInstance();
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+            throw exception;
+        }
+
+        final FileStatus fileStatus = pathToStatus.get(path);
+        if (fileStatus == null) {
+            throw new FileNotFoundException();
+        }
+        return fileStatus;
+    }
+
+    @Override
+    public boolean exists(Path f) throws IOException {
+        if (failOnExists) {
+            throw new IOException(new GSSException(13));
+        }
+        return pathToStatus.containsKey(f);
+    }
+
+    public FileStatus newFile(Path p, FsPermission permission) {
+        return new FileStatus(100L, false, 3, 128 * 1024 * 1024, 1523456000000L, 1523457000000L, permission, "owner", "group", p);
+    }
+
+    public FileStatus newDir(Path p) {
+        return new FileStatus(1L, true, 3, 128 * 1024 * 1024, 1523456000000L, 1523457000000L, perms((short) 0755), "owner", "group", (Path)null, p, true, false, false);
+    }
+
+    public FileStatus newFile(String p) {
+        return new FileStatus(100L, false, 3, 128*1024*1024, 1523456000000L, 1523457000000L, perms((short)0644), "owner", "group", new Path(p));
+    }
+    public FileStatus newDir(String p) {
+        return new FileStatus(1L, true, 3, 128*1024*1024, 1523456000000L, 1523457000000L, perms((short)0755), "owner", "group", new Path(p));
+    }
+
+    @Override
+    public long getDefaultBlockSize(Path f) {
+        return 33554432L;
+    }
+
+    public void addFileStatus(final FileStatus parent, final FileStatus child) {
+        Set<FileStatus> children = fileStatuses.computeIfAbsent(parent.getPath(), k -> new HashSet<>());
+        if (child != null) {
+            children.add(child);
+            if (child.isDirectory() && !fileStatuses.containsKey(child.getPath())) {
+                fileStatuses.put(child.getPath(), new HashSet<>());
+            }
+        }
+
+        pathToStatus.put(parent.getPath(), parent);
+        pathToStatus.put(child.getPath(), child);
+    }
+
+    @Override
+    public FileStatus[] listStatus(final Path f) throws IOException {
+        if (!fileStatuses.containsKey(f)) {
+            throw new FileNotFoundException();
+        }
+
+        if (f.getName().startsWith("list_exception_")) {
+            final String className = f.getName().substring("list_exception_".length());
+            final IOException exception;
+            try {
+                exception = (IOException) Class.forName(className).getDeclaredConstructor().newInstance();
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+            throw exception;
+        }
+
+        final Set<FileStatus> statuses = fileStatuses.get(f);
+        if (statuses == null) {
+            return new FileStatus[0];
+        }
+
+        for (FileStatus s : statuses) {
+            getFileStatus(s.getPath()); //support exception handling only.
+        }
+
+        return statuses.toArray(new FileStatus[0]);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public long getDefaultBlockSize() {
+        return 1024L;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public short getDefaultReplication() {
+        return 1;
+    }
+
+
+    private static FsPermission perms(short p) {
+        return new FsPermission(p);
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-12889](https://issues.apache.org/jira/browse/NIFI-12889) This PR is the 1.x version of #8495 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `support/nifi-1.x` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
