### PR TITLE
[NIFI-13142] configure typography

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package-lock.json
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package-lock.json
@@ -33,7 +33,6 @@
                 "ngx-skeleton-loader": "^8.1.0",
                 "rxjs": "~7.8.1",
                 "tslib": "^2.6.2",
-                "webfontloader": "^1.6.28",
                 "zone.js": "0.14.4"
             },
             "devDependencies": {
@@ -56,7 +55,6 @@
                 "@types/d3": "^7.4.3",
                 "@types/humanize-duration": "^3.27.3",
                 "@types/jest": "^29.5.12",
-                "@types/webfontloader": "^1.6.38",
                 "@typescript-eslint/eslint-plugin": "6.21.0",
                 "@typescript-eslint/parser": "6.21.0",
                 "autoprefixer": "^10.4.16",
@@ -73,15 +71,6 @@
             },
             "engines": {
                 "node": ">=22.0.0"
-            }
-        },
-        "node_modules/@aashutoshrathi/word-wrap": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -153,12 +142,12 @@
             }
         },
         "node_modules/@angular-devkit/architect": {
-            "version": "0.1703.4",
-            "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.4.tgz",
-            "integrity": "sha512-o+XCMOiMh8tmQGEwcxjAj2/lmUVT7CGSUAM31ydDomVOFFw4CnBvsoyKqQNRC+/AUXvovb2dCegQl/lTAnrwOg==",
+            "version": "0.1703.6",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.6.tgz",
+            "integrity": "sha512-Ck501FD/QuOjeKVFs7hU92w8+Ffetv0d5Sq09XY2/uygo5c/thMzp9nkevaIWBxUSeU5RqYZizDrhFVgYzbbOw==",
             "dev": true,
             "dependencies": {
-                "@angular-devkit/core": "17.3.4",
+                "@angular-devkit/core": "17.3.6",
                 "rxjs": "7.8.1"
             },
             "engines": {
@@ -168,9 +157,9 @@
             }
         },
         "node_modules/@angular-devkit/architect/node_modules/@angular-devkit/core": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.4.tgz",
-            "integrity": "sha512-vE69/Db555NTRPh+LUFO3rAQBbv7QGrK59F7chRggDZKamtCq/FfhEg2O+0BXQnUitOQN6WgQ79+payFYWyCCg==",
+            "version": "17.3.6",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.6.tgz",
+            "integrity": "sha512-FVbkT9dEwHEvjnxr4mvMNSMg2bCFoGoP4X68xXU9dhLEUpC05opLvfbaR3Qh543eCJ5AstosBFVzB/krfIkOvA==",
             "dev": true,
             "dependencies": {
                 "ajv": "8.12.0",
@@ -1862,9 +1851,9 @@
             }
         },
         "node_modules/@angular/animations": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-17.3.4.tgz",
-            "integrity": "sha512-2nBgXRdTSVPZMueV6ZJjajDRucwJBLxwiVhGafk/nI5MJF0Yss/Jfp2Kfzk5Xw2AqGhz0rd00IyNNUQIzO2mlw==",
+            "version": "17.3.7",
+            "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-17.3.7.tgz",
+            "integrity": "sha512-ahenGALPPweeHgqtl9BMkGIAV4fUNI5kOWUrLNbKBfwIJN+aOBOYV1Jz6NKUQq6eYn/1ZYtm0f3lIkHIdtLKEw==",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1872,13 +1861,13 @@
                 "node": "^18.13.0 || >=20.9.0"
             },
             "peerDependencies": {
-                "@angular/core": "17.3.4"
+                "@angular/core": "17.3.7"
             }
         },
         "node_modules/@angular/cdk": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-17.3.4.tgz",
-            "integrity": "sha512-/wbKUbc0YC3HGE2TCgW7D07Q99PZ/5uoRvMyWw0/wHa8VLNavXZPecbvtyLs//3HnqoCMSUFE7E2Mrd7jAWfcA==",
+            "version": "17.3.7",
+            "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-17.3.7.tgz",
+            "integrity": "sha512-aFEh8tzKFOwini6aNEp57S54Ocp9T7YIJfBVMESptu2TCPdMTlJ1HJTg5XS8NcQO+vwi9cFPGVwGF1frOx4LXA==",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2058,9 +2047,9 @@
             "dev": true
         },
         "node_modules/@angular/common": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.4.tgz",
-            "integrity": "sha512-rEsmtwUMJaNvaimh9hwaHdDLXaOIrjEnYdhmJUvDaKPQaFfSbH3CGGVz9brUyzVJyiWJYkYM0ssxavczeiEe8g==",
+            "version": "17.3.7",
+            "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.7.tgz",
+            "integrity": "sha512-A7LRJu1vVCGGgrfZXjU+njz50SiU4weheKCar5PIUprcdIofS1IrHAJDqYh+kwXxkjXbZMOr/ijQY0+AESLEsw==",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2068,14 +2057,14 @@
                 "node": "^18.13.0 || >=20.9.0"
             },
             "peerDependencies": {
-                "@angular/core": "17.3.4",
+                "@angular/core": "17.3.7",
                 "rxjs": "^6.5.3 || ^7.4.0"
             }
         },
         "node_modules/@angular/compiler": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.4.tgz",
-            "integrity": "sha512-YrDClIzgj6nQwiYHrfV6AkT1C5LCDgJh+LICus/2EY1w80j1Qf48Zh4asictReePdVE2Tarq6dnpDh4RW6LenQ==",
+            "version": "17.3.7",
+            "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.7.tgz",
+            "integrity": "sha512-AlKiqPoxnrpQ0hn13fIaQPSVodaVAIjBW4vpFyuKFqs2LBKg6iolwZ21s8rEI0KR2gXl+8ugj0/UZ6YADiVM5w==",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2083,7 +2072,7 @@
                 "node": "^18.13.0 || >=20.9.0"
             },
             "peerDependencies": {
-                "@angular/core": "17.3.4"
+                "@angular/core": "17.3.7"
             },
             "peerDependenciesMeta": {
                 "@angular/core": {
@@ -2092,9 +2081,9 @@
             }
         },
         "node_modules/@angular/compiler-cli": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.4.tgz",
-            "integrity": "sha512-TVWjpZSI/GIXTYsmVgEKYjBckcW8Aj62DcxLNehRFR+c7UB95OY3ZFjU8U4jL0XvWPgTkkVWQVq+P6N4KCBsyw==",
+            "version": "17.3.7",
+            "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.7.tgz",
+            "integrity": "sha512-vSg5IQZ9jGmvYjpbfH8KbH4Sl1IVeE+Mr1ogcxkGEsURSRvKo7EWc0K7LSEI9+gg0VLamMiP9EyCJdPxiJeLJQ==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "7.23.9",
@@ -2115,14 +2104,14 @@
                 "node": "^18.13.0 || >=20.9.0"
             },
             "peerDependencies": {
-                "@angular/compiler": "17.3.4",
+                "@angular/compiler": "17.3.7",
                 "typescript": ">=5.2 <5.5"
             }
         },
         "node_modules/@angular/core": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.4.tgz",
-            "integrity": "sha512-fvhBkfa/DDBzp1UcNzSxHj+Z9DebSS/o9pZpZlbu/0uEiu9hScmScnhaty5E0EbutzHB0SVUCz7zZuDeAywvWg==",
+            "version": "17.3.7",
+            "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.7.tgz",
+            "integrity": "sha512-HWcrbxqnvIMSxFuQdN0KPt08bc87hqr0LKm89yuRTUwx/2sNJlNQUobk6aJj4trswGBttcRDT+GOS4DQP2Nr4g==",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2135,9 +2124,9 @@
             }
         },
         "node_modules/@angular/forms": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-17.3.4.tgz",
-            "integrity": "sha512-XWA/FAs0r7VRdztMIfGU9EE0Chj+1U/sDnzJK3ZPO0n8F8oDAEWGJyiw8GIyWTLs+mz43thVIED3DhbRNsXbWw==",
+            "version": "17.3.7",
+            "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-17.3.7.tgz",
+            "integrity": "sha512-FEhXh/VmT++XCoO8i7bBtzxG7Am/cE1zrr9aF+fWW+4jpWvJvVN1IaSiJxgBB+iPsOJ9lTBRwfRW3onlcDkhrw==",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2145,16 +2134,16 @@
                 "node": "^18.13.0 || >=20.9.0"
             },
             "peerDependencies": {
-                "@angular/common": "17.3.4",
-                "@angular/core": "17.3.4",
-                "@angular/platform-browser": "17.3.4",
+                "@angular/common": "17.3.7",
+                "@angular/core": "17.3.7",
+                "@angular/platform-browser": "17.3.7",
                 "rxjs": "^6.5.3 || ^7.4.0"
             }
         },
         "node_modules/@angular/material": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular/material/-/material-17.3.4.tgz",
-            "integrity": "sha512-SgCroIlHKt3s9pTEYlhW4ww6Gm1sIzJKuk0wlputPZvQS5PTJ8YY8vDg4QohpQcltlaXCbutt4qw+CBNU9W9iA==",
+            "version": "17.3.7",
+            "resolved": "https://registry.npmjs.org/@angular/material/-/material-17.3.7.tgz",
+            "integrity": "sha512-wjSKkk9KZE8QiBPkMd5axh5u/3pUSxoLKNO7OasFhEagMmSv5oYTLm40cErhtb4UdkSmbC19WuuluS6P3leoPA==",
             "dependencies": {
                 "@material/animation": "15.0.0-canary.7f224ddd4.0",
                 "@material/auto-init": "15.0.0-canary.7f224ddd4.0",
@@ -2207,7 +2196,7 @@
             },
             "peerDependencies": {
                 "@angular/animations": "^17.0.0 || ^18.0.0",
-                "@angular/cdk": "17.3.4",
+                "@angular/cdk": "17.3.7",
                 "@angular/common": "^17.0.0 || ^18.0.0",
                 "@angular/core": "^17.0.0 || ^18.0.0",
                 "@angular/forms": "^17.0.0 || ^18.0.0",
@@ -2216,9 +2205,9 @@
             }
         },
         "node_modules/@angular/platform-browser": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.4.tgz",
-            "integrity": "sha512-W2nH9WSQJfdNG4HH9B1Cvj5CTmy9gF3321I+65Tnb8jFmpeljYDBC/VVUhTZUCRpg8udMWeMHEQHuSb8CbozmQ==",
+            "version": "17.3.7",
+            "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.7.tgz",
+            "integrity": "sha512-Nn8ZMaftAvO9dEwribWdNv+QBHhYIBrRkv85G6et80AXfXoYAr/xcfnQECRFtZgPmANqHC5auv/xrmExQG+Yeg==",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2226,9 +2215,9 @@
                 "node": "^18.13.0 || >=20.9.0"
             },
             "peerDependencies": {
-                "@angular/animations": "17.3.4",
-                "@angular/common": "17.3.4",
-                "@angular/core": "17.3.4"
+                "@angular/animations": "17.3.7",
+                "@angular/common": "17.3.7",
+                "@angular/core": "17.3.7"
             },
             "peerDependenciesMeta": {
                 "@angular/animations": {
@@ -2237,9 +2226,9 @@
             }
         },
         "node_modules/@angular/platform-browser-dynamic": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.4.tgz",
-            "integrity": "sha512-S53jPyQtInVYkjdGEFt4dxM1NrHNkWCvXGRsCO7Uh+laDf1OpIDp9YHf49OZohYLajJradN6y4QfdZL6IUwXKA==",
+            "version": "17.3.7",
+            "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-17.3.7.tgz",
+            "integrity": "sha512-9c2I4u0L1p2v1/lW8qy+WaNHisUWbyy6wqsv2v9FfCaSM49Lxymgo9LPFPC4qEG5ei5nE+eIQ2ocRiXXsf5QkQ==",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2247,16 +2236,16 @@
                 "node": "^18.13.0 || >=20.9.0"
             },
             "peerDependencies": {
-                "@angular/common": "17.3.4",
-                "@angular/compiler": "17.3.4",
-                "@angular/core": "17.3.4",
-                "@angular/platform-browser": "17.3.4"
+                "@angular/common": "17.3.7",
+                "@angular/compiler": "17.3.7",
+                "@angular/core": "17.3.7",
+                "@angular/platform-browser": "17.3.7"
             }
         },
         "node_modules/@angular/router": {
-            "version": "17.3.4",
-            "resolved": "https://registry.npmjs.org/@angular/router/-/router-17.3.4.tgz",
-            "integrity": "sha512-B1zjUYyhN66dp47zdF96NRwo0dEdM5In4Ob8HN64PAbnaK3y1EPp31aN6EGernPvKum1ibgwSZw+Uwnbkuv7Ww==",
+            "version": "17.3.7",
+            "resolved": "https://registry.npmjs.org/@angular/router/-/router-17.3.7.tgz",
+            "integrity": "sha512-lMkuRrc1ZjP5JPDxNHqoAhB0uAnfPQ/q6mJrw1s8IZoVV6VyM+FxR5r13ajNcXWC38xy/YhBjpXPF1vBdxuLXg==",
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -2264,9 +2253,9 @@
                 "node": "^18.13.0 || >=20.9.0"
             },
             "peerDependencies": {
-                "@angular/common": "17.3.4",
-                "@angular/core": "17.3.4",
-                "@angular/platform-browser": "17.3.4",
+                "@angular/common": "17.3.7",
+                "@angular/core": "17.3.7",
+                "@angular/platform-browser": "17.3.7",
                 "rxjs": "^6.5.3 || ^7.4.0"
             }
         },
@@ -2402,19 +2391,19 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.4.tgz",
-            "integrity": "sha512-lG75yeuUSVu0pIcbhiYMXBXANHrpUPaOfu7ryAzskCgKUHuAxRQI5ssrtmF0X9UXldPlvT0XM/A4F44OXRt6iQ==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.5.tgz",
+            "integrity": "sha512-uRc4Cv8UQWnE4NXlYTIIdM7wfFkOqlFztcC/gVXDKohKoVB3OyonfelUBaJzSwpBntZ2KYGF/9S7asCHsXwW6g==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-member-expression-to-functions": "^7.23.0",
+                "@babel/helper-member-expression-to-functions": "^7.24.5",
                 "@babel/helper-optimise-call-expression": "^7.22.5",
                 "@babel/helper-replace-supers": "^7.24.1",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/helper-split-export-declaration": "^7.24.5",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -2422,6 +2411,18 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-create-class-features-plugin/node_modules/@babel/helper-split-export-declaration": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+            "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.24.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
@@ -2460,9 +2461,9 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.1.tgz",
-            "integrity": "sha512-o7SDgTJuvx5vLKD6SFvkydkSMBvahDKGiNJzG22IZYXhiqoe9efY7zocICBgzHV4IRg5wdgl2nEL/tulKIEIbA==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
+            "integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-compilation-targets": "^7.22.6",
@@ -2510,12 +2511,12 @@
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
-            "integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.5.tgz",
+            "integrity": "sha512-4owRteeihKWKamtqg4JmWSsEZU445xpFRXPEwp44HbgbxdWlUV1b4Agg4lkA806Lil5XM/e+FJyS0vj5T6vmcA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.23.0"
+                "@babel/types": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2534,22 +2535,34 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-            "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz",
+            "integrity": "sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-module-imports": "^7.22.15",
-                "@babel/helper-simple-access": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/helper-validator-identifier": "^7.22.20"
+                "@babel/helper-module-imports": "^7.24.3",
+                "@babel/helper-simple-access": "^7.24.5",
+                "@babel/helper-split-export-declaration": "^7.24.5",
+                "@babel/helper-validator-identifier": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms/node_modules/@babel/helper-split-export-declaration": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+            "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.24.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
@@ -2565,9 +2578,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
-            "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
+            "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -2608,12 +2621,12 @@
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-            "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz",
+            "integrity": "sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2653,9 +2666,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+            "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -2671,40 +2684,40 @@
             }
         },
         "node_modules/@babel/helper-wrap-function": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.20.tgz",
