### PR TITLE
NIFI-13042 Support Python 3.12 for Python Processors

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -24,7 +24,7 @@ Apache NiFi Team <dev@nifi.apache.org>
 Apache NiFi can run on something as simple as a laptop, but it can also be clustered across many enterprise-class servers. Therefore, the amount of hardware and memory needed will depend on the size and nature of the dataflow involved. The data is stored on disk while NiFi is processing it. So NiFi needs to have sufficient disk space allocated for its various repositories, particularly the content repository, flowfile repository, and provenance repository (see the <<system_properties>> section for more information about these repositories). NiFi has the following minimum system requirements:
 
 * Requires Java 21
-* Use of Python-based Processors (beta feature) requires Python 3.9, 3.10 or 3.11
+* Use of Python-based Processors (beta feature) requires Python 3.9, 3.10, 3.11, or 3.12
 * Supported Operating Systems:
 ** Linux
 ** Unix
@@ -231,7 +231,7 @@ The `name` attribute must start with `deprecation`, followed by the component cl
 
 NiFi is a Java-based application. NiFi 2.0 introduces support for a Python-based Processor API. This capability is still
 considered to be in "Beta" mode and should not be used in production. By default, support for Python-based Processors is disabled. In order to enable it,
-Python 3.9, 3.10 or 3.11 must be installed on the NiFi node (Python 3.12 is not supported yet).
+Python 3.9, 3.10, 3.11, or 3.12 must be installed on the NiFi node.
 
 The following properties may be used to configure the Python 3 installation and process management. These properties are all located under the
 "Python Extensions" heading in the _nifi.properties_ file:

--- a/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
@@ -509,7 +509,7 @@ because we know that the ListFile Processor will produce these attributes for us
 [[requirements]]
 == Requirements
 
-The Python API requires that Python 3.9, 3.10 or 3.11 is available on the machine hosting NiFi (Python 3.12 is not supported yet).
+The Python API requires that Python 3.9, 3.10, 3.11, or 3.12 is available on the machine hosting NiFi.
 
 Each Processor may have its own list of requirements / dependencies. These are made available to the Processor by creating a separate
 environment for each Processor implementation (not for each instance of a Processor on the canvas). PyPI is then used to install these

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/Controller.py
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/Controller.py
@@ -128,3 +128,10 @@ if __name__ == "__main__":
     gateway.java_gateway_server.resetCallbackClient(
         gateway.java_gateway_server.getCallbackClient().getAddress(),
         python_port)
+
+    # Join main thread to non-daemon threads in order to avoid RuntimeError on Python 3.12 blocking new thread creation in Py4J
+    import threading
+    for thread in threading.enumerate():
+        if thread.daemon or thread is threading.current_thread():
+            continue
+        thread.join()

--- a/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/ExtensionManager.py
+++ b/nifi-nar-bundles/nifi-py4j-bundle/nifi-python-framework/src/main/python/framework/ExtensionManager.py
@@ -188,8 +188,8 @@ class ExtensionManager:
                 if not require_nifi_prefix or name.startswith('nifi_'):
                     module_file = '<Unknown Module File>'
                     try:
-                        module = finder.find_module(name)
-                        module_file = module.path
+                        module = finder.find_spec(name)
+                        module_file = module.origin
 
                         # Ignore any packaged dependencies
                         if 'NAR-INF/bundled-dependencies' in module_file:


### PR DESCRIPTION
# Summary

[NIFI-13042](https://issues.apache.org/jira/browse/NIFI-13042) Updates `Controller.py` and `ExtensionManager.py` to provide framework compatibility with Python 3.12.

Updates to `Controller.py` include joining to non-daemon threads at the conclusion of the `main` function, avoiding a `RuntimeError` thrown in Python 3.12 as a result of increased protections against spawning new child threads after finalization of the main process. This approach follows the recommendation from [CPython Issue 115533](https://github.com/python/cpython/issues/115533#issuecomment-1959143451). This is necessary for the NiFi `Controller.py` because the `main` function otherwise completes, but Py4J socket threads must continue running.

Updates to `ExtensionManager.py` include replacing the deprecated [find_module](https://docs.python.org/3.10/library/importlib.html#importlib.machinery.PathFinder.find_module) method with the recommend [find_spec](https://docs.python.org/3.10/library/importlib.html#importlib.machinery.PathFinder.find_spec) method. The `find_spec` method was added in Python 3.4 and `find_module` was removed in Python 3.12.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
