### PR TITLE
NIFI-13097 Set project.version in Python Extension Processors

### DIFF
--- a/nifi-python-extensions/nifi-openai-module/pom.xml
+++ b/nifi-python-extensions/nifi-openai-module/pom.xml
@@ -35,6 +35,7 @@
                     <resources>
                         <resource>
                             <directory>src/main/python</directory>
+                            <filtering>true</filtering>
                             <includes>
                                 <include>**/</include>
                             </includes>

--- a/nifi-python-extensions/nifi-openai-module/src/main/python/PromptChatGPT.py
+++ b/nifi-python-extensions/nifi-openai-module/src/main/python/PromptChatGPT.py
@@ -30,7 +30,7 @@ class PromptChatGPT(FlowFileTransform):
         implements = ['org.apache.nifi.python.processor.FlowFileTransform']
 
     class ProcessorDetails:
-        version = '2.0.0-SNAPSHOT'
+        version = '@project.version@'
         description = "Submits a prompt to ChatGPT, writing the results either to a FlowFile attribute or to the contents of the FlowFile"
         tags = ["text", "chatgpt", "gpt", "machine learning", "ML", "artificial intelligence", "ai", "document", "langchain"]
         dependencies = ['langchain==0.1.2', 'openai==1.9.0', 'jsonpath-ng']

--- a/nifi-python-extensions/nifi-text-embeddings-module/pom.xml
+++ b/nifi-python-extensions/nifi-text-embeddings-module/pom.xml
@@ -35,6 +35,7 @@
                     <resources>
                         <resource>
                             <directory>src/main/python</directory>
+                            <filtering>true</filtering>
                             <includes>
                                 <include>**/</include>
                             </includes>

--- a/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/ChunkDocument.py
+++ b/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/ChunkDocument.py
@@ -104,7 +104,7 @@ class ChunkDocument(FlowFileTransform):
     class Java:
         implements = ['org.apache.nifi.python.processor.FlowFileTransform']
     class ProcessorDetails:
-        version = '2.0.0-SNAPSHOT'
+        version = '@project.version@'
         description = """Chunks incoming documents that are formatted as JSON Lines into chunks that are appropriately sized for creating Text Embeddings.
             The input is expected to be in "json-lines" format, with each line having a 'text' and a 'metadata' element.
             Each line will then be split into one or more lines in the output."""

--- a/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/ParseDocument.py
+++ b/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/ParseDocument.py
@@ -45,7 +45,7 @@ class ParseDocument(FlowFileTransform):
         implements = ["org.apache.nifi.python.processor.FlowFileTransform"]
 
     class ProcessorDetails:
-        version = "2.0.0-SNAPSHOT"
+        version = '@project.version@'
         description = """Parses incoming unstructured text documents and performs optical character recognition (OCR) in order to extract text from PDF and image files.
             The output is formatted as "json-lines" with two keys: 'text' and 'metadata'.
             Note that use of this Processor may require significant storage space and RAM utilization due to third-party dependencies necessary for processing PDF and image files.

--- a/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/vectorstores/PutChroma.py
+++ b/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/vectorstores/PutChroma.py
@@ -26,7 +26,7 @@ class PutChroma(FlowFileTransform):
         implements = ['org.apache.nifi.python.processor.FlowFileTransform']
 
     class ProcessorDetails:
-        version = '2.0.0-SNAPSHOT'
+        version = '@project.version@'
         description = """Publishes JSON data to a Chroma VectorDB. The Incoming data must be in single JSON per Line format, each with two keys: 'text' and 'metadata'.
                        The text must be a string, while metadata must be a map with strings for values. Any additional fields will be ignored. If the collection name specified
                        does not exist, the Processor will automatically create the collection."""

--- a/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/vectorstores/PutPinecone.py
+++ b/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/vectorstores/PutPinecone.py
@@ -52,7 +52,7 @@ class PutPinecone(FlowFileTransform):
         implements = ['org.apache.nifi.python.processor.FlowFileTransform']
 
     class ProcessorDetails:
-        version = '2.0.0-SNAPSHOT'
+        version = '@project.version@'
         description = """Publishes JSON data to Pinecone. The Incoming data must be in single JSON per Line format, each with two keys: 'text' and 'metadata'.
                        The text must be a string, while metadata must be a map with strings for values. Any additional fields will be ignored."""
         tags = ["pinecone", "vector", "vectordb", "vectorstore", "embeddings", "ai", "artificial intelligence", "ml", "machine learning", "text", "LLM"]

--- a/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/vectorstores/QueryChroma.py
+++ b/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/vectorstores/QueryChroma.py
@@ -27,7 +27,7 @@ class QueryChroma(FlowFileTransform):
         implements = ['org.apache.nifi.python.processor.FlowFileTransform']
 
     class ProcessorDetails:
-        version = '2.0.0-SNAPSHOT'
+        version = '@project.version@'
         description = "Queries a Chroma Vector Database in order to gather a specified number of documents that are most closely related to the given query."
         tags = ["chroma", "vector", "vectordb", "embeddings", "enrich", "enrichment", "ai", "artificial intelligence", "ml", "machine learning", "text", "LLM"]
 

--- a/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/vectorstores/QueryPinecone.py
+++ b/nifi-python-extensions/nifi-text-embeddings-module/src/main/python/vectorstores/QueryPinecone.py
@@ -27,7 +27,7 @@ class QueryPinecone(FlowFileTransform):
         implements = ['org.apache.nifi.python.processor.FlowFileTransform']
 
     class ProcessorDetails:
-        version = '2.0.0-SNAPSHOT'
+        version = '@project.version@'
         description = "Queries Pinecone in order to gather a specified number of documents that are most closely related to the given query."
         tags = ["pinecone", "vector", "vectordb", "vectorstore", "embeddings", "ai", "artificial intelligence", "ml", "machine learning", "text", "LLM"]
 


### PR DESCRIPTION
# Summary

[NIFI-13097](https://issues.apache.org/jira/browse/NIFI-13097) Sets the current project version in Python Processors under the `nifi-python-extensions` directory using standard Maven resource filtering. Enabling resource filtering for the existing plugin configuration and setting the `version` field using the `project.version` placeholder allows the packaged Processor to reflect the current version. This change enables Python Processors to reflect the current project during standard build and release processing.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