-            "integrity": "sha512-pms/UwkOpnQe/PDAEdV/d7dVCoBbB+R4FvYoHGZz+4VPcg7RtYy2KP7S2lbuWM6FCSgob5wshfGESbC/hzNXZw==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.24.5.tgz",
+            "integrity": "sha512-/xxzuNvgRl4/HLNKvnFwdhdgN3cpLxgLROeLDl83Yx0AJ1SGvq1ak0OszTOjDfiB8Vx03eJbeDWh9r+jCCWttw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-function-name": "^7.22.5",
-                "@babel/template": "^7.22.15",
-                "@babel/types": "^7.22.19"
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/template": "^7.24.0",
+                "@babel/types": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
-            "integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
+            "integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.24.0",
-                "@babel/traverse": "^7.24.1",
-                "@babel/types": "^7.24.0"
+                "@babel/traverse": "^7.24.5",
+                "@babel/types": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.24.2",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-            "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
+            "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.20",
+                "@babel/helper-validator-identifier": "^7.24.5",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
@@ -2714,9 +2727,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
-            "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -3160,12 +3173,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.4.tgz",
-            "integrity": "sha512-nIFUZIpGKDf9O9ttyRXpHFpKC+X3Y5mtshZONuEUYBomAKoM4y029Jr+uB1bHGPhNmK8YXHevDtKDOLmtRrp6g==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.5.tgz",
+            "integrity": "sha512-sMfBc3OxghjC95BkYrYocHL3NaOplrcaunblzwXhGmlPwpmfsxr4vK+mBBt49r+S240vahmv+kUxkeKgs+haCw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3208,18 +3221,18 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.1.tgz",
-            "integrity": "sha512-ZTIe3W7UejJd3/3R4p7ScyyOoafetUShSf4kCqV0O7F/RiHxVj/wRaRnQlrGwflvcehNA8M42HkAiEDYZu2F1Q==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.5.tgz",
+            "integrity": "sha512-gWkLP25DFj2dwe9Ck8uwMOpko4YsqyfZJrOmqqcegeDYEbp7rmn4U6UQZNj08UF6MaX39XenSpKRCvpDRBtZ7Q==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
                 "@babel/helper-compilation-targets": "^7.23.6",
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-plugin-utils": "^7.24.5",
                 "@babel/helper-replace-supers": "^7.24.1",
-                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/helper-split-export-declaration": "^7.24.5",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -3227,6 +3240,18 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-classes/node_modules/@babel/helper-split-export-declaration": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+            "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.24.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties": {
@@ -3246,12 +3271,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.1.tgz",
-            "integrity": "sha512-ow8jciWqNxR3RYbSNVuF4U2Jx130nwnBnhRw6N6h1bOejNkABmcI5X5oz29K4alWX7vf1C+o6gtKXikzRKkVdw==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.5.tgz",
+            "integrity": "sha512-SZuuLyfxvsm+Ah57I/i1HVjveBENYK9ue8MJ7qkc7ndoNjqquJiElzA7f5yaAXjyW2hKojosOTAQQRX50bPSVg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3565,15 +3590,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-rest-spread": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.1.tgz",
-            "integrity": "sha512-XjD5f0YqOtebto4HGISLNfiNMTTs6tbkFf2TOqJlYKYmbo+mN9Dnpl4SRoofiziuOWMIyq3sZEUqLo3hLITFEA==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.5.tgz",
+            "integrity": "sha512-7EauQHszLGM3ay7a161tTQH7fj+3vVM/gThlz5HpFtnygTxjrlvoeq7MPVA1Vy9Q555OB8SnAOsMkLShNkkrHA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-compilation-targets": "^7.23.6",
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-plugin-utils": "^7.24.5",
                 "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-transform-parameters": "^7.24.1"
+                "@babel/plugin-transform-parameters": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3615,12 +3640,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.1.tgz",
-            "integrity": "sha512-n03wmDt+987qXwAgcBlnUUivrZBPZ8z1plL0YvgQalLm+ZE5BMhGm94jhxXtA1wzv1Cu2aaOv1BM9vbVttrzSg==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.5.tgz",
+            "integrity": "sha512-xWCkmwKT+ihmA6l7SSTpk8e4qQl/274iNbSKRRS8mpqFR32ksy36+a+LWY8OXCCEefF8WFlnOHVsaDI2231wBg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-plugin-utils": "^7.24.5",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.3"
             },
@@ -3632,12 +3657,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.1.tgz",
-            "integrity": "sha512-8Jl6V24g+Uw5OGPeWNKrKqXPDw2YDjLc53ojwfMcKwlEoETKU9rU0mHUtcg9JntWI/QYzGAXNWEcVHZ+fR+XXg==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.5.tgz",
+            "integrity": "sha512-9Co00MqZ2aoky+4j2jhofErthm6QVLKbpQrvz20c3CH9KQCLHyNB+t2ya4/UrRpQGR+Wrwjg9foopoeSdnHOkA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3663,14 +3688,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-property-in-object": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.1.tgz",
-            "integrity": "sha512-pTHxDVa0BpUbvAgX3Gat+7cSciXqUcY9j2VZKTbSB6+VQGpNgNO9ailxTGHSXlqOnX1Hcx1Enme2+yv7VqP9bg==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.5.tgz",
+            "integrity": "sha512-JM4MHZqnWR04jPMujQDTBVRnqxpLLpx2tkn7iPn+Hmsc0Gnb79yvRWOkvqFOx3Z7P7VxiRIR22c4eGSNj87OBQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-create-class-features-plugin": "^7.24.1",
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-create-class-features-plugin": "^7.24.5",
+                "@babel/helper-plugin-utils": "^7.24.5",
                 "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
             },
             "engines": {
@@ -3817,12 +3842,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.1.tgz",
-            "integrity": "sha512-CBfU4l/A+KruSUoW+vTQthwcAdwuqbpRNB8HQKlZABwHRhsdHZ9fezp4Sn18PeAlYxTNiLMlx4xUBV3AWfg1BA==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.5.tgz",
+            "integrity": "sha512-UTGnhYVZtTAjdwOTzT+sCyXmTn8AhaxOS/MjG9REclZ6ULHWF9KoCZur0HSGU7hk8PdBFKKbYe6+gqdXWz84Jg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.0"
+                "@babel/helper-plugin-utils": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3832,14 +3857,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.4.tgz",
-            "integrity": "sha512-79t3CQ8+oBGk/80SQ8MN3Bs3obf83zJ0YZjDmDaEZN8MqhMI760apl5z6a20kFeMXBwJX99VpKT8CKxEBp5H1g==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.5.tgz",
+            "integrity": "sha512-E0VWu/hk83BIFUWnsKZ4D81KXjN5L3MobvevOHErASk9IPwKHOkTgvqzvNo1yP/ePJWqqK2SpUR5z+KQbl6NVw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-create-class-features-plugin": "^7.24.4",
-                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-create-class-features-plugin": "^7.24.5",
+                "@babel/helper-plugin-utils": "^7.24.5",
                 "@babel/plugin-syntax-typescript": "^7.24.1"
             },
             "engines": {
@@ -4081,19 +4106,19 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
-            "integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
+            "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.24.1",
-                "@babel/generator": "^7.24.1",
+                "@babel/code-frame": "^7.24.2",
+                "@babel/generator": "^7.24.5",
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.24.1",
-                "@babel/types": "^7.24.0",
+                "@babel/helper-split-export-declaration": "^7.24.5",
+                "@babel/parser": "^7.24.5",
+                "@babel/types": "^7.24.5",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -4102,12 +4127,12 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/generator": {
-            "version": "7.24.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
-            "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+            "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.0",
+                "@babel/types": "^7.24.5",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
@@ -4116,14 +4141,26 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/types": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-            "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+        "node_modules/@babel/traverse/node_modules/@babel/helper-split-export-declaration": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+            "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.23.4",
-                "@babel/helper-validator-identifier": "^7.22.20",
+                "@babel/types": "^7.24.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -4686,14 +4723,14 @@
             }
         },
         "node_modules/@fontsource/roboto": {
-            "version": "5.0.12",
-            "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.0.12.tgz",
-            "integrity": "sha512-x0o17jvgoSSbS9OZnUX2+xJmVRvVCfeaYJjkS7w62iN7CuJWtMf5vJj8LqgC7ibqIkitOHVW+XssRjgrcHn62g=="
+            "version": "5.0.13",
+            "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.0.13.tgz",
+            "integrity": "sha512-j61DHjsdUCKMXSdNLTOxcG701FWnF0jcqNNQi2iPCDxU8seN/sMxeh62dC++UiagCWq9ghTypX+Pcy7kX+QOeQ=="
         },
         "node_modules/@fontsource/roboto-slab": {
-            "version": "5.0.19",
-            "resolved": "https://registry.npmjs.org/@fontsource/roboto-slab/-/roboto-slab-5.0.19.tgz",
-            "integrity": "sha512-rqZ+XbhNhLj8L0OnOFioQmd9ElpolZlOGqJSRCZHdjJPk4C6kmbQKO4rGvLrs18eIFCyoqc3dV8i4l2BGZswUQ=="
+            "version": "5.0.20",
+            "resolved": "https://registry.npmjs.org/@fontsource/roboto-slab/-/roboto-slab-5.0.20.tgz",
+            "integrity": "sha512-71QJs8SvE0xcVtBb/Jg2/1TKWb7wVaENXRpFLp8fz+sq9Rp/xoKQRMcHQ8yIUIfKlL+SI2z4tYqUViC0SuRzSQ=="
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.14",
@@ -6500,9 +6537,9 @@
             }
         },
         "node_modules/@npmcli/agent/node_modules/lru-cache": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-            "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+            "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
             "dev": true,
             "engines": {
                 "node": "14 || >=16.14"
@@ -6521,15 +6558,15 @@
             }
         },
         "node_modules/@npmcli/git": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.5.tgz",
-            "integrity": "sha512-x8hXItC8OFOwdgERzRIxg0ic1lQqW6kSZFFQtZTCNYOeGb9UqzVcod02TYljI9UBl4RtfcyQ0A7ygmcGFvEqWw==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.7.tgz",
+            "integrity": "sha512-WaOVvto604d5IpdCRV2KjQu8PzkfE96d50CQGKgywXh2GxXmDeUO5EWcBC4V57uFyrNqx83+MewuJh3WTR3xPA==",
             "dev": true,
             "dependencies": {
                 "@npmcli/promise-spawn": "^7.0.0",
                 "lru-cache": "^10.0.1",
                 "npm-pick-manifest": "^9.0.0",
-                "proc-log": "^3.0.0",
+                "proc-log": "^4.0.0",
                 "promise-inflight": "^1.0.1",
                 "promise-retry": "^2.0.1",
                 "semver": "^7.3.5",
@@ -6549,12 +6586,21 @@
             }
         },
         "node_modules/@npmcli/git/node_modules/lru-cache": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-            "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+            "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
             "dev": true,
             "engines": {
                 "node": "14 || >=16.14"
+            }
+        },
+        "node_modules/@npmcli/git/node_modules/proc-log": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+            "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+            "dev": true,
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@npmcli/git/node_modules/which": {
@@ -6573,16 +6619,16 @@
             }
         },
         "node_modules/@npmcli/installed-package-contents": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-2.0.2.tgz",
-            "integrity": "sha512-xACzLPhnfD51GKvTOOuNX2/V4G4mz9/1I2MfDoye9kBM3RYe5g2YbscsaGoTlaWqkxeiapBWyseULVKpSVHtKQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-2.1.0.tgz",
+            "integrity": "sha512-c8UuGLeZpm69BryRykLuKRyKFZYJsZSCT4aVY5ds4omyZqJ172ApzgfKJ5eV/r3HgLdUYgFVe54KSFVjKoe27w==",
             "dev": true,
             "dependencies": {
                 "npm-bundled": "^3.0.0",
                 "npm-normalize-package-bin": "^3.0.0"
             },
             "bin": {
-                "installed-package-contents": "lib/index.js"
+                "installed-package-contents": "bin/index.js"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -6598,9 +6644,9 @@
             }
         },
         "node_modules/@npmcli/package-json": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.2.tgz",
-            "integrity": "sha512-LmW+tueGSK+FCM3OpcKtwKKo3igpefh6HHiw23sGd8OdJ8l0GrfGfVdGOFVtJRMaXVnvI1RUdEPlB9VUln5Wbw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.1.0.tgz",
+            "integrity": "sha512-1aL4TuVrLS9sf8quCLerU3H9J4vtCtgu8VauYozrmEyU57i/EdKleCnsQ7vpnABIH6c9mnTxcH5sFkO3BlV8wQ==",
             "dev": true,
             "dependencies": {
                 "@npmcli/git": "^5.0.0",
@@ -6608,7 +6654,7 @@
                 "hosted-git-info": "^7.0.0",
                 "json-parse-even-better-errors": "^3.0.0",
                 "normalize-package-data": "^6.0.0",
-                "proc-log": "^3.0.0",
+                "proc-log": "^4.0.0",
                 "semver": "^7.5.3"
             },
             "engines": {
@@ -6637,10 +6683,19 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/@npmcli/package-json/node_modules/proc-log": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+            "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+            "dev": true,
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/@npmcli/promise-spawn": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.1.tgz",
-            "integrity": "sha512-P4KkF9jX3y+7yFUxgcUdDtLy+t4OlDGuEBLNs57AZsfSfg+uV6MLndqGpnl4831ggaEdXwR50XFoZP4VFtHolg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz",
+            "integrity": "sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==",
             "dev": true,
             "dependencies": {
                 "which": "^4.0.0"
@@ -6742,12 +6797,12 @@
             }
         },
         "node_modules/@nrwl/jest": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/jest/-/jest-18.2.4.tgz",
-            "integrity": "sha512-MGXmh/ZiT/C9GCMnI3hAGw9uKbR5W+ZjEUen6/2WkOglZvDaz40obI83PJTnK7XzcqUDzFAmWi3Y5eDSQxDvWQ==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nrwl/jest/-/jest-18.3.4.tgz",
+            "integrity": "sha512-pIYd8WBQz6DKfhIKkZn9VsNBPR0QGnbAdI9AfrQPoGfj19x3tzqLSjcg/O5UvIs6174U1b+0ccxWmQvFep22Kw==",
             "dev": true,
             "dependencies": {
-                "@nx/jest": "18.2.4"
+                "@nx/jest": "18.3.4"
             }
         },
         "node_modules/@nrwl/js": {
@@ -7039,16 +7094,16 @@
             }
         },
         "node_modules/@nx/jest": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-18.2.4.tgz",
-            "integrity": "sha512-rG3QtWOjkZnix6gu7CxUP3Wpnm7N/ynoOF1SGJAEm254m0YX7mlhyQA74TlXSvNiM5P9wT9NFvVhJDt8rePqwQ==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-18.3.4.tgz",
+            "integrity": "sha512-sWbrhz8RYZ7j1uUbyB7tvulnRncNwtnEEMIGYUrHSQB1of+aG+FA2VtI3KCoWrfzMc5EDl7DLpKY1VMW2ArWhQ==",
             "dev": true,
             "dependencies": {
                 "@jest/reporters": "^29.4.1",
                 "@jest/test-result": "^29.4.1",
-                "@nrwl/jest": "18.2.4",
-                "@nx/devkit": "18.2.4",
-                "@nx/js": "18.2.4",
+                "@nrwl/jest": "18.3.4",
+                "@nx/devkit": "18.3.4",
+                "@nx/js": "18.3.4",
                 "@phenomnomnominal/tsquery": "~5.0.1",
                 "chalk": "^4.1.0",
                 "identity-obj-proxy": "3.0.0",
@@ -7062,30 +7117,30 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nrwl/devkit": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-18.2.4.tgz",
-            "integrity": "sha512-dLK8MMb3eEFWlhtI1kNDNbWIT1Xbrgg3eAQ+Ix/N5JDbxJkJhE28WsIJgQb1NTwe/N87O5JtOpxz4/TsSLJCsQ==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-18.3.4.tgz",
+            "integrity": "sha512-Fty9Huqm12OYueU3uLJl3uvBUl5BvEyPfvw8+rLiNx9iftdEattM8C+268eAbIRRSLSOVXlWsJH4brlc6QZYYw==",
             "dev": true,
             "dependencies": {
-                "@nx/devkit": "18.2.4"
+                "@nx/devkit": "18.3.4"
             }
         },
         "node_modules/@nx/jest/node_modules/@nrwl/js": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/js/-/js-18.2.4.tgz",
-            "integrity": "sha512-/NZUOoR13BdKsuuuusNXH9wUDpWuPHIvHAQiI0hF16mmQOBJb+xz5M81+AtyTfF4ITKaMn+RV12mLesfo3zwxg==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nrwl/js/-/js-18.3.4.tgz",
+            "integrity": "sha512-oyiMoxzDVGQe5E4UFGO/WAOU211HEIdRxSEOfs1lPhvA8lKbUa0IWDqPOugNws/YHAr+vUTU3sZDJ3uU3RJuYQ==",
             "dev": true,
             "dependencies": {
-                "@nx/js": "18.2.4"
+                "@nx/js": "18.3.4"
             }
         },
         "node_modules/@nx/jest/node_modules/@nrwl/tao": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-18.2.4.tgz",
