### PR TITLE
NIFI-13160 Support Skipping Frontend Unit Tests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -77,6 +77,7 @@ concurrency:
 permissions:
   security-events: write
   contents: read
+  pull-requests: read
 
 jobs:
   static-analysis:
@@ -158,10 +159,18 @@ jobs:
           distribution: 'corretto'
           java-version: '21'
           cache: 'maven'
+      - name: Evaluate Changed Paths
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            frontend:
+              - 'nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/**'
       - name: Maven Compile
         env:
           MAVEN_OPTS: >-
             ${{ env.COMPILE_MAVEN_OPTS }}
+            -Dfrontend.skipTests=${{ !steps.changes.outputs.frontend }}
         run: >
           ${{ env.MAVEN_COMMAND }}
           ${{ env.MAVEN_COMPILE_COMMAND }}
@@ -169,6 +178,7 @@ jobs:
         env:
           MAVEN_OPTS: >-
             ${{ env.DEFAULT_MAVEN_OPTS }}
+            -Dfrontend.skipTests=${{ !steps.changes.outputs.frontend }}
         run: >
           ${{ env.MAVEN_COMMAND }}
           jacoco:prepare-agent
@@ -220,10 +230,18 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
           cache: 'maven'
+      - name: Evaluate Changed Paths
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            frontend:
+              - 'nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/**'
       - name: Maven Compile
         env:
           MAVEN_OPTS: >-
             ${{ env.COMPILE_MAVEN_OPTS }}
+            -Dfrontend.skipTests=${{ !steps.changes.outputs.frontend }}
         run: >
           ${{ env.MAVEN_COMMAND }}
           ${{ env.MAVEN_COMPILE_COMMAND }}
@@ -287,10 +305,18 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
           cache: 'maven'
+      - name: Evaluate Changed Paths
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            frontend:
+              - 'nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/**'
       - name: Maven Compile
         env:
           MAVEN_OPTS: >-
             ${{ env.COMPILE_MAVEN_OPTS }}
+            -Dfrontend.skipTests=${{ !steps.changes.outputs.frontend }}
         run: >
           ${{ env.MAVEN_COMMAND_WINDOWS }}
           ${{ env.MAVEN_COMPILE_COMMAND }}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/pom.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/pom.xml
@@ -36,6 +36,7 @@
             Ex: 'purple' // will overwrite the 'material' theme file with the 'purple' theme.
         -->
         <frontend.theme>material</frontend.theme>
+        <frontend.skipTests>true</frontend.skipTests>
     </properties>
 
     <build>
@@ -160,6 +161,7 @@
                         <configuration>
                             <arguments>nx lint</arguments>
                             <workingDirectory>${frontend.working.dir}</workingDirectory>
+                            <skip>${frontend.skipTests}</skip>
                         </configuration>
                     </execution>
 
@@ -175,6 +177,7 @@
                         <configuration>
                             <arguments>nx test --maxWorkers=2</arguments>
                             <workingDirectory>${frontend.working.dir}</workingDirectory>
+                            <skip>${frontend.skipTests}</skip>
                         </configuration>
                     </execution>
 


### PR DESCRIPTION
# Summary

[NIFI-13160](https://issues.apache.org/jira/browse/NIFI-13160) Supports skipping unit tests in the `nifi-web-frontend` module using a property named `frontend.skipTests`.

The property defaults to `false`, avoiding running tests on default builds. Changes include adding a [paths-filter](https://github.com/dorny/paths-filter) step to the GitHub `ci-workflow` to support conditional enabling of frontend unit tests when pull requests include changes for the `nifi-web-frontend` module.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
