### PR TITLE
NIFI-12858 Correct Order of Previous Property Values

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-administration/src/main/java/org/apache/nifi/admin/service/EntityStoreAuditService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-administration/src/main/java/org/apache/nifi/admin/service/EntityStoreAuditService.java
@@ -135,7 +135,8 @@ public class EntityStoreAuditService implements AuditService, Closeable {
             final Map<String, List<PreviousValue>> previousValuesFound = new LinkedHashMap<>();
 
             final EntityIterable actionEntities = storeTransaction.find(EntityType.ACTION.getEntityType(), ActionEntity.SOURCE_ID.getProperty(), componentId);
-            for (Entity actionEntity : actionEntities) {
+            // Reverse default ordering to return oldest entries before newest entries
+            for (Entity actionEntity : actionEntities.reverse()) {
                 final Entity configureDetails = actionEntity.getLink(ActionLink.CONFIGURE_DETAILS.getProperty());
                 if (configureDetails != null) {
                     final String name = getProperty(configureDetails, ConfigureDetailsEntity.NAME);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-administration/src/test/java/org/apache/nifi/admin/service/EntityStoreAuditServiceTest.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-administration/src/test/java/org/apache/nifi/admin/service/EntityStoreAuditServiceTest.java
@@ -95,6 +95,8 @@ class EntityStoreAuditServiceTest {
 
     private static final String SECOND_VALUE = "SecondValue";
 
+    private static final String THIRD_VALUE = "ThirdValue";
+
     private static final String DATABASE_FILE_EXTENSION = ".xd";
 
     @TempDir
@@ -331,7 +333,14 @@ class EntityStoreAuditServiceTest {
         secondConfigureDetails.setValue(SECOND_VALUE);
         secondAction.setActionDetails(secondConfigureDetails);
 
-        final Collection<Action> actions = Arrays.asList(firstAction, secondAction);
+        final FlowChangeAction thirdAction = newAction();
+        thirdAction.setOperation(Operation.Configure);
+        final FlowChangeConfigureDetails thirdConfigureDetails = new FlowChangeConfigureDetails();
+        thirdConfigureDetails.setName(SECOND_PROPERTY_NAME);
+        thirdConfigureDetails.setValue(THIRD_VALUE);
+        thirdAction.setActionDetails(thirdConfigureDetails);
+
+        final Collection<Action> actions = Arrays.asList(firstAction, secondAction, thirdAction);
         service.addActions(actions);
 
         final Map<String, List<PreviousValue>> previousValues = service.getPreviousValues(SOURCE_ID);
@@ -348,7 +357,14 @@ class EntityStoreAuditServiceTest {
 
         final List<PreviousValue> secondPreviousValues = previousValues.get(SECOND_PROPERTY_NAME);
         assertNotNull(secondPreviousValues);
-        final PreviousValue secondPreviousValue = secondPreviousValues.get(0);
+
+        final PreviousValue thirdPreviousValue = secondPreviousValues.get(0);
+        assertNotNull(thirdPreviousValue);
+        assertEquals(THIRD_VALUE, thirdPreviousValue.getPreviousValue());
+        assertNotNull(thirdPreviousValue.getTimestamp());
+        assertEquals(USER_IDENTITY, thirdPreviousValue.getUserIdentity());
+
+        final PreviousValue secondPreviousValue = secondPreviousValues.get(1);
         assertNotNull(secondPreviousValue);
         assertEquals(SECOND_VALUE, secondPreviousValue.getPreviousValue());
         assertNotNull(secondPreviousValue.getTimestamp());


### PR DESCRIPTION
# Summary

[NIFI-12858](https://issues.apache.org/jira/browse/NIFI-12858) Corrects the ordering of previous property values shown when hovering over the information icon for component configuration.

Migration from H2 to Xodus in NiFi 1.24.0 and following inadvertently changed the order to return the newest entries first, instead of the oldest entries first. The correction reverses the default ordering and updated unit tests confirm the expected behavior.

This change should be backported to the support branch.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