-            "integrity": "sha512-kgJwZ26F+AzvFXaW5eh1g4HLntPcJ6+EE7JyEvrdRzpw7KxTqWy6Ql7dYys6zGlpP4c3PbsXwdc7tGM3Df2PNg==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-18.3.4.tgz",
+            "integrity": "sha512-+7KsDYmGj1cvNaXZcjSYOPN1h17hsGFBtVX7MqnpJLLkQTUhKg2rQxqyluzshJ+RoDUVtYPGyHg1AizlB66RIA==",
             "dev": true,
             "dependencies": {
-                "nx": "18.2.4",
+                "nx": "18.3.4",
                 "tslib": "^2.3.0"
             },
             "bin": {
@@ -7093,21 +7148,21 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nrwl/workspace": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/workspace/-/workspace-18.2.4.tgz",
-            "integrity": "sha512-rlKDKyqwd8IFWwGFhJ0/KW0P+ae6gQEwzpF9P91DLC1BAEJt9gOA0GLKNy7XyhoPX2EvXg/GwDRGMqGxqKnFuQ==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nrwl/workspace/-/workspace-18.3.4.tgz",
+            "integrity": "sha512-ziPHZcSYj46aPYrRHaKu56/SmYCijLT5vIm/UaoWD5v5Fy5CRigO/ezUImsHGHMEZWfHt44s4jsv7QdJWAXe7w==",
             "dev": true,
             "dependencies": {
-                "@nx/workspace": "18.2.4"
+                "@nx/workspace": "18.3.4"
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/devkit": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-18.2.4.tgz",
-            "integrity": "sha512-Ws3BcA/aeXuwsCQ5e7PYy2H7DswareTOEfgs7izxNyGugpydktVH9DZZTOFNDsc06yzgvyTucDbDQ+JsrJ9PcQ==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-18.3.4.tgz",
+            "integrity": "sha512-M3htxl5WvlNKK5KNOndCAApbyBCZNTFFs+rtdwvudNZk5+84zAAPaWzSoX9C4XLAW78/f98LzF68/ch05aN12A==",
             "dev": true,
             "dependencies": {
-                "@nrwl/devkit": "18.2.4",
+                "@nrwl/devkit": "18.3.4",
                 "ejs": "^3.1.7",
                 "enquirer": "~2.3.6",
                 "ignore": "^5.0.4",
@@ -7117,13 +7172,13 @@
                 "yargs-parser": "21.1.1"
             },
             "peerDependencies": {
-                "nx": ">= 16 <= 18"
+                "nx": ">= 16 <= 19"
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/js": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/js/-/js-18.2.4.tgz",
-            "integrity": "sha512-ZZ32tSmd9ZvQ95AeFCCG4mvvbwbqTVB1qHwvpTfkTDPt41Ich+ITf3ugavtIpp/T47yP2KszJWBzTOH3UxlIqQ==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/js/-/js-18.3.4.tgz",
+            "integrity": "sha512-+MPacp/B09e5QwaFQBkev9pW862ZpmesqR2lUUnFAXUBKtjYVIAmhJWHOtevqC1om4OxvTsbluYHsbAkAUzlMA==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.23.2",
@@ -7133,9 +7188,9 @@
                 "@babel/preset-env": "^7.23.2",
                 "@babel/preset-typescript": "^7.22.5",
                 "@babel/runtime": "^7.22.6",
-                "@nrwl/js": "18.2.4",
-                "@nx/devkit": "18.2.4",
-                "@nx/workspace": "18.2.4",
+                "@nrwl/js": "18.3.4",
+                "@nx/devkit": "18.3.4",
+                "@nx/workspace": "18.3.4",
                 "@phenomnomnominal/tsquery": "~5.0.1",
                 "babel-plugin-const-enum": "^1.0.1",
                 "babel-plugin-macros": "^2.8.0",
@@ -7167,9 +7222,9 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/nx-darwin-arm64": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.2.4.tgz",
-            "integrity": "sha512-RYhMImghdyHmwnbNoR2CkLz4Opj9EmuHY3lMfsorg+T4wIOql/iXACrqjnreN7Hy9myJDo1EIbYZ4x8VSxFWtA==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-18.3.4.tgz",
+            "integrity": "sha512-MOGk9z4fIoOkJB68diH3bwoWrC8X9IzMNsz1mu0cbVfgCRAfIV3b+lMsiwQYzWal3UWW5DE5Rkss4F8whiV5Uw==",
             "cpu": [
                 "arm64"
             ],
@@ -7183,9 +7238,9 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/nx-darwin-x64": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-18.2.4.tgz",
-            "integrity": "sha512-2mXMslSRD/ZoI/oaX+0Mh9J/hucXtNgdwC4YFbp1u8UKquAaQ6hf4uo0s4i+AfLX0F7roMtkFPaG/+MQUJE1Rw==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-18.3.4.tgz",
+            "integrity": "sha512-tSzPRnNB3QdPM+KYiIuRCUtyCwcuIRC95FfP0ZB3WvfDeNxJChEAChNqmCMDE4iFvZhGuze8WqkJuIVdte+lyQ==",
             "cpu": [
                 "x64"
             ],
@@ -7199,9 +7254,9 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/nx-freebsd-x64": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.2.4.tgz",
-            "integrity": "sha512-QUiYLvyUT0PS7D8erf49xa1Jyw4Gfev5gtYfME34Twmn/JPx/99ZkBG4wHbzLqRGwlO5K6m6P4qs30Pzfwtw7A==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-18.3.4.tgz",
+            "integrity": "sha512-bjSPak/d+bcR95/pxHMRhnnpHc6MnrQcG6f5AjX15Esm4JdrdQKPBmG1RybuK0WKSyD5wgVhkAGc/QQUom9l8g==",
             "cpu": [
                 "x64"
             ],
@@ -7215,9 +7270,9 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/nx-linux-arm-gnueabihf": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.2.4.tgz",
-            "integrity": "sha512-+fjFciSUhvDV8dPa97Brwb83k3Xa4gHPI2Un8wlpp28Cv4horeGruRZrrifR1VmD2wp2UBIMl5n7YsDP8KvYhQ==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-18.3.4.tgz",
+            "integrity": "sha512-/1HnUL7jhH0S7PxJqf6R1pk3QlAU22GY89EQV9fd+RDUtp7IyzaTlkebijTIqfxlSjC4OO3bPizaxEaxdd3uKQ==",
             "cpu": [
                 "arm"
             ],
@@ -7231,9 +7286,9 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/nx-linux-arm64-gnu": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.2.4.tgz",
-            "integrity": "sha512-lfaTc+AvV56Uv5mXROiRwh2REiI/7IsqeRDfL+prcuuvJ5Oxi2wYVgnmqcHL+ryQnk0Qn7/d+j/BmYHX5Ve5jQ==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-18.3.4.tgz",
+            "integrity": "sha512-g/2IaB2bZTKaBNPEf9LxtIXb1XHdhh3VO9PnePIrwkkixPMLN0dTxT5Sttt75lvLP3EU1AUR5w3Aaz2Q1mYtWA==",
             "cpu": [
                 "arm64"
             ],
@@ -7247,9 +7302,9 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/nx-linux-arm64-musl": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.2.4.tgz",
-            "integrity": "sha512-U6eoLTQmbxUWU9kZxx6hsYN4zmmOrsDDeW+i3aj5aeahfYlmyz6TsT0V3FSB70WGJC5aMVgEi4RkntQMKkm5vQ==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-18.3.4.tgz",
+            "integrity": "sha512-MgfKLoEF6I1cCS+0ooFLEjJSSVdCYyCT9Q96IHRJntAEL8u/0GR2OUoBoLC+q1lnbIkJr/uqTJxA2Jh+sJTIbA==",
             "cpu": [
                 "arm64"
             ],
@@ -7263,9 +7318,9 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/nx-linux-x64-gnu": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.2.4.tgz",
-            "integrity": "sha512-q8WcJhmcRNORkKjax6WcUwMJe/1mQs+RYlUkGqmi7tD7lfcLSqdLPJVjqVmQAwmy1Wh/MHPsbqRwSerUnCxB1A==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-18.3.4.tgz",
+            "integrity": "sha512-vbHxv7m3gjthBvw50EYCtgyY0Zg5nVTaQtX+wRsmKybV2i7wHbw5zIe1aL4zHUm6TcPGbIQK+utVM+hyCqKHVA==",
             "cpu": [
                 "x64"
             ],
@@ -7279,9 +7334,9 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/nx-linux-x64-musl": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.2.4.tgz",
-            "integrity": "sha512-0MDuoPgHa6kkBrjg7hwZ2qQivhJbh3lk7r3q4osDrqZcGxq5XVJqeAmYFyChQy4dbQfUm4hhYkEfzpU8M2lnvQ==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-18.3.4.tgz",
+            "integrity": "sha512-qIJKJCYFRLVSALsvg3avjReOjuYk91Q0hFXMJ2KaEM1Y3tdzcFN0fKBiaHexgbFIUk8zJuS4dJObTqSYMXowbg==",
             "cpu": [
                 "x64"
             ],
@@ -7295,9 +7350,9 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/nx-win32-arm64-msvc": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.2.4.tgz",
-            "integrity": "sha512-uLhSRtfnXzN000Qf27GOjEPXzd4/jBWqv2x419IMh+AEtKHuCEpQNBUAyLvBbQ79SMr+FmCXHB8AeeJ7bEUiRw==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-18.3.4.tgz",
+            "integrity": "sha512-UxC8mRkFTPdZbKFprZkiBqVw8624xU38kI0xyooxKlFpt5lccTBwJ0B7+R8p1RoWyvh2DSyFI9VvfD7lczg1lA==",
             "cpu": [
                 "arm64"
             ],
@@ -7311,9 +7366,9 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/nx-win32-x64-msvc": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.2.4.tgz",
-            "integrity": "sha512-Y52Afz02Ub1kRZXd6NUTwPMjKQqBKZ35e5dUEpl14na2fWvdgdMz4bYOBPUcmQrovlxBGhmFXtFzxkdW3zyRbQ==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-18.3.4.tgz",
+            "integrity": "sha512-/RqEjNU9hxIBxRLafCNKoH3SaB2FShf+1ZnIYCdAoCZBxLJebDpnhiyrVs0lPnMj9248JbizEMdJj1+bs/bXig==",
             "cpu": [
                 "x64"
             ],
@@ -7327,16 +7382,16 @@
             }
         },
         "node_modules/@nx/jest/node_modules/@nx/workspace": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-18.2.4.tgz",
-            "integrity": "sha512-c3Bca6aBwhpMegvAXAyKO8+dBBZOej8EIVo7m22IXL7APbq+hRetoc0LBCa/wTRcEZpYYPGrN1PzfFZqME21+g==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-18.3.4.tgz",
+            "integrity": "sha512-H5HmEOWb9wnrNXfI2DhK6AmMVz1snuJvjT2jcMf9kxlVW0pKGTFW+OyHfSYq6Ni3OGWb1f9O63erLYHo45zPeA==",
             "dev": true,
             "dependencies": {
-                "@nrwl/workspace": "18.2.4",
-                "@nx/devkit": "18.2.4",
+                "@nrwl/workspace": "18.3.4",
+                "@nx/devkit": "18.3.4",
                 "chalk": "^4.1.0",
                 "enquirer": "~2.3.6",
-                "nx": "18.2.4",
+                "nx": "18.3.4",
                 "tslib": "^2.3.0",
                 "yargs-parser": "21.1.1"
             }
@@ -7428,13 +7483,13 @@
             "dev": true
         },
         "node_modules/@nx/jest/node_modules/nx": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/nx/-/nx-18.2.4.tgz",
-            "integrity": "sha512-GxqJcDOhfLa9jsPmip0jG73CZKA96wCryss2DhixCiCU66I3GLYF4+585ObO8Tx7Z1GqhT92RaNGjCxjMIwaPg==",
+            "version": "18.3.4",
+            "resolved": "https://registry.npmjs.org/nx/-/nx-18.3.4.tgz",
+            "integrity": "sha512-7rOHRyxpnZGJ3pHnwmpoAMHt9hNuwibWhOhPBJDhJVcbQJtGfwcWWyV/iSEnVXwKZ2lfHVE3TwE+gXFdT/GFiw==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@nrwl/tao": "18.2.4",
+                "@nrwl/tao": "18.3.4",
                 "@yarnpkg/lockfile": "^1.1.0",
                 "@yarnpkg/parsers": "3.0.0-rc.46",
                 "@zkochan/js-yaml": "0.0.6",
