### PR TITLE
NIFI-13084 Backport Allow disabling scientific notation when writing …

### DIFF
--- a/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
+++ b/nifi-nar-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
@@ -19,6 +19,7 @@ package org.apache.nifi.json;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -143,6 +144,8 @@ public abstract class AbstractJsonRowRecordReader implements RecordReader {
         try {
             final StreamReadConstraints configuredStreamReadConstraints = streamReadConstraints == null ? DEFAULT_STREAM_READ_CONSTRAINTS : streamReadConstraints;
             jsonParser = tokenParserFactory.getJsonParser(in, configuredStreamReadConstraints, allowComments);
+            jsonParser.enable(Feature.USE_FAST_DOUBLE_PARSER);
+            jsonParser.enable(Feature.USE_FAST_BIG_NUMBER_PARSER);
 
             if (strategy == StartingFieldStrategy.NESTED_FIELD) {
                 while (jsonParser.nextToken() != null) {

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonRecordSetWriter.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonRecordSetWriter.java
@@ -90,6 +90,14 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
             .defaultValue("false")
             .required(true)
             .build();
+    public static final PropertyDescriptor ALLOW_SCIENTIFIC_NOTATION = new PropertyDescriptor.Builder()
+            .name("Allow Scientific Notation")
+            .description("Specifies whether or not scientific notation should be used when writing numbers")
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .allowableValues("true", "false")
+            .defaultValue("false")
+            .required(true)
+            .build();
     public static final PropertyDescriptor OUTPUT_GROUPING = new PropertyDescriptor.Builder()
             .name("output-grouping")
             .displayName("Output Grouping")
@@ -120,6 +128,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
             .build();
 
     private volatile boolean prettyPrint;
+    private volatile boolean allowScientificNotation;
     private volatile NullSuppression nullSuppression;
     private volatile OutputGrouping outputGrouping;
     private volatile String compressionFormat;
@@ -130,6 +139,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
         final List<PropertyDescriptor> properties = new ArrayList<>(super.getSupportedPropertyDescriptors());
         properties.add(PRETTY_PRINT_JSON);
         properties.add(SUPPRESS_NULLS);
+        properties.add(ALLOW_SCIENTIFIC_NOTATION);
         properties.add(OUTPUT_GROUPING);
         properties.add(COMPRESSION_FORMAT);
         properties.add(COMPRESSION_LEVEL);
@@ -150,6 +160,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
     @OnEnabled
     public void onEnabled(final ConfigurationContext context) {
         prettyPrint = context.getProperty(PRETTY_PRINT_JSON).asBoolean();
+        allowScientificNotation = context.getProperty(ALLOW_SCIENTIFIC_NOTATION).asBoolean();
 
         final NullSuppression suppression;
         final String suppressNullValue = context.getProperty(SUPPRESS_NULLS).getValue();
@@ -180,36 +191,36 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
 
         final OutputStream bufferedOut = new BufferedOutputStream(out, 65536);
         final OutputStream compressionOut;
-        String mimeTypeRef;
+        String mimeType;
 
         try {
             switch (compressionFormat.toLowerCase()) {
                 case COMPRESSION_FORMAT_GZIP:
                     compressionOut = new GZIPOutputStream(bufferedOut, compressionLevel);
-                    mimeTypeRef = "application/gzip";
+                    mimeType = "application/gzip";
                     break;
                 case COMPRESSION_FORMAT_XZ_LZMA2:
                     compressionOut = new XZOutputStream(bufferedOut, new LZMA2Options());
-                    mimeTypeRef = "application/x-xz";
+                    mimeType = "application/x-xz";
                     break;
                 case COMPRESSION_FORMAT_SNAPPY:
                     compressionOut = new SnappyOutputStream(bufferedOut);
-                    mimeTypeRef = "application/x-snappy";
+                    mimeType = "application/x-snappy";
                     break;
                 case COMPRESSION_FORMAT_SNAPPY_FRAMED:
                     compressionOut = new SnappyFramedOutputStream(bufferedOut);
-                    mimeTypeRef = "application/x-snappy-framed";
+                    mimeType = "application/x-snappy-framed";
                     break;
                 case COMPRESSION_FORMAT_BZIP2:
-                    mimeTypeRef = "application/x-bzip2";
+                    mimeType = "application/x-bzip2";
                     compressionOut = new CompressorStreamFactory().createCompressorOutputStream(compressionFormat.toLowerCase(), bufferedOut);
                     break;
                 case COMPRESSION_FORMAT_ZSTD:
-                    mimeTypeRef = "application/zstd";
+                    mimeType = "application/zstd";
                     compressionOut = new CompressorStreamFactory().createCompressorOutputStream(compressionFormat.toLowerCase(), bufferedOut);
                     break;
                 default:
-                    mimeTypeRef = "application/json";
+                    mimeType = "application/json";
                     compressionOut = out;
             }
         } catch (CompressorException e) {
@@ -217,7 +228,7 @@ public class JsonRecordSetWriter extends DateTimeTextRecordSetWriter implements 
         }
 
         return new WriteJsonResult(logger, schema, getSchemaAccessWriter(schema, variables), compressionOut, prettyPrint, nullSuppression, outputGrouping,
-                getDateFormat().orElse(null), getTimeFormat().orElse(null), getTimestampFormat().orElse(null), mimeTypeRef);
+                getDateFormat().orElse(null), getTimeFormat().orElse(null), getTimestampFormat().orElse(null), mimeType, allowScientificNotation);
     }
 
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestWriteJsonResult.java
@@ -55,8 +55,81 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestWriteJsonResult {
+
+    @Test
+    public void testScientificNotationUsage() throws IOException {
+        final List<RecordField> fields = new ArrayList<>();
+        fields.add(new RecordField("float", RecordFieldType.FLOAT.getDataType()));
+        fields.add(new RecordField("double", RecordFieldType.DOUBLE.getDataType()));
+        fields.add(new RecordField("decimal", RecordFieldType.DECIMAL.getDecimalDataType(5, 10)));
+        final RecordSchema schema = new SimpleRecordSchema(fields);
+
+        final String expectedWithScientificNotation = "{\"float\":-4.2910323,\"double\":4.51E-7,\"decimal\":8.0E-8}"
+                .trim();
+        final String expectedWithScientificNotationArray = "[" + expectedWithScientificNotation + "]";
+        final String expectedWithoutScientificNotation = "{\"float\":-4.2910323,\"double\":0.000000451,\"decimal\":0.000000080}".trim();
+        final String expectedWithoutScientificNotationArray = "[" + expectedWithoutScientificNotation + "]";
+
+        final Map<String, Object> values = new HashMap<>();
+        values.put("float", -4.291032244F);
+        values.put("double", 0.000000451D);
+        values.put("decimal", new BigDecimal("0.000000080"));
+        final Record record = new MapRecord(schema, values);
+
+        final String withScientificNotation = writeRecord(record, true, false);
+        assertEquals(expectedWithScientificNotationArray, withScientificNotation);
+
+        // We cannot be sure of the ordering when writing the raw record
+        final String rawWithScientificNotation = writeRecord(record, true, true);
+        assertTrue(rawWithScientificNotation.contains("\"float\":-4.2910323"));
+        assertTrue(rawWithScientificNotation.contains("\"double\":4.51E-7"));
+        assertTrue(rawWithScientificNotation.contains("\"decimal\":8.0E-8"));
+
+        final String withoutScientificNotation = writeRecord(record, false, false);
+        assertEquals(expectedWithoutScientificNotationArray, withoutScientificNotation);
+
+        // We cannot be sure of the ordering when writing the raw record
+        final String rawWithoutScientificNotation = writeRecord(record, false, true);
+        assertTrue(rawWithoutScientificNotation.contains("\"float\":-4.2910323"));
+        assertTrue(rawWithoutScientificNotation.contains("\"double\":0.000000451"));
+        assertTrue(rawWithoutScientificNotation.contains("\"decimal\":0.000000080"));
+
+        final Record recordWithSerializedForm = new MapRecord(schema, values, SerializedForm.of(expectedWithScientificNotation, "application/json"));
+        final String writtenWith = writeRecord(recordWithSerializedForm, true, false);
+        assertEquals(expectedWithScientificNotationArray, writtenWith);
+
+        final String writtenWithout = writeRecord(recordWithSerializedForm, false, false);
+        assertEquals(expectedWithoutScientificNotationArray, writtenWithout);
+
+        // We cannot be sure of the ordering when writing the raw record
+        final String writtenWithoutRaw = writeRecord(recordWithSerializedForm, false, true);
+        assertTrue(writtenWithoutRaw.contains("\"float\":-4.2910323"));
+        assertTrue(writtenWithoutRaw.contains("\"double\":0.000000451"));
+        assertTrue(writtenWithoutRaw.contains("\"decimal\":0.000000080"));
+    }
+
+    private String writeRecord(final Record record, final boolean allowScientificNotation, final boolean writeRawRecord) throws IOException {
+        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             final WriteJsonResult writer = new WriteJsonResult(Mockito.mock(ComponentLog.class), record.getSchema(), new SchemaNameAsAttribute(), baos, false,
+                 NullSuppression.NEVER_SUPPRESS, OutputGrouping.OUTPUT_ARRAY, RecordFieldType.DATE.getDefaultFormat(),
+                 RecordFieldType.TIME.getDefaultFormat(), RecordFieldType.TIMESTAMP.getDefaultFormat(), "application/json", allowScientificNotation)) {
+
+            writer.beginRecordSet();
+            if (writeRawRecord) {
+                writer.writeRawRecord(record);
+            } else {
+                writer.write(record);
+            }
+
+            writer.finishRecordSet();
+            writer.flush();
+
+            return baos.toString(StandardCharsets.UTF_8.name());
+        }
+    }
 
     @Test
     void testDataTypes() throws IOException, ParseException {
@@ -116,7 +189,7 @@ class TestWriteJsonResult {
             writer.write(rs);
         }
 
-        final String output = baos.toString("UTF-8");
+        final String output = baos.toString(StandardCharsets.UTF_8.name());
 
         final String expected = new String(Files.readAllBytes(Paths.get("src/test/resources/json/output/dataTypes.json")));
         assertEquals(StringUtils.deleteWhitespace(expected), StringUtils.deleteWhitespace(output));
@@ -555,7 +628,7 @@ class TestWriteJsonResult {
 
         final byte[] data = baos.toByteArray();
 
-        final String output = new String(data, StandardCharsets.UTF_8);
+        final String output = new String(data, StandardCharsets.UTF_8.name());
         assertEquals(json, output);
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13084](https://issues.apache.org/jira/browse/NIFI-13084)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `support/nifi-1.x` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x ] JDK 8

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
