### PR TITLE
[NIFI-13034] Change Component Version

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
@@ -28,6 +28,7 @@ import {
     goToRemoteProcessGroup,
     leaveProcessGroup,
     moveComponents,
+    moveToFront,
     navigateToAdvancedProcessorUi,
     navigateToComponent,
     navigateToControllerServicesForProcessGroup,
@@ -38,7 +39,7 @@ import {
     navigateToProvenanceForComponent,
     navigateToQueueListing,
     navigateToViewStatusHistoryForComponent,
-    openChangeProcessorVersionDialogRequest,
+    openChangeProcessorVersionDialog,
     openChangeVersionDialogRequest,
     openCommitLocalChangesDialogRequest,
     openForceCommitLocalChangesDialogRequest,
@@ -53,12 +54,10 @@ import {
     startCurrentProcessGroup,
     stopComponents,
     stopCurrentProcessGroup,
-    stopVersionControlRequest,
-    moveToFront
+    stopVersionControlRequest
 } from '../state/flow/flow.actions';
 import { ComponentType } from '../../../state/shared';
 import {
-    ComponentEntity,
     ConfirmStopVersionControlRequest,
     DeleteComponentRequest,
     MoveComponentRequest,
@@ -980,7 +979,7 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
                 action: (selection: d3.Selection<any, any, any, any>) => {
                     const data = selection.datum();
                     this.store.dispatch(
-                        openChangeProcessorVersionDialogRequest({
+                        openChangeProcessorVersionDialog({
                             request: {
                                 id: data.component.id,
                                 uri: data.uri,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
@@ -22,14 +22,15 @@ import { CanvasState } from '../state';
 import {
     centerSelectedComponents,
     deleteComponents,
+    downloadFlow,
     enterProcessGroup,
     getParameterContextsAndOpenGroupComponentsDialog,
     goToRemoteProcessGroup,
     leaveProcessGroup,
     moveComponents,
+    navigateToAdvancedProcessorUi,
     navigateToComponent,
     navigateToControllerServicesForProcessGroup,
-    navigateToAdvancedProcessorUi,
     navigateToEditComponent,
     navigateToEditCurrentProcessGroup,
     navigateToManageComponentPolicies,
@@ -37,6 +38,7 @@ import {
     navigateToProvenanceForComponent,
     navigateToQueueListing,
     navigateToViewStatusHistoryForComponent,
+    openChangeProcessorVersionDialogRequest,
     openChangeVersionDialogRequest,
     openCommitLocalChangesDialogRequest,
     openForceCommitLocalChangesDialogRequest,
@@ -52,11 +54,11 @@ import {
     stopComponents,
     stopCurrentProcessGroup,
     stopVersionControlRequest,
-    downloadFlow,
     moveToFront
 } from '../state/flow/flow.actions';
 import { ComponentType } from '../../../state/shared';
 import {
+    ComponentEntity,
     ConfirmStopVersionControlRequest,
     DeleteComponentRequest,
     MoveComponentRequest,
@@ -970,14 +972,24 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
                 }
             },
             {
-                condition: (selection: any) => {
-                    // TODO - canChangeProcessorVersion
-                    return false;
+                condition: (selection: d3.Selection<any, any, any, any>) => {
+                    return this.canvasUtils.canChangeProcessorVersion(selection);
                 },
                 clazz: 'fa fa-exchange',
                 text: 'Change version',
-                action: () => {
-                    // TODO - changeVersion
+                action: (selection: d3.Selection<any, any, any, any>) => {
+                    const data = selection.datum();
+                    this.store.dispatch(
+                        openChangeProcessorVersionDialogRequest({
+                            request: {
+                                id: data.component.id,
+                                uri: data.uri,
+                                revision: data.revision,
+                                type: data.component.type,
+                                bundle: data.component.bundle
+                            }
+                        })
+                    );
                 }
             },
             {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
@@ -1712,6 +1712,33 @@ export class CanvasUtils {
         return false;
     }
 
+    /**
+     * Determines whether the current selection is a processor with more than one version.
+     *
+     * @argument {d3.Selection} selection      The selection
+     * @returns {boolean}
+     */
+    public canChangeProcessorVersion(selection: d3.Selection<any, any, any, any>): boolean {
+        if (selection.size() !== 1) {
+            return false;
+        }
+
+        if (!this.canRead(selection) || !this.canModify(selection)) {
+            return false;
+        }
+
+        if (this.isProcessor(selection)) {
+            const data = selection.datum();
+            const supportsModification = !(
+                data.status.aggregateSnapshot.runStatus === 'Running' ||
+                data.status.aggregateSnapshot.activeThreadCount > 0
+            );
+
+            return supportsModification && data.component.multipleVersionsAvailable;
+        }
+        return false;
+    }
+
     public canMoveToFront(selection: d3.Selection<any, any, any, any>): boolean {
         // ensure the correct number of components are selected
         if (selection.size() !== 1) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.actions.ts
@@ -125,11 +125,11 @@ export const selectControllerService = createAction(
 );
 
 export const openChangeControllerServiceVersionDialogRequest = createAction(
-    `[Controller Services] Open Change Controller Service Version Control Dialog Request`,
+    `[Controller Services] Open Change Controller Service Version Dialog Request`,
     props<{ request: FetchComponentVersionsRequest }>()
 );
 
 export const openChangeControllerServiceVersionDialog = createAction(
-    `[Controller Services] Open Change Controller Service Version Control Dialog`,
+    `[Controller Services] Open Change Controller Service Version Dialog`,
     props<{ request: OpenChangeComponentVersionDialogRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.actions.ts
@@ -31,7 +31,6 @@ import {
     DisableControllerServiceDialogRequest,
     EditControllerServiceDialogRequest,
     FetchComponentVersionsRequest,
-    OpenChangeComponentVersionDialogRequest,
     SetEnableControllerServiceDialogRequest
 } from '../../../../state/shared';
 
@@ -124,12 +123,7 @@ export const selectControllerService = createAction(
     props<{ request: SelectControllerServiceRequest }>()
 );
 
-export const openChangeControllerServiceVersionDialogRequest = createAction(
-    `[Controller Services] Open Change Controller Service Version Dialog Request`,
-    props<{ request: FetchComponentVersionsRequest }>()
-);
-
 export const openChangeControllerServiceVersionDialog = createAction(
     `[Controller Services] Open Change Controller Service Version Dialog`,
-    props<{ request: OpenChangeComponentVersionDialogRequest }>()
+    props<{ request: FetchComponentVersionsRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.actions.ts
@@ -30,6 +30,8 @@ import {
     CreateControllerServiceRequest,
     DisableControllerServiceDialogRequest,
     EditControllerServiceDialogRequest,
+    FetchComponentVersionsRequest,
+    OpenChangeComponentVersionDialogRequest,
     SetEnableControllerServiceDialogRequest
 } from '../../../../state/shared';
 
@@ -120,4 +122,14 @@ export const deleteControllerServiceSuccess = createAction(
 export const selectControllerService = createAction(
     '[Controller Services] Select Controller Service',
     props<{ request: SelectControllerServiceRequest }>()
+);
+
+export const openChangeControllerServiceVersionDialogRequest = createAction(
+    `[Controller Services] Open Change Controller Service Version Control Dialog Request`,
+    props<{ request: FetchComponentVersionsRequest }>()
+);
+
+export const openChangeControllerServiceVersionDialog = createAction(
+    `[Controller Services] Open Change Controller Service Version Control Dialog`,
+    props<{ request: OpenChangeComponentVersionDialogRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
@@ -38,7 +38,6 @@ import {
     EditConnectionDialogRequest,
     EditCurrentProcessGroupRequest,
     EnterProcessGroupRequest,
-    FetchComponentVersionsRequest,
     FlowUpdateRequestEntity,
     GoToRemoteProcessGroupRequest,
     GroupComponentsDialogRequest,
@@ -60,7 +59,6 @@ import {
     NavigateToControllerServicesRequest,
     NavigateToManageComponentPoliciesRequest,
     NavigateToQueueListing,
-    OpenChangeComponentVersionDialogRequest,
     OpenChangeVersionDialogRequest,
     OpenComponentDialogRequest,
     OpenGroupComponentsDialogRequest,
@@ -96,7 +94,7 @@ import {
     VersionControlInformationEntity
 } from './index';
 import { StatusHistoryRequest } from '../../../../state/status-history';
-import { Bundle, DocumentedType } from '../../../../state/shared';
+import { FetchComponentVersionsRequest, OpenChangeComponentVersionDialogRequest } from '../../../../state/shared';
 
 const CANVAS_PREFIX = '[Canvas]';
 

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
@@ -38,6 +38,7 @@ import {
     EditConnectionDialogRequest,
     EditCurrentProcessGroupRequest,
     EnterProcessGroupRequest,
+    FetchComponentVersionsRequest,
     FlowUpdateRequestEntity,
     GoToRemoteProcessGroupRequest,
     GroupComponentsDialogRequest,
@@ -59,6 +60,7 @@ import {
     NavigateToControllerServicesRequest,
     NavigateToManageComponentPoliciesRequest,
     NavigateToQueueListing,
+    OpenChangeComponentVersionDialogRequest,
     OpenChangeVersionDialogRequest,
     OpenComponentDialogRequest,
     OpenGroupComponentsDialogRequest,
@@ -94,6 +96,7 @@ import {
     VersionControlInformationEntity
 } from './index';
 import { StatusHistoryRequest } from '../../../../state/status-history';
+import { Bundle, DocumentedType } from '../../../../state/shared';
 
 const CANVAS_PREFIX = '[Canvas]';
 
@@ -769,3 +772,13 @@ export const downloadFlow = createAction(
 );
 
 export const moveToFront = createAction(`${CANVAS_PREFIX} Move To Front`, props<{ request: MoveToFrontRequest }>());
+
+export const openChangeProcessorVersionDialogRequest = createAction(
+    `${CANVAS_PREFIX} Open Change Processor Version Control Dialog Request`,
+    props<{ request: FetchComponentVersionsRequest }>()
+);
+
+export const openChangeProcessorVersionDialog = createAction(
+    `${CANVAS_PREFIX} Open Change Processor Version Control Dialog`,
+    props<{ request: OpenChangeComponentVersionDialogRequest }>()
+);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
@@ -772,11 +772,11 @@ export const downloadFlow = createAction(
 export const moveToFront = createAction(`${CANVAS_PREFIX} Move To Front`, props<{ request: MoveToFrontRequest }>());
 
 export const openChangeProcessorVersionDialogRequest = createAction(
-    `${CANVAS_PREFIX} Open Change Processor Version Control Dialog Request`,
+    `${CANVAS_PREFIX} Open Change Processor Version Dialog Request`,
     props<{ request: FetchComponentVersionsRequest }>()
 );
 
 export const openChangeProcessorVersionDialog = createAction(
-    `${CANVAS_PREFIX} Open Change Processor Version Control Dialog`,
+    `${CANVAS_PREFIX} Open Change Processor Version Dialog`,
     props<{ request: OpenChangeComponentVersionDialogRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
@@ -94,7 +94,7 @@ import {
     VersionControlInformationEntity
 } from './index';
 import { StatusHistoryRequest } from '../../../../state/status-history';
-import { FetchComponentVersionsRequest, OpenChangeComponentVersionDialogRequest } from '../../../../state/shared';
+import { FetchComponentVersionsRequest } from '../../../../state/shared';
 
 const CANVAS_PREFIX = '[Canvas]';
 
@@ -771,12 +771,7 @@ export const downloadFlow = createAction(
 
 export const moveToFront = createAction(`${CANVAS_PREFIX} Move To Front`, props<{ request: MoveToFrontRequest }>());
 
-export const openChangeProcessorVersionDialogRequest = createAction(
-    `${CANVAS_PREFIX} Open Change Processor Version Dialog Request`,
-    props<{ request: FetchComponentVersionsRequest }>()
-);
-
 export const openChangeProcessorVersionDialog = createAction(
     `${CANVAS_PREFIX} Open Change Processor Version Dialog`,
-    props<{ request: OpenChangeComponentVersionDialogRequest }>()
+    props<{ request: FetchComponentVersionsRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -3208,7 +3208,7 @@ export class FlowEffects {
             ofType(FlowActions.openChangeProcessorVersionDialogRequest),
             map((action) => action.request),
             switchMap((request) =>
-                from(this.extensionTypesService.getProcessorTypesFiltered(request.type, request.bundle)).pipe(
+                from(this.extensionTypesService.getProcessorVersionsForType(request.type, request.bundle)).pipe(
                     map((response) =>
                         FlowActions.openChangeProcessorVersionDialog({
                             request: {
@@ -3232,12 +3232,11 @@ export class FlowEffects {
                 map((action) => action.request),
                 tap((request) => {
                     const dialogRequest = this.dialog.open(ChangeComponentVersionDialog, {
-                        ...MEDIUM_DIALOG,
+                        ...LARGE_DIALOG,
                         data: request
                     });
 
                     dialogRequest.componentInstance.changeVersion.pipe(take(1)).subscribe((newVersion) => {
-                        console.log('Change to version', newVersion);
                         this.store.dispatch(
                             FlowActions.updateProcessor({
                                 request: {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
@@ -759,15 +759,3 @@ export interface MoveToFrontRequest {
     zIndex: number;
 }
 
-export interface FetchComponentVersionsRequest {
-    id: string;
-    uri: string;
-    revision: Revision;
-    type: string;
-    bundle: Bundle;
-}
-
-export interface OpenChangeComponentVersionDialogRequest {
-    fetchRequest: FetchComponentVersionsRequest;
-    componentVersions: DocumentedType[];
-}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
@@ -758,4 +758,3 @@ export interface MoveToFrontRequest {
     revision: Revision;
     zIndex: number;
 }
-

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
@@ -758,3 +758,16 @@ export interface MoveToFrontRequest {
     revision: Revision;
     zIndex: number;
 }
+
+export interface FetchComponentVersionsRequest {
+    id: string;
+    uri: string;
+    revision: Revision;
+    type: string;
+    bundle: Bundle;
+}
+
+export interface OpenChangeComponentVersionDialogRequest {
+    fetchRequest: FetchComponentVersionsRequest;
+    componentVersions: DocumentedType[];
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.html
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.html
@@ -53,6 +53,7 @@
                                 (enableControllerService)="enableControllerService($event)"
                                 (disableControllerService)="disableControllerService($event)"
                                 (viewStateControllerService)="viewStateControllerService($event)"
+                                (changeControllerServiceVersion)="changeControllerServiceVersion($event)"
                                 (deleteControllerService)="deleteControllerService($event)"></controller-service-table>
                         </div>
                     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.ts
@@ -31,6 +31,7 @@ import {
     loadControllerServices,
     navigateToAdvancedServiceUi,
     navigateToEditService,
+    openChangeControllerServiceVersionDialogRequest,
     openConfigureControllerServiceDialog,
     openDisableControllerServiceDialog,
     openEnableControllerServiceDialog,
@@ -223,6 +224,20 @@ export class ControllerServices implements OnInit, OnDestroy {
                     componentUri: entity.uri,
                     componentName: entity.component.name,
                     canClear: entity.component.state === 'DISABLED'
+                }
+            })
+        );
+    }
+
+    changeControllerServiceVersion(entity: ControllerServiceEntity): void {
+        this.store.dispatch(
+            openChangeControllerServiceVersionDialogRequest({
+                request: {
+                    id: entity.id,
+                    bundle: entity.component.bundle,
+                    uri: entity.uri,
+                    type: entity.component.type,
+                    revision: entity.revision
                 }
             })
         );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.ts
@@ -31,7 +31,7 @@ import {
     loadControllerServices,
     navigateToAdvancedServiceUi,
     navigateToEditService,
-    openChangeControllerServiceVersionDialogRequest,
+    openChangeControllerServiceVersionDialog,
     openConfigureControllerServiceDialog,
     openDisableControllerServiceDialog,
     openEnableControllerServiceDialog,
@@ -231,7 +231,7 @@ export class ControllerServices implements OnInit, OnDestroy {
 
     changeControllerServiceVersion(entity: ControllerServiceEntity): void {
         this.store.dispatch(
-            openChangeControllerServiceVersionDialogRequest({
+            openChangeControllerServiceVersionDialog({
                 request: {
                     id: entity.id,
                     bundle: entity.component.bundle,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/edit-parameter-context/edit-parameter-context.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/edit-parameter-context/edit-parameter-context.component.ts
@@ -156,6 +156,7 @@ export class EditParameterContext {
             const payload: any = {
                 revision: this.client.getRevision(pc),
                 disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged(),
+                id: pc.id,
                 component: {
                     id: pc.id,
                     name: this.editParameterContextForm.get('name')?.value,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/flow-analysis-rules.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/flow-analysis-rules.actions.ts
@@ -31,6 +31,7 @@ import {
     EnableFlowAnalysisRuleSuccess,
     DisableFlowAnalysisRuleSuccess
 } from './index';
+import { FetchComponentVersionsRequest, OpenChangeComponentVersionDialogRequest } from '../../../../state/shared';
 
 export const resetFlowAnalysisRulesState = createAction('[Flow Analysis Rules] Reset Flow Analysis Rules State');
 
@@ -125,4 +126,14 @@ export const deleteFlowAnalysisRuleSuccess = createAction(
 export const selectFlowAnalysisRule = createAction(
     '[Flow Analysis Rules] Select Flow Analysis Rule',
     props<{ request: SelectFlowAnalysisRuleRequest }>()
+);
+
+export const openChangeFlowAnalysisRuleVersionDialogRequest = createAction(
+    `[Flow Analysis Rules] Open Change Flow Analysis Rule Version Dialog Request`,
+    props<{ request: FetchComponentVersionsRequest }>()
+);
+
+export const openChangeFlowAnalysisRuleVersionDialog = createAction(
+    `[Flow Analysis Rules] Open Change Flow Analysis Rule Version Dialog`,
+    props<{ request: OpenChangeComponentVersionDialogRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/flow-analysis-rules.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/flow-analysis-rules.actions.ts
@@ -23,15 +23,15 @@ import {
     CreateFlowAnalysisRuleSuccess,
     DeleteFlowAnalysisRuleRequest,
     DeleteFlowAnalysisRuleSuccess,
-    EditFlowAnalysisRuleDialogRequest,
-    LoadFlowAnalysisRulesResponse,
-    SelectFlowAnalysisRuleRequest,
     DisableFlowAnalysisRuleRequest,
+    DisableFlowAnalysisRuleSuccess,
+    EditFlowAnalysisRuleDialogRequest,
     EnableFlowAnalysisRuleRequest,
     EnableFlowAnalysisRuleSuccess,
-    DisableFlowAnalysisRuleSuccess
+    LoadFlowAnalysisRulesResponse,
+    SelectFlowAnalysisRuleRequest
 } from './index';
-import { FetchComponentVersionsRequest, OpenChangeComponentVersionDialogRequest } from '../../../../state/shared';
+import { FetchComponentVersionsRequest } from '../../../../state/shared';
 
 export const resetFlowAnalysisRulesState = createAction('[Flow Analysis Rules] Reset Flow Analysis Rules State');
 
@@ -128,12 +128,7 @@ export const selectFlowAnalysisRule = createAction(
     props<{ request: SelectFlowAnalysisRuleRequest }>()
 );
 
-export const openChangeFlowAnalysisRuleVersionDialogRequest = createAction(
-    `[Flow Analysis Rules] Open Change Flow Analysis Rule Version Dialog Request`,
-    props<{ request: FetchComponentVersionsRequest }>()
-);
-
 export const openChangeFlowAnalysisRuleVersionDialog = createAction(
     `[Flow Analysis Rules] Open Change Flow Analysis Rule Version Dialog`,
-    props<{ request: OpenChangeComponentVersionDialogRequest }>()
+    props<{ request: FetchComponentVersionsRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.actions.ts
@@ -29,6 +29,8 @@ import {
     CreateControllerServiceRequest,
     DisableControllerServiceDialogRequest,
     EditControllerServiceDialogRequest,
+    FetchComponentVersionsRequest,
+    OpenChangeComponentVersionDialogRequest,
     SetEnableControllerServiceDialogRequest
 } from '../../../../state/shared';
 
@@ -127,4 +129,14 @@ export const deleteControllerServiceSuccess = createAction(
 export const selectControllerService = createAction(
     '[Management Controller Services] Select Controller Service',
     props<{ request: SelectControllerServiceRequest }>()
+);
+
+export const openChangeMgtControllerServiceVersionDialogRequest = createAction(
+    `[Management Controller Services] Open Change Management Controller Service Version Control Dialog Request`,
+    props<{ request: FetchComponentVersionsRequest }>()
+);
+
+export const openChangeMgtControllerServiceVersionDialog = createAction(
+    `[Management Controller Services] Open Change Management Controller Service Version Control Dialog`,
+    props<{ request: OpenChangeComponentVersionDialogRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.actions.ts
@@ -132,11 +132,11 @@ export const selectControllerService = createAction(
 );
 
 export const openChangeMgtControllerServiceVersionDialogRequest = createAction(
-    `[Management Controller Services] Open Change Management Controller Service Version Control Dialog Request`,
+    `[Management Controller Services] Open Change Management Controller Service Version Control Request`,
     props<{ request: FetchComponentVersionsRequest }>()
 );
 
 export const openChangeMgtControllerServiceVersionDialog = createAction(
-    `[Management Controller Services] Open Change Management Controller Service Version Control Dialog`,
+    `[Management Controller Services] Open Change Management Controller Service Version Dialog`,
     props<{ request: OpenChangeComponentVersionDialogRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.actions.ts
@@ -30,7 +30,6 @@ import {
     DisableControllerServiceDialogRequest,
     EditControllerServiceDialogRequest,
     FetchComponentVersionsRequest,
-    OpenChangeComponentVersionDialogRequest,
     SetEnableControllerServiceDialogRequest
 } from '../../../../state/shared';
 
@@ -131,12 +130,7 @@ export const selectControllerService = createAction(
     props<{ request: SelectControllerServiceRequest }>()
 );
 
-export const openChangeMgtControllerServiceVersionDialogRequest = createAction(
-    `[Management Controller Services] Open Change Management Controller Service Version Control Request`,
-    props<{ request: FetchComponentVersionsRequest }>()
-);
-
 export const openChangeMgtControllerServiceVersionDialog = createAction(
     `[Management Controller Services] Open Change Management Controller Service Version Dialog`,
-    props<{ request: OpenChangeComponentVersionDialogRequest }>()
+    props<{ request: FetchComponentVersionsRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.actions.ts
@@ -31,6 +31,7 @@ import {
     ConfigureReportingTaskRequest,
     ConfigureReportingTaskSuccess
 } from './index';
+import { FetchComponentVersionsRequest, OpenChangeComponentVersionDialogRequest } from '../../../../state/shared';
 
 export const resetReportingTasksState = createAction('[Reporting Tasks] Reset Reporting Tasks State');
 
@@ -126,4 +127,14 @@ export const deleteReportingTaskSuccess = createAction(
 export const selectReportingTask = createAction(
     '[Reporting Tasks] Select Reporting Task',
     props<{ request: SelectReportingTaskRequest }>()
+);
+
+export const openChangeReportingTaskVersionDialogRequest = createAction(
+    `[Reporting Tasks] Open Change Reporting Task Version Dialog Request`,
+    props<{ request: FetchComponentVersionsRequest }>()
+);
+
+export const openChangeReportingTaskVersionDialog = createAction(
+    `[Reporting Tasks] Open Change Reporting Task Version Dialog`,
+    props<{ request: OpenChangeComponentVersionDialogRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.actions.ts
@@ -17,6 +17,8 @@
 
 import { createAction, props } from '@ngrx/store';
 import {
+    ConfigureReportingTaskRequest,
+    ConfigureReportingTaskSuccess,
     CreateReportingTaskRequest,
     CreateReportingTaskSuccess,
     DeleteReportingTaskRequest,
@@ -27,11 +29,9 @@ import {
     StartReportingTaskRequest,
     StartReportingTaskSuccess,
     StopReportingTaskRequest,
-    StopReportingTaskSuccess,
-    ConfigureReportingTaskRequest,
-    ConfigureReportingTaskSuccess
+    StopReportingTaskSuccess
 } from './index';
-import { FetchComponentVersionsRequest, OpenChangeComponentVersionDialogRequest } from '../../../../state/shared';
+import { FetchComponentVersionsRequest } from '../../../../state/shared';
 
 export const resetReportingTasksState = createAction('[Reporting Tasks] Reset Reporting Tasks State');
 
@@ -129,12 +129,7 @@ export const selectReportingTask = createAction(
     props<{ request: SelectReportingTaskRequest }>()
 );
 
-export const openChangeReportingTaskVersionDialogRequest = createAction(
-    `[Reporting Tasks] Open Change Reporting Task Version Dialog Request`,
-    props<{ request: FetchComponentVersionsRequest }>()
-);
-
 export const openChangeReportingTaskVersionDialog = createAction(
     `[Reporting Tasks] Open Change Reporting Task Version Dialog`,
-    props<{ request: OpenChangeComponentVersionDialogRequest }>()
+    props<{ request: FetchComponentVersionsRequest }>()
 );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rule-table/flow-analysis-rule-table.component.html
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rule-table/flow-analysis-rule-table.component.html
@@ -142,7 +142,10 @@
                                 title="Enable"></div>
                         }
                         @if (canChangeVersion(item)) {
-                            <div class="pointer fa fa-exchange primary-color" title="Change Version"></div>
+                            <div
+                                class="pointer fa fa-exchange primary-color"
+                                (click)="changeVersionClicked(item)"
+                                title="Change Version"></div>
                         }
                         @if (canDelete(item)) {
                             <div

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rule-table/flow-analysis-rule-table.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rule-table/flow-analysis-rule-table.component.ts
@@ -66,6 +66,8 @@ export class FlowAnalysisRuleTable {
         new EventEmitter<FlowAnalysisRuleEntity>();
     @Output() disableFlowAnalysisRule: EventEmitter<FlowAnalysisRuleEntity> =
         new EventEmitter<FlowAnalysisRuleEntity>();
+    @Output() changeFlowAnalysisRuleVersion: EventEmitter<FlowAnalysisRuleEntity> =
+        new EventEmitter<FlowAnalysisRuleEntity>();
 
     sort: Sort = {
         active: 'name',
@@ -228,6 +230,10 @@ export class FlowAnalysisRuleTable {
 
     enabledClicked(entity: FlowAnalysisRuleEntity): void {
         this.enableFlowAnalysisRule.next(entity);
+    }
+
+    changeVersionClicked(entity: FlowAnalysisRuleEntity): void {
+        this.changeFlowAnalysisRuleVersion.next(entity);
     }
 
     canDisable(entity: FlowAnalysisRuleEntity): boolean {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.html
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.html
@@ -41,6 +41,7 @@
                         (enableFlowAnalysisRule)="enableFlowAnalysisRule($event)"
                         (disableFlowAnalysisRule)="disableFlowAnalysisRule($event)"
                         (viewStateFlowAnalysisRule)="viewStateFlowAnalysisRule($event)"
+                        (changeFlowAnalysisRuleVersion)="changeFlowAnalysisRuleVersion($event)"
                         (deleteFlowAnalysisRule)="deleteFlowAnalysisRule($event)"></flow-analysis-rule-table>
                 </div>
                 <div class="flex justify-between">

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.ts
@@ -30,6 +30,7 @@ import {
     enableFlowAnalysisRule,
     loadFlowAnalysisRules,
     navigateToEditFlowAnalysisRule,
+    openChangeFlowAnalysisRuleVersionDialogRequest,
     openConfigureFlowAnalysisRuleDialog,
     openNewFlowAnalysisRuleDialog,
     promptFlowAnalysisRuleDeletion,
@@ -150,6 +151,20 @@ export class FlowAnalysisRules implements OnInit, OnDestroy {
                     componentUri: entity.uri,
                     componentName: entity.component.name,
                     canClear
+                }
+            })
+        );
+    }
+
+    changeFlowAnalysisRuleVersion(entity: FlowAnalysisRuleEntity): void {
+        this.store.dispatch(
+            openChangeFlowAnalysisRuleVersionDialogRequest({
+                request: {
+                    id: entity.id,
+                    bundle: entity.component.bundle,
+                    uri: entity.uri,
+                    type: entity.component.type,
+                    revision: entity.revision
                 }
             })
         );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.ts
@@ -30,7 +30,7 @@ import {
     enableFlowAnalysisRule,
     loadFlowAnalysisRules,
     navigateToEditFlowAnalysisRule,
-    openChangeFlowAnalysisRuleVersionDialogRequest,
+    openChangeFlowAnalysisRuleVersionDialog,
     openConfigureFlowAnalysisRuleDialog,
     openNewFlowAnalysisRuleDialog,
     promptFlowAnalysisRuleDeletion,
@@ -158,7 +158,7 @@ export class FlowAnalysisRules implements OnInit, OnDestroy {
 
     changeFlowAnalysisRuleVersion(entity: FlowAnalysisRuleEntity): void {
         this.store.dispatch(
-            openChangeFlowAnalysisRuleVersionDialogRequest({
+            openChangeFlowAnalysisRuleVersionDialog({
                 request: {
                     id: entity.id,
                     bundle: entity.component.bundle,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.html
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.html
@@ -46,6 +46,7 @@
                         (enableControllerService)="enableControllerService($event)"
                         (disableControllerService)="disableControllerService($event)"
                         (viewStateControllerService)="viewStateControllerService($event)"
+                        (changeControllerServiceVersion)="changeControllerServiceVersion($event)"
                         (deleteControllerService)="deleteControllerService($event)"></controller-service-table>
                 </div>
                 <div class="flex justify-between">

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.ts
@@ -28,6 +28,7 @@ import {
     loadManagementControllerServices,
     navigateToAdvancedServiceUi,
     navigateToEditService,
+    openChangeMgtControllerServiceVersionDialogRequest,
     openConfigureControllerServiceDialog,
     openDisableControllerServiceDialog,
     openEnableControllerServiceDialog,
@@ -170,6 +171,20 @@ export class ManagementControllerServices implements OnInit, OnDestroy {
                     componentUri: entity.uri,
                     componentName: entity.component.name,
                     canClear: entity.component.state === 'DISABLED'
+                }
+            })
+        );
+    }
+
+    changeControllerServiceVersion(entity: ControllerServiceEntity): void {
+        this.store.dispatch(
+            openChangeMgtControllerServiceVersionDialogRequest({
+                request: {
+                    id: entity.id,
+                    bundle: entity.component.bundle,
+                    uri: entity.uri,
+                    type: entity.component.type,
+                    revision: entity.revision
                 }
             })
         );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.ts
@@ -28,7 +28,7 @@ import {
     loadManagementControllerServices,
     navigateToAdvancedServiceUi,
     navigateToEditService,
-    openChangeMgtControllerServiceVersionDialogRequest,
+    openChangeMgtControllerServiceVersionDialog,
     openConfigureControllerServiceDialog,
     openDisableControllerServiceDialog,
     openEnableControllerServiceDialog,
@@ -178,7 +178,7 @@ export class ManagementControllerServices implements OnInit, OnDestroy {
 
     changeControllerServiceVersion(entity: ControllerServiceEntity): void {
         this.store.dispatch(
-            openChangeMgtControllerServiceVersionDialogRequest({
+            openChangeMgtControllerServiceVersionDialog({
                 request: {
                     id: entity.id,
                     bundle: entity.component.bundle,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-task-table/reporting-task-table.component.html
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-task-table/reporting-task-table.component.html
@@ -143,7 +143,10 @@
                                 title="Start"></div>
                         }
                         @if (canChangeVersion(item)) {
-                            <div class="pointer fa fa-exchange primary-color" title="Change Version"></div>
+                            <div
+                                class="pointer fa fa-exchange primary-color"
+                                (click)="changeVersionClicked(item)"
+                                title="Change Version"></div>
                         }
                         @if (canDelete(item)) {
                             <div

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-task-table/reporting-task-table.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-task-table/reporting-task-table.component.ts
@@ -57,6 +57,7 @@ export class ReportingTaskTable {
     @Output() openAdvancedUi: EventEmitter<ReportingTaskEntity> = new EventEmitter<ReportingTaskEntity>();
     @Output() viewStateReportingTask: EventEmitter<ReportingTaskEntity> = new EventEmitter<ReportingTaskEntity>();
     @Output() stopReportingTask: EventEmitter<ReportingTaskEntity> = new EventEmitter<ReportingTaskEntity>();
+    @Output() changeReportingTaskVersion: EventEmitter<ReportingTaskEntity> = new EventEmitter<ReportingTaskEntity>();
 
     protected readonly TextTip = TextTip;
     protected readonly BulletinsTip = BulletinsTip;
@@ -233,6 +234,10 @@ export class ReportingTaskTable {
             this.canWrite(entity) &&
             canWriteParent
         );
+    }
+
+    changeVersionClicked(entity: ReportingTaskEntity): void {
+        this.changeReportingTaskVersion.next(entity);
     }
 
     deleteClicked(entity: ReportingTaskEntity): void {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.html
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.html
@@ -43,6 +43,7 @@
                         (viewReportingTaskDocumentation)="viewReportingTaskDocumentation($event)"
                         (deleteReportingTask)="deleteReportingTask($event)"
                         (stopReportingTask)="stopReportingTask($event)"
+                        (changeReportingTaskVersion)="changeReportingTaskVersion($event)"
                         (startReportingTask)="startReportingTask($event)"></reporting-task-table>
                 </div>
                 <div class="flex justify-between">

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.ts
@@ -28,15 +28,16 @@ import {
 } from '../../state/reporting-tasks/reporting-tasks.selectors';
 import {
     loadReportingTasks,
+    navigateToAdvancedReportingTaskUi,
     navigateToEditReportingTask,
+    openChangeReportingTaskVersionDialogRequest,
     openConfigureReportingTaskDialog,
     openNewReportingTaskDialog,
     promptReportingTaskDeletion,
     resetReportingTasksState,
-    startReportingTask,
-    stopReportingTask,
     selectReportingTask,
-    navigateToAdvancedReportingTaskUi
+    startReportingTask,
+    stopReportingTask
 } from '../../state/reporting-tasks/reporting-tasks.actions';
 import { initialState } from '../../state/reporting-tasks/reporting-tasks.reducer';
 import { selectCurrentUser } from '../../../../state/current-user/current-user.selectors';
@@ -179,6 +180,20 @@ export class ReportingTasks implements OnInit, OnDestroy {
             stopReportingTask({
                 request: {
                     reportingTask: entity
+                }
+            })
+        );
+    }
+
+    changeReportingTaskVersion(entity: ReportingTaskEntity): void {
+        this.store.dispatch(
+            openChangeReportingTaskVersionDialogRequest({
+                request: {
+                    id: entity.id,
+                    bundle: entity.component.bundle,
+                    uri: entity.uri,
+                    type: entity.component.type,
+                    revision: entity.revision
                 }
             })
         );

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.ts
@@ -30,7 +30,7 @@ import {
     loadReportingTasks,
     navigateToAdvancedReportingTaskUi,
     navigateToEditReportingTask,
-    openChangeReportingTaskVersionDialogRequest,
+    openChangeReportingTaskVersionDialog,
     openConfigureReportingTaskDialog,
     openNewReportingTaskDialog,
     promptReportingTaskDeletion,
@@ -187,7 +187,7 @@ export class ReportingTasks implements OnInit, OnDestroy {
 
     changeReportingTaskVersion(entity: ReportingTaskEntity): void {
         this.store.dispatch(
-            openChangeReportingTaskVersionDialogRequest({
+            openChangeReportingTaskVersionDialog({
                 request: {
                     id: entity.id,
                     bundle: entity.component.bundle,

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/service/extension-types.service.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/service/extension-types.service.ts
@@ -66,6 +66,15 @@ export class ExtensionTypesService {
         return this.httpClient.get(`${ExtensionTypesService.API}/flow/reporting-task-types`);
     }
 
+    getReportingTaskVersionsForType(reportingTaskType: string, bundle: Bundle): Observable<any> {
+        const params = {
+            serviceBundleGroup: bundle.group,
+            serviceBundleArtifact: bundle.artifact,
+            type: reportingTaskType
+        };
+        return this.httpClient.get(`${ExtensionTypesService.API}/flow/reporting-task-types`, { params });
+    }
+
     getRegistryClientTypes(): Observable<any> {
         return this.httpClient.get(`${ExtensionTypesService.API}/controller/registry-types`);
     }
@@ -76,6 +85,15 @@ export class ExtensionTypesService {
 
     getFlowAnalysisRuleTypes(): Observable<any> {
         return this.httpClient.get(`${ExtensionTypesService.API}/flow/flow-analysis-rule-types`);
+    }
+
+    getFlowAnalysisRuleVersionsForType(flowAnalysisRuleType: string, bundle: Bundle): Observable<any> {
+        const params: any = {
+            serviceBundleGroup: bundle.group,
+            serviceBundleArtifact: bundle.artifact,
+            type: flowAnalysisRuleType
+        };
+        return this.httpClient.get(`${ExtensionTypesService.API}/flow/flow-analysis-rule-types`, { params });
     }
 
     getParameterProviderTypes(): Observable<any> {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/service/extension-types.service.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/service/extension-types.service.ts
@@ -30,7 +30,7 @@ export class ExtensionTypesService {
         return this.httpClient.get(`${ExtensionTypesService.API}/flow/processor-types`);
     }
 
-    getProcessorTypesFiltered(processorType: string, bundle: Bundle): Observable<any> {
+    getProcessorVersionsForType(processorType: string, bundle: Bundle): Observable<any> {
         const params = {
             bundleGroupFilter: bundle.group,
             bundleArtifactFilter: bundle.artifact,
@@ -41,6 +41,15 @@ export class ExtensionTypesService {
 
     getControllerServiceTypes(): Observable<any> {
         return this.httpClient.get(`${ExtensionTypesService.API}/flow/controller-service-types`);
+    }
+
+    getControllerServiceVersionsForType(serviceType: string, bundle: Bundle): Observable<any> {
+        const params: any = {
+            serviceBundleGroup: bundle.group,
+            serviceBundleArtifact: bundle.artifact,
+            typeFilter: serviceType
+        };
+        return this.httpClient.get(`${ExtensionTypesService.API}/flow/controller-service-types`, { params });
     }
 
     getImplementingControllerServiceTypes(serviceType: string, bundle: Bundle): Observable<any> {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/service/extension-types.service.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/service/extension-types.service.ts
@@ -30,6 +30,15 @@ export class ExtensionTypesService {
         return this.httpClient.get(`${ExtensionTypesService.API}/flow/processor-types`);
     }
 
+    getProcessorTypesFiltered(processorType: string, bundle: Bundle): Observable<any> {
+        const params = {
+            bundleGroupFilter: bundle.group,
+            bundleArtifactFilter: bundle.artifact,
+            type: processorType
+        };
+        return this.httpClient.get(`${ExtensionTypesService.API}/flow/processor-types`, { params });
+    }
+
     getControllerServiceTypes(): Observable<any> {
         return this.httpClient.get(`${ExtensionTypesService.API}/flow/controller-service-types`);
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/shared/index.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/shared/index.ts
@@ -646,3 +646,16 @@ export interface ParameterProviderConfigurationEntity {
     id: string;
     component: ParameterProviderConfiguration;
 }
+
+export interface FetchComponentVersionsRequest {
+    id: string;
+    uri: string;
+    revision: Revision;
+    type: string;
+    bundle: Bundle;
+}
+
+export interface OpenChangeComponentVersionDialogRequest {
+    fetchRequest: FetchComponentVersionsRequest;
+    componentVersions: DocumentedType[];
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.html
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.html
@@ -16,13 +16,15 @@
   -->
 
 <h2 mat-dialog-title>Change Version</h2>
-<div class="change-version" tabindex="0">
+<div class="change-version">
     <form [formGroup]="changeComponentVersionForm">
         <mat-dialog-content>
             <div class="flex flex-col gap-y-4 w-full">
                 <div>
                     <div>Name</div>
-                    <div class="accent-color font-medium">{{ selected?.type }}</div>
+                    <div class="accent-color font-medium">
+                        {{ getName(selected) }}
+                    </div>
                 </div>
                 <div>
                     <div>Bundle</div>
@@ -32,7 +34,7 @@
                 </div>
                 <mat-form-field subscriptSizing="dynamic">
                     <mat-label>Version</mat-label>
-                    <mat-select [(value)]="selected">
+                    <mat-select [(value)]="selected" tabindex="0">
                         @for (version of versions; track version) {
                             <mat-option [value]="version" [disabled]="isCurrent(version)">
                                 {{ version.bundle.version }}
@@ -40,6 +42,22 @@
                         }
                     </mat-select>
                 </mat-form-field>
+                @if (selected?.controllerServiceApis) {
+                    <div>
+                        <div>Supports Controller Services</div>
+                        <div class="accent-color font-medium">
+                            <ul>
+                                @for (serviceApi of selected?.controllerServiceApis; track serviceApi) {
+                                    <li>
+                                        <controller-service-api
+                                            [type]="serviceApi.type"
+                                            [bundle]="serviceApi.bundle"></controller-service-api>
+                                    </li>
+                                }
+                            </ul>
+                        </div>
+                    </div>
+                }
                 <div>
                     <div>Restriction</div>
                     @if (selected?.usageRestriction) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.html
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.html
@@ -1,0 +1,66 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<h2 mat-dialog-title>Change Version</h2>
+<div class="change-version" tabindex="0">
+    <form [formGroup]="changeComponentVersionForm">
+        <mat-dialog-content>
+            <div class="flex flex-col gap-y-4 w-full">
+                <div>
+                    <div>Name</div>
+                    <div class="accent-color font-medium">{{ selected?.type }}</div>
+                </div>
+                <div>
+                    <div>Bundle</div>
+                    <div class="accent-color font-medium">
+                        {{ selected?.bundle?.group }} - {{ selected?.bundle?.artifact }}
+                    </div>
+                </div>
+                <mat-form-field subscriptSizing="dynamic">
+                    <mat-label>Version</mat-label>
+                    <mat-select [(value)]="selected">
+                        @for (version of versions; track version) {
+                            <mat-option [value]="version" [disabled]="isCurrent(version)">
+                                {{ version.bundle.version }}
+                            </mat-option>
+                        }
+                    </mat-select>
+                </mat-form-field>
+                <div>
+                    <div>Restriction</div>
+                    @if (selected?.usageRestriction) {
+                        <div class="accent-color font-medium">
+                            {{ selected?.usageRestriction }}
+                        </div>
+                    } @else {
+                        <div class="unset nifi-surface-default">Not Restricted</div>
+                    }
+                </div>
+                <div>
+                    <div>Description</div>
+                    <div class="accent-color font-medium">{{ selected?.description }}</div>
+                </div>
+            </div>
+        </mat-dialog-content>
+        <mat-dialog-actions align="end">
+            <button mat-button mat-dialog-close>Cancel</button>
+            <button type="button" color="primary" mat-button (click)="apply()" [disabled]="isCurrent(selected)">
+                Apply
+            </button>
+        </mat-dialog-actions>
+    </form>
+</div>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.scss
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.scss
@@ -1,0 +1,16 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.spec.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.spec.ts
@@ -21,7 +21,7 @@ import { ChangeComponentVersionDialog } from './change-component-version-dialog'
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { OpenChangeComponentVersionDialogRequest } from '../../../pages/flow-designer/state/flow';
+import { OpenChangeComponentVersionDialogRequest } from '../../../state/shared';
 
 describe('ChangeComponentVersionDialog', () => {
     let component: ChangeComponentVersionDialog;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.spec.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.spec.ts
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangeComponentVersionDialog } from './change-component-version-dialog';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { OpenChangeComponentVersionDialogRequest } from '../../../pages/flow-designer/state/flow';
+
+describe('ChangeComponentVersionDialog', () => {
+    let component: ChangeComponentVersionDialog;
+    let fixture: ComponentFixture<ChangeComponentVersionDialog>;
+    const data: OpenChangeComponentVersionDialogRequest = {
+        fetchRequest: {
+            id: 'd3acc2a0-018e-1000-e4c1-1fd32cb579b6',
+            uri: 'https://localhost:4200/nifi-api/processors/d3acc2a0-018e-1000-e4c1-1fd32cb579b6',
+            revision: {
+                clientId: 'e23146d1-018e-1000-9d09-6a3c09c72420',
+                version: 8
+            },
+            type: 'org.apache.nifi.processors.standard.GenerateFlowFile',
+            bundle: {
+                group: 'org.apache.nifi',
+                artifact: 'nifi-standard-nar',
+                version: '2.0.0-M2'
+            }
+        },
+        componentVersions: [
+            {
+                type: 'org.apache.nifi.processors.standard.GenerateFlowFile',
+                bundle: {
+                    group: 'org.apache.nifi',
+                    artifact: 'nifi-standard-nar',
+                    version: '2.0.0-SNAPSHOT'
+                },
+                description:
+                    'This processor creates FlowFiles with random data or custom content. GenerateFlowFile is useful for load testing, configuration, and simulation. Also see DuplicateFlowFile for additional load testing.',
+                restricted: false,
+                tags: ['random', 'test', 'load', 'generate']
+            },
+            {
+                type: 'org.apache.nifi.processors.standard.GenerateFlowFile',
+                bundle: {
+                    group: 'org.apache.nifi',
+                    artifact: 'nifi-standard-nar',
+                    version: '2.0.0-M2'
+                },
+                description:
+                    'This processor creates FlowFiles with random data or custom content. GenerateFlowFile is useful for load testing, configuration, and simulation. Also see DuplicateFlowFile for additional load testing.',
+                restricted: false,
+                tags: ['random', 'test', 'load', 'generate']
+            }
+        ]
+    };
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [ChangeComponentVersionDialog, MatDialogModule, NoopAnimationsModule, MatFormFieldModule],
+            providers: [{ provide: MAT_DIALOG_DATA, useValue: data }]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ChangeComponentVersionDialog);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.ts
@@ -1,0 +1,61 @@
+import { Component, EventEmitter, Inject, Output } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButton } from '@angular/material/button';
+import { OpenChangeComponentVersionDialogRequest } from '../../../pages/flow-designer/state/flow';
+import { Bundle, DocumentedType } from '../../../state/shared';
+import { MatFormField, MatLabel, MatOption, MatSelect } from '@angular/material/select';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TextTip } from '../tooltips/text-tip/text-tip.component';
+import { NifiTooltipDirective } from '../tooltips/nifi-tooltip.directive';
+
+@Component({
+    selector: 'change-component-version-dialog',
+    standalone: true,
+    imports: [
+        MatDialogModule,
+        MatButton,
+        MatSelect,
+        MatLabel,
+        MatOption,
+        MatFormField,
+        ReactiveFormsModule,
+        NifiTooltipDirective
+    ],
+    templateUrl: './change-component-version-dialog.html',
+    styleUrl: './change-component-version-dialog.scss'
+})
+export class ChangeComponentVersionDialog {
+    versions: DocumentedType[];
+    selected: DocumentedType | null = null;
+    changeComponentVersionForm: FormGroup;
+    private currentBundle: Bundle;
+
+    @Output() changeVersion: EventEmitter<DocumentedType> = new EventEmitter<DocumentedType>();
+
+    constructor(
+        @Inject(MAT_DIALOG_DATA) private dialogRequest: OpenChangeComponentVersionDialogRequest,
+        private formBuilder: FormBuilder
+    ) {
+        this.versions = dialogRequest.componentVersions;
+        this.currentBundle = dialogRequest.fetchRequest.bundle;
+        const idx = this.versions.findIndex(
+            (version: DocumentedType) => version.bundle.version === this.currentBundle.version
+        );
+        this.selected = this.versions[idx > 0 ? idx : 0];
+        this.changeComponentVersionForm = this.formBuilder.group({
+            bundle: new FormControl(this.selected, [Validators.required])
+        });
+    }
+
+    apply(): void {
+        if (this.selected) {
+            this.changeVersion.next(this.selected);
+        }
+    }
+
+    isCurrent(selection: DocumentedType | null): boolean {
+        return selection?.bundle.version === this.currentBundle.version;
+    }
+
+    protected readonly TextTip = TextTip;
+}

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.ts
@@ -1,12 +1,13 @@
 import { Component, EventEmitter, Inject, Output } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatButton } from '@angular/material/button';
-import { OpenChangeComponentVersionDialogRequest } from '../../../pages/flow-designer/state/flow';
-import { Bundle, DocumentedType } from '../../../state/shared';
+import { Bundle, DocumentedType, OpenChangeComponentVersionDialogRequest } from '../../../state/shared';
 import { MatFormField, MatLabel, MatOption, MatSelect } from '@angular/material/select';
 import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TextTip } from '../tooltips/text-tip/text-tip.component';
 import { NifiTooltipDirective } from '../tooltips/nifi-tooltip.directive';
+import { NiFiCommon } from '../../../service/nifi-common.service';
+import { ControllerServiceApi } from '../controller-service/controller-service-api/controller-service-api.component';
 
 @Component({
     selector: 'change-component-version-dialog',
@@ -19,7 +20,8 @@ import { NifiTooltipDirective } from '../tooltips/nifi-tooltip.directive';
         MatOption,
         MatFormField,
         ReactiveFormsModule,
-        NifiTooltipDirective
+        NifiTooltipDirective,
+        ControllerServiceApi
     ],
     templateUrl: './change-component-version-dialog.html',
     styleUrl: './change-component-version-dialog.scss'
@@ -34,7 +36,8 @@ export class ChangeComponentVersionDialog {
 
     constructor(
         @Inject(MAT_DIALOG_DATA) private dialogRequest: OpenChangeComponentVersionDialogRequest,
-        private formBuilder: FormBuilder
+        private formBuilder: FormBuilder,
+        private nifiCommon: NiFiCommon
     ) {
         this.versions = dialogRequest.componentVersions;
         this.currentBundle = dialogRequest.fetchRequest.bundle;
@@ -55,6 +58,10 @@ export class ChangeComponentVersionDialog {
 
     isCurrent(selection: DocumentedType | null): boolean {
         return selection?.bundle.version === this.currentBundle.version;
+    }
+
+    getName(selected: DocumentedType | null): string {
+        return this.nifiCommon.substringAfterLast(selected?.type || '', '.');
     }
 
     protected readonly TextTip = TextTip;

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.ts
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Component, EventEmitter, Inject, Output } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatButton } from '@angular/material/button';

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.html
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.html
@@ -150,7 +150,10 @@
                                     title="Enable"></div>
                             }
                             @if (canChangeVersion(item)) {
-                                <div class="pointer fa fa-exchange primary-color" title="Change Version"></div>
+                                <div
+                                    class="pointer fa fa-exchange primary-color"
+                                    (click)="changeVersionClicked(item)"
+                                    title="Change Version"></div>
                             }
                             @if (canDelete(item)) {
                                 <div

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.ts
@@ -85,6 +85,8 @@ export class ControllerServiceTable {
         new EventEmitter<ControllerServiceEntity>();
     @Output() viewStateControllerService: EventEmitter<ControllerServiceEntity> =
         new EventEmitter<ControllerServiceEntity>();
+    @Output() changeControllerServiceVersion: EventEmitter<ControllerServiceEntity> =
+        new EventEmitter<ControllerServiceEntity>();
 
     protected readonly TextTip = TextTip;
     protected readonly BulletinsTip = BulletinsTip;
@@ -264,6 +266,10 @@ export class ControllerServiceTable {
     deleteClicked(entity: ControllerServiceEntity, event: MouseEvent): void {
         event.stopPropagation();
         this.deleteControllerService.next(entity);
+    }
+
+    changeVersionClicked(entity: ControllerServiceEntity) {
+        this.changeControllerServiceVersion.next(entity);
     }
 
     canViewState(entity: ControllerServiceEntity): boolean {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/extension-creation/extension-creation.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/extension-creation/extension-creation.component.ts
@@ -159,10 +159,19 @@ export class ExtensionCreation {
     }
 
     isSelected(documentedType: DocumentedType): boolean {
-        if (this.selectedType) {
+        return this.areDocumentedTypesTheSame(this.selectedType, documentedType);
+    }
+
+    private areDocumentedTypesTheSame(type1: DocumentedType | null, type2: DocumentedType | null): boolean {
+        if (type1 == type2) {
+            return true;
+        }
+        if (type1 && type2) {
             return (
-                documentedType.type == this.selectedType.type &&
-                documentedType.bundle.version == this.selectedType.bundle.version
+                type1.type === type2.type &&
+                type1.bundle.version === type2.bundle.version &&
+                type1.bundle.group === type2.bundle.group &&
+                type1.bundle.artifact === type2.bundle.artifact
             );
         }
         return false;
@@ -200,9 +209,8 @@ export class ExtensionCreation {
     private selectRow(offset: number) {
         if (this.selectedType && this.dataSource.filteredData.length > 0) {
             // find the index of the currently selected row
-            const selectedIndex = this.dataSource.filteredData.findIndex(
-                (data) =>
-                    data.type === this.selectedType?.type && data.bundle.version === this.selectedType?.bundle.version
+            const selectedIndex = this.dataSource.filteredData.findIndex((data) =>
+                this.areDocumentedTypesTheSame(this.selectedType, data)
             );
 
             if (selectedIndex > -1) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/extension-creation/extension-creation.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/extension-creation/extension-creation.component.ts
@@ -160,7 +160,10 @@ export class ExtensionCreation {
 
     isSelected(documentedType: DocumentedType): boolean {
         if (this.selectedType) {
-            return documentedType.type == this.selectedType.type;
+            return (
+                documentedType.type == this.selectedType.type &&
+                documentedType.bundle.version == this.selectedType.bundle.version
+            );
         }
         return false;
     }
@@ -198,7 +201,8 @@ export class ExtensionCreation {
         if (this.selectedType && this.dataSource.filteredData.length > 0) {
             // find the index of the currently selected row
             const selectedIndex = this.dataSource.filteredData.findIndex(
-                (data) => data.type === this.selectedType?.type
+                (data) =>
+                    data.type === this.selectedType?.type && data.bundle.version === this.selectedType?.bundle.version
             );
 
             if (selectedIndex > -1) {


### PR DESCRIPTION
[NIFI-13034](https://issues.apache.org/jira/browse/NIFI-13034)

To test/verify this you will need to drop in a nar from a different version than you are building. In my case, I downloaded the 2.0.0-M2 convenience zip from https://dlcdn.apache.org/nifi/2.0.0-M2/nifi-2.0.0-M2-bin.zip and used some of those nars.

Be sure to verify that you can change versions for:
* processors
* controller services
* management controller services
* flow analysis rules
* reporting tasks


For reference, I added these nars to ensure I had all of the types covered:
* nifi-gcp-nar-2.0.0-M2.nar
* nifi-datadog-nar-2.0.0-M2.nar
* nifi-standard-nar-2.0.0-M2.nar