@@ -7474,16 +7529,16 @@
                 "nx-cloud": "bin/nx-cloud.js"
             },
             "optionalDependencies": {
-                "@nx/nx-darwin-arm64": "18.2.4",
-                "@nx/nx-darwin-x64": "18.2.4",
-                "@nx/nx-freebsd-x64": "18.2.4",
-                "@nx/nx-linux-arm-gnueabihf": "18.2.4",
-                "@nx/nx-linux-arm64-gnu": "18.2.4",
-                "@nx/nx-linux-arm64-musl": "18.2.4",
-                "@nx/nx-linux-x64-gnu": "18.2.4",
-                "@nx/nx-linux-x64-musl": "18.2.4",
-                "@nx/nx-win32-arm64-msvc": "18.2.4",
-                "@nx/nx-win32-x64-msvc": "18.2.4"
+                "@nx/nx-darwin-arm64": "18.3.4",
+                "@nx/nx-darwin-x64": "18.3.4",
+                "@nx/nx-freebsd-x64": "18.3.4",
+                "@nx/nx-linux-arm-gnueabihf": "18.3.4",
+                "@nx/nx-linux-arm64-gnu": "18.3.4",
+                "@nx/nx-linux-arm64-musl": "18.3.4",
+                "@nx/nx-linux-x64-gnu": "18.3.4",
+                "@nx/nx-linux-x64-musl": "18.3.4",
+                "@nx/nx-win32-arm64-msvc": "18.3.4",
+                "@nx/nx-win32-x64-msvc": "18.3.4"
             },
             "peerDependencies": {
                 "@swc-node/register": "^1.8.0",
@@ -8703,9 +8758,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.2.tgz",
-            "integrity": "sha512-ahxSgCkAEk+P/AVO0vYr7DxOD3CwAQrT0Go9BJyGQ9Ef0QxVOfjDZMiF4Y2s3mLyPrjonchIMH/tbWHucJMykQ==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.17.2.tgz",
+            "integrity": "sha512-NM0jFxY8bB8QLkoKxIQeObCaDlJKewVlIEkuyYKm5An1tdVZ966w2+MPQ2l8LBZLjR+SgyV+nRkTIunzOYBMLQ==",
             "cpu": [
                 "arm"
             ],
@@ -8716,9 +8771,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.2.tgz",
-            "integrity": "sha512-lAarIdxZWbFSHFSDao9+I/F5jDaKyCqAPMq5HqnfpBw8dKDiCaaqM0lq5h1pQTLeIqueeay4PieGR5jGZMWprw==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.17.2.tgz",
+            "integrity": "sha512-yeX/Usk7daNIVwkq2uGoq2BYJKZY1JfyLTaHO/jaiSwi/lsf8fTFoQW/n6IdAsx5tx+iotu2zCJwz8MxI6D/Bw==",
             "cpu": [
                 "arm64"
             ],
@@ -8729,9 +8784,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.2.tgz",
-            "integrity": "sha512-SWsr8zEUk82KSqquIMgZEg2GE5mCSfr9sE/thDROkX6pb3QQWPp8Vw8zOq2GyxZ2t0XoSIUlvHDkrf5Gmf7x3Q==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.17.2.tgz",
+            "integrity": "sha512-kcMLpE6uCwls023+kknm71ug7MZOrtXo+y5p/tsg6jltpDtgQY1Eq5sGfHcQfb+lfuKwhBmEURDga9N0ol4YPw==",
             "cpu": [
                 "arm64"
             ],
@@ -8742,9 +8797,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.2.tgz",
-            "integrity": "sha512-o/HAIrQq0jIxJAhgtIvV5FWviYK4WB0WwV91SLUnsliw1lSAoLsmgEEgRWzDguAFeUEUUoIWXiJrPqU7vGiVkA==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.17.2.tgz",
+            "integrity": "sha512-AtKwD0VEx0zWkL0ZjixEkp5tbNLzX+FCqGG1SvOu993HnSz4qDI6S4kGzubrEJAljpVkhRSlg5bzpV//E6ysTQ==",
             "cpu": [
                 "x64"
             ],
@@ -8755,9 +8810,22 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.2.tgz",
-            "integrity": "sha512-nwlJ65UY9eGq91cBi6VyDfArUJSKOYt5dJQBq8xyLhvS23qO+4Nr/RreibFHjP6t+5ap2ohZrUJcHv5zk5ju/g==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.17.2.tgz",
+            "integrity": "sha512-3reX2fUHqN7sffBNqmEyMQVj/CKhIHZd4y631duy0hZqI8Qoqf6lTtmAKvJFYa6bhU95B1D0WgzHkmTg33In0A==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.17.2.tgz",
+            "integrity": "sha512-uSqpsp91mheRgw96xtyAGP9FW5ChctTFEoXP0r5FAzj/3ZRv3Uxjtc7taRQSaQM/q85KEKjKsZuiZM3GyUivRg==",
             "cpu": [
                 "arm"
             ],
@@ -8768,9 +8836,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.2.tgz",
-            "integrity": "sha512-Pg5TxxO2IVlMj79+c/9G0LREC9SY3HM+pfAwX7zj5/cAuwrbfj2Wv9JbMHIdPCfQpYsI4g9mE+2Bw/3aeSs2rQ==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.17.2.tgz",
+            "integrity": "sha512-EMMPHkiCRtE8Wdk3Qhtciq6BndLtstqZIroHiiGzB3C5LDJmIZcSzVtLRbwuXuUft1Cnv+9fxuDtDxz3k3EW2A==",
             "cpu": [
                 "arm64"
             ],
@@ -8781,9 +8849,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.2.tgz",
-            "integrity": "sha512-cAOTjGNm84gc6tS02D1EXtG7tDRsVSDTBVXOLbj31DkwfZwgTPYZ6aafSU7rD/4R2a34JOwlF9fQayuTSkoclA==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.17.2.tgz",
+            "integrity": "sha512-NMPylUUZ1i0z/xJUIx6VUhISZDRT+uTWpBcjdv0/zkp7b/bQDF+NfnfdzuTiB1G6HTodgoFa93hp0O1xl+/UbA==",
             "cpu": [
                 "arm64"
             ],
@@ -8794,9 +8862,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.2.tgz",
-            "integrity": "sha512-4RyT6v1kXb7C0fn6zV33rvaX05P0zHoNzaXI/5oFHklfKm602j+N4mn2YvoezQViRLPnxP8M1NaY4s/5kXO5cw==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.17.2.tgz",
+            "integrity": "sha512-T19My13y8uYXPw/L/k0JYaX1fJKFT/PWdXiHr8mTbXWxjVF1t+8Xl31DgBBvEKclw+1b00Chg0hxE2O7bTG7GQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -8807,9 +8875,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.2.tgz",
-            "integrity": "sha512-KNUH6jC/vRGAKSorySTyc/yRYlCwN/5pnMjXylfBniwtJx5O7X17KG/0efj8XM3TZU7raYRXJFFReOzNmL1n1w==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.17.2.tgz",
+            "integrity": "sha512-BOaNfthf3X3fOWAB+IJ9kxTgPmMqPPH5f5k2DcCsRrBIbWnaJCgX2ll77dV1TdSy9SaXTR5iDXRL8n7AnoP5cg==",
             "cpu": [
                 "riscv64"
             ],
@@ -8820,9 +8888,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.2.tgz",
-            "integrity": "sha512-xPV4y73IBEXToNPa3h5lbgXOi/v0NcvKxU0xejiFw6DtIYQqOTMhZ2DN18/HrrP0PmiL3rGtRG9gz1QE8vFKXQ==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.17.2.tgz",
+            "integrity": "sha512-W0UP/x7bnn3xN2eYMql2T/+wpASLE5SjObXILTMPUBDB/Fg/FxC+gX4nvCfPBCbNhz51C+HcqQp2qQ4u25ok6g==",
             "cpu": [
                 "s390x"
             ],
@@ -8833,9 +8901,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.2.tgz",
-            "integrity": "sha512-QBhtr07iFGmF9egrPOWyO5wciwgtzKkYPNLVCFZTmr4TWmY0oY2Dm/bmhHjKRwZoGiaKdNcKhFtUMBKvlchH+Q==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.17.2.tgz",
+            "integrity": "sha512-Hy7pLwByUOuyaFC6mAr7m+oMC+V7qyifzs/nW2OJfC8H4hbCzOX07Ov0VFk/zP3kBsELWNFi7rJtgbKYsav9QQ==",
             "cpu": [
                 "x64"
             ],
@@ -8846,9 +8914,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.2.tgz",
-            "integrity": "sha512-8zfsQRQGH23O6qazZSFY5jP5gt4cFvRuKTpuBsC1ZnSWxV8ZKQpPqOZIUtdfMOugCcBvFGRa1pDC/tkf19EgBw==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.17.2.tgz",
+            "integrity": "sha512-h1+yTWeYbRdAyJ/jMiVw0l6fOOm/0D1vNLui9iPuqgRGnXA0u21gAqOyB5iHjlM9MMfNOm9RHCQ7zLIzT0x11Q==",
             "cpu": [
                 "x64"
             ],
@@ -8859,9 +8927,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.2.tgz",
-            "integrity": "sha512-H4s8UjgkPnlChl6JF5empNvFHp77Jx+Wfy2EtmYPe9G22XV+PMuCinZVHurNe8ggtwoaohxARJZbaH/3xjB/FA==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.17.2.tgz",
+            "integrity": "sha512-tmdtXMfKAjy5+IQsVtDiCfqbynAQE/TQRpWdVataHmhMb9DCoJxp9vLcCBjEQWMiUYxO1QprH/HbY9ragCEFLA==",
             "cpu": [
                 "arm64"
             ],
@@ -8872,9 +8940,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.2.tgz",
-            "integrity": "sha512-djqpAjm/i8erWYF0K6UY4kRO3X5+T4TypIqw60Q8MTqSBaQNpNXDhxdjpZ3ikgb+wn99svA7jxcXpiyg9MUsdw==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.17.2.tgz",
+            "integrity": "sha512-7II/QCSTAHuE5vdZaQEwJq2ZACkBpQDOmQsE6D6XUbnBHW8IAhm4eTufL6msLJorzrHDFv3CF8oCA/hSIRuZeQ==",
             "cpu": [
                 "ia32"
             ],
@@ -8885,9 +8953,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.2.tgz",
-            "integrity": "sha512-teAqzLT0yTYZa8ZP7zhFKEx4cotS8Tkk5XiqNMJhD4CpaWB1BHARE4Qy+RzwnXvSAYv+Q3jAqCVBS+PS+Yee8Q==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.17.2.tgz",
+            "integrity": "sha512-TGGO7v7qOq4CYmSBVEYpI1Y5xDuCEnbVC5Vth8mOsW0gDSzxNrVERPc790IGHsrT2dQSimgMr9Ub3Y1Jci5/8w==",
             "cpu": [
                 "x64"
             ],
@@ -9420,9 +9488,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.56.9",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.9.tgz",
-            "integrity": "sha512-W4W3KcqzjJ0sHg2vAq9vfml6OhsJ53TcUjUqfzzZf/EChUtwspszj/S0pzMxnfRcO55/iGq47dscXw71Fxc4Zg==",
+            "version": "8.56.10",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+            "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -9562,9 +9630,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.12.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-            "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+            "version": "20.12.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
+            "integrity": "sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -9586,9 +9654,9 @@
             "dev": true
         },
         "node_modules/@types/qs": {
-            "version": "6.9.14",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
-            "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==",
+            "version": "6.9.15",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+            "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
             "dev": true
         },
         "node_modules/@types/range-parser": {
@@ -9666,12 +9734,6 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
             "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-            "dev": true
-        },
-        "node_modules/@types/webfontloader": {
-            "version": "1.6.38",
-            "resolved": "https://registry.npmjs.org/@types/webfontloader/-/webfontloader-1.6.38.tgz",
-            "integrity": "sha512-kUaF72Fv202suFx6yBrwXqeVRMx7hGtJTesyESZgn9sEPCUeDXm2p0SiyS1MTqW74nQP4p7JyrOCwZ7pNFns4w==",
             "dev": true
         },
         "node_modules/@types/ws": {
@@ -10982,13 +11044,13 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.4.10",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.10.tgz",
-            "integrity": "sha512-rpIuu//y5OX6jVU+a5BCn1R5RSZYWAl2Nar76iwaOdycqb6JPxediskWFMMl7stfwNJR4b7eiQvh5fB5TEQJTQ==",
+            "version": "0.4.11",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
+            "integrity": "sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==",
             "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.22.6",
-                "@babel/helper-define-polyfill-provider": "^0.6.1",
+                "@babel/helper-define-polyfill-provider": "^0.6.2",
                 "semver": "^6.3.1"
             },
             "peerDependencies": {
@@ -11399,9 +11461,9 @@
             }
         },
         "node_modules/cacache": {
-            "version": "18.0.2",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.2.tgz",
-            "integrity": "sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==",
+            "version": "18.0.3",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.3.tgz",
+            "integrity": "sha512-qXCd4rh6I07cnDqh8V48/94Tc/WSfj+o3Gn6NZ0aZovS255bUx8O13uKxRFd2eWG0xgsco7+YItQNPaa5E85hg==",
             "dev": true,
             "dependencies": {
                 "@npmcli/fs": "^3.1.0",
@@ -11444,9 +11506,9 @@
             }
         },
         "node_modules/cacache/node_modules/lru-cache": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-            "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+            "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
             "dev": true,
             "engines": {
                 "node": "14 || >=16.14"
@@ -11511,9 +11573,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001609",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001609.tgz",
-            "integrity": "sha512-JFPQs34lHKx1B5t1EpQpWH4c+29zIyn/haGsbpfq3suuV9v56enjFt23zqijxGTMwy1p/4H2tjnQMY+p1WoAyA==",
+            "version": "1.0.30001615",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001615.tgz",
+            "integrity": "sha512-1IpazM5G3r38meiae0bHRnPhz+CBQ3ZLqbQMtrg+AsTPKAXgW38JNsXkyZ+v8waCsDmPq87lmfun5Q2AGysNEQ==",
             "dev": true,
             "funding": [
                 {
@@ -11617,9 +11679,9 @@
             }
         },
         "node_modules/cjs-module-lexer": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-            "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
+            "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
             "dev": true
         },
         "node_modules/clean-stack": {
@@ -12046,9 +12108,9 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.36.1",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
-            "integrity": "sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
+            "version": "3.37.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
+            "integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.23.0"
@@ -13297,9 +13359,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.735",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.735.tgz",
-            "integrity": "sha512-pkYpvwg8VyOTQAeBqZ7jsmpCjko1Qc6We1ZtZCjRyYbT5v4AIUKDy5cQTRotQlSSZmMr8jqpEt6JtOj5k7lR7A==",
+            "version": "1.4.756",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.756.tgz",
+            "integrity": "sha512-RJKZ9+vEBMeiPAvKNWyZjuYyUqMndcP1f335oHqn3BEQbs2NFtVrnK5+6Xg5wSM9TknNNpWghGDUCKGYF+xWXw==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -13453,9 +13515,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
-            "integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.2.tgz",
+            "integrity": "sha512-l60ETUTmLqbVbVHv1J4/qj+M8nq7AwMzEcg3kmJDt9dCNrTk+yHcYFf/Kw75pMDwd9mPcIGCG5LcS20SxYRzFA==",
             "dev": true
         },
         "node_modules/esbuild": {
@@ -14756,9 +14818,9 @@
             }
         },
         "node_modules/fs-monkey": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
-            "integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.6.tgz",
+            "integrity": "sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==",
             "dev": true
         },
         "node_modules/fs.realpath": {
@@ -15040,9 +15102,9 @@
             }
         },
         "node_modules/hosted-git-info": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-            "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^10.0.1"
@@ -15052,9 +15114,9 @@
             }
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-            "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+            "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
             "dev": true,
             "engines": {
                 "node": "14 || >=16.14"
@@ -15436,9 +15498,9 @@
             }
         },
         "node_modules/ignore-walk": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.4.tgz",
-            "integrity": "sha512-t7sv42WkwFkyKbivUCglsQW5YWMskWtbEf4MNKX5u/CCWHKSPzN4FtBQGsQZgCLbxOzpVlcbWVK5KB3auIOjSw==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.5.tgz",
+            "integrity": "sha512-VuuG0wCnjhnylG1ABXT3dAuIpTNDs/G8jlpmwXY03fXoXy/8ZK8/T+hMzt8L4WnrLCJgdybqgPagnF/f97cg3A==",
             "dev": true,
             "dependencies": {
                 "minimatch": "^9.0.0"
@@ -15628,9 +15690,9 @@
             "dev": true
         },
         "node_modules/ipaddr.js": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
-            "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+            "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
             "dev": true,
             "engines": {
                 "node": ">= 10"
@@ -15976,9 +16038,9 @@
             }
         },
         "node_modules/jake": {
-            "version": "10.8.7",
-            "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
-            "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.1.tgz",
+            "integrity": "sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==",
             "dev": true,
             "dependencies": {
                 "async": "^3.2.3",
@@ -17895,9 +17957,9 @@
             "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
-            "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+            "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
             "dev": true,
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -18357,9 +18419,9 @@
             "dev": true
         },
         "node_modules/make-fetch-happen": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.0.tgz",
-            "integrity": "sha512-7ThobcL8brtGo9CavByQrQi+23aIfgYU++wg4B87AIS8Rb2ZBt/MEaDqzA00Xwv/jUjAjYkLHjVolYuTLKda2A==",
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+            "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
             "dev": true,
             "dependencies": {
                 "@npmcli/agent": "^2.0.0",
@@ -18371,11 +18433,21 @@
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
                 "negotiator": "^0.6.3",
+                "proc-log": "^4.2.0",
                 "promise-retry": "^2.0.1",
                 "ssri": "^10.0.0"
             },
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/proc-log": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+            "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+            "dev": true,
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/makeerror": {
@@ -18562,9 +18634,9 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-            "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
+            "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
             "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -18583,9 +18655,9 @@
             }
         },
         "node_modules/minipass-fetch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.4.tgz",
-            "integrity": "sha512-jHAqnA728uUpIaFm7NWsCnqKT6UqZz7GcI/bDpPATuwYyKwJwW0remxSCxUlKiEty+eopHGa3oc8WxgQ1FFJqg==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+            "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
             "dev": true,
             "dependencies": {
                 "minipass": "^7.0.3",
@@ -18938,9 +19010,9 @@
             }
         },
         "node_modules/node-gyp-build": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
-            "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+            "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
             "dev": true,
             "optional": true,
             "bin": {
@@ -19014,9 +19086,9 @@
             "dev": true
         },
         "node_modules/nopt": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.0.tgz",
-            "integrity": "sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
             "dev": true,
             "dependencies": {
                 "abbrev": "^2.0.0"
@@ -19029,9 +19101,9 @@
             }
         },
         "node_modules/normalize-package-data": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
-            "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.1.tgz",
+            "integrity": "sha512-6rvCfeRW+OEZagAB4lMLSNuTNYZWLVtKccK79VSTf//yTY5VOCgcpH80O+bZK8Neps7pUnd5G+QlMg1yV/2iZQ==",
             "dev": true,
             "dependencies": {
                 "hosted-git-info": "^7.0.0",
@@ -19137,9 +19209,9 @@
             }
         },
         "node_modules/npm-registry-fetch": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.2.0.tgz",
-            "integrity": "sha512-zVH+G0q1O2hqgQBUvQ2LWp6ujr6VJAeDnmWxqiMlCguvLexEzBnuQIwC70r04vcvCMAcYEIpA/rO9YyVi+fmJQ==",
+            "version": "16.2.1",
+            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.2.1.tgz",
+            "integrity": "sha512-8l+7jxhim55S85fjiDGJ1rZXBWGtRLi1OSb4Z3BPLObPuIaeKRlPRiYMSHU4/81ck3t71Z+UwDDl47gcpmfQQA==",
             "dev": true,
             "dependencies": {
                 "@npmcli/redact": "^1.1.0",
@@ -19149,10 +19221,19 @@
                 "minipass-json-stream": "^1.0.1",
                 "minizlib": "^2.1.2",
                 "npm-package-arg": "^11.0.0",
-                "proc-log": "^3.0.0"
+                "proc-log": "^4.0.0"
             },
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm-registry-fetch/node_modules/proc-log": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+            "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+            "dev": true,
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/npm-run-path": {
@@ -19180,9 +19261,9 @@
             }
         },
         "node_modules/nwsapi": {
-            "version": "2.2.7",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-            "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
+            "version": "2.2.9",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.9.tgz",
+            "integrity": "sha512-2f3F0SEEer8bBu0dsNCFF50N0cTThV1nWFYcEYFZttdW0lDAoybv9cQoK7X7/68Z89S7FoRrVjP1LPX4XRf9vg==",
             "dev": true
         },
         "node_modules/nx": {
@@ -19459,17 +19540,17 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "dependencies": {
-                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0"
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -19845,9 +19926,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-            "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+            "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
             "dev": true,
             "engines": {
                 "node": "14 || >=16.14"
@@ -20155,9 +20236,9 @@
             }
         },
         "node_modules/postcss-load-config/node_modules/yaml": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
-            "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.2.tgz",
+            "integrity": "sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==",
             "dev": true,
             "bin": {
                 "yaml": "bin.mjs"
@@ -20817,9 +20898,9 @@
             ]
         },
         "node_modules/qs": {
-            "version": "6.12.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
-            "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+            "version": "6.12.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+            "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
             "dev": true,
             "dependencies": {
                 "side-channel": "^1.0.6"
@@ -20912,9 +20993,9 @@
             }
         },
         "node_modules/react-is": {
-            "version": "18.2.0",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-            "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "dev": true
         },
         "node_modules/read-cache": {
@@ -20927,9 +21008,9 @@
             }
         },
         "node_modules/read-package-json": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-7.0.0.tgz",
