### PR TITLE
NIFI-13067 Upgrade Spring Security from 6.2.3 to 6.2.4

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -26,7 +26,7 @@
         <curator.version>5.6.0</curator.version>
         <guava.version>33.1.0-jre</guava.version>
         <tika.version>2.9.2</tika.version>
-        <org.opensaml.version>4.3.0</org.opensaml.version>
+        <org.opensaml.version>4.3.1</org.opensaml.version>
     </properties>
     <modules>
         <module>nifi-framework</module>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -35,7 +35,7 @@
         <module>nifi-registry-docker-maven</module>
     </modules>
     <properties>
-        <spring.boot.version>3.2.4</spring.boot.version>
+        <spring.boot.version>3.2.5</spring.boot.version>
         <flyway.version>9.22.3</flyway.version>
         <flyway.tests.version>9.5.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <hadoop.version>3.4.0</hadoop.version>
         <ozone.version>1.2.1</ozone.version>
         <gcs.version>2.1.5</gcs.version>
-        <aspectj.version>1.9.21</aspectj.version>
+        <aspectj.version>1.9.22</aspectj.version>
         <jersey.bom.version>3.1.4</jersey.bom.version>
         <log4j2.version>2.23.0</log4j2.version>
         <logback.version>1.5.5</logback.version>
@@ -154,7 +154,7 @@
         <netty.4.version>4.1.108.Final</netty.4.version>
         <servlet-api.version>6.0.0</servlet-api.version>
         <spring.version>6.1.6</spring.version>
-        <spring.security.version>6.2.3</spring.security.version>
+        <spring.security.version>6.2.4</spring.security.version>
         <swagger.annotations.version>2.2.20</swagger.annotations.version>
         <h2.version>2.2.224</h2.version>
         <zookeeper.version>3.9.2</zookeeper.version>


### PR DESCRIPTION
# Summary

[NIFI-13067](https://issues.apache.org/jira/browse/NIFI-13067) Upgrades Spring Security dependencies from 6.2.3 to [6.2.4](https://github.com/spring-projects/spring-security/releases/tag/6.2.4) along with supporting libraries including OpenSAML 4.3.1 and AspectJ [1.9.22](https://github.com/eclipse-aspectj/aspectj/releases/tag/V1_9_22).

Changes also include upgrading Spring Boot for Registry from 3.2.4 to [3.2.5](https://github.com/spring-projects/spring-boot/releases/tag/v3.2.5) aligning with the versions of Spring Security and Spring Framework.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
