### PR TITLE
NIFI-13037 Upgrade Spring Framework from 5.3.31 to 5.3.34

### DIFF
--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <jax.rs.api.version>2.1.1</jax.rs.api.version>
-        <spring.boot.version>2.7.16</spring.boot.version>
+        <spring.boot.version>2.7.18</spring.boot.version>
         <flyway.version>8.5.13</flyway.version>
         <flyway.tests.version>7.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <org.slf4j.version>2.0.12</org.slf4j.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <ranger.version>2.4.0</ranger.version>
-        <jetty.version>9.4.53.v20231009</jetty.version>
+        <jetty.version>9.4.54.v20240208</jetty.version>
         <jackson.bom.version>2.17.0</jackson.bom.version>
         <avro.version>1.11.3</avro.version>
         <jaxb.runtime.version>2.3.9</jaxb.runtime.version>
@@ -146,8 +146,8 @@
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <netty.4.version>4.1.108.Final</netty.4.version>
-        <spring.version>5.3.31</spring.version>
-        <spring.security.version>5.8.7</spring.security.version>
+        <spring.version>5.3.34</spring.version>
+        <spring.security.version>5.8.11</spring.security.version>
         <swagger.annotations.version>1.6.12</swagger.annotations.version>
         <h2.version>2.2.224</h2.version>
         <zookeeper.version>3.9.2</zookeeper.version>


### PR DESCRIPTION
# Summary

[NIFI-13037](https://issues.apache.org/jira/browse/NIFI-13037) Upgrades Spring Framework dependencies on the support branch from 5.3.31 to [5.3.34](https://github.com/spring-projects/spring-framework/releases/tag/v5.3.34).

Additional upgrades include related dependencies:

- Upgraded Spring Boot from 2.7.16 to [2.7.18](https://github.com/spring-projects/spring-boot/releases/tag/v2.7.18) for Registry
- Upgraded Spring Security from 5.8.7 to [5.8.11](https://github.com/spring-projects/spring-security/releases/tag/5.8.11)
- Upgraded Jetty from 9.4.53 to [9.4.54](https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.54.v20240208)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