-            "integrity": "sha512-uL4Z10OKV4p6vbdvIXB+OzhInYtIozl/VxUBPgNkBuUi2DeRonnuspmaVAMcrkmfjKGNmRndyQAbE7/AmzGwFg==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-7.0.1.tgz",
+            "integrity": "sha512-8PcDiZ8DXUjLf687Ol4BR8Bpm2umR7vhoZOzNRt+uxD9GpBh/K+CAAALVIiYFknmvlmyg7hM7BSNUXPaCCqd0Q==",
             "dev": true,
             "dependencies": {
                 "glob": "^10.2.2",
@@ -21260,9 +21341,9 @@
             "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
         },
         "node_modules/rollup": {
-            "version": "4.14.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.2.tgz",
-            "integrity": "sha512-WkeoTWvuBoFjFAhsEOHKRoZ3r9GfTyhh7Vff1zwebEFLEFjT1lG3784xEgKiTa7E+e70vsC81roVL2MP4tgEEQ==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.17.2.tgz",
+            "integrity": "sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "1.0.5"
@@ -21275,21 +21356,22 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.14.2",
-                "@rollup/rollup-android-arm64": "4.14.2",
-                "@rollup/rollup-darwin-arm64": "4.14.2",
-                "@rollup/rollup-darwin-x64": "4.14.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.14.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.14.2",
-                "@rollup/rollup-linux-arm64-musl": "4.14.2",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.14.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.14.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.14.2",
-                "@rollup/rollup-linux-x64-gnu": "4.14.2",
-                "@rollup/rollup-linux-x64-musl": "4.14.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.14.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.14.2",
-                "@rollup/rollup-win32-x64-msvc": "4.14.2",
+                "@rollup/rollup-android-arm-eabi": "4.17.2",
+                "@rollup/rollup-android-arm64": "4.17.2",
+                "@rollup/rollup-darwin-arm64": "4.17.2",
+                "@rollup/rollup-darwin-x64": "4.17.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.17.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.17.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.17.2",
+                "@rollup/rollup-linux-arm64-musl": "4.17.2",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.17.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.17.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.17.2",
+                "@rollup/rollup-linux-x64-gnu": "4.17.2",
+                "@rollup/rollup-linux-x64-musl": "4.17.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.17.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.17.2",
+                "@rollup/rollup-win32-x64-msvc": "4.17.2",
                 "fsevents": "~2.3.2"
             }
         },
