### PR TITLE
NIFI-13052 allow CRON driven components to be searchable

### DIFF
--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -1968,6 +1968,8 @@ The supported keywords are the following:
 
 ** *timer*: Adds Processors to the result list where the Scheduling Strategy is "Timer Driven".
 
+** *cron*: Adds Processors to the result list where the Scheduling Strategy is "CRON Driven".
+
 - *Execution*
 
 ** *primary:* Adds Processors to the result list that are set to run on the primary node only (whether if the Processor is currently running or not).

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/search/attributematchers/SchedulingMatcher.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/search/attributematchers/SchedulingMatcher.java
@@ -23,6 +23,7 @@ import org.apache.nifi.web.search.query.SearchQuery;
 
 import java.util.List;
 
+import static org.apache.nifi.scheduling.SchedulingStrategy.CRON_DRIVEN;
 import static org.apache.nifi.scheduling.SchedulingStrategy.EVENT_DRIVEN;
 import static org.apache.nifi.scheduling.SchedulingStrategy.PRIMARY_NODE_ONLY;
 import static org.apache.nifi.scheduling.SchedulingStrategy.TIMER_DRIVEN;
@@ -30,11 +31,13 @@ import static org.apache.nifi.scheduling.SchedulingStrategy.TIMER_DRIVEN;
 public class SchedulingMatcher implements AttributeMatcher<ProcessorNode> {
     private static final String SEARCH_TERM_EVENT = "event";
     private static final String SEARCH_TERM_TIMER = "timer";
+    private static final String SEARCH_TERM_CRON = "cron";
     private static final String SEARCH_TERM_PRIMARY = "primary";
 
     private static final String MATCH_PREFIX = "Scheduling strategy: ";
     private static final String MATCH_EVENT = "Event driven";
     private static final String MATCH_TIMER = "Timer driven";
+    private static final String MATCH_CRON = "CRON driven";
     private static final String MATCH_PRIMARY = "On primary node";
 
     @Override
@@ -46,6 +49,8 @@ public class SchedulingMatcher implements AttributeMatcher<ProcessorNode> {
             matches.add(MATCH_PREFIX + MATCH_EVENT);
         } else if (TIMER_DRIVEN.equals(schedulingStrategy) && StringUtils.containsIgnoreCase(SEARCH_TERM_TIMER, searchTerm)) {
             matches.add(MATCH_PREFIX + MATCH_TIMER);
+        } else if (CRON_DRIVEN.equals(schedulingStrategy) && StringUtils.containsIgnoreCase(SEARCH_TERM_CRON, searchTerm)) {
+            matches.add(MATCH_PREFIX + MATCH_CRON);
         } else if (PRIMARY_NODE_ONLY.equals(schedulingStrategy) && StringUtils.containsIgnoreCase(SEARCH_TERM_PRIMARY, searchTerm)) {
             // PRIMARY_NODE_ONLY has been deprecated as a SchedulingStrategy and replaced by PRIMARY as an ExecutionNode.
             matches.add(MATCH_PREFIX + MATCH_PRIMARY);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/search/attributematchers/SchedulingMatcherTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/search/attributematchers/SchedulingMatcherTest.java
@@ -59,8 +59,8 @@ public class SchedulingMatcherTest extends AbstractAttributeMatcherTest {
     public void testWhenKeywordDoesNotAppearAndEvent() {
         // given
         final SchedulingMatcher testSubject = new SchedulingMatcher();
-        givenSchedulingStrategy(SchedulingStrategy.TIMER_DRIVEN);
-        givenSearchTerm("event");
+        givenSchedulingStrategy(SchedulingStrategy.EVENT_DRIVEN);
+        givenSearchTerm("timer");
 
         // when
         testSubject.match(component, searchQuery, matches);
@@ -95,6 +95,20 @@ public class SchedulingMatcherTest extends AbstractAttributeMatcherTest {
 
         // then
         thenMatchConsistsOf("Scheduling strategy: On primary node");
+    }
+
+    @Test
+    public void testWhenKeywordAppearsAndCron() {
+        // given
+        final SchedulingMatcher testSubject = new SchedulingMatcher();
+        givenSchedulingStrategy(SchedulingStrategy.CRON_DRIVEN);
+        givenSearchTerm("cron");
+
+        // when
+        testSubject.match(component, searchQuery, matches);
+
+        // then
+        thenMatchConsistsOf("Scheduling strategy: CRON driven");
     }
 
     private void givenSchedulingStrategy(final SchedulingStrategy schedulingStrategy) {


### PR DESCRIPTION

# Summary

[NIFI-13052](https://issues.apache.org/jira/browse/NIFI-13052)
NIFI-1x support branch PR for allowing CRON driven components to be searchable.
Also changed testWhenKeywordDoesNotAppearAndEvent unit test to be unique and match the wording of the test.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
