### PR TITLE
NIFI-13148 Exclude unused xmlunit dependency from nifi-registry-test

### DIFF
--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -25,11 +25,6 @@
         <cve>CVE-2017-10355</cve>
     </suppress>
     <suppress>
-        <notes>CVE-2020-13955 applies to Apache Calcite not Apache Calcite Druid</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.calcite\/calcite-druid@.*$</packageUrl>
-        <cve>CVE-2020-13955</cve>
-    </suppress>
-    <suppress>
         <notes>CVE-2007-6465 applies to Ganglia Server not Ganglia client libraries</notes>
         <packageUrl regex="true">^pkg:maven/com\.yammer\.metrics/metrics\-ganglia@.*$</packageUrl>
         <cve>CVE-2007-6465</cve>
@@ -103,11 +98,6 @@
         <notes>CVE-2023-25194 applies to Kafka Connect workers not client libraries</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka.*?@.*$</packageUrl>
         <cve>CVE-2023-25194</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2022-24823 applies to Netty HTTP decoding which is not applicable to Apache Kudu clients</notes>
-        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*?@.*$</packageUrl>
-        <cve>CVE-2022-24823</cve>
     </suppress>
     <suppress>
         <notes>CVE-2022-41915 applies to Netty HTTP decoding which is not applicable to Apache Kudu clients</notes>
@@ -190,11 +180,6 @@
         <cve>CVE-2019-3559</cve>
     </suppress>
     <suppress>
-        <notes>The jetty-servlet-api is versioned according to the Java Servlet API version not the Jetty version</notes>
-        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.toolchain/jetty\-servlet\-api@.*$</packageUrl>
-        <cpe>cpe:/a:eclipse:jetty</cpe>
-    </suppress>
-    <suppress>
         <notes>CVE-2023-37475 applies to Hamba Avro in Go not Apache Avro for Java</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.avro/.*$</packageUrl>
         <cve>CVE-2023-37475</cve>
@@ -218,11 +203,6 @@
         <notes>Parquet MR vulnerabilities do not apply to other Parquet libraries</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.parquet/parquet\-(?!mr).*$</packageUrl>
         <cpe>cpe:/a:apache:parquet-mr</cpe>
-    </suppress>
-    <suppress>
-        <notes>Apache Hadoop vulnerabilities do not apply to Parquet Hadoop Bundle library</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.parquet/parquet\-hadoop\-bundle@.*$</packageUrl>
-        <cpe>cpe:/a:apache:hadoop</cpe>
     </suppress>
     <suppress>
         <notes>CVE-2019-11358 applies to bundled copies of jQuery not used in the project</notes>
@@ -285,28 +265,18 @@
         <cve>CVE-2023-36052</cve>
     </suppress>
     <suppress>
-        <notes>software.amazon.ion:ion-java is newer than com.amazonaws.ion:ion-java and does not share the same vulnerabilities</notes>
-        <packageUrl regex="true">^pkg:maven/software\.amazon\.ion/ion\-java@.*$</packageUrl>
-        <cpe>cpe:/a:amazon:ion</cpe>
-    </suppress>
-    <suppress>
-        <notes>CVE-2017-20189 applies to the Clojure library not the spec files which have a different version number</notes>
-        <packageUrl regex="true">^pkg:maven/org\.clojure/spec\.alpha@.*$</packageUrl>
-        <cve>CVE-2017-20189</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2017-20189 applies to the Clojure library not the spec files which have a different version number</notes>
-        <packageUrl regex="true">^pkg:maven/org\.clojure/core\.specs\.alpha@.*$</packageUrl>
-        <cve>CVE-2017-20189</cve>
-    </suppress>
-    <suppress>
         <notes>Findings for Apache Hadoop do not apply to the shaded Protobuf library</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop\.thirdparty/hadoop\-shaded\-protobuf_3_21@.*$</packageUrl>
         <cpe>cpe:/a:apache:hadoop</cpe>
     </suppress>
     <suppress>
-        <notes>CVE-2024-22201 applies to Jetty Server 10.0.19 and not Jetty client usage in Solr</notes>
-        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2\-common@.*$</packageUrl>
-        <vulnerabilityName>CVE-2024-22201</vulnerabilityName>
+        <notes>CVE-2024-23081 applies to threetenbp 1.6.8 and earlier not 1.6.9</notes>
+        <packageUrl regex="true">^pkg:maven/org\.threeten/threetenbp@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-23081</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2024-23082 applies to threetenbp 1.6.8 and earlier not 1.6.9</notes>
+        <packageUrl regex="true">^pkg:maven/org\.threeten/threetenbp@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-23082</vulnerabilityName>
     </suppress>
 </suppressions>

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -31,6 +31,11 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
+                <!-- XML Unit is not used -->
+                <exclusion>
+                    <groupId>org.xmlunit</groupId>
+                    <artifactId>xmlunit-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
# Summary

[NIFI-13148](https://issues.apache.org/jira/browse/NIFI-13148) Excludes the unused `xmlunit` dependency from `nifi-registry-test` to avoid current and future vulnerability findings related to the library. Additional changes include updating the OWASP Dependency Check Suppression configuration to remove non-applicable items.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
