### PR TITLE
NIFI-13036 Upgrade Logback from 1.4.14 to 1.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
         <org.bouncycastle.version>1.77</org.bouncycastle.version>
         <testcontainers.version>1.19.4</testcontainers.version>
-        <org.slf4j.version>2.0.12</org.slf4j.version>
+        <org.slf4j.version>2.0.13</org.slf4j.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <derby.version>10.17.1.0</derby.version>
         <jetty.version>12.0.7</jetty.version>
@@ -147,7 +147,7 @@
         <aspectj.version>1.9.21</aspectj.version>
         <jersey.bom.version>3.1.4</jersey.bom.version>
         <log4j2.version>2.23.0</log4j2.version>
-        <logback.version>1.4.14</logback.version>
+        <logback.version>1.5.5</logback.version>
         <mockito.version>5.8.0</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.2</snakeyaml.version>


### PR DESCRIPTION
# Summary

[NIFI-13035](https://issues.apache.org/jira/browse/NIFI-13035) Upgrades Logback from 1.4.14 to [1.5.5](https://logback.qos.ch/news.html#1.5.5). Logback 1.5.0 and later require Java 11 as the minimum version, but otherwise retain compatibility with Logback 1.4.

Additional changes include upgrading SLF4J from 2.0.12 to [2.0.13](https://www.slf4j.org/news.html#2.0.13) incorporating a minor bug fix over version 2.0.12.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
