### PR TITLE
NIFI-13066 Upgrade Bouncy Castle from 1.77 to 1.78.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <org.apache.commons.text.version>1.11.0</org.apache.commons.text.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
-        <org.bouncycastle.version>1.77</org.bouncycastle.version>
+        <org.bouncycastle.version>1.78.1</org.bouncycastle.version>
         <testcontainers.version>1.19.4</testcontainers.version>
         <org.slf4j.version>2.0.13</org.slf4j.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>


### PR DESCRIPTION
# Summary

[NIFI-13066](https://issues.apache.org/jira/browse/NIFI-13066) Upgrades Bouncy Castle dependencies from 1.77 to [1.78.1](https://www.bouncycastle.org/releasenotes.html#r1rv78) incorporating several bug fixes and resolving several flagged vulnerabilities. Bouncy Castle 1.78.1 resolves a dependency relationship issue in version 1.78 that impacted OpenPGP classes.

This upgrade should be backported to the support branch.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
