### PR TITLE
NIFI-13116 PutDatabaseRecord (INSERT_IGNORE) uses Update keys while n…

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MySQLDatabaseAdapter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MySQLDatabaseAdapter.java
@@ -87,9 +87,6 @@ public class MySQLDatabaseAdapter extends GenericDatabaseAdapter {
         if (columnNames == null || columnNames.isEmpty()) {
             throw new IllegalArgumentException("Column names cannot be null or empty");
         }
-        if (uniqueKeyColumnNames == null || uniqueKeyColumnNames.isEmpty()) {
-            throw new IllegalArgumentException("Key column names cannot be null or empty");
-        }
 
         String columns = columnNames.stream()
                 .collect(Collectors.joining(", "));
@@ -121,9 +118,6 @@ public class MySQLDatabaseAdapter extends GenericDatabaseAdapter {
         }
         if (columnNames == null || columnNames.isEmpty()) {
             throw new IllegalArgumentException("Column names cannot be null or empty");
-        }
-        if (uniqueKeyColumnNames == null || uniqueKeyColumnNames.isEmpty()) {
-            throw new IllegalArgumentException("Key column names cannot be null or empty");
         }
 
         String columns = columnNames.stream()

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PostgreSQLDatabaseAdapter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PostgreSQLDatabaseAdapter.java
@@ -68,9 +68,6 @@ public class PostgreSQLDatabaseAdapter extends GenericDatabaseAdapter {
         if (columnNames == null || columnNames.isEmpty()) {
             throw new IllegalArgumentException("Column names cannot be null or empty");
         }
-        if (uniqueKeyColumnNames == null || uniqueKeyColumnNames.isEmpty()) {
-            throw new IllegalArgumentException("Key column names cannot be null or empty");
-        }
 
         String columns = columnNames.stream()
                 .collect(Collectors.joining(", "));
@@ -107,9 +104,6 @@ public class PostgreSQLDatabaseAdapter extends GenericDatabaseAdapter {
         }
         if (columnNames == null || columnNames.isEmpty()) {
             throw new IllegalArgumentException("Column names cannot be null or empty");
-        }
-        if (uniqueKeyColumnNames == null || uniqueKeyColumnNames.isEmpty()) {
-            throw new IllegalArgumentException("Key column names cannot be null or empty");
         }
 
         String columns = columnNames.stream()


### PR DESCRIPTION
…ot specified

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13116](https://issues.apache.org/jira/browse/NIFI-13116)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
