### PR TITLE
NIFI-13025 - NifiRegistryFlowRegistryClient to allow for truststore only SSL Context Service

### DIFF
--- a/nifi-nar-bundles/nifi-flow-registry-client-bundle/nifi-flow-registry-client-services/src/main/java/org/apache/nifi/registry/flow/NifiRegistryFlowRegistryClient.java
+++ b/nifi-nar-bundles/nifi-flow-registry-client-bundle/nifi-flow-registry-client-services/src/main/java/org/apache/nifi/registry/flow/NifiRegistryFlowRegistryClient.java
@@ -128,16 +128,16 @@ public class NifiRegistryFlowRegistryClient extends AbstractFlowRegistryClient {
         this.registryClient = null;
     }
 
+    @Override
     protected Collection<ValidationResult> customValidate(final ValidationContext context) {
         final Collection<ValidationResult> result = new HashSet<>();
         if (context.getProperty(SSL_CONTEXT_SERVICE).isSet()) {
             final SSLContextService sslContextService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
 
-
-            if (sslContextService.isTrustStoreConfigured() ^ sslContextService.isKeyStoreConfigured()) {
+            if (!sslContextService.isTrustStoreConfigured()) {
                 result.add(new ValidationResult.Builder().subject(this.getClass().getSimpleName())
                     .valid(false)
-                    .explanation("It is expected to either set all the properties for the SSLContext or set none")
+                    .explanation("At minimum, the truststore should be configured in the SSL context service")
                     .build());
             }
         }

--- a/nifi-nar-bundles/nifi-flow-registry-client-bundle/nifi-flow-registry-client-services/src/main/java/org/apache/nifi/registry/flow/NifiRegistryFlowRegistryClient.java
+++ b/nifi-nar-bundles/nifi-flow-registry-client-bundle/nifi-flow-registry-client-services/src/main/java/org/apache/nifi/registry/flow/NifiRegistryFlowRegistryClient.java
@@ -17,8 +17,6 @@
 package org.apache.nifi.registry.flow;
 
 import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.components.ValidationContext;
-import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.flow.VersionedFlowCoordinates;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.registry.bucket.Bucket;
@@ -40,8 +38,6 @@ import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -126,23 +122,6 @@ public class NifiRegistryFlowRegistryClient extends AbstractFlowRegistryClient {
 
     private synchronized void invalidateClient() {
         this.registryClient = null;
-    }
-
-    @Override
-    protected Collection<ValidationResult> customValidate(final ValidationContext context) {
-        final Collection<ValidationResult> result = new HashSet<>();
-        if (context.getProperty(SSL_CONTEXT_SERVICE).isSet()) {
-            final SSLContextService sslContextService = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
-
-            if (!sslContextService.isTrustStoreConfigured()) {
-                result.add(new ValidationResult.Builder().subject(this.getClass().getSimpleName())
-                    .valid(false)
-                    .explanation("At minimum, the truststore should be configured in the SSL context service")
-                    .build());
-            }
-        }
-
-        return result;
     }
 
     private String extractIdentity(final FlowRegistryClientConfigurationContext context) {


### PR DESCRIPTION
# Summary

[NIFI-13025](https://issues.apache.org/jira/browse/NIFI-13025) - NifiRegistryFlowRegistryClient to allow for truststore only SSL Context Service

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
