### PR TITLE
NIFI-13019 Exclude Jetty EE10 jars from MiNiFi lib directory

### DIFF
--- a/minifi/minifi-assembly/src/main/assembly/dependencies-windows-service.xml
+++ b/minifi/minifi-assembly/src/main/assembly/dependencies-windows-service.xml
@@ -36,6 +36,7 @@
                 <exclude>*:minifi-bootstrap</exclude>
                 <exclude>*:minifi-resources</exclude>
                 <exclude>org.eclipse.jetty:*</exclude>
+                <exclude>org.eclipse.jetty.ee10:*</exclude>
                 <!-- Filter items introduced via transitive dependencies that are provided in associated NARs -->
                 <exclude>*:swagger-annotations</exclude>
             </excludes>

--- a/minifi/minifi-assembly/src/main/assembly/dependencies.xml
+++ b/minifi/minifi-assembly/src/main/assembly/dependencies.xml
@@ -36,6 +36,7 @@
                 <exclude>*:minifi-bootstrap</exclude>
                 <exclude>*:minifi-resources</exclude>
                 <exclude>org.eclipse.jetty:*</exclude>
+                <exclude>org.eclipse.jetty.ee10:*</exclude>
                 <!-- Filter items introduced via transitive dependencies that are provided in associated NARs -->
                 <exclude>*:swagger-annotations</exclude>
             </excludes>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13019](https://issues.apache.org/jira/browse/NIFI-13019)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
