### PR TITLE
NIFI-10657 Free Clob after reading from ResultSet to avoid out of memory errors

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
@@ -274,7 +274,7 @@ public class JdbcCommon {
                     final int javaSqlType = meta.getColumnType(i);
                     final Schema fieldSchema = schema.getFields().get(i - 1).schema();
 
-                    // Need to handle CLOB and BLOB before getObject() is called, due to ResultSet's maximum portability statement
+                    // Need to handle CLOB and NCLOB before getObject() is called, due to ResultSet's maximum portability statement
                     if (javaSqlType == CLOB || javaSqlType == NCLOB) {
                         Clob clob = rs.getClob(i);
                         if (clob != null) {
@@ -287,6 +287,11 @@ public class JdbcCommon {
                                 }
                             }
                             rec.put(i - 1, sb.toString());
+                            try {
+                                clob.free();
+                            } catch (SQLFeatureNotSupportedException sfnse) {
+                                // The driver doesn't support free, but allow processing to continue
+                            }
                         } else {
                             rec.put(i - 1, null);
                         }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10657](https://issues.apache.org/jira/browse/NIFI-10657)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-10657) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-10657`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-10657`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

I added a unit test to check the new condition

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

New new dependencies

### Documentation

No documentation changes required
