### PR TITLE
NIFI-12960 Added ability to read password-protected Excel spreadsheets.

### DIFF
--- a/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelReader.java
+++ b/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelReader.java
@@ -62,11 +62,11 @@ import java.util.Map;
         + "(XSSF 2007 OOXML file format) Excel documents and not older .xls (HSSF '97(-2007) file format) documents.")
 public class ExcelReader extends SchemaRegistryService implements RecordReaderFactory {
 
-    public enum ProtectedStrategy implements DescribedValue {
+    public enum ProtectionType implements DescribedValue {
         UNPROTECTED("Unprotected", "An Excel spreadsheet not protected by a password"),
         PASSWORD("Password Protected", "An Excel spreadsheet protected by a password");
 
-        ProtectedStrategy(String displayName, String description) {
+        ProtectionType(String displayName, String description) {
             this.displayName = displayName;
             this.description = description;
         }
@@ -112,13 +112,13 @@ public class ExcelReader extends SchemaRegistryService implements RecordReaderFa
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .build();
 
-    public static final PropertyDescriptor PROTECTED_STRATEGY = new PropertyDescriptor
-            .Builder().name("Protected Strategy")
-            .displayName("Protected Strategy")
+    public static final PropertyDescriptor PROTECTION_TYPE = new PropertyDescriptor
+            .Builder().name("Protection Type")
+            .displayName("Protection Type")
             .description("Specifies whether an Excel spreadsheet is protected by a password or not.")
             .required(true)
-            .allowableValues(ProtectedStrategy.class)
-            .defaultValue(ProtectedStrategy.UNPROTECTED)
+            .allowableValues(ProtectionType.class)
+            .defaultValue(ProtectionType.UNPROTECTED)
             .build();
 
     public static final PropertyDescriptor PASSWORD = new PropertyDescriptor
@@ -128,7 +128,7 @@ public class ExcelReader extends SchemaRegistryService implements RecordReaderFa
             .required(true)
             .sensitive(true)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-            .dependsOn(PROTECTED_STRATEGY, ProtectedStrategy.PASSWORD)
+            .dependsOn(PROTECTION_TYPE, ProtectionType.PASSWORD)
             .build();
 
     private volatile ConfigurationContext configurationContext;
@@ -173,7 +173,7 @@ public class ExcelReader extends SchemaRegistryService implements RecordReaderFa
         final List<PropertyDescriptor> properties = new ArrayList<>(super.getSupportedPropertyDescriptors());
         properties.add(STARTING_ROW);
         properties.add(REQUIRED_SHEETS);
-        properties.add(PROTECTED_STRATEGY);
+        properties.add(PROTECTION_TYPE);
         properties.add(PASSWORD);
         properties.add(DateTimeUtils.DATE_FORMAT);
         properties.add(DateTimeUtils.TIME_FORMAT);

--- a/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
+++ b/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
@@ -68,7 +68,7 @@ public class ExcelRecordReader implements RecordReader {
         }
 
         try {
-            this.rowIterator = new RowIterator(inputStream, configuration.getRequiredSheets(), configuration.getFirstRow(), logger);
+            this.rowIterator = new RowIterator(inputStream, configuration, logger);
         } catch (RuntimeException e) {
             throw new MalformedRecordException("Read initial Record from Excel XLSX failed", e);
         }

--- a/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReaderConfiguration.java
+++ b/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReaderConfiguration.java
@@ -28,6 +28,8 @@ public class ExcelRecordReaderConfiguration {
     private String dateFormat;
     private String timeFormat;
     private String timestampFormat;
+    private String password;
+    private boolean avoidTempFiles;
 
     private ExcelRecordReaderConfiguration() {
     }
@@ -56,6 +58,14 @@ public class ExcelRecordReaderConfiguration {
         return timestampFormat;
     }
 
+    public String getPassword() {
+        return password;
+    }
+
+    public boolean isAvoidTempFiles() {
+        return avoidTempFiles;
+    }
+
     public static final class Builder {
         private RecordSchema schema;
         private List<String> requiredSheets;
@@ -63,6 +73,8 @@ public class ExcelRecordReaderConfiguration {
         private String dateFormat;
         private String timeFormat;
         private String timestampFormat;
+        private String password;
+        private boolean avoidTempFiles;
 
         public Builder withSchema(RecordSchema schema) {
             this.schema = schema;
@@ -94,6 +106,16 @@ public class ExcelRecordReaderConfiguration {
             return this;
         }
 
+        public Builder withPassword(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder withAvoidTempFiles(boolean avoidTempFiles) {
+            this.avoidTempFiles = avoidTempFiles;
+            return this;
+        }
+
         public ExcelRecordReaderConfiguration build() {
             ExcelRecordReaderConfiguration excelRecordReaderConfiguration = new ExcelRecordReaderConfiguration();
             excelRecordReaderConfiguration.schema = this.schema;
@@ -102,6 +124,9 @@ public class ExcelRecordReaderConfiguration {
             excelRecordReaderConfiguration.requiredSheets = this.requiredSheets == null ? Collections.emptyList() : this.requiredSheets;
             excelRecordReaderConfiguration.dateFormat = this.dateFormat;
             excelRecordReaderConfiguration.firstRow = this.firstRow;
+            excelRecordReaderConfiguration.password = password;
+            excelRecordReaderConfiguration.avoidTempFiles = avoidTempFiles;
+
             return excelRecordReaderConfiguration;
         }
     }

--- a/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordSource.java
+++ b/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordSource.java
@@ -35,7 +35,13 @@ public class ExcelRecordSource implements RecordSource<Row> {
         final Integer rawFirstRow = context.getProperty(ExcelReader.STARTING_ROW).evaluateAttributeExpressions(variables).asInteger();
         final int firstRow = rawFirstRow == null ? NumberUtils.toInt(ExcelReader.STARTING_ROW.getDefaultValue()) : rawFirstRow;
         final int zeroBasedFirstRow = ExcelReader.getZeroBasedIndex(firstRow);
-        this.rowIterator = new RowIterator(in, requiredSheets, zeroBasedFirstRow, logger);
+        final String password = context.getProperty(ExcelReader.PASSWORD).getValue();
+        final ExcelRecordReaderConfiguration configuration = new ExcelRecordReaderConfiguration.Builder()
+                .withRequiredSheets(requiredSheets)
+                .withFirstRow(zeroBasedFirstRow)
+                .withPassword(password)
+                .build();
+        this.rowIterator = new RowIterator(in, configuration, logger);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/RowIterator.java
+++ b/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/RowIterator.java
@@ -41,12 +41,15 @@ class RowIterator implements Iterator<Row>, Closeable {
     private Iterator<Row> currentRows;
     private Row currentRow;
 
-    RowIterator(final InputStream in, final List<String> requiredSheets, final int firstRow, final ComponentLog logger) {
+    RowIterator(final InputStream in, final ExcelRecordReaderConfiguration configuration, final ComponentLog logger) {
         this.workbook = StreamingReader.builder()
                 .rowCacheSize(100)
                 .bufferSize(4096)
+                .password(configuration.getPassword())
+                .setAvoidTempFiles(configuration.isAvoidTempFiles())
                 .open(in);
 
+        final List<String> requiredSheets = configuration.getRequiredSheets();
         if (requiredSheets == null || requiredSheets.isEmpty()) {
             this.sheets = this.workbook.iterator();
         } else {
@@ -65,7 +68,7 @@ class RowIterator implements Iterator<Row>, Closeable {
                     .collect(Collectors.toList()).iterator();
         }
 
-        this.firstRow = firstRow;
+        this.firstRow = configuration.getFirstRow();
         this.logger = logger;
         setCurrent();
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12960](https://issues.apache.org/jira/browse/NIFI-12960)
In order to test this feature a password protected Excel spreadsheet is created in memory. This is in order to avoid potential issues with virus scanners which will quarantine such a file. In order to test an in memory Excel spreadsheet the underlying API com.github.pjfanning excel-streaming-reader had to be configured not to use temp files (which otherwise would have the same issue of being quarantined by virus scanners).
This PR is specifically for the 2.x branch but I am requesting this be back ported to the 1.x branch if possible otherwise I will open another PR.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
