### PR TITLE
NIFI-13026 - Add a read only mode to non secured NiFi Registry

### DIFF
--- a/nifi-registry/nifi-registry-assembly/pom.xml
+++ b/nifi-registry/nifi-registry-assembly/pom.xml
@@ -180,6 +180,7 @@
         <nifi.registry.security.needClientAuth />
         <nifi.registry.security.authorizers.configuration.file>./conf/authorizers.xml</nifi.registry.security.authorizers.configuration.file>
         <nifi.registry.security.authorizer>managed-authorizer</nifi.registry.security.authorizer>
+        <nifi.registry.security.readonly>false</nifi.registry.security.readonly>
         <nifi.registry.security.identity.providers.configuration.file>./conf/identity-providers.xml</nifi.registry.security.identity.providers.configuration.file>
         <nifi.registry.security.identity.provider />
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-docker/dockerhub/sh/start.sh
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docker/dockerhub/sh/start.sh
@@ -22,6 +22,7 @@ scripts_dir='/opt/nifi-registry/scripts'
 # Establish baseline properties
 prop_replace 'nifi.registry.web.http.port'      "${NIFI_REGISTRY_WEB_HTTP_PORT:-18080}"
 prop_replace 'nifi.registry.web.http.host'      "${NIFI_REGISTRY_WEB_HTTP_HOST:-$HOSTNAME}"
+prop_replace 'nifi.registry.security.readonly' 	"${NIFI_REGISTRY_READONLY:-false}"
 
 . ${scripts_dir}/update_database.sh
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
@@ -129,7 +129,7 @@ The semantics match the use of the following Jetty APIs:
 
 A secured instance of NiFi Registry cannot be accessed anonymously, so a method of user authentication must be configured.
 
-NOTE: NiFi Registry does not perform user authentication over HTTP. Using HTTP, all users will have full permissions.
+NOTE: NiFi Registry does not perform user authentication over HTTP. Using HTTP, all users will have full permissions unless the property `nifi.registry.security.readonly` is set to `true`.
 
 Any secured instance of NiFi Registry supports authentication via client certificates that are trusted by the NiFi Registry's SSL Context Truststore.
 Alternatively, a secured NiFi Registry can be configured to authenticate users via username/password.

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/AuthorizerFactory.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/AuthorizerFactory.java
@@ -523,6 +523,9 @@ public class AuthorizerFactory implements UserGroupProviderLookup, AccessPolicyP
         return new Authorizer() {
             @Override
             public AuthorizationResult authorize(final AuthorizationRequest request) throws AuthorizationAccessException {
+                if(properties.isReadOnly() && !request.getAction().equals(RequestAction.READ)) {
+                    return AuthorizationResult.denied("NiFi Registry is configured with read only.");
+                }
                 return AuthorizationResult.approved();
             }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryProperties.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryProperties.java
@@ -71,6 +71,7 @@ public class NiFiRegistryProperties extends ApplicationProperties {
     public static final String SECURITY_NEED_CLIENT_AUTH = "nifi.registry.security.needClientAuth";
     public static final String SECURITY_AUTHORIZERS_CONFIGURATION_FILE = "nifi.registry.security.authorizers.configuration.file";
     public static final String SECURITY_AUTHORIZER = "nifi.registry.security.authorizer";
+    public static final String SECURITY_READ_ONLY = "nifi.registry.security.readonly";
     public static final String SECURITY_IDENTITY_PROVIDERS_CONFIGURATION_FILE = "nifi.registry.security.identity.providers.configuration.file";
     public static final String SECURITY_IDENTITY_PROVIDER = "nifi.registry.security.identity.provider";
     public static final String SECURITY_IDENTITY_MAPPING_PATTERN_PREFIX = "nifi.registry.security.identity.mapping.pattern.";
@@ -196,6 +197,15 @@ public class NiFiRegistryProperties extends ApplicationProperties {
             needClientAuth = false;
         }
         return needClientAuth;
+    }
+
+    public boolean isReadOnly() {
+        boolean isReadOnly = false;
+        String rawReadOnly = getProperty(SECURITY_READ_ONLY);
+        if ("true".equalsIgnoreCase(rawReadOnly)) {
+            isReadOnly = true;
+        }
+        return isReadOnly;
     }
 
     public String getKeyStorePath() {

--- a/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/nifi-registry.properties
+++ b/nifi-registry/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/nifi-registry.properties
@@ -39,6 +39,9 @@ nifi.registry.security.authorizer=${nifi.registry.security.authorizer}
 nifi.registry.security.identity.providers.configuration.file=${nifi.registry.security.identity.providers.configuration.file}
 nifi.registry.security.identity.provider=${nifi.registry.security.identity.provider}
 
+# This property applies only in case the NiFi Registry is not secured and anonymous access should be read only
+nifi.registry.security.readonly=${nifi.registry.security.readonly}
+
 # sensitive property protection properties #
 # nifi.registry.sensitive.props.additional.keys=
 


### PR DESCRIPTION
# Summary

[NIFI-13026](https://issues.apache.org/jira/browse/NIFI-13026) - Add a read only mode to non secured NiFi Registry

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