@@ -21950,9 +22032,9 @@
             "dev": true
         },
         "node_modules/ssri": {
-            "version": "10.0.5",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
-            "integrity": "sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==",
+            "version": "10.0.6",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+            "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
             "dev": true,
             "dependencies": {
                 "minipass": "^7.0.3"
@@ -22791,9 +22873,9 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-            "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+            "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
             "dev": true,
             "dependencies": {
                 "psl": "^1.1.33",
@@ -23339,9 +23421,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.15.tgz",
+            "integrity": "sha512-K9HWH62x3/EalU1U6sjSZiylm9C8tgq2mSvshZpqc7QE69RaA2qjhkW2HlNA0tFpEbtyFz7HTqbSdN4MSwUodA==",
             "dev": true,
             "funding": [
                 {
@@ -23358,7 +23440,7 @@
                 }
             ],
             "dependencies": {
-                "escalade": "^3.1.1",
+                "escalade": "^3.1.2",
                 "picocolors": "^1.0.0"
             },
             "bin": {
@@ -23580,11 +23662,6 @@
             "dependencies": {
                 "defaults": "^1.0.3"
             }
-        },
-        "node_modules/webfontloader": {
-            "version": "1.6.28",
-            "resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz",
-            "integrity": "sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ=="
         },
         "node_modules/webidl-conversions": {
             "version": "7.0.0",
@@ -23960,6 +24037,15 @@
             "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
             "dev": true
         },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/wrap-ansi": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -24078,9 +24164,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+            "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package-lock.json
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package-lock.json
@@ -20,7 +20,6 @@
                 "@angular/router": "^17.1.3",
                 "@ctrl/ngx-codemirror": "^7.0.0",
                 "@fontsource/roboto": "^5.0.12",
-                "@fontsource/roboto-slab": "^5.0.19",
                 "@ngrx/effects": "^17.1.0",
                 "@ngrx/router-store": "^17.1.0",
                 "@ngrx/store": "^17.1.0",
@@ -4726,11 +4725,6 @@
             "version": "5.0.13",
             "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.0.13.tgz",
             "integrity": "sha512-j61DHjsdUCKMXSdNLTOxcG701FWnF0jcqNNQi2iPCDxU8seN/sMxeh62dC++UiagCWq9ghTypX+Pcy7kX+QOeQ=="
-        },
-        "node_modules/@fontsource/roboto-slab": {
-            "version": "5.0.20",
-            "resolved": "https://registry.npmjs.org/@fontsource/roboto-slab/-/roboto-slab-5.0.20.tgz",
-            "integrity": "sha512-71QJs8SvE0xcVtBb/Jg2/1TKWb7wVaENXRpFLp8fz+sq9Rp/xoKQRMcHQ8yIUIfKlL+SI2z4tYqUViC0SuRzSQ=="
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.14",
@@ -9630,9 +9624,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.12.8",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
-            "integrity": "sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==",
+            "version": "20.12.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
+            "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -11573,9 +11567,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001615",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001615.tgz",
-            "integrity": "sha512-1IpazM5G3r38meiae0bHRnPhz+CBQ3ZLqbQMtrg+AsTPKAXgW38JNsXkyZ+v8waCsDmPq87lmfun5Q2AGysNEQ==",
+            "version": "1.0.30001616",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001616.tgz",
+            "integrity": "sha512-RHVYKov7IcdNjVHJFNY/78RdG4oGVjbayxv8u5IO74Wv7Hlq4PnJE6mo/OjFijjVFNy5ijnCt6H3IIo4t+wfEw==",
             "dev": true,
             "funding": [
                 {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package.json
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package.json
@@ -28,7 +28,6 @@
         "@angular/router": "^17.1.3",
         "@ctrl/ngx-codemirror": "^7.0.0",
         "@fontsource/roboto": "^5.0.12",
-        "@fontsource/roboto-slab": "^5.0.19",
         "@ngrx/effects": "^17.1.0",
         "@ngrx/router-store": "^17.1.0",
         "@ngrx/store": "^17.1.0",

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package.json
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package.json
@@ -41,7 +41,6 @@
         "ngx-skeleton-loader": "^8.1.0",
         "rxjs": "~7.8.1",
         "tslib": "^2.6.2",
-        "webfontloader": "^1.6.28",
         "zone.js": "0.14.4"
     },
     "devDependencies": {
@@ -64,7 +63,6 @@
         "@types/d3": "^7.4.3",
         "@types/humanize-duration": "^3.27.3",
         "@types/jest": "^29.5.12",
-        "@types/webfontloader": "^1.6.38",
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
         "autoprefixer": "^10.4.16",

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/app.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/app.component.html
@@ -23,6 +23,4 @@
     </div>
 }
 
-<div class="mat-app-background">
-    <router-outlet></router-outlet>
-</div>
+<router-outlet></router-outlet>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/access-policies/feature/access-policies.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/access-policies/feature/access-policies.component.html
@@ -20,7 +20,7 @@
         <navigation></navigation>
     </header>
     <div class="px-5">
-        <h3 class="text-xl bold primary-color">Access Policies</h3>
+        <h3 class="primary-color">Access Policies</h3>
     </div>
     <div class="px-5 flex-1">
         <router-outlet></router-outlet>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/bulletins/feature/bulletins.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/bulletins/feature/bulletins.component.html
@@ -20,7 +20,7 @@
         <navigation></navigation>
     </header>
     <div class="px-5 flex-1 flex flex-col">
-        <h3 class="text-xl bold primary-color">NiFi Bulletin Board</h3>
+        <h3 class="primary-color">NiFi Bulletin Board</h3>
         <bulletin-board class="flex-1"></bulletin-board>
     </div>
 </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/cluster/feature/cluster.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/cluster/feature/cluster.component.html
@@ -20,7 +20,7 @@
         <navigation></navigation>
     </header>
     <div class="px-5 flex-1 flex flex-col gap-y-2">
-        <h3 class="text-xl bold primary-color">NiFi Cluster</h3>
+        <h3 class="primary-color">NiFi Cluster</h3>
         <error-banner></error-banner>
         @if (getTabLinks(); as tabs) {
             <!-- Don't show the tab bar if there is only 1 tab to show -->

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/counters/feature/counters.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/counters/feature/counters.component.html
@@ -20,7 +20,7 @@
         <navigation></navigation>
     </header>
     <div class="px-5 flex-1 flex flex-col">
-        <h3 class="text-xl bold primary-color">NiFi Counters</h3>
+        <h3 class="primary-color">NiFi Counters</h3>
         <counter-listing class="flex-1"></counter-listing>
     </div>
 </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-configuration-history/feature/flow-configuration-history.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-configuration-history/feature/flow-configuration-history.component.html
@@ -20,7 +20,7 @@
         <navigation></navigation>
     </header>
     <div class="px-5 flex-1 flex flex-col">
-        <h3 class="text-xl bold primary-color">Flow Configuration History</h3>
+        <h3 class="primary-color">Flow Configuration History</h3>
         <flow-configuration-history-listing class="flex-1"></flow-configuration-history-listing>
     </div>
 </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-view.service.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-view.service.ts
@@ -17,7 +17,6 @@
 
 import { Injectable } from '@angular/core';
 import * as d3 from 'd3';
-import * as WebFont from 'webfontloader';
 import { Store } from '@ngrx/store';
 import { CanvasState } from '../state';
 import { refreshBirdseyeView, transformComplete } from '../state/transform/transform.actions';
@@ -67,23 +66,6 @@ export class CanvasView {
     ) {}
 
     public init(svg: any, canvas: any): void {
-        WebFont.load({
-            custom: {
-                families: ['Roboto', 'Roboto Slab', 'flowfont', 'FontAwesome']
-            },
-            active: function () {
-                // re-render once the fonts have loaded, without the fonts
-                // positions of elements on the canvas may be incorrect
-                self.processorManager.render();
-                self.processGroupManager.render();
-                self.remoteProcessGroupManager.render();
-                self.portManager.render();
-                self.labelManager.render();
-                self.funnelManager.render();
-                self.connectionManager.render();
-            }
-        });
-
         this.svg = svg;
         this.canvas = canvas;
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/_canvas.component-theme.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/_canvas.component-theme.scss
@@ -151,7 +151,7 @@
 
         text.stats-label {
             @extend .surface-contrast;
-            font-family: mat.get-theme-typography($nifi-theme, body-1, font-family);
+            font-family: mat.get-theme-typography($material-theme, body-1, font-family);
         }
 
         text.stats-value {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/_canvas.component-theme.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/_canvas.component-theme.scss
@@ -90,6 +90,11 @@
         /*
           All components
       */
+
+        g.component {
+            font-family: mat.get-theme-typography($material-theme, body-1, font-family);
+        }
+
         .transparent {
             fill: transparent;
         }
@@ -146,6 +151,7 @@
 
         text.stats-label {
             @extend .surface-contrast;
+            font-family: mat.get-theme-typography($nifi-theme, body-1, font-family);
         }
 
         text.stats-value {
@@ -255,6 +261,10 @@
         /*
           Connection
       */
+
+        g.connection {
+            font-family: mat.get-theme-typography($material-theme, body-1, font-family);
+        }
 
         g.connection rect.body {
             fill: if($is-dark, $nifi-theme-surface-palette-darker, $nifi-theme-surface-palette-lighter);
@@ -427,6 +437,7 @@
 
         text.process-group-contents-count {
             fill: $material-theme-accent-palette-default;
+            font-family: mat.get-theme-typography($material-theme, body-1, font-family);
         }
 
         g.process-group.drop rect.border {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.scss
@@ -43,10 +43,6 @@
       All components
   */
 
-    g.component {
-        font-family: Roboto;
-    }
-
     g.component rect.border.unauthorized {
         stroke-width: 3;
         stroke-dasharray: 4;
@@ -63,7 +59,6 @@
 
     text.stats-label {
         font-size: 12px;
-        font-family: Roboto Slab;
     }
 
     text.stats-value {
@@ -205,10 +200,6 @@
     /*
       Connection
   */
-
-    g.connection {
-        font-family: Roboto;
-    }
 
     g.connection rect.border.unauthorized {
         stroke-width: 1.5;
@@ -372,7 +363,6 @@
     text.process-group-contents-count {
         font-size: 15px;
         font-weight: 500;
-        font-family: Roboto, sans-serif;
     }
 
     g.process-group.drop rect.border {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/_navigation-control.component-theme.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/_navigation-control.component-theme.scss
@@ -43,5 +43,9 @@
                 );
             }
         }
+
+        .navigation-control-title {
+            font-family: mat.get-theme-typography($nifi-theme, body-1, font-family);
+        }
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/_navigation-control.component-theme.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/_navigation-control.component-theme.scss
@@ -43,9 +43,5 @@
                 );
             }
         }
-
-        .navigation-control-title {
-            font-family: mat.get-theme-typography($nifi-theme, body-1, font-family);
-        }
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/navigation-control.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/navigation-control.component.scss
@@ -34,7 +34,6 @@ div.navigation-control {
 
     .navigation-control-title {
         font-size: 12px;
-        font-family: 'Roboto Slab';
         letter-spacing: 0.05rem;
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/_operation-control.component-theme.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/_operation-control.component-theme.scss
@@ -43,9 +43,5 @@
                 );
             }
         }
-
-        .operation-control-title {
-            font-family: mat.get-theme-typography($nifi-theme, body-1, font-family);
-        }
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/_operation-control.component-theme.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/_operation-control.component-theme.scss
@@ -43,5 +43,9 @@
                 );
             }
         }
+
+        .operation-control-title {
+            font-family: mat.get-theme-typography($nifi-theme, body-1, font-family);
+        }
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/operation-control.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/operation-control.component.scss
@@ -34,7 +34,6 @@ div.operation-control {
 
     .operation-control-title {
         font-size: 12px;
-        font-family: 'Roboto Slab';
         letter-spacing: 0.05rem;
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/header/flow-status/flow-status.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/header/flow-status/flow-status.component.scss
@@ -24,12 +24,6 @@
         font-style: normal;
     }
 
-    .status-value {
-        white-space: nowrap;
-        font-weight: 500;
-        text-shadow: none;
-    }
-
     .controller-bulletins {
         cursor: default;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/source/source-processor/source-processor.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/source/source-processor/source-processor.component.html
@@ -28,7 +28,7 @@
         <div>Relationships</div>
         <div class="flex flex-col gap-y-3">
             @for (item of relationshipItems; track item; let i = $index) {
-                @if (isDisabled && item.selected || !isDisabled) {
+                @if ((isDisabled && item.selected) || !isDisabled) {
                     <div class="flex flex-col gap-y-1.5">
                         <div class="flex items-center gap-x-2">
                             <mat-checkbox

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/common/breadcrumbs/breadcrumbs.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/common/breadcrumbs/breadcrumbs.component.html
@@ -28,7 +28,10 @@
                     [title]="getVersionControlTooltip(breadcrumb)"></div>
             }
             @if (isCurrentProcessGroupBreadcrumb(breadcrumb)) {
-                <a #currentProcessGroup class="current-process-group" [routerLink]="['/process-groups', breadcrumb.id]">
+                <a
+                    #currentProcessGroup
+                    class="current-process-group font-bold"
+                    [routerLink]="['/process-groups', breadcrumb.id]">
                     {{ getBreadcrumbLabel(breadcrumb) }}
                 </a>
             } @else {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/common/breadcrumbs/breadcrumbs.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/common/breadcrumbs/breadcrumbs.component.scss
@@ -21,7 +21,6 @@
     }
 
     a.current-process-group {
-        font-weight: bold;
         text-decoration: none;
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.html
@@ -20,7 +20,7 @@
         <navigation></navigation>
     </header>
     <div class="px-5 flex-1 flex flex-col">
-        <h3 class="text-xl bold primary-color">Controller Services</h3>
+        <h3 class="primary-color">Controller Services</h3>
         @if (serviceState$ | async; as serviceState) {
             @if (isInitialLoading(serviceState)) {
                 <div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/manage-remote-ports/manage-remote-ports.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/manage-remote-ports/manage-remote-ports.component.html
@@ -20,7 +20,7 @@
         <navigation></navigation>
     </header>
     <div class="px-5 flex-1 flex flex-col">
-        <h3 class="text-xl bold primary-color pb-5">Manage Remote Ports</h3>
+        <h3 class="primary-color pb-5">Manage Remote Ports</h3>
         @if (portsState$ | async; as portsState) {
             <div class="grid-container grid grid-cols-2">
                 <div class="col-span-1 pr-5">

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/login/ui/login-form/login-form.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/login/ui/login-form/login-form.component.html
@@ -17,7 +17,7 @@
 
 <div class="login-form w-96 flex flex-col gap-y-5">
     <div class="flex justify-between items-center">
-        <div class="login-title primary-color">Log In</div>
+        <h3 class="primary-color">Log In</h3>
         <div class="flex gap-x-2">
             @if (hasToken()) {
                 <a (click)="logout()">log out</a>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/login/ui/login-form/login-form.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/login/ui/login-form/login-form.component.scss
@@ -16,12 +16,6 @@
  */
 
 .login-form {
-    .login-title {
-        font-size: 18px;
-        font-weight: 600;
-        font-family: Roboto Slab;
-    }
-
     .mat-mdc-form-field {
         width: 100%;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/feature/parameter-contexts.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/feature/parameter-contexts.component.html
@@ -20,7 +20,7 @@
         <navigation></navigation>
     </header>
     <div class="px-5 flex-1 flex flex-col">
-        <h3 class="text-xl bold primary-color">Parameter Contexts</h3>
+        <h3 class="primary-color">Parameter Contexts</h3>
         <parameter-context-listing class="flex-1"></parameter-context-listing>
     </div>
 </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/process-group-references/process-group-references.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/process-group-references/process-group-references.component.html
@@ -22,7 +22,7 @@
         <ul>
             @if (authorizedProcessGroupReferences.length > 0) {
                 <li>
-                    <h4>
+                    <h4 class="primary-color">
                         <b>Process Groups ({{ authorizedProcessGroupReferences.length }})</b>
                     </h4>
                     <ul class="nested">
@@ -36,7 +36,7 @@
             }
             @if (unauthorizedProcessGroupReferences.length > 0) {
                 <li>
-                    <h4>
+                    <h4 class="primary-color">
                         <b>Unauthorized ({{ unauthorizedProcessGroupReferences.length }})</b>
                     </h4>
                     <ul class="nested">

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/provenance/feature/provenance.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/provenance/feature/provenance.component.html
@@ -19,7 +19,7 @@
     <header class="nifi-header">
         <navigation></navigation>
     </header>
-    <h3 class="px-5 text-xl bold primary-color">Provenance</h3>
+    <h3 class="px-5 primary-color">Provenance</h3>
     <div class="px-5 flex-1">
         <router-outlet></router-outlet>
     </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/provenance/ui/provenance-event-listing/provenance-event-table/lineage/_lineage.component-theme.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/provenance/ui/provenance-event-listing/provenance-event-table/lineage/_lineage.component-theme.scss
@@ -41,6 +41,12 @@
         svg {
             text.event-type {
                 @extend .surface-contrast;
+                font-family: mat.get-theme-typography($material-theme, body-1, font-family);
+            }
+
+            text.event-type.expand-parents,
+            text.event-type.expand-children {
+                font-family: mat.get-theme-typography($material-theme, body-1, font-family);
             }
 
             path.link.selected {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/provenance/ui/provenance-event-listing/provenance-event-table/lineage/lineage.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/provenance/ui/provenance-event-listing/provenance-event-table/lineage/lineage.component.scss
@@ -30,7 +30,6 @@
         }
 
         text.event-type {
-            font-family: Roboto;
             font-size: 11px;
             font-style: normal;
             font-weight: normal;
@@ -39,7 +38,6 @@
         text.event-type.expand-parents,
         text.event-type.expand-children {
             font-weight: 500;
-            font-family: 'Roboto';
             font-style: normal;
             font-size: 13px;
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/flowfile-dialog/flowfile-dialog.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/flowfile-dialog/flowfile-dialog.component.html
@@ -24,7 +24,7 @@
                     <div class="absolute inset-0 flex gap-x-4">
                         <div class="w-full flex flex-col gap-y-3">
                             <div class="flex flex-col">
-                                <div class="flowfile-header primary-color">FlowFile Details</div>
+                                <div class="flowfile-header font-bold primary-color">FlowFile Details</div>
                             </div>
                             <div class="flex flex-col">
                                 <div>UUID</div>
@@ -106,7 +106,7 @@
                         </div>
                         <div class="w-full flex flex-col gap-y-3">
                             <div class="flex flex-col">
-                                <div class="flowfile-header primary-color">Content Claim</div>
+                                <div class="flowfile-header font-bold primary-color">Content Claim</div>
                             </div>
                             <div
                                 class="flex flex-col gap-y-3"
@@ -181,7 +181,7 @@
                 <div class="tab-content py-4">
                     <div class="absolute inset-0 flex flex-col gap-y-4">
                         <div class="flex">
-                            <div class="flowfile-header primary-color">Attribute Values</div>
+                            <div class="flowfile-header font-bold primary-color">Attribute Values</div>
                         </div>
                         <div class="flex flex-col">
                             <div *ngFor="let attribute of request.flowfile.attributes | keyvalue">

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/flowfile-dialog/flowfile-dialog.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/flowfile-dialog/flowfile-dialog.component.scss
@@ -31,9 +31,7 @@
 
             .flowfile-header {
                 font-size: 15px;
-                font-family: 'Roboto Slab';
                 font-style: normal;
-                font-weight: bold;
             }
         }
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/flowfile-table/flowfile-table.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/flowfile-table/flowfile-table.component.html
@@ -16,7 +16,7 @@
   -->
 
 <div class="flowfile-table h-full flex flex-col gap-y-2">
-    <h3 class="text-xl bold queue-listing-header primary-color">{{ connectionLabel }}</h3>
+    <h3 class="queue-listing-header primary-color">{{ connectionLabel }}</h3>
     <error-banner></error-banner>
     <div class="flex justify-between">
         <div class="accent-color font-medium">

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/feature/settings.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/feature/settings.component.html
@@ -20,7 +20,7 @@
         <navigation></navigation>
     </header>
     <div class="px-5 flex-1 flex flex-col">
-        <h3 class="text-xl bold primary-color">NiFi Settings</h3>
+        <h3 class="primary-color">NiFi Settings</h3>
         <div class="settings-tabs">
             <nav mat-tab-nav-bar color="primary" [tabPanel]="tabPanel">
                 @for (tab of tabLinks; track tab) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-context-references/parameter-providers-references.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-context-references/parameter-providers-references.component.html
@@ -42,9 +42,7 @@
     <ng-template #parameterContexts let-references let-label="label">
         @if (references.length > 0) {
             <li>
-                <h4>
-                    <span class="accent-color font-medium">{{ label }}</span> ({{ references.length }})
-                </h4>
+                <h4 class="accent-color">{{ label }} ({{ references.length }})</h4>
                 <div class="references">
                     @for (reference of references; track reference) {
                         <div class="flex items-center gap-x-2">
@@ -61,9 +59,7 @@
     <ng-template #unauthorized let-references let-label="label">
         @if (references.length > 0) {
             <li>
-                <h4>
-                    <span class="accent-color font-medium">{{ label }}</span> ({{ references.length }})
-                </h4>
+                <h4 class="accent-color">{{ label }} ({{ references.length }})</h4>
                 <div class="references">
                     @for (reference of references; track reference) {
                         <div class="flex items-center gap-x-2">

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/summary/feature/summary.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/summary/feature/summary.component.html
@@ -20,7 +20,7 @@
         <navigation></navigation>
     </header>
     <div class="px-5 flex-1 flex flex-col gap-y-2">
-        <h3 class="text-xl bold primary-color">
+        <h3 class="primary-color">
             @if (selectedClusterNode$ | async; as selectedNode) {
                 @if (selectedNode.id !== 'All') {
                     {{ selectedNode.address }} Summary

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/summary/ui/processor-status-listing/processor-status-table/processor-status-table.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/summary/ui/processor-status-listing/processor-status-table/processor-status-table.component.html
@@ -65,7 +65,7 @@
                                     <div class="flex align-middle">
                                         @if (item.processorStatusSnapshot.executionNode === 'PRIMARY') {
                                             <div
-                                                class="primary-node-only border surface-contrast mt-0.5 mr-1"
+                                                class="primary-node-only border surface-contrast mt-0.5 mr-1 font-bold"
                                                 title="This component is only scheduled to execute on the Primary Node">
                                                 P
                                             </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/summary/ui/processor-status-listing/processor-status-table/processor-status-table.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/summary/ui/processor-status-listing/processor-status-table/processor-status-table.component.html
@@ -65,7 +65,7 @@
                                     <div class="flex align-middle">
                                         @if (item.processorStatusSnapshot.executionNode === 'PRIMARY') {
                                             <div
-                                                class="primary-node-only border surface-contrast mt-0.5 mr-1 font-bold"
+                                                class="primary-node-only border surface-contrast mr-1 font-bold"
                                                 title="This component is only scheduled to execute on the Primary Node">
                                                 P
                                             </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/summary/ui/processor-status-listing/processor-status-table/processor-status-table.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/summary/ui/processor-status-listing/processor-status-table/processor-status-table.component.scss
@@ -32,9 +32,9 @@
 
     .primary-node-only {
         font-size: 10px;
-        line-height: 14px;
-        width: 16px;
-        height: 16px;
+        line-height: 13px;
+        width: 14px;
+        height: 15px;
         border-radius: 8px;
         float: left;
         text-align: center;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/summary/ui/processor-status-listing/processor-status-table/processor-status-table.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/summary/ui/processor-status-listing/processor-status-table/processor-status-table.component.scss
@@ -14,6 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 .processor-status-table {
     .listing-table {
         .mat-column-moreDetails {
@@ -28,10 +29,9 @@
             width: 74px;
         }
     }
+
     .primary-node-only {
-        font-family: Roboto;
         font-size: 10px;
-        font-weight: bold;
         line-height: 14px;
         width: 16px;
         height: 16px;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/users/feature/users.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/users/feature/users.component.html
@@ -20,7 +20,7 @@
         <navigation></navigation>
     </header>
     <div class="px-5 flex-1 flex flex-col">
-        <h3 class="text-xl bold user-header primary-color">NiFi Users</h3>
+        <h3 class="user-header primary-color">NiFi Users</h3>
         <user-listing class="flex-1"></user-listing>
     </div>
 </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/users/ui/user-listing/user-access-policies/user-access-policies.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/users/ui/user-listing/user-access-policies/user-access-policies.component.html
@@ -16,7 +16,7 @@
   -->
 
 <div class="user-access-policies">
-    <h3 mat-dialog-title>User Policies</h3>
+    <h2 mat-dialog-title>User Policies</h2>
     <mat-dialog-content>
         <div class="flex flex-col justify-between gap-y-3">
             <div class="flex flex-col">

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-references/controller-service-references.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-references/controller-service-references.component.html
@@ -81,7 +81,7 @@
         <ng-template #nonService let-references let-referenceTypeLabel="referenceTypeLabel">
             @if (references.length > 0) {
                 <li>
-                    <h4>
+                    <h4 class="primary-color">
                         <span class="accent-color font-medium">{{ referenceTypeLabel }}</span>
                         ({{ references.length }})
                     </h4>
@@ -121,7 +121,7 @@
         <ng-template #service let-references>
             @if (references.length > 0) {
                 <li>
-                    <h4><span class="accent-color font-medium">Controller Services</span> ({{ references.length }})</h4>
+                    <h4 class="accent-color">Controller Services ({{ references.length }})</h4>
                     <div class="references">
                         @for (service of references; track service) {
                             <div class="flex flex-col">
@@ -171,7 +171,7 @@
         <ng-template #unauthorized let-references>
             @if (references.length > 0) {
                 <li>
-                    <h4><span class="accent-color font-medium">Unauthorized</span> ({{ references.length }})</h4>
+                    <h4 class="accent-color">Unauthorized ({{ references.length }})</h4>
                     <div class="references">
                         @for (reference of references; track reference) {
                             <div class="flex">

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/extension-creation/extension-creation.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/extension-creation/extension-creation.component.html
@@ -14,24 +14,23 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-<section tabindex="0" (keyup)="navigateSelectionList($event)">
-    <div class="extension-creation-dialog p-4 flex flex-col justify-between gap-y-3">
-        <div class="flex justify-between items-center">
-            <h3 class="text-lg">Add {{ componentType }}</h3>
-            <div>
-                <mat-form-field>
-                    <mat-label>Filter types</mat-label>
-                    <input
-                        matInput
-                        class="px-1.5 py-1 w-64"
-                        type="text"
-                        (keyup)="filterTypes($event)"
-                        cdkFocusInitial
-                        placeholder="Filter types..." />
-                </mat-form-field>
-            </div>
+<div class="extension-creation-dialog" (keyup)="navigateSelectionList($event)">
+    <div class="flex justify-between items-center">
+        <h2 mat-dialog-title>Add {{ componentType }}</h2>
+        <div class="pt-5 pr-5">
+            <mat-form-field>
+                <mat-label>Filter types</mat-label>
+                <input
+                    matInput
+                    class="px-1.5 py-1 w-64"
+                    type="text"
+                    (keyup)="filterTypes($event)"
+                    tabindex="0"
+                    placeholder="Filter types..." />
+            </mat-form-field>
         </div>
+    </div>
+    <mat-dialog-content>
         <div class="listing-table select-none">
             <div class="h-96 overflow-y-auto overflow-x-hidden">
                 <table
@@ -102,10 +101,10 @@
                 </table>
             </div>
         </div>
-        <div class="flex flex-col">
+        <div class="flex flex-col pt-3">
             @if (selectedType) {
                 <div class="flex items-center">
-                    <div class="selected-type-name accent-color">
+                    <div class="selected-type-name font-medium accent-color">
                         {{ formatType(selectedType) }}
                     </div>
                     <div class="selected-type-bundle surface-color">{{ formatBundle(selectedType) }}</div>
@@ -117,15 +116,15 @@
                 <div class="no-selected-type unset surface-color">No type selected</div>
             }
         </div>
-        <div class="flex justify-end gap-x-2">
-            <button mat-button mat-dialog-close>Cancel</button>
-            <button
-                [disabled]="selectedType == null || saving"
-                color="primary"
-                (click)="createExtension(selectedType)"
-                mat-button>
-                <span *nifiSpinner="saving">Add</span>
-            </button>
-        </div>
-    </div>
-</section>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+        <button mat-button mat-dialog-close>Cancel</button>
+        <button
+            [disabled]="selectedType == null || saving"
+            color="primary"
+            (click)="createExtension(selectedType)"
+            mat-button>
+            <span *nifiSpinner="saving">Add</span>
+        </button>
+    </mat-dialog-actions>
+</div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/extension-creation/extension-creation.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/extension-creation/extension-creation.component.scss
@@ -34,7 +34,6 @@
 
     .selected-type-name {
         font-size: 16px;
-        font-weight: 500;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/_navigation.component-theme.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/_navigation.component-theme.scss
@@ -19,7 +19,7 @@
 @use '@angular/material' as mat;
 @use '../../../../../node_modules/@angular/material/core/theming/inspection' as inspection;
 
-@mixin generate-theme($material-theme) {
+@mixin generate-theme($material-theme, $nifi-theme) {
     // Get the color config from the theme.
     $material-theme-color-config: mat.get-color-config($material-theme);
 
@@ -55,6 +55,7 @@
 
         .current-user {
             @extend .primary-contrast;
+            font-family: mat.get-theme-typography($nifi-theme, body-1, font-family);
         }
 
         a {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/_navigation.component-theme.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/_navigation.component-theme.scss
@@ -55,7 +55,7 @@
 
         .current-user {
             @extend .primary-contrast;
-            font-family: mat.get-theme-typography($nifi-theme, body-1, font-family);
+            font-family: mat.get-theme-typography($material-theme, body-1, font-family);
         }
 
         a {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.scss
@@ -21,9 +21,6 @@
     }
 
     .current-user {
-        font-family: 'Roboto Slab';
-        font-style: normal;
-        font-weight: normal;
         font-size: 12px;
         max-width: 250px;
         text-overflow: ellipsis;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/page-content/page-content.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/page-content/page-content.component.html
@@ -17,7 +17,7 @@
 
 <div class="page-content w-1/2 flex flex-col gap-y-5">
     <div class="flex justify-between items-center gap-x-3">
-        <div class="title whitespace-nowrap overflow-hidden text-ellipsis" [title]="title">{{ title }}</div>
+        <h3 class="primary-color whitespace-nowrap overflow-hidden text-ellipsis" [title]="title">{{ title }}</h3>
         <div class="flex gap-x-3">
             @if (hasToken()) {
                 <a (click)="logout()" class="whitespace-nowrap">log out</a>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/page-content/page-content.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/page-content/page-content.component.scss
@@ -14,11 +14,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-.page-content {
-    .title {
-        font-size: 18px;
-        font-weight: 600;
-        font-family: Roboto Slab;
-    }
-}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/parameter-references/parameter-references.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/parameter-references/parameter-references.component.html
@@ -25,7 +25,7 @@
         <ng-template #pgListing let-pg>
             <ul>
                 <li>
-                    <h4>
+                    <h4 class="primary-color">
                         <b>{{ pg.name }}</b>
                     </h4>
                     @if (parameterReferenceMap.get(pg.id); as references) {
@@ -53,7 +53,7 @@
         <ng-template #processor let-references>
             @if (references.length > 0) {
                 <li>
-                    <h4><span class="accent-color font-medium">Processors</span> ({{ references.length }})</h4>
+                    <h4 class="accent-color">Processors ({{ references.length }})</h4>
                     <div class="references">
                         @for (reference of references; track reference) {
                             <div class="flex items-center gap-x-2">
@@ -88,7 +88,7 @@
         <ng-template #service let-references>
             @if (references.length > 0) {
                 <li>
-                    <h4><span class="accent-color font-medium">Controller Services</span> ({{ references.length }})</h4>
+                    <h4 class="accent-color">Controller Services ({{ references.length }})</h4>
                     <div class="references">
                         @for (service of references; track service) {
                             <div class="flex flex-col">
@@ -124,7 +124,7 @@
         <ng-template #unauthorized let-references>
             @if (references.length > 0) {
                 <li>
-                    <h4><span class="accent-color font-medium">Unauthorized</span> ({{ references.length }})</h4>
+                    <h4 class="accent-color">Unauthorized ({{ references.length }})</h4>
                     <div class="references">
                         @for (reference of references; track reference) {
                             <div class="flex">

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/provenance-event-dialog/provenance-event-dialog.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/provenance-event-dialog/provenance-event-dialog.component.html
@@ -187,7 +187,7 @@
                         </div>
                         <div class="w-full flex flex-col gap-y-3">
                             <div class="flex flex-col">
-                                <div class="event-header primary-color">
+                                <div class="event-header font-bold primary-color">
                                     Parent FlowFiles ({{ request.event.parentUuids.length }})
                                 </div>
                                 <ng-container
@@ -197,7 +197,7 @@
                                     "></ng-container>
                             </div>
                             <div class="flex flex-col">
-                                <div class="event-header primary-color">
+                                <div class="event-header font-bold primary-color">
                                     Child FlowFiles ({{ request.event.childUuids.length }})
                                 </div>
                                 <ng-container
@@ -224,7 +224,7 @@
                 <div class="tab-content py-4">
                     <div class="absolute inset-0 flex flex-col gap-y-4">
                         <div class="flex justify-between">
-                            <div class="event-header primary-color">Attribute Values</div>
+                            <div class="event-header font-bold primary-color">Attribute Values</div>
                             <div class="flex items-center gap-x-1">
                                 <mat-checkbox color="primary" [(ngModel)]="onlyShowModifiedAttributes"></mat-checkbox>
                                 <div>Show modified attributes only</div>
@@ -257,7 +257,7 @@
                     <div class="absolute inset-0 flex flex-col gap-y-4">
                         <div class="flex gap-x-4">
                             <div class="w-full">
-                                <div class="event-header primary-color">Input Claim</div>
+                                <div class="event-header font-bold primary-color">Input Claim</div>
                                 <div class="flex flex-col gap-y-3">
                                     <div>
                                         <div>Container</div>
@@ -323,7 +323,7 @@
                                 </div>
                             </div>
                             <div class="w-full">
-                                <div class="event-header primary-color">Output Claim</div>
+                                <div class="event-header font-bold primary-color">Output Claim</div>
                                 <div class="flex flex-col gap-y-3">
                                     <div>
                                         <div>Container</div>
@@ -390,7 +390,7 @@
                             </div>
                         </div>
                         <div class="flex flex-col">
-                            <div class="event-header primary-color">Replay</div>
+                            <div class="event-header font-bold primary-color">Replay</div>
                             <div
                                 *ngIf="request.event.replayAvailable; else replayNotAvailable"
                                 class="flex flex-col gap-y-3">

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/provenance-event-dialog/provenance-event-dialog.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/provenance-event-dialog/provenance-event-dialog.component.scss
@@ -31,9 +31,6 @@
 
             .event-header {
                 font-size: 15px;
-                font-family: 'Roboto Slab';
-                font-style: normal;
-                font-weight: bold;
             }
         }
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/system-diagnostics-dialog/system-diagnostics-dialog.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/system-diagnostics-dialog/system-diagnostics-dialog.component.html
@@ -27,7 +27,9 @@
                             <div class="inset-0 flex gap-y-4">
                                 <div class="flex flex-col flex-1 gap-y-4">
                                     <section>
-                                        <div class="section-header">Heap ({{ systemDiagnostics.heapUtilization }})</div>
+                                        <div class="section-header font-bold">
+                                            Heap ({{ systemDiagnostics.heapUtilization }})
+                                        </div>
                                         <div class="flex flex-col gap-y-3">
                                             <div class="flex flex-col">
                                                 <div>Max</div>
@@ -56,7 +58,7 @@
                                         </div>
                                     </section>
                                     <section>
-                                        <div class="section-header primary-color">Garbage Collection</div>
+                                        <div class="section-header font-bold primary-color">Garbage Collection</div>
                                         @if (sortedGarbageCollections) {
                                             <div class="flex flex-col gap-y-3">
                                                 @for (gc of sortedGarbageCollections; track gc) {
@@ -73,7 +75,7 @@
                                 </div>
                                 <div class="flex flex-col flex-1 gap-y-4">
                                     <section>
-                                        <div class="section-header">Non Heap</div>
+                                        <div class="section-header font-bold">Non Heap</div>
                                         <div class="flex flex-col gap-y-3">
                                             <div class="flex flex-col">
                                                 <div>Max</div>
@@ -102,7 +104,7 @@
                                         </div>
                                     </section>
                                     <section>
-                                        <div class="section-header">Runtime</div>
+                                        <div class="section-header font-bold">Runtime</div>
                                         <div class="flex flex-col gap-y-3">
                                             <div class="flex flex-col">
                                                 <div>Uptime</div>
@@ -148,7 +150,7 @@
                                 </div>
                             </div>
                             <section class="flex flex-col pr-4">
-                                <div class="section-header">FlowFile Repository Usage</div>
+                                <div class="section-header font-bold">FlowFile Repository Usage</div>
                                 <div>
                                     <div class="capitalize">Usage:</div>
                                     <mat-progress-bar
@@ -168,7 +170,7 @@
                                 </div>
                             </section>
                             <section class="flex flex-col pr-4">
-                                <div class="section-header">Content Repository Usage</div>
+                                <div class="section-header font-bold">Content Repository Usage</div>
                                 <div class="repository-storage-container flex flex-col gap-y-2">
                                     @for (repo of systemDiagnostics.contentRepositoryStorageUsage; track repo) {
                                         <div>
@@ -185,7 +187,7 @@
                                 </div>
                             </section>
                             <section class="flex flex-col pr-4">
-                                <div class="section-header">Provenance Repository Usage</div>
+                                <div class="section-header font-bold">Provenance Repository Usage</div>
                                 <div class="repository-storage-container flex flex-col gap-y-2">
                                     @for (repo of systemDiagnostics.provenanceRepositoryStorageUsage; track repo) {
                                         <div>
@@ -207,37 +209,37 @@
                         <div class="tab-content py-4 h-full w-full">
                             <div class="inset-0 flex flex-col gap-y-4">
                                 <section>
-                                    <div class="section-header">NiFi</div>
+                                    <div class="section-header font-bold">NiFi</div>
                                     <dl class="setting-attributes-list">
-                                        <dt>NiFi Version</dt>
+                                        <dt class="font-bold">NiFi Version</dt>
                                         <dd>{{ systemDiagnostics.versionInfo.niFiVersion }}</dd>
-                                        <dt>Tag</dt>
+                                        <dt class="font-bold">Tag</dt>
                                         <dd>{{ systemDiagnostics.versionInfo.buildTag }}</dd>
-                                        <dt>Build Date/Time</dt>
+                                        <dt class="font-bold">Build Date/Time</dt>
                                         <dd>{{ systemDiagnostics.versionInfo.buildTimestamp }}</dd>
-                                        <dt>Branch</dt>
+                                        <dt class="font-bold">Branch</dt>
                                         <dd>{{ systemDiagnostics.versionInfo.buildBranch }}</dd>
-                                        <dt>Revision</dt>
+                                        <dt class="font-bold">Revision</dt>
                                         <dd>{{ systemDiagnostics.versionInfo.buildRevision }}</dd>
                                     </dl>
                                 </section>
                                 <section>
-                                    <div class="section-header">Java</div>
+                                    <div class="section-header font-bold">Java</div>
                                     <dl class="setting-attributes-list">
-                                        <dt>Version</dt>
+                                        <dt class="font-bold">Version</dt>
                                         <dd>{{ systemDiagnostics.versionInfo.javaVersion }}</dd>
-                                        <dt>Vendor</dt>
+                                        <dt class="font-bold">Vendor</dt>
                                         <dd>{{ systemDiagnostics.versionInfo.javaVendor }}</dd>
                                     </dl>
                                 </section>
                                 <section>
-                                    <div class="section-header">Operating System</div>
+                                    <div class="section-header font-bold">Operating System</div>
                                     <dl class="setting-attributes-list">
-                                        <dt>Name</dt>
+                                        <dt class="font-bold">Name</dt>
                                         <dd>{{ systemDiagnostics.versionInfo.osName }}</dd>
-                                        <dt>Version</dt>
+                                        <dt class="font-bold">Version</dt>
                                         <dd>{{ systemDiagnostics.versionInfo.osVersion }}</dd>
-                                        <dt>Architecture</dt>
+                                        <dt class="font-bold">Architecture</dt>
                                         <dd>{{ systemDiagnostics.versionInfo.osArchitecture }}</dd>
                                     </dl>
                                 </section>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/system-diagnostics-dialog/system-diagnostics-dialog.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/system-diagnostics-dialog/system-diagnostics-dialog.component.scss
@@ -26,9 +26,6 @@
 
         .section-header {
             font-size: 15px;
-            font-family: 'Roboto Slab';
-            font-style: normal;
-            font-weight: bold;
         }
     }
 
@@ -37,7 +34,6 @@
             float: left;
             clear: left;
             padding: 0 0.5em 0.2em 0;
-            font-weight: bold;
         }
         dd {
             margin-left: 9em;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/el-function-tip/el-function-tip.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/el-function-tip/el-function-tip.component.html
@@ -18,7 +18,7 @@
 <div class="el-function-tooltip tooltip" [style.left.px]="left" [style.bottom.px]="bottom">
     @if (data?.elFunction; as elFunction) {
         <div class="flex flex-col gap-y-3">
-            <div class="el-name">{{ elFunction.name }}</div>
+            <div class="el-name font-bold">{{ elFunction.name }}</div>
             @if (hasDescription(elFunction)) {
                 <div>{{ elFunction.description }}</div>
             }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/el-function-tip/el-function-tip.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/el-function-tip/el-function-tip.component.scss
@@ -20,14 +20,9 @@
     width: 400px;
 
     .el-name {
-        font-weight: bold;
         font-family: monospace;
         font-size: 16px;
         margin-bottom: 10px;
-    }
-
-    div.el-header {
-        font-weight: bold;
     }
 
     ul.el-arguments {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/parameter-tip/parameter-tip.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/parameter-tip/parameter-tip.component.html
@@ -18,7 +18,7 @@
 <div class="tooltip parameter-tip" [style.left.px]="left" [style.bottom.px]="bottom">
     @if (data?.parameter; as parameter) {
         <div class="flex flex-col gap-y-3">
-            <div class="parameter-name">{{ parameter.name }}</div>
+            <div class="parameter-name font-bold">{{ parameter.name }}</div>
             @if (hasDescription(parameter)) {
                 <div>{{ parameter.description }}</div>
             } @else {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/parameter-tip/parameter-tip.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/parameter-tip/parameter-tip.component.scss
@@ -20,7 +20,6 @@
     width: 400px;
 
     .parameter-name {
-        font-weight: 700;
         font-family: monospace;
         font-size: 16px;
         margin-bottom: 10px;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/property-hint-tip/property-hint-tip.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/property-hint-tip/property-hint-tip.component.html
@@ -23,7 +23,7 @@
             <div class="flex items-baseline gap-x-3">
                 <div class="fa fa-check"></div>
                 <div class="flex flex-col">
-                    <div>Expression Language (EL) supported</div>
+                    <div class="font-bold">Expression Language (EL) supported</div>
                     <div>
                         After beginning with the start delimiter <span class="hint-pattern">$&#123;</span> use the
                         keystroke <span class="hint-keystroke">control+space</span> to see a list of available
@@ -42,10 +42,11 @@
             <div class="flex items-baseline gap-x-3">
                 <div class="fa fa-check"></div>
                 <div class="flex flex-col">
-                    <div>Parameters (PARAM) supported</div>
+                    <div class="font-bold">Parameters (PARAM) supported</div>
                     <div>
-                        After beginning with the start delimiter <span class="hint-pattern">#&#123;</span> use the
-                        keystroke <span class="hint-keystroke">control+space</span> to see a list of available
+                        After beginning with the start delimiter
+                        <span class="hint-pattern font-normal">#&#123;</span> use the keystroke
+                        <span class="hint-keystroke font-light">control+space</span> to see a list of available
                         parameters.
                     </div>
                 </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/property-hint-tip/property-hint-tip.component.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/tooltips/property-hint-tip/property-hint-tip.component.scss
@@ -18,10 +18,8 @@
 .hint-pattern {
     padding: 0 2px;
     letter-spacing: 1px;
-    font-weight: 400;
 }
 
 .hint-keystroke {
-    font-weight: 300;
     font-style: italic;
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/styles/_app.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/styles/_app.scss
@@ -268,6 +268,7 @@
                 $material-theme-accent-palette-darker,
                 $material-theme-accent-palette-lighter
             )};
+        //font-family: mat.get-theme-typography($material-theme, body-1, font-family);
     }
 
     .mat-h2,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/styles/_app.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/styles/_app.scss
@@ -28,15 +28,11 @@
 
     body {
         margin: 0;
-        font-family: Roboto, 'Helvetica Neue', sans-serif;
     }
 
     a {
-        font-size: 13px;
         cursor: pointer;
-        font-weight: normal;
         display: inline-block;
-        font-family: Roboto;
         text-decoration: underline;
         text-underline-offset: 3px;
     }
@@ -47,8 +43,6 @@
         border-radius: 2px;
         border-width: 1px;
         font-size: 13px;
-        font-family: Roboto;
-        font-weight: 400;
         word-wrap: break-word;
         white-space: normal;
 
@@ -60,8 +54,6 @@
 
     .property-editor {
         font-size: 13px;
-        font-family: Roboto;
-        font-weight: 400;
     }
 
     .blank,
@@ -276,6 +268,27 @@
                 $material-theme-accent-palette-darker,
                 $material-theme-accent-palette-lighter
             )};
+    }
+
+    .mat-h2,
+    .mat-typography .mat-h2,
+    .mat-typography h2 {
+        // Because angular material typography adds bottom margin
+        margin: unset;
+    }
+
+    .mat-h3,
+    .mat-typography .mat-h3,
+    .mat-typography h3 {
+        // Because angular material typography adds bottom margin
+        margin: unset;
+    }
+
+    .mat-h4,
+    .mat-typography .mat-h4,
+    .mat-typography h4 {
+        // Because angular material typography adds bottom margin
+        margin: unset;
     }
 
     .cdk-drop-list {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/material.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/material.scss
@@ -63,7 +63,7 @@ $warn-light-palette: (
     600: #ec3030,
     700: #ff1507,
     800: #ff0000,
-    900: #ba554a, // g.component rect.border.unauthorized, #connection-full-drop-shadow feFlood, text.restricted, g.connection rect.border.unauthorized, g.connection path.connection-path.full, g.connection path.connection-path.unauthorized, .controller-bulletins.has-bulletins, path.link.selected, g.event circle.selected
+    900: #ba554a,
     contrast: (
         50: rgba(#000000, 0.87),
         100: rgba(#000000, 0.87),
@@ -100,6 +100,31 @@ $material-accent-light: mat.define-palette($material-accent-light-palette, 500, 
 // warn material palette color default hue must have enough contrast on top of the mat-app-background. For light mode this is a minimum of 600 up to 900.
 $warn-light: mat.define-palette($warn-light-palette, 400, 200, 900);
 
+@use '@fontsource/roboto/latin.css' as roboto-normal;
+@use '@fontsource/roboto/latin-300-italic.css' as roboto-light-italic;
+@use '@fontsource/roboto/latin-400-italic.css' as roboto-normal-italic;
+
+//https://m2.material.io/design/typography/the-type-system.html#type-scale
+$typography-config: mat.define-typography-config(
+    $font-family: Roboto,
+    //h2
+    $headline-6: mat.define-typography-level(16px, 24px, 400, $letter-spacing: 0.4375px),
+    //h3
+    $subtitle-1: mat.define-typography-level(20px, 20px, 700, $letter-spacing: 0.4375px),
+    //h4
+    $subtitle-2: mat.define-typography-level(14px, 26px, 400, $letter-spacing: 0.4375px),
+    //body
+    $body-1: mat.define-typography-level(16px, 24px, 400),
+    //body2
+    $body-2: mat.define-typography-level(14px, 14px, 400),
+    //caption <mat-error> or <mat-hint>
+    $caption: mat.define-typography-level(12px, 20px, 400, $letter-spacing: 0.4px),
+    //button
+    $button: mat.define-typography-level(16px, 24px, 400),
+);
+
+@include mat.typography-hierarchy($typography-config);
+
 // Create the theme objects. We can extract the values we need from the theme passed into the mixins.
 $material-theme-light: mat.define-light-theme(
         (
@@ -108,7 +133,7 @@ $material-theme-light: mat.define-light-theme(
                 accent: $material-accent-light,
                 warn: $warn-light
             ),
-            //typography: mat.define-typography-config(), // TODO: typography
+            typography: $typography-config,
             density: -3
         )
 );
@@ -138,8 +163,8 @@ $material-theme-dark: mat.define-dark-theme(
                 accent: $material-accent-dark,
                 warn: $warn-dark
             ),
-            density: 0,
-            typography: mat.define-typography-config(),
+            typography: $typography-config,
+            density: 0
         )
 );
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/material.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/material.scss
@@ -108,9 +108,9 @@ $warn-light: mat.define-palette($warn-light-palette, 400, 200, 900);
 $typography-config: mat.define-typography-config(
     $font-family: Roboto,
     //h2
-    $headline-6: mat.define-typography-level(16px, 24px, 400, $letter-spacing: 0.4375px),
+    $headline-6: mat.define-typography-level(16px, 24px, 400, $letter-spacing: 0.5px),
     //h3
-    $subtitle-1: mat.define-typography-level(20px, 20px, 700, $letter-spacing: 0.4375px),
+    $subtitle-1: mat.define-typography-level(20px, 20px, 700),
     //h4
     $subtitle-2: mat.define-typography-level(14px, 26px, 400, $letter-spacing: 0.4375px),
     //body

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/nifi.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/nifi.scss
@@ -107,11 +107,27 @@ $surface-light-palette: mat.define-palette($surface-palette, 600, 100, 900);
 $success-light-palette: mat.define-palette($success-palette, 400, 200, 800);
 $caution-light-palette: mat.define-palette($caution-palette, A400, A200, A700);
 
-@use '@fontsource/roboto-slab/latin.css' as roboto-slab-normal;
+@use '@fontsource/roboto/latin.css' as roboto-normal;
+@use '@fontsource/roboto/latin-300-italic.css' as roboto-light-italic;
+@use '@fontsource/roboto/latin-400-italic.css' as roboto-normal-italic;
 
 //https://m2.material.io/design/typography/the-type-system.html#type-scale
 $typography-config: mat.define-typography-config(
-    $font-family: Roboto Slab
+    $font-family: Roboto,
+        //h2
+    $headline-6: mat.define-typography-level(16px, 24px, 400, $letter-spacing: 0.4375px),
+        //h3
+    $subtitle-1: mat.define-typography-level(20px, 20px, 700, $letter-spacing: 0.4375px),
+        //h4
+    $subtitle-2: mat.define-typography-level(14px, 26px, 400, $letter-spacing: 0.4375px),
+        //body
+    $body-1: mat.define-typography-level(16px, 24px, 400),
+        //body2
+    $body-2: mat.define-typography-level(14px, 14px, 400),
+        //caption <mat-error> or <mat-hint>
+    $caption: mat.define-typography-level(12px, 20px, 400, $letter-spacing: 0.4px),
+        //button
+    $button: mat.define-typography-level(16px, 24px, 400),
 );
 
 @include mat.typography-hierarchy($typography-config);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/nifi.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/nifi.scss
@@ -107,31 +107,6 @@ $surface-light-palette: mat.define-palette($surface-palette, 600, 100, 900);
 $success-light-palette: mat.define-palette($success-palette, 400, 200, 800);
 $caution-light-palette: mat.define-palette($caution-palette, A400, A200, A700);
 
-@use '@fontsource/roboto/latin.css' as roboto-normal;
-@use '@fontsource/roboto/latin-300-italic.css' as roboto-light-italic;
-@use '@fontsource/roboto/latin-400-italic.css' as roboto-normal-italic;
-
-//https://m2.material.io/design/typography/the-type-system.html#type-scale
-$typography-config: mat.define-typography-config(
-    $font-family: Roboto,
-    //h2
-    $headline-6: mat.define-typography-level(16px, 24px, 400, $letter-spacing: 0.5px),
-    //h3
-    $subtitle-1: mat.define-typography-level(20px, 20px, 700),
-    //h4
-    $subtitle-2: mat.define-typography-level(14px, 26px, 400, $letter-spacing: 0.4375px),
-    //body
-    $body-1: mat.define-typography-level(16px, 24px, 400),
-    //body2
-    $body-2: mat.define-typography-level(14px, 14px, 400),
-    //caption <mat-error> or <mat-hint>
-    $caption: mat.define-typography-level(12px, 20px, 400, $letter-spacing: 0.4px),
-    //button
-    $button: mat.define-typography-level(16px, 24px, 400),
-);
-
-@include mat.typography-hierarchy($typography-config);
-
 $nifi-theme-light: mat.define-light-theme(
         (
             color: (
@@ -139,7 +114,6 @@ $nifi-theme-light: mat.define-light-theme(
                 accent: $success-light-palette,
                 warn: $caution-light-palette
             ),
-            typography: $typography-config,
             density: -3
         )
 );
@@ -157,7 +131,6 @@ $nifi-theme-dark: mat.define-dark-theme(
                 accent: $success-dark-palette,
                 warn: $caution-dark-palette,
             ),
-            typography: $typography-config,
             density: -3
         )
 );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/nifi.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/nifi.scss
@@ -107,6 +107,15 @@ $surface-light-palette: mat.define-palette($surface-palette, 600, 100, 900);
 $success-light-palette: mat.define-palette($success-palette, 400, 200, 800);
 $caution-light-palette: mat.define-palette($caution-palette, A400, A200, A700);
 
+@use '@fontsource/roboto-slab/latin.css' as roboto-slab-normal;
+
+//https://m2.material.io/design/typography/the-type-system.html#type-scale
+$typography-config: mat.define-typography-config(
+    $font-family: Roboto Slab
+);
+
+@include mat.typography-hierarchy($typography-config);
+
 $nifi-theme-light: mat.define-light-theme(
         (
             color: (
@@ -114,7 +123,7 @@ $nifi-theme-light: mat.define-light-theme(
                 accent: $success-light-palette,
                 warn: $caution-light-palette
             ),
-            //typography: mat.define-typography-config(), // TODO: typography
+            typography: $typography-config,
             density: -3
         )
 );
@@ -132,7 +141,7 @@ $nifi-theme-dark: mat.define-dark-theme(
                 accent: $success-dark-palette,
                 warn: $caution-dark-palette,
             ),
-            //typography: mat.define-typography-config(), // TODO: typography
+            typography: $typography-config,
             density: -3
         )
 );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/nifi.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/nifi.scss
@@ -114,19 +114,19 @@ $caution-light-palette: mat.define-palette($caution-palette, A400, A200, A700);
 //https://m2.material.io/design/typography/the-type-system.html#type-scale
 $typography-config: mat.define-typography-config(
     $font-family: Roboto,
-        //h2
-    $headline-6: mat.define-typography-level(16px, 24px, 400, $letter-spacing: 0.4375px),
-        //h3
-    $subtitle-1: mat.define-typography-level(20px, 20px, 700, $letter-spacing: 0.4375px),
-        //h4
+    //h2
+    $headline-6: mat.define-typography-level(16px, 24px, 400, $letter-spacing: 0.5px),
+    //h3
+    $subtitle-1: mat.define-typography-level(20px, 20px, 700),
+    //h4
     $subtitle-2: mat.define-typography-level(14px, 26px, 400, $letter-spacing: 0.4375px),
-        //body
+    //body
     $body-1: mat.define-typography-level(16px, 24px, 400),
-        //body2
+    //body2
     $body-2: mat.define-typography-level(14px, 14px, 400),
-        //caption <mat-error> or <mat-hint>
+    //caption <mat-error> or <mat-hint>
     $caption: mat.define-typography-level(12px, 20px, 400, $letter-spacing: 0.4px),
-        //button
+    //button
     $button: mat.define-typography-level(16px, 24px, 400),
 );
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/purple.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/purple.scss
@@ -30,6 +30,25 @@ $material-primary-light: mat.define-palette($material-primary-light-palette, 800
 $material-accent-light: mat.define-palette($material-accent-light-palette, 600, 50, A700);
 $warn-light: mat.define-palette($warn-light-palette, 400, 200, 900);
 
+//https://m2.material.io/design/typography/the-type-system.html#type-scale
+$typography-config: mat.define-typography-config(
+    $font-family: Courier New,
+    //h2
+    $headline-6: mat.define-typography-level(16px, 24px, 400, $letter-spacing: 0.4375px),
+    //h3
+    $subtitle-1: mat.define-typography-level(20px, 20px, 700, $letter-spacing: 0.4375px),
+    //h4
+    $subtitle-2: mat.define-typography-level(14px, 26px, 400, $letter-spacing: 0.4375px),
+    //body
+    $body-1: mat.define-typography-level(16px, 24px, 400),
+    //body2
+    $body-2: mat.define-typography-level(14px, 14px, 400),
+    //caption <mat-error> or <mat-hint>
+    $caption: mat.define-typography-level(12px, 20px, 400, $letter-spacing: 0.4px),
+    //button
+    $button: mat.define-typography-level(16px, 24px, 400),
+);
+
 // Create the theme objects. We can extract the values we need from the theme passed into the mixins.
 $material-theme-light: mat.define-light-theme(
         (
@@ -38,6 +57,7 @@ $material-theme-light: mat.define-light-theme(
                 accent: $material-accent-light,
                 warn: $warn-light
             ),
+            typography: $typography-config,
             density: -3
         )
 );
@@ -54,6 +74,7 @@ $material-theme-dark: mat.define-dark-theme(
                 accent: $material-accent-dark,
                 warn: $warn-dark
             ),
+            typography: $typography-config,
             density: -3
         )
 );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/purple.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/purple.scss
@@ -34,9 +34,9 @@ $warn-light: mat.define-palette($warn-light-palette, 400, 200, 900);
 $typography-config: mat.define-typography-config(
     $font-family: Courier New,
     //h2
-    $headline-6: mat.define-typography-level(16px, 24px, 400, $letter-spacing: 0.4375px),
+    $headline-6: mat.define-typography-level(16px, 24px, 400, $letter-spacing: 0.5px),
     //h3
-    $subtitle-1: mat.define-typography-level(20px, 20px, 700, $letter-spacing: 0.4375px),
+    $subtitle-1: mat.define-typography-level(20px, 20px, 700),
     //h4
     $subtitle-2: mat.define-typography-level(14px, 26px, 400, $letter-spacing: 0.4375px),
     //body

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/purple.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/purple.scss
@@ -49,6 +49,8 @@ $typography-config: mat.define-typography-config(
     $button: mat.define-typography-level(16px, 24px, 400),
 );
 
+@include mat.typography-hierarchy($typography-config);
+
 // Create the theme objects. We can extract the values we need from the theme passed into the mixins.
 $material-theme-light: mat.define-light-theme(
         (

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/purple.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/themes/purple.scss
@@ -32,7 +32,7 @@ $warn-light: mat.define-palette($warn-light-palette, 400, 200, 900);
 
 //https://m2.material.io/design/typography/the-type-system.html#type-scale
 $typography-config: mat.define-typography-config(
-    $font-family: Courier New,
+    $font-family: "Comic Sans MS, Tahoma",
     //h2
     $headline-6: mat.define-typography-level(16px, 24px, 400, $letter-spacing: 0.5px),
     //h3

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/index.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/index.html
@@ -22,10 +22,8 @@
         <title>NiFi</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" type="image/svg+xml" href="assets/icons/nifi-drop.svg" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" />
-        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     </head>
-    <body class="mat-app-background">
+    <body class="mat-app-background mat-typography">
         <nifi></nifi>
     </body>
 </html>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
@@ -42,10 +42,6 @@
 @use 'app/pages/summary/ui/processor-status-listing/processor-status-table/processor-status-table.component-theme' as processor-status-table;
 
 // Plus imports for other components in your app.
-@use '@fontsource/roboto/latin.css' as roboto-normal;
-@use '@fontsource/roboto/latin-300-italic.css' as roboto-light-italic;
-@use '@fontsource/roboto/latin-400-italic.css' as roboto-normal-italic;
-@use '@fontsource/roboto-slab/latin.css' as roboto-slab-normal;
 @use 'assets/fonts/flowfont/flowfont.css';
 @use 'font-awesome/css/font-awesome.min.css';
 @use 'codemirror/lib/codemirror.css';
@@ -90,7 +86,7 @@
 @include provenance.generate-theme($material-theme-light, $nifi-theme-light);
 @include lineage.generate-theme($material-theme-light, $nifi-theme-light);
 @include context-menu.generate-theme($material-theme-light, $nifi-theme-light);
-@include navigation.generate-theme($material-theme-light);
+@include navigation.generate-theme($material-theme-light, $nifi-theme-light);
 @include nf-editor.generate-theme($material-theme-light, $nifi-theme-light);
 @include status-history.generate-theme($nifi-theme-light);
 @include property-hint-tip.generate-theme($material-theme-light, $nifi-theme-light);
@@ -118,7 +114,7 @@
     @include provenance.generate-theme($material-theme-dark, $nifi-theme-dark);
     @include lineage.generate-theme($material-theme-dark, $nifi-theme-dark);
     @include context-menu.generate-theme($material-theme-dark, $nifi-theme-dark);
-    @include navigation.generate-theme($material-theme-dark);
+    @include navigation.generate-theme($material-theme-dark, $nifi-theme-dark);
     @include nf-editor.generate-theme($material-theme-dark, $nifi-theme-dark);
     @include status-history.generate-theme($nifi-theme-dark);
     @include property-hint-tip.generate-theme($material-theme-dark, $nifi-theme-dark);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
@@ -50,7 +50,7 @@
 // To override the canvas theme, you need to set the variables $nifi-theme-light and $nifi-theme-dark
 @import 'assets/themes/nifi';
 // To override the NiFi theme, you need to set the variables $material-theme-light and $material-theme-dark
-@import 'assets/themes/material';
+@import 'assets/themes/purple';
 
 // Include the common styles for Angular Material. We include this here so that you only
 // have to load a single css file for Angular Material in your app.

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/styles.scss
@@ -50,7 +50,7 @@
 // To override the canvas theme, you need to set the variables $nifi-theme-light and $nifi-theme-dark
 @import 'assets/themes/nifi';
 // To override the NiFi theme, you need to set the variables $material-theme-light and $material-theme-dark
-@import 'assets/themes/purple';
+@import 'assets/themes/material';
 
 // Include the common styles for Angular Material. We include this here so that you only
 // have to load a single css file for Angular Material in your app.


### PR DESCRIPTION
Theme files now configure their font-family and can customize their typography. To demonstrate the art of the possible the default material theme uses the 'Roboto' font while the purple theme has been updated to use the standard 'Courier New' font.

Default material theme with 'Roboto' font:

<img width="1728" alt="Screenshot 2024-05-04 at 11 55 11 AM" src="https://github.com/apache/nifi/assets/6797571/8f46196d-7d49-465a-b8a8-b467c371bf8a">
<img width="1728" alt="Screenshot 2024-05-04 at 11 55 24 AM" src="https://github.com/apache/nifi/assets/6797571/5ad3a1b0-bc67-447c-8f1d-8e3a3c578dac">


Purple theme with 'Comic sans' font:

![Screenshot 2024-05-06 at 2 40 19 PM](https://github.com/apache/nifi/assets/6797571/c7205935-b7fb-4eb0-aff2-6c49fd296009)
![Screenshot 2024-05-06 at 2 40 27 PM](https://github.com/apache/nifi/assets/6797571/75dd399d-1b8c-44b8-81ae-25a22a2f7ac3)


The nifi theme file is configured with 'Roboto Slab'. This can also be changed in the nifi.scss file to make use of different fonts.