### PR TITLE
NIFI-13083: Parameter sensitivity issue when deleting and re-adding

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
@@ -57,7 +57,8 @@ import {
     stopVersionControlRequest,
     copy,
     paste,
-    terminateThreads
+    terminateThreads,
+    navigateToParameterContext
 } from '../state/flow/flow.actions';
 import { ComponentType } from '../../../state/shared';
 import {
@@ -504,14 +505,29 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
                 }
             },
             {
-                condition: (selection: any) => {
-                    // TODO - hasParameterContext
-                    return false;
+                condition: (selection: d3.Selection<any, any, any, any>) => {
+                    return this.canvasUtils.hasParameterContext(selection);
                 },
                 clazz: 'fa',
                 text: 'Parameters',
-                action: () => {
-                    // TODO - open parameter context
+                action: (selection: d3.Selection<any, any, any, any>) => {
+                    let id;
+                    if (selection.empty()) {
+                        id = this.canvasUtils.getParameterContextId();
+                    } else {
+                        const selectionData = selection.datum();
+                        id = selectionData.parameterContext.id;
+                    }
+
+                    if (id) {
+                        this.store.dispatch(
+                            navigateToParameterContext({
+                                request: {
+                                    id
+                                }
+                            })
+                        );
+                    }
                 }
             },
             {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
@@ -59,6 +59,7 @@ import {
     NavigateToComponentRequest,
     NavigateToControllerServicesRequest,
     NavigateToManageComponentPoliciesRequest,
+    NavigateToParameterContext,
     NavigateToQueueListing,
     OpenChangeVersionDialogRequest,
     OpenComponentDialogRequest,
@@ -386,6 +387,11 @@ export const navigateToControllerServicesForProcessGroup = createAction(
 export const navigateToQueueListing = createAction(
     `${CANVAS_PREFIX} Navigate To Queue Listing`,
     props<{ request: NavigateToQueueListing }>()
+);
+
+export const navigateToParameterContext = createAction(
+    `${CANVAS_PREFIX} Navigate To Parameter Context`,
+    props<{ request: NavigateToParameterContext }>()
 );
 
 export const editCurrentProcessGroup = createAction(

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -933,6 +933,18 @@ export class FlowEffects {
         { dispatch: false }
     );
 
+    navigateToParameterContext$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(FlowActions.navigateToParameterContext),
+                map((action) => action.request),
+                tap((request) => {
+                    this.router.navigate(['/parameter-contexts', request.id]);
+                })
+            ),
+        { dispatch: false }
+    );
+
     navigateToEditCurrentProcessGroup$ = createEffect(
         () =>
             this.actions$.pipe(

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
@@ -367,6 +367,10 @@ export interface NavigateToQueueListing {
     connectionId: string;
 }
 
+export interface NavigateToParameterContext {
+    id: string;
+}
+
 export interface EditCurrentProcessGroupRequest {
     id: string;
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.ts
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.ts
@@ -31,7 +31,7 @@ import { Observable, take } from 'rxjs';
 import { ParameterReferences } from '../../../../../ui/common/parameter-references/parameter-references.component';
 import { Store } from '@ngrx/store';
 import { ParameterContextListingState } from '../../../state/parameter-context-listing';
-import { showOkDialog } from '../../../../flow-designer/state/flow/flow.actions';
+import { showOkDialog } from '../../../state/parameter-context-listing/parameter-context-listing.actions';
 
 export interface ParameterItem {
     deleted: boolean;
@@ -157,7 +157,10 @@ export class ParameterTable implements AfterViewInit, ControlValueAccessor {
                 );
 
                 if (item) {
-                    if (item.entity.parameter.sensitive !== parameter.sensitive) {
+                    // if the item is added that means it hasn't been saved yet. in this case, we
+                    // can simply update the existing parameter. if the item has been saved, and the
+                    // sensitivity has changed, the user must apply the changes first.
+                    if (!item.added && item.entity.parameter.sensitive !== parameter.sensitive) {
                         this.store.dispatch(
                             showOkDialog({
                                 title: 'Parameter Exists',


### PR DESCRIPTION
NIFI-13083:
- Fixing import preventing the dialog from warning the user that they must apply changes before deleting/adding the same parameter with different sensitivities.
- Allowing the sensitivity to change when deleting/adding the same parameter as long as it hasn't been saved yet.
- Adding the Parameters context menu item for Process Groups.