### PR TITLE
NIFI-13052 allow CRON driven components to be searchable

### DIFF
--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -2139,6 +2139,8 @@ The supported keywords are the following:
 
 ** *timer*: Adds Processors to the result list where the Scheduling Strategy is "Timer Driven".
 
+** *cron*: Adds Processors to the result list where the Scheduling Strategy is "CRON Driven".
+
 - *Execution*
 
 ** *primary:* Adds Processors to the result list that are set to run on the primary node only (whether if the Processor is currently running or not).

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/search/attributematchers/SchedulingMatcher.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/search/attributematchers/SchedulingMatcher.java
@@ -23,13 +23,16 @@ import org.apache.nifi.web.search.query.SearchQuery;
 
 import java.util.List;
 
+import static org.apache.nifi.scheduling.SchedulingStrategy.CRON_DRIVEN;
 import static org.apache.nifi.scheduling.SchedulingStrategy.TIMER_DRIVEN;
 
 public class SchedulingMatcher implements AttributeMatcher<ProcessorNode> {
     private static final String SEARCH_TERM_TIMER = "timer";
+    private static final String SEARCH_TERM_CRON = "cron";
 
     private static final String MATCH_PREFIX = "Scheduling strategy: ";
     private static final String MATCH_TIMER = "Timer driven";
+    private static final String MATCH_CRON = "CRON driven";
 
     @Override
     public void match(final ProcessorNode component, final SearchQuery query, final List<String> matches) {
@@ -38,6 +41,8 @@ public class SchedulingMatcher implements AttributeMatcher<ProcessorNode> {
 
         if (TIMER_DRIVEN.equals(schedulingStrategy) && StringUtils.containsIgnoreCase(SEARCH_TERM_TIMER, searchTerm)) {
             matches.add(MATCH_PREFIX + MATCH_TIMER);
+        } else if (CRON_DRIVEN.equals(schedulingStrategy) && StringUtils.containsIgnoreCase(SEARCH_TERM_CRON, searchTerm)) {
+            matches.add(MATCH_PREFIX + MATCH_CRON);
         }
     }
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/search/attributematchers/SchedulingMatcherTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/search/attributematchers/SchedulingMatcherTest.java
@@ -28,11 +28,11 @@ public class SchedulingMatcherTest extends AbstractAttributeMatcherTest {
     private ProcessorNode component;
 
     @Test
-    public void testWhenKeywordAppearsAndNotEvent() {
+    public void testWhenKeywordAppearsAndNotTimer() {
         // given
         final SchedulingMatcher testSubject = new SchedulingMatcher();
-        givenSchedulingStrategy(SchedulingStrategy.TIMER_DRIVEN);
-        givenSearchTerm("event");
+        givenSchedulingStrategy(SchedulingStrategy.CRON_DRIVEN);
+        givenSearchTerm("timer");
 
         // when
         testSubject.match(component, searchQuery, matches);
@@ -42,11 +42,11 @@ public class SchedulingMatcherTest extends AbstractAttributeMatcherTest {
     }
 
     @Test
-    public void testWhenKeywordDoesNotAppearAndEvent() {
+    public void testWhenKeywordDoesNotAppearAndTimer() {
         // given
         final SchedulingMatcher testSubject = new SchedulingMatcher();
         givenSchedulingStrategy(SchedulingStrategy.TIMER_DRIVEN);
-        givenSearchTerm("event");
+        givenSearchTerm("cron");
 
         // when
         testSubject.match(component, searchQuery, matches);
@@ -67,6 +67,20 @@ public class SchedulingMatcherTest extends AbstractAttributeMatcherTest {
 
         // then
         thenMatchConsistsOf("Scheduling strategy: Timer driven");
+    }
+
+    @Test
+    public void testWhenKeywordAppearsAndCron() {
+        // given
+        final SchedulingMatcher testSubject = new SchedulingMatcher();
+        givenSchedulingStrategy(SchedulingStrategy.CRON_DRIVEN);
+        givenSearchTerm("cron");
+
+        // when
+        testSubject.match(component, searchQuery, matches);
+
+        // then
+        thenMatchConsistsOf("Scheduling strategy: CRON driven");
     }
 
     private void givenSchedulingStrategy(final SchedulingStrategy schedulingStrategy) {


### PR DESCRIPTION
# Summary

[NIFI-13052](https://issues.apache.org/jira/browse/NIFI-13052)
Searching with the word "cron" will now find all components with Scheduling Strategy = CRON driven

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
