### PR TITLE
NIFI-13160 Correct frontend changes evaluation in ci-workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -170,7 +170,7 @@ jobs:
         env:
           MAVEN_OPTS: >-
             ${{ env.COMPILE_MAVEN_OPTS }}
-            -Dfrontend.skipTests=${{ !steps.changes.outputs.frontend }}
+            -Dfrontend.skipTests=${{ steps.changes.outputs.frontend == 'true' && 'false' || 'true' }}
         run: >
           ${{ env.MAVEN_COMMAND }}
           ${{ env.MAVEN_COMPILE_COMMAND }}
@@ -178,7 +178,7 @@ jobs:
         env:
           MAVEN_OPTS: >-
             ${{ env.DEFAULT_MAVEN_OPTS }}
-            -Dfrontend.skipTests=${{ !steps.changes.outputs.frontend }}
+            -Dfrontend.skipTests=${{ steps.changes.outputs.frontend == 'true' && 'false' || 'true' }}
         run: >
           ${{ env.MAVEN_COMMAND }}
           jacoco:prepare-agent
@@ -241,7 +241,7 @@ jobs:
         env:
           MAVEN_OPTS: >-
             ${{ env.COMPILE_MAVEN_OPTS }}
-            -Dfrontend.skipTests=${{ !steps.changes.outputs.frontend }}
+            -Dfrontend.skipTests=${{ steps.changes.outputs.frontend == 'true' && 'false' || 'true' }}
         run: >
           ${{ env.MAVEN_COMMAND }}
           ${{ env.MAVEN_COMPILE_COMMAND }}
@@ -316,7 +316,7 @@ jobs:
         env:
           MAVEN_OPTS: >-
             ${{ env.COMPILE_MAVEN_OPTS }}
-            -Dfrontend.skipTests=${{ !steps.changes.outputs.frontend }}
+            -Dfrontend.skipTests=${{ steps.changes.outputs.frontend == 'true' && 'false' || 'true' }}
         run: >
           ${{ env.MAVEN_COMMAND_WINDOWS }}
           ${{ env.MAVEN_COMPILE_COMMAND }}


### PR DESCRIPTION
# Summary

[NIFI-13160](https://issues.apache.org/jira/browse/NIFI-13160) Corrects evaluation of the `steps.changes.outputs.frontend` variable in the GitHub `ci-workflow` when setting the `frontend.skipTests` build property. The initial implementation always set the `frontend.skipTests` value to `false`. The updated approach follows ternary example from [GitHub Actions Expressions](https://docs.github.com/en/actions/learn-github-actions/expressions#example) documentation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
