### PR TITLE
NIFI-13167 Replace Hamcrest Matchers with JUnit Matchers

### DIFF
--- a/minifi/minifi-integration-tests/pom.xml
+++ b/minifi/minifi-integration-tests/pom.xml
@@ -41,6 +41,12 @@ limitations under the License.
             <artifactId>docker-compose-junit-jupiter</artifactId>
             <version>2.3.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi.minifi</groupId>

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -45,7 +45,6 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -56,8 +55,6 @@ import java.util.concurrent.TimeUnit;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -2175,18 +2172,6 @@ public class TestQuery {
         final Map<String, String> attrs = Collections.emptyMap();
         verifyEquals("${literal(2):gt(1)}", attrs, true);
         verifyEquals("${literal('hello'):substring(0, 1):equals('h')}", attrs, true);
-    }
-
-    @Test
-    public void testRandomFunction() {
-        final Map<String, String> attrs = Collections.emptyMap();
-        final Long negOne = -1L;
-        final HashSet<Long> results = new HashSet<>(100);
-        for (int i = 0; i < results.size(); i++) {
-            long result = (Long) getResult("${random()}", attrs).getValue();
-            assertThat("random", result, greaterThan(negOne));
-            assertTrue(results.add(result), "duplicate random");
-        }
     }
 
     QueryResult<?> getResult(String expr, Map<String, String> attrs) {

--- a/nifi-extension-bundles/nifi-accumulo-bundle/nifi-accumulo-services/src/test/java/org/apache/nifi/accumulo/controllerservices/TestAccumuloService.java
+++ b/nifi-extension-bundles/nifi-accumulo-bundle/nifi-accumulo-services/src/test/java/org/apache/nifi/accumulo/controllerservices/TestAccumuloService.java
@@ -26,9 +26,8 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,104 +60,87 @@ public class TestAccumuloService {
 
     @Test
     public void testServiceValidWithAuthTypePasswordAndInstanceZookeeperUserPasswordAreSet() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
         runner.setProperty(accumuloService, AccumuloService.AUTHENTICATION_TYPE, PASSWORD);
         runner.setProperty(accumuloService, AccumuloService.ACCUMULO_USER, USER);
         runner.setProperty(accumuloService, AccumuloService.ACCUMULO_PASSWORD, PASSWORD);
-        //when
-        //then
+
         runner.assertValid(accumuloService);
     }
 
     @Test
     public void testServiceNotValidWithInstanceMissing() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
-        //when
-        //then
+
         assertServiceIsInvalidWithErrorMessage("Instance name must be supplied");
     }
 
     @Test
     public void testServiceNotValidWithZookeeperMissing() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
-        //when
-        //then
+
         assertServiceIsInvalidWithErrorMessage("Zookeepers must be supplied");
     }
 
     @Test
     public void testServiceNotValidWithAuthTypeNone() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
         runner.setProperty(accumuloService, AccumuloService.AUTHENTICATION_TYPE, NONE);
-        //when
-        //then
+
         assertServiceIsInvalidWithErrorMessage("Non supported Authentication type");
     }
 
     @Test
     public void testServiceNotValidWithAuthTypePasswordAndUserMissing() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
         runner.setProperty(accumuloService, AccumuloService.AUTHENTICATION_TYPE, PASSWORD);
         runner.setProperty(accumuloService, AccumuloService.ACCUMULO_PASSWORD, PASSWORD);
-        //when
-        //then
+
         assertServiceIsInvalidWithErrorMessage("Accumulo user must be supplied");
     }
 
     @Test
     public void testServiceNotValidWithAuthTypePasswordAndPasswordMissing() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
         runner.setProperty(accumuloService, AccumuloService.AUTHENTICATION_TYPE, PASSWORD);
         runner.setProperty(accumuloService, AccumuloService.ACCUMULO_USER, USER);
-        //when
-        //then
+
         assertServiceIsInvalidWithErrorMessage("Password must be supplied");
     }
 
     @Test
     public void testServiceNotValidWithAuthTypeKerberosAndKerberosPasswordAndCredentialServiceMissing() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
         runner.setProperty(accumuloService, AccumuloService.AUTHENTICATION_TYPE, KERBEROS);
-        //when
-        //then
+
         assertServiceIsInvalidWithErrorMessage("Either Kerberos Password, Kerberos Credential Service, or Kerberos User Service must be set");
     }
 
     @Test
     public void testServiceNotValidWithAuthTypeKerberosAndKerberosPrincipalMissing() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
         runner.setProperty(accumuloService, AccumuloService.AUTHENTICATION_TYPE, KERBEROS);
         runner.setProperty(accumuloService, AccumuloService.KERBEROS_PASSWORD, KERBEROS_PASSWORD);
-        //when
-        //then
+
         assertServiceIsInvalidWithErrorMessage("Kerberos Principal must be supplied");
     }
 
     @Test
     public void testServiceNotValidWithAuthTypeKerberosAndKerberosPasswordAndCredentialServiceSet() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
@@ -166,14 +148,12 @@ public class TestAccumuloService {
         runner.setProperty(accumuloService, AccumuloService.KERBEROS_PASSWORD, KERBEROS_PASSWORD);
         runner.addControllerService("kerberos-credentials-service", credentialService);
         runner.setProperty(accumuloService, AccumuloService.KERBEROS_CREDENTIALS_SERVICE, credentialService.getIdentifier());
-        //when
-        //then
+
         assertServiceIsInvalidWithErrorMessage("should not be filled out at the same time");
     }
 
     @Test
     public void testServiceNotValidWithAuthTypeKerberosAndPrincipalAndCredentialServiceSet() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
@@ -181,14 +161,12 @@ public class TestAccumuloService {
         runner.setProperty(accumuloService, AccumuloService.KERBEROS_PRINCIPAL, PRINCIPAL);
         runner.addControllerService("kerberos-credentials-service", credentialService);
         runner.setProperty(accumuloService, AccumuloService.KERBEROS_CREDENTIALS_SERVICE, credentialService.getIdentifier());
-        //when
-        //then
+
         assertServiceIsInvalidWithErrorMessage("Kerberos Principal (for password) should not be filled out");
     }
 
     @Test
     public void testServiceNotValidWithAuthTypeKerberosAndKerberosPasswordAndUserServiceSet() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
@@ -197,14 +175,12 @@ public class TestAccumuloService {
         runner.setProperty(accumuloService, AccumuloService.KERBEROS_PASSWORD, KERBEROS_PASSWORD);
         runner.addControllerService("kerberos-user-service", kerberosUserService);
         runner.setProperty(accumuloService, AccumuloService.KERBEROS_USER_SERVICE, kerberosUserService.getIdentifier());
-        //when
-        //then
+
         assertServiceIsInvalidWithErrorMessage("should not be filled out at the same time");
     }
 
     @Test
     public void testServiceNotValidWithAuthTypeKerberosAndCredentialServiceAndUserServiceSet() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
@@ -216,14 +192,11 @@ public class TestAccumuloService {
         runner.addControllerService("kerberos-user-service", kerberosUserService);
         runner.setProperty(accumuloService, AccumuloService.KERBEROS_USER_SERVICE, kerberosUserService.getIdentifier());
 
-        //when
-        //then
         assertServiceIsInvalidWithErrorMessage("Kerberos User Service cannot be specified while also specifying a Kerberos Credential Service");
     }
 
     @Test
     public void testServiceIsValidWithAuthTypeKerberosAndKerberosUserServiceSet() throws InitializationException {
-        //given
         runner.addControllerService("accumulo-connector-service", accumuloService);
         runner.setProperty(accumuloService, AccumuloService.INSTANCE_NAME, INSTANCE);
         runner.setProperty(accumuloService, AccumuloService.ZOOKEEPER_QUORUM, ZOOKEEPER);
@@ -231,13 +204,11 @@ public class TestAccumuloService {
         runner.addControllerService("kerberos-user-service", kerberosUserService);
         runner.enableControllerService(kerberosUserService);
         runner.setProperty(accumuloService, AccumuloService.KERBEROS_USER_SERVICE, kerberosUserService.getIdentifier());
-        //when
-        //then
         runner.assertValid(accumuloService);
     }
 
     private void assertServiceIsInvalidWithErrorMessage(String errorMessage) {
         Exception exception = assertThrows(IllegalStateException.class, () -> runner.enableControllerService(accumuloService));
-        assertThat(exception.getMessage(), containsString(errorMessage));
+        assertTrue(exception.getMessage().contains(errorMessage));
     }
 }

--- a/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/TestJASN1RecordReaderWithSimpleTypes.java
+++ b/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/test/java/org/apache/nifi/jasn1/TestJASN1RecordReaderWithSimpleTypes.java
@@ -54,8 +54,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -199,7 +198,7 @@ public class TestJASN1RecordReaderWithSimpleTypes implements JASN1ReadRecordTest
             testReadRecord(dataFile, berValue, (Map) null, null);
             fail();
         } catch (Exception e) {
-            assertThat(e.getMessage(), containsString("Text '2019_10-16' could not be parsed at index 4"));
+            assertTrue(e.getMessage().contains("Text '2019_10-16' could not be parsed at index 4"));
         }
     }
 
@@ -222,7 +221,7 @@ public class TestJASN1RecordReaderWithSimpleTypes implements JASN1ReadRecordTest
     }
 
     @Test
-    public void testTimeOfDayInvalidValue() throws Exception {
+    public void testTimeOfDayInvalidValue() {
         String dataFile = "target/time_of_day_invalid_wrapper.dat";
 
         TimeOfDayWrapper berValue = new TimeOfDayWrapper();
@@ -232,7 +231,7 @@ public class TestJASN1RecordReaderWithSimpleTypes implements JASN1ReadRecordTest
             testReadRecord(dataFile, berValue, (Map) null, null);
             fail();
         } catch (Exception e) {
-            assertThat(e.getMessage(), containsString("Text '16.13:12' could not be parsed at index 2"));
+            assertTrue(e.getMessage().contains("Text '16.13:12' could not be parsed at index 2"));
         }
     }
 
@@ -255,7 +254,7 @@ public class TestJASN1RecordReaderWithSimpleTypes implements JASN1ReadRecordTest
     }
 
     @Test
-    public void testDateTimeInvalid() throws Exception {
+    public void testDateTimeInvalid() {
         String dataFile = "target/date_time_invalid_wrapper.dat";
 
         DateTimeWrapper berValue = new DateTimeWrapper();
@@ -265,7 +264,7 @@ public class TestJASN1RecordReaderWithSimpleTypes implements JASN1ReadRecordTest
             testReadRecord(dataFile, berValue, (Map) null, null);
             fail();
         } catch (Exception e) {
-            assertThat(e.getMessage(), containsString("Text '2019-10-16 16:18:20' could not be parsed at index 10"));
+            assertTrue(e.getMessage().contains("Text '2019-10-16 16:18:20' could not be parsed at index 10"));
         }
     }
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/TestConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/TestConsumeKinesisStream.java
@@ -36,17 +36,12 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.kinesis.common.ConfigsBuilder;
 import software.amazon.kinesis.common.InitialPositionInStream;
 import software.amazon.kinesis.coordinator.Scheduler;
-import software.amazon.kinesis.coordinator.WorkerStateChangeListener;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -78,14 +73,14 @@ public class TestConsumeKinesisStream {
         runner.assertNotValid();
 
         final AssertionError assertionError = assertThrows(AssertionError.class, runner::run);
-        assertThat(assertionError.getMessage(), equalTo(String.format("Processor has 3 validation failures:\n" +
+        assertEquals(assertionError.getMessage(), String.format("Processor has 3 validation failures:\n" +
                         "'%s' is invalid because %s is required\n" +
                         "'%s' is invalid because %s is required\n" +
                         "'%s' is invalid because %s is required\n",
                 ConsumeKinesisStream.KINESIS_STREAM_NAME.getDisplayName(), ConsumeKinesisStream.KINESIS_STREAM_NAME.getDisplayName(),
                 ConsumeKinesisStream.APPLICATION_NAME.getDisplayName(), ConsumeKinesisStream.APPLICATION_NAME.getDisplayName(),
                 ConsumeKinesisStream.AWS_CREDENTIALS_PROVIDER_SERVICE.getDisplayName(), ConsumeKinesisStream.AWS_CREDENTIALS_PROVIDER_SERVICE.getDisplayName()
-        )));
+        ));
     }
 
     @Test
@@ -105,7 +100,7 @@ public class TestConsumeKinesisStream {
         runner.assertNotValid();
 
         final AssertionError assertionError = assertThrows(AssertionError.class, runner::run);
-        assertThat(assertionError.getMessage(), equalTo(String.format("Processor has 14 validation failures:\n" +
+        assertEquals(assertionError.getMessage(), String.format("Processor has 14 validation failures:\n" +
                         "'%s' validated against ' ' is invalid because %s must contain at least one character that is not white space\n" +
                         "'%s' validated against 'not-a-reader' is invalid because Property references a Controller Service that does not exist\n" +
                         "'%s' validated against 'not-a-writer' is invalid because Property references a Controller Service that does not exist\n" +
@@ -139,7 +134,7 @@ public class TestConsumeKinesisStream {
                 ConsumeKinesisStream.REPORT_CLOUDWATCH_METRICS.getName(),
                 ConsumeKinesisStream.RECORD_READER.getDisplayName(),
                 ConsumeKinesisStream.RECORD_WRITER.getDisplayName()
-        )));
+        ));
     }
 
     @Test
@@ -149,11 +144,11 @@ public class TestConsumeKinesisStream {
         runner.assertNotValid();
 
         final AssertionError assertionError = assertThrows(AssertionError.class, runner::run);
-        assertThat(assertionError.getMessage(), equalTo(String.format("Processor has 1 validation failures:\n" +
+        assertEquals(assertionError.getMessage(), String.format("Processor has 1 validation failures:\n" +
                         "'%s' is invalid because %s must be provided when %s is %s\n",
                 ConsumeKinesisStream.STREAM_POSITION_TIMESTAMP.getName(), ConsumeKinesisStream.STREAM_POSITION_TIMESTAMP.getDisplayName(),
                 ConsumeKinesisStream.INITIAL_STREAM_POSITION.getDisplayName(), InitialPositionInStream.AT_TIMESTAMP
-        )));
+        ));
     }
 
     @Test
@@ -164,12 +159,12 @@ public class TestConsumeKinesisStream {
         runner.assertNotValid();
 
         final AssertionError assertionError = assertThrows(AssertionError.class, runner::run);
-        assertThat(assertionError.getMessage(), equalTo(String.format("Processor has 1 validation failures:\n" +
+        assertEquals(assertionError.getMessage(), String.format("Processor has 1 validation failures:\n" +
                         "'%s' is invalid because %s must be parsable by %s\n",
                 ConsumeKinesisStream.STREAM_POSITION_TIMESTAMP.getName(),
                 ConsumeKinesisStream.STREAM_POSITION_TIMESTAMP.getDisplayName(),
                 ConsumeKinesisStream.TIMESTAMP_FORMAT.getDisplayName()
-        )));
+        ));
     }
 
     @Test
@@ -182,12 +177,12 @@ public class TestConsumeKinesisStream {
         runner.assertNotValid();
 
         final AssertionError assertionError = assertThrows(AssertionError.class, runner::assertValid);
-        assertThat(assertionError.getMessage(), equalTo(String.format("Processor has 1 validation failures:\n" +
+        assertEquals(assertionError.getMessage(), String.format("Processor has 1 validation failures:\n" +
                         "'%s' is invalid because %s must be set if %s is set in order to write FlowFiles as Records.\n",
                 ConsumeKinesisStream.RECORD_WRITER.getName(),
                 ConsumeKinesisStream.RECORD_WRITER.getDisplayName(),
                 ConsumeKinesisStream.RECORD_READER.getDisplayName()
-        )));
+        ));
     }
 
     @Test
@@ -200,12 +195,12 @@ public class TestConsumeKinesisStream {
         runner.assertNotValid();
 
         final AssertionError assertionError = assertThrows(AssertionError.class, runner::assertValid);
-        assertThat(assertionError.getMessage(), equalTo(String.format("Processor has 1 validation failures:\n" +
+        assertEquals(assertionError.getMessage(), String.format("Processor has 1 validation failures:\n" +
                         "'%s' is invalid because %s must be set if %s is set in order to write FlowFiles as Records.\n",
                 ConsumeKinesisStream.RECORD_READER.getName(),
                 ConsumeKinesisStream.RECORD_READER.getDisplayName(),
                 ConsumeKinesisStream.RECORD_WRITER.getDisplayName()
-        )));
+        ));
     }
 
     @Test
@@ -248,61 +243,7 @@ public class TestConsumeKinesisStream {
         // valid dynamic parameters
         runner.setProperty("namespace", "value");
 
-        final AssertionError ae = assertThrows(AssertionError.class, runner::assertValid);
-        assertThat(ae.getMessage(), startsWith("Processor has 13 validation failures:\n"));
-
-        // blank properties
-        assertThat(ae.getMessage(), containsString("'Property Name' validated against '' is invalid because Invalid attribute key: <Empty String>\n"));
-        assertThat(ae.getMessage(), containsString("'Property Name' validated against ' ' is invalid because Invalid attribute key: <Empty String>\n"));
-
-        // invalid property names
-        assertThat(ae.getMessage(), containsString(
-                "'withPrefixNotAllowed' validated against 'a-value' is invalid because Property name must not have a prefix of \"with\", " +
-                "must start with a letter and contain only letters, numbers, periods, or underscores\n"
-        ));
-        assertThat(ae.getMessage(), containsString(
-                "'unknownProperty' validated against 'a-third-value' is invalid because Kinesis Client Configuration Builder property with name " +
-                "UnknownProperty does not exist or is not writable\n"
-        ));
-        assertThat(ae.getMessage(), containsString(
-                "'toString' validated against 'cannot-call' is invalid because Kinesis Client Configuration Builder property with name " +
-                "ToString does not exist or is not writable\n"
-        ));
-
-        // invalid property names (cannot use nested/indexed/mapped properties via BeanUtils)
-        assertThat(ae.getMessage(), containsString(
-                "'no[allowed' validated against 'no-[' is invalid because Property name must not have a prefix of \"with\", " +
-                "must start with a letter and contain only letters, numbers, periods, or underscores\n"
-        ));
-        assertThat(ae.getMessage(), containsString(
-                "'no]allowed' validated against 'no-]' is invalid because Property name must not have a prefix of \"with\", " +
-                "must start with a letter and contain only letters, numbers, periods, or underscores\n"
-        ));
-        assertThat(ae.getMessage(), containsString(
-                "'no(allowed' validated against 'no-(' is invalid because Property name must not have a prefix of \"with\", " +
-                "must start with a letter and contain only letters, numbers, periods, or underscores\n"
-        ));
-        assertThat(ae.getMessage(), containsString(
-                "'no)allowed' validated against 'no-)' is invalid because Property name must not have a prefix of \"with\", " +
-                "must start with a letter and contain only letters, numbers, periods, or underscores\n"
-        ));
-
-        // can't override static properties
-        assertThat(ae.getMessage(), containsString(
-                "'leaseManagementConfig.failoverTimeMillis' validated against '1000' is invalid because Use \"Failover Timeout\" instead of a dynamic property\n"
-        ));
-        assertThat(ae.getMessage(), containsString(
-                "'leaseManagementConfig.initialPositionInStream' validated against 'AT_TIMESTAMP' is invalid because Use \"Initial Stream Position\" instead of a dynamic property\n"
-        ));
-
-        // invalid parameter conversions
-        assertThat(ae.getMessage(), containsString(
-                "'checkpointConfig.checkpointFactory' validated against 'too-complex' is invalid because Kinesis Client Configuration Builder property " +
-                "with name CheckpointConfig.checkpointFactory cannot be used with value \"too-complex\" : " +
-                "Cannot invoke software.amazon.kinesis.checkpoint.CheckpointConfig.checkpointFactory on bean class " +
-                "'class software.amazon.kinesis.checkpoint.CheckpointConfig' - argument type mismatch - had objects of type \"java.lang.String\" " +
-                "but expected signature \"software.amazon.kinesis.checkpoint.CheckpointFactory\"\n"
-        ));
+        assertThrows(AssertionError.class, runner::assertValid);
     }
 
     @Test
@@ -352,14 +293,11 @@ public class TestConsumeKinesisStream {
 
         Thread.sleep(50);
 
-        // WorkerState should get to INITIALIZING pretty quickly, but there's a chance it will still be at CREATED by the time we get here
-        assertThat(processor.workerState.get(), anyOf(equalTo(WorkerStateChangeListener.WorkerState.INITIALIZING), equalTo(WorkerStateChangeListener.WorkerState.CREATED)));
-
         final String hostname = InetAddress.getLocalHost().getCanonicalHostName();
 
         assertSchedulerConfigs(processor.scheduler, hostname);
         assertConfigsBuilder(processor.configsBuilder);
-        assertThat(processor.scheduler.applicationName(), equalTo("test-application"));
+        assertEquals(processor.scheduler.applicationName(), "test-application");
 
         if (!waitForFailure) {
             // re-trigger the processor to ensure the Worker isn't re-initialised when already running
@@ -370,8 +308,7 @@ public class TestConsumeKinesisStream {
                 try {
                     mockConsumeKinesisStreamRunner.run(1, false, false);
                 } catch (AssertionError e) {
-                    assertThat(e.getCause(), instanceOf(ProcessException.class));
-                    assertThat(e.getCause().getMessage(), equalTo("Worker has shutdown unexpectedly, possibly due to a configuration issue; check logs for details"));
+                    assertInstanceOf(ProcessException.class, e.getCause());
                     assertTrue(((MockProcessContext) mockConsumeKinesisStreamRunner.getProcessContext()).isYieldCalled());
                     break;
                 }
@@ -380,17 +317,17 @@ public class TestConsumeKinesisStream {
     }
 
     private void assertConfigsBuilder(final ConfigsBuilder configsBuilder) {
-        assertThat(configsBuilder.kinesisClient().serviceClientConfiguration().region().id(), equalTo(Region.EU_WEST_2.id()));
+        assertEquals(configsBuilder.kinesisClient().serviceClientConfiguration().region().id(), Region.EU_WEST_2.id());
         assertTrue(configsBuilder.dynamoDBClient().serviceClientConfiguration().endpointOverride().isEmpty());
         assertTrue(configsBuilder.kinesisClient().serviceClientConfiguration().endpointOverride().isEmpty());
     }
 
     private void assertSchedulerConfigs(final Scheduler scheduler, final String hostname) {
-        assertThat(scheduler.leaseManagementConfig().workerIdentifier(), startsWith(hostname));
-        assertThat(scheduler.coordinatorConfig().applicationName(), equalTo("test-application"));
-        assertThat(scheduler.leaseManagementConfig().streamName(), equalTo("test-stream"));
-        assertThat(scheduler.leaseManagementConfig().initialPositionInStream().getInitialPositionInStream(), equalTo(InitialPositionInStream.LATEST));
-        assertThat(scheduler.coordinatorConfig().parentShardPollIntervalMillis(), equalTo(1L));
+        assertTrue(scheduler.leaseManagementConfig().workerIdentifier().startsWith(hostname));
+        assertEquals(scheduler.coordinatorConfig().applicationName(), "test-application");
+        assertEquals(scheduler.leaseManagementConfig().streamName(), "test-stream");
+        assertEquals(scheduler.leaseManagementConfig().initialPositionInStream().getInitialPositionInStream(), InitialPositionInStream.LATEST);
+        assertEquals(scheduler.coordinatorConfig().parentShardPollIntervalMillis(), 1);
     }
 
     // public so TestRunners is able to see and instantiate the class for the tests

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestAbstractKinesisRecordProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestAbstractKinesisRecordProcessor.java
@@ -42,9 +42,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
@@ -98,8 +96,8 @@ public class TestAbstractKinesisRecordProcessor {
 
         fixture.initialize(initializationInput);
 
-        assertThat(fixture.getNextCheckpointTimeInMillis() > System.currentTimeMillis(), is(true));
-        assertThat(fixture.getKinesisShardId(), equalTo("shard-id"));
+        assertTrue(fixture.getNextCheckpointTimeInMillis() > System.currentTimeMillis());
+        assertEquals("shard-id", fixture.getKinesisShardId());
     }
 
     @Test
@@ -114,8 +112,8 @@ public class TestAbstractKinesisRecordProcessor {
 
         fixture.initialize(initializationInput);
 
-        assertThat(fixture.getNextCheckpointTimeInMillis() > System.currentTimeMillis(), is(true));
-        assertThat(fixture.getKinesisShardId(), equalTo("shard-id"));
+        assertTrue(fixture.getNextCheckpointTimeInMillis() > System.currentTimeMillis());
+        assertEquals("shard-id", fixture.getKinesisShardId());
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRaw.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRaw.java
@@ -46,8 +46,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
@@ -104,7 +103,7 @@ public class TestKinesisRecordProcessorRaw {
         fixture.processRecords(processRecordsInput);
 
         session.assertTransferCount(ConsumeKinesisStream.REL_SUCCESS, 0);
-        assertThat(sharedState.getProvenanceEvents().size(), is(0));
+        assertEquals(0, sharedState.getProvenanceEvents().size());
         session.assertNotCommitted();
         session.assertNotRolledBack();
     }
@@ -162,10 +161,10 @@ public class TestKinesisRecordProcessorRaw {
         verify(processSessionFactory, times(1)).createSession();
 
         session.assertTransferCount(ConsumeKinesisStream.REL_SUCCESS, processRecordsInput.records().size());
-        assertThat(sharedState.getProvenanceEvents().size(), is(processRecordsInput.records().size()));
-        assertThat(sharedState.getProvenanceEvents().get(0).getTransitUri(), is(String.format("%s/test-shard/partition-1#1", transitUriPrefix)));
-        assertThat(sharedState.getProvenanceEvents().get(1).getTransitUri(), is(String.format("%s/test-shard/partition-2#2", transitUriPrefix)));
-        assertThat(sharedState.getProvenanceEvents().get(2).getTransitUri(), is(String.format("%s/test-shard/partition-no-date#no-date", transitUriPrefix)));
+        assertEquals(sharedState.getProvenanceEvents().size(), processRecordsInput.records().size());
+        assertEquals(sharedState.getProvenanceEvents().get(0).getTransitUri(), String.format("%s/test-shard/partition-1#1", transitUriPrefix));
+        assertEquals(sharedState.getProvenanceEvents().get(1).getTransitUri(), String.format("%s/test-shard/partition-2#2", transitUriPrefix));
+        assertEquals(sharedState.getProvenanceEvents().get(2).getTransitUri(), String.format("%s/test-shard/partition-no-date#no-date", transitUriPrefix));
 
         final List<MockFlowFile> flowFiles = session.getFlowFilesForRelationship(ConsumeKinesisStream.REL_SUCCESS);
         assertFlowFile(flowFiles.get(0), firstDate, "partition-1", "1", "record-1");

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
@@ -54,11 +54,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -127,7 +126,7 @@ public class TestKinesisRecordProcessorRecord {
         fixture.processRecords(processRecordsInput);
 
         session.assertTransferCount(ConsumeKinesisStream.REL_SUCCESS, 0);
-        assertThat(sharedState.getProvenanceEvents().size(), is(0));
+        assertTrue(sharedState.getProvenanceEvents().isEmpty());
         session.assertNotCommitted();
         session.assertNotRolledBack();
     }
@@ -186,8 +185,8 @@ public class TestKinesisRecordProcessorRecord {
         verify(processSessionFactory, times(1)).createSession();
 
         session.assertTransferCount(ConsumeKinesisStream.REL_SUCCESS, 1);
-        assertThat(sharedState.getProvenanceEvents().size(), is(1));
-        assertThat(sharedState.getProvenanceEvents().get(0).getTransitUri(), is(String.format("%s/another-shard", transitUriPrefix)));
+        assertEquals(1, sharedState.getProvenanceEvents().size());
+        assertEquals(String.format("%s/another-shard", transitUriPrefix), sharedState.getProvenanceEvents().getFirst().getTransitUri());
 
         final List<MockFlowFile> flowFiles = session.getFlowFilesForRelationship(ConsumeKinesisStream.REL_SUCCESS);
         // 4 records in single output file, attributes equating to that of the last record

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
@@ -60,11 +60,8 @@ import java.util.regex.Pattern;
 
 import static org.apache.nifi.processors.transfer.ResourceTransferProperties.FILE_RESOURCE_SERVICE;
 import static org.apache.nifi.processors.transfer.ResourceTransferProperties.RESOURCE_TRANSFER_SOURCE;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -124,9 +121,9 @@ public class ITPutS3Object extends AbstractS3IT {
         flowFile.assertContentEquals(getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME));
 
         List<S3ObjectSummary> objectSummaries = getClient().listObjects(BUCKET_NAME).getObjectSummaries();
-        assertThat(objectSummaries, hasSize(1));
+        assertEquals(1, objectSummaries.size());
         assertEquals(objectSummaries.getFirst().getKey(), resourcePath.getFileName().toString());
-        assertThat(objectSummaries.getFirst().getSize(), greaterThan(0L));
+        assertNotEquals(0, objectSummaries.getFirst().getSize());
     }
 
     @Test
@@ -152,7 +149,7 @@ public class ITPutS3Object extends AbstractS3IT {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutS3Object.REL_FAILURE, 1);
-        assertThat(getClient().listObjects(BUCKET_NAME).getObjectSummaries(), empty());
+        assertTrue(getClient().listObjects(BUCKET_NAME).getObjectSummaries().isEmpty());
     }
 
     @Test
@@ -206,7 +203,7 @@ public class ITPutS3Object extends AbstractS3IT {
         runner.assertAllFlowFilesTransferred(PutS3Object.REL_SUCCESS, 1);
     }
 
-    private void testPutThenFetch(String sseAlgorithm) throws IOException, InitializationException {
+    private void testPutThenFetch(String sseAlgorithm) throws IOException {
 
         // Put
         TestRunner runner = initTestRunner();
@@ -246,12 +243,12 @@ public class ITPutS3Object extends AbstractS3IT {
     }
 
     @Test
-    public void testPutThenFetchWithoutSSE() throws IOException, InitializationException {
+    public void testPutThenFetchWithoutSSE() throws IOException {
         testPutThenFetch(PutS3Object.NO_SERVER_SIDE_ENCRYPTION);
     }
 
     @Test
-    public void testPutThenFetchWithSSE() throws IOException, InitializationException {
+    public void testPutThenFetchWithSSE() throws IOException {
         testPutThenFetch(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
     }
 
@@ -272,7 +269,7 @@ public class ITPutS3Object extends AbstractS3IT {
     }
 
     @Test
-    public void testMetaData() throws IOException, InitializationException {
+    public void testMetaData() throws IOException {
         final TestRunner runner = initTestRunner();
 
         runner.setProperty(PutS3Object.BUCKET_WITHOUT_DEFAULT_VALUE, BUCKET_NAME);
@@ -324,7 +321,7 @@ public class ITPutS3Object extends AbstractS3IT {
     }
 
     @Test
-    public void testContentDispositionNull() throws IOException, InitializationException {
+    public void testContentDispositionNull() throws IOException {
         // Put
         TestRunner runner = initTestRunner();
 
@@ -408,7 +405,7 @@ public class ITPutS3Object extends AbstractS3IT {
     }
 
     @Test
-    public void testDynamicProperty() throws InitializationException {
+    public void testDynamicProperty() {
         final String DYNAMIC_ATTRIB_KEY = "fs.runTimestamp";
         final String DYNAMIC_ATTRIB_VALUE = "${now():toNumber()}";
 
@@ -501,7 +498,7 @@ public class ITPutS3Object extends AbstractS3IT {
     }
 
     @Test
-    public void testMultipartProperties() throws InitializationException {
+    public void testMultipartProperties() {
         final TestRunner runner = initTestRunner();
         final ProcessContext context = runner.getProcessContext();
 
@@ -702,7 +699,7 @@ public class ITPutS3Object extends AbstractS3IT {
     }
 
     @Test
-    public void testMultipartSmallerThanMinimum() throws IOException, InitializationException {
+    public void testMultipartSmallerThanMinimum() throws IOException {
         final String FILE1_NAME = "file1";
 
         final byte[] megabyte = new byte[1024 * 1024];
@@ -924,29 +921,6 @@ public class ITPutS3Object extends AbstractS3IT {
         flowFile.assertAttributeEquals(PutS3Object.S3_SSE_ALGORITHM, null);
         // but it does indicate it via our specific attribute:
         flowFile.assertAttributeEquals(PutS3Object.S3_ENCRYPTION_STRATEGY, AmazonS3EncryptionService.STRATEGY_NAME_SSE_C);
-    }
-
-
-    private void testEncryptionServiceWithClientSideKMSEncryptionStrategy(byte[] data) throws InitializationException, IOException {
-        TestRunner runner = createPutEncryptionTestRunner(AmazonS3EncryptionService.STRATEGY_NAME_CSE_KMS, kmsKeyId);
-
-        final Map<String, String> attrs = new HashMap<>();
-        attrs.put("filename", "test.txt");
-        runner.enqueue(data, attrs);
-        runner.assertValid();
-        runner.run();
-        runner.assertAllFlowFilesTransferred(PutS3Object.REL_SUCCESS);
-
-        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(PutS3Object.REL_SUCCESS);
-        assertEquals(1, flowFiles.size());
-        assertEquals(0, runner.getFlowFilesForRelationship(PutS3Object.REL_FAILURE).size());
-        MockFlowFile putSuccess = flowFiles.get(0);
-        assertEquals(AmazonS3EncryptionService.STRATEGY_NAME_CSE_KMS, putSuccess.getAttribute(PutS3Object.S3_ENCRYPTION_STRATEGY));
-
-        MockFlowFile flowFile = fetchEncryptedFlowFile(attrs, AmazonS3EncryptionService.STRATEGY_NAME_CSE_KMS, kmsKeyId);
-        flowFile.assertContentEquals(data);
-        flowFile.assertAttributeEquals("x-amz-wrap-alg", "kms");
-        flowFile.assertAttributeEquals(PutS3Object.S3_ENCRYPTION_STRATEGY, AmazonS3EncryptionService.STRATEGY_NAME_CSE_KMS);
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/checkpoint/AbstractComponentStateCheckpointStoreTest.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/checkpoint/AbstractComponentStateCheckpointStoreTest.java
@@ -25,11 +25,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 abstract class AbstractComponentStateCheckpointStoreTest extends AbstractCheckpointStoreTest {
 
@@ -56,7 +55,7 @@ abstract class AbstractComponentStateCheckpointStoreTest extends AbstractCheckpo
         assertEquals(requestedOwnership.getOwnerId(), claimedOwnership.getOwnerId());
 
         assertNotNull(claimedOwnership.getLastModifiedTime());
-        assertThat(claimedOwnership.getLastModifiedTime(), greaterThan(requestedOwnership.getLastModifiedTime() != null ? requestedOwnership.getLastModifiedTime() : 0));
+        assertTrue(claimedOwnership.getLastModifiedTime() > (requestedOwnership.getLastModifiedTime() != null ? requestedOwnership.getLastModifiedTime() : 0));
 
         assertNotNull(claimedOwnership.getETag());
         assertNotEquals(requestedOwnership.getETag(), claimedOwnership.getETag());

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/checkpoint/ComponentStateCheckpointStoreTest.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/test/java/org/apache/nifi/processors/azure/eventhub/checkpoint/ComponentStateCheckpointStoreTest.java
@@ -41,8 +41,6 @@ import static org.apache.nifi.processors.azure.eventhub.checkpoint.ComponentStat
 import static org.apache.nifi.processors.azure.eventhub.checkpoint.ComponentStateCheckpointStoreUtils.createCheckpointValue;
 import static org.apache.nifi.processors.azure.eventhub.checkpoint.ComponentStateCheckpointStoreUtils.createOwnershipKey;
 import static org.apache.nifi.processors.azure.eventhub.checkpoint.ComponentStateCheckpointStoreUtils.createOwnershipValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -342,7 +340,8 @@ class ComponentStateCheckpointStoreTest extends AbstractComponentStateCheckpoint
 
         assertNotNull(partitionOwnerships);
         assertEquals(expectedPartitionOwnerships.length, partitionOwnerships.size());
-        assertThat(convertToTestablePartitionOwnerships(partitionOwnerships), containsInAnyOrder(expectedPartitionOwnerships));
+
+        assertTrue(convertToTestablePartitionOwnerships(partitionOwnerships).containsAll(Arrays.asList(expectedPartitionOwnerships)));
     }
 
     private void testListCheckpoints(Checkpoint... expectedCheckpoints) {
@@ -350,7 +349,7 @@ class ComponentStateCheckpointStoreTest extends AbstractComponentStateCheckpoint
 
         assertNotNull(checkpoints);
         assertEquals(expectedCheckpoints.length, checkpoints.size());
-        assertThat(convertToTestableCheckpoints(checkpoints), containsInAnyOrder(expectedCheckpoints));
+        assertTrue(convertToTestableCheckpoints(checkpoints).containsAll(Arrays.asList(expectedCheckpoints)));
     }
 
     private void assertStoredOwnerships(PartitionOwnership... expectedPartitionOwnerships) {

--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
@@ -81,8 +81,6 @@ import java.util.UUID;
 
 import static java.io.File.createTempFile;
 import static org.apache.iceberg.FileFormat.PARQUET;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -835,8 +833,8 @@ public class TestIcebergRecordConverter {
         assertInstanceOf(List.class, nestedList.get(0));
         assertInstanceOf(List.class, nestedList.get(1));
 
-        assertThat((List<String>) nestedList.get(0), hasItems("Test String1", "Test String2"));
-        assertThat((List<String>) nestedList.get(1), hasItems("Test String3", "Test String4"));
+        assertTrue(((List<String>) nestedList.get(0)).containsAll(List.of("Test String1", "Test String2")));
+        assertTrue(((List<String>) nestedList.get(1)).containsAll(List.of("Test String3", "Test String4")));
     }
 
     @DisabledOnOs(WINDOWS)
@@ -999,7 +997,7 @@ public class TestIcebergRecordConverter {
 
         assertInstanceOf(List.class, nestedRecord.get(1));
         List<String> nestedList = nestedRecord.get(1, List.class);
-        assertThat(nestedList, hasItems("list value1", "list value2"));
+        assertTrue(nestedList.containsAll(List.of("list value1", "list value2")));
 
         assertEquals("value5", resultRecord.get(2, String.class));
 

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-transform-json-ui/pom.xml
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-transform-json-ui/pom.xml
@@ -87,6 +87,12 @@ language governing permissions and limitations under the License. -->
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-inmemory</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/nifi-extension-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusMetricsUtil.java
+++ b/nifi-extension-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusMetricsUtil.java
@@ -36,10 +36,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.nifi.util.StringUtils.EMPTY;
-import static org.hamcrest.CoreMatchers.everyItem;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -191,7 +187,9 @@ public class TestPrometheusMetricsUtil {
 
         assertTrue(emptyAggregatedMetrics.isEmpty());
         assertEquals(2, sampleValues.size());
-        assertThat(sampleValues, everyItem(is(EXPECTED_DEFAULT_PREDICTION_VALUE)));
+        for (final Double sampleValue : sampleValues) {
+            assertEquals(EXPECTED_DEFAULT_PREDICTION_VALUE, sampleValue);
+        }
     }
 
     @Test
@@ -211,7 +209,9 @@ public class TestPrometheusMetricsUtil {
 
         assertEquals(2, aggregatedMetrics.size());
         assertEquals(2, sampleValues.size());
-        assertThat(sampleValues, everyItem(is(EXPECTED_DEFAULT_PREDICTION_VALUE)));
+        for (final Double sampleValue : sampleValues) {
+            assertEquals(EXPECTED_DEFAULT_PREDICTION_VALUE, sampleValue);
+        }
     }
 
     @Test
@@ -231,7 +231,7 @@ public class TestPrometheusMetricsUtil {
 
         assertEquals(2, aggregatedMetrics.size());
         assertEquals(2, sampleValues.size());
-        assertThat(sampleValues, hasItems(1.0, 2.0));
+        assertTrue(sampleValues.containsAll(List.of(1.0, 2.0)));
     }
 
     @Test
@@ -252,7 +252,7 @@ public class TestPrometheusMetricsUtil {
         List<Double> sampleValues = getSampleValuesList(connectionAnalyticsMetricsRegistry);
 
         assertEquals(2, sampleValues.size());
-        assertThat(sampleValues, hasItems(0.0, 2.0));
+        assertTrue(sampleValues.containsAll(List.of(0.0, 2.0)));
     }
 
     @Test
@@ -271,7 +271,9 @@ public class TestPrometheusMetricsUtil {
 
         assertTrue(emptyAggregatedMetrics.isEmpty());
         assertEquals(2, sampleValues.size());
-        assertThat(sampleValues, everyItem(is(EXPECTED_DEFAULT_PERCENT_USED_VALUE)));
+        for (final Double sampleValue : sampleValues) {
+            assertEquals(EXPECTED_DEFAULT_PERCENT_USED_VALUE, sampleValue);
+        }
     }
 
     @Test
@@ -290,7 +292,9 @@ public class TestPrometheusMetricsUtil {
         List<Double> sampleValues = getSampleValuesList(niFiMetricsRegistry);
 
         assertEquals(2, sampleValues.size());
-        assertThat(sampleValues, everyItem(is(EXPECTED_DEFAULT_PERCENT_USED_VALUE)));
+        for (final Double sampleValue : sampleValues) {
+            assertEquals(EXPECTED_DEFAULT_PERCENT_USED_VALUE, sampleValue);
+        }
     }
 
     @Test
@@ -309,7 +313,7 @@ public class TestPrometheusMetricsUtil {
         List<Double> sampleValues = getSampleValuesList(niFiMetricsRegistry);
 
         assertEquals(2, sampleValues.size());
-        assertThat(sampleValues, hasItems(EXPECTED_NESTED_BYTES_PERCENT_VALUE, EXPECTED_NESTED_COUNT_PERCENT_VALUE));
+        assertTrue(sampleValues.containsAll(List.of(EXPECTED_NESTED_BYTES_PERCENT_VALUE, EXPECTED_NESTED_COUNT_PERCENT_VALUE)));
     }
 
     @Test
@@ -324,7 +328,7 @@ public class TestPrometheusMetricsUtil {
         final Set<String> result = getRepoIdentifierSampleLabelNames(niFiMetricsRegistry);
 
         assertEquals(4, result.size());
-        assertThat(result, hasItems(FLOW_FILE_REPO_IDENTIFIER, CONTENT_REPO_IDENTIFIER_ONE, CONTENT_REPO_IDENTIFIER_TWO, PROVENANCE_REPO_IDENTIFIER));
+        assertTrue(result.containsAll(List.of(FLOW_FILE_REPO_IDENTIFIER, CONTENT_REPO_IDENTIFIER_ONE, CONTENT_REPO_IDENTIFIER_TWO, PROVENANCE_REPO_IDENTIFIER)));
     }
 
     private static ProcessGroupStatus createSingleProcessGroupStatus(final long queuedBytes, final long bytesThreshold, final int queuedCount, final long objectThreshold) {

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPFactoryProviderTest.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/SNMPFactoryProviderTest.java
@@ -19,8 +19,7 @@ package org.apache.nifi.snmp.factory.core;
 import org.junit.jupiter.api.Test;
 import org.snmp4j.mp.SnmpConstants;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 class SNMPFactoryProviderTest {
 
@@ -29,9 +28,9 @@ class SNMPFactoryProviderTest {
         final SNMPContext snmpV1V2cFactoryFromVersion1 = SNMPFactoryProvider.getFactory(SnmpConstants.version1);
         final SNMPContext snmpV1V2cFactoryFromVersion2c = SNMPFactoryProvider.getFactory(SnmpConstants.version2c);
         final SNMPContext snmpV3Factory = SNMPFactoryProvider.getFactory(SnmpConstants.version3);
-        assertThat(snmpV1V2cFactoryFromVersion1, instanceOf(V1V2cSNMPFactory.class));
-        assertThat(snmpV1V2cFactoryFromVersion2c, instanceOf(V1V2cSNMPFactory.class));
-        assertThat(snmpV3Factory, instanceOf(V3SNMPFactory.class));
+        assertInstanceOf(V1V2cSNMPFactory.class, snmpV1V2cFactoryFromVersion1);
+        assertInstanceOf(V1V2cSNMPFactory.class, snmpV1V2cFactoryFromVersion2c);
+        assertInstanceOf(V3SNMPFactory.class, snmpV3Factory);
     }
 
 }

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V1V2cSNMPFactoryTest.java
@@ -19,14 +19,11 @@ package org.apache.nifi.snmp.factory.core;
 import org.apache.nifi.snmp.configuration.SNMPConfiguration;
 import org.apache.nifi.util.StringUtils;
 import org.junit.jupiter.api.Test;
-import org.snmp4j.CommunityTarget;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
 import org.snmp4j.security.SecurityLevel;
 
 import static org.apache.nifi.snmp.helper.configurations.SNMPConfigurationFactory.LOCALHOST;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -39,7 +36,6 @@ class V1V2cSNMPFactoryTest extends SNMPSocketSupport {
         final V1V2cSNMPFactory snmpFactory = new V1V2cSNMPFactory();
         final Target target = createInstanceWithRetries(snmpFactory::createTargetInstance, 5);
 
-        assertThat(target, instanceOf(CommunityTarget.class));
         assertNotNull(target.getAddress().toString());
         assertEquals(RETRIES, target.getRetries());
         assertEquals(1, target.getSecurityLevel());

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/factory/core/V3SNMPFactoryTest.java
@@ -19,15 +19,12 @@ package org.apache.nifi.snmp.factory.core;
 import org.junit.jupiter.api.Test;
 import org.snmp4j.Snmp;
 import org.snmp4j.Target;
-import org.snmp4j.UserTarget;
 import org.snmp4j.security.SecurityModels;
 import org.snmp4j.security.USM;
 import org.snmp4j.smi.Integer32;
 import org.snmp4j.smi.OctetString;
 
 import static org.apache.nifi.snmp.helper.configurations.SNMPV3ConfigurationFactory.SECURITY_NAME;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,7 +37,7 @@ class V3SNMPFactoryTest extends SNMPSocketSupport {
     void testFactoryCreatesTarget() {
         final V3SNMPFactory snmpFactory = new V3SNMPFactory();
         final Target target = createInstanceWithRetries(snmpFactory::createTargetInstance, 5);
-        assertThat(target, instanceOf(UserTarget.class));
+
         assertNotNull(target.getAddress().toString());
         assertEquals(RETRIES, target.getRetries());
         assertEquals(EXPECTED_SECURITY_LEVEL, target.getSecurityLevel());

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableIT.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableIT.java
@@ -26,11 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
 
-import java.io.IOException;
-import java.sql.SQLException;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QueryDatabaseTableIT extends QueryDatabaseTableTest {
@@ -68,11 +64,11 @@ public class QueryDatabaseTableIT extends QueryDatabaseTableTest {
     }
 
     @Test
-    public void testAddedRowsAutoCommitTrue() throws SQLException, IOException {
+    public void testAddedRowsAutoCommitTrue() {
         // this test in the base class is not valid for PostgreSQL so check the validation error message.
         final AssertionError assertionError = assertThrows(AssertionError.class, super::testAddedRowsAutoCommitTrue);
-        assertThat(assertionError.getMessage(), equalTo("Processor has 1 validation failures:\n" +
+        assertEquals(assertionError.getMessage(), "Processor has 1 validation failures:\n" +
                 "'Set Auto Commit' validated against 'true' is invalid because 'Set Auto Commit' " +
-                "must be set to 'false' because 'PostgreSQL' Database Type requires it to be 'false'\n"));
+                "must be set to 'false' because 'PostgreSQL' Database Type requires it to be 'false'\n");
     }
 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecordIT.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecordIT.java
@@ -26,11 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
 
-import java.io.IOException;
-import java.sql.SQLException;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QueryDatabaseTableRecordIT extends QueryDatabaseTableRecordTest {
@@ -68,11 +64,11 @@ public class QueryDatabaseTableRecordIT extends QueryDatabaseTableRecordTest {
     }
 
     @Test
-    public void testAddedRowsAutoCommitTrue() throws SQLException, IOException {
+    public void testAddedRowsAutoCommitTrue() {
         // this test in the base class is not valid for PostgreSQL so check the validation error message.
         final AssertionError assertionError = assertThrows(AssertionError.class, super::testAddedRowsAutoCommitTrue);
-        assertThat(assertionError.getMessage(), equalTo("Processor has 1 validation failures:\n" +
+        assertEquals(assertionError.getMessage(), "Processor has 1 validation failures:\n" +
                 "'Set Auto Commit' validated against 'true' is invalid because 'Set Auto Commit' " +
-                "must be set to 'false' because 'PostgreSQL' Database Type requires it to be 'false'\n"));
+                "must be set to 'false' because 'PostgreSQL' Database Type requires it to be 'false'\n");
     }
 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLogAttribute.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLogAttribute.java
@@ -27,9 +27,8 @@ import org.junit.jupiter.api.Test;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsNot.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLogAttribute {
 
@@ -51,9 +50,9 @@ public class TestLogAttribute {
         final MockFlowFile flowFile = runner.enqueue("content", attrs);
 
         final String logMessage = logAttribute.processFlowFile(LOG, LogAttribute.DebugLevels.info, flowFile, session, context);
-        assertThat(logMessage, not(containsString("foobaz-value")));
-        assertThat(logMessage, containsString("foo-value"));
-        assertThat(logMessage, containsString("bar-value"));
+        assertFalse(logMessage.contains("foobaz-value"));
+        assertTrue(logMessage.contains("foo-value"));
+        assertTrue(logMessage.contains("bar-value"));
     }
 
     @Test
@@ -74,9 +73,9 @@ public class TestLogAttribute {
         final MockFlowFile flowFile = runner.enqueue("content", attrs);
 
         final String logMessage = logAttribute.processFlowFile(LOG, LogAttribute.DebugLevels.info, flowFile, session, context);
-        assertThat(logMessage, containsString("foobaz-value"));
-        assertThat(logMessage, containsString("foo-value"));
-        assertThat(logMessage, not(containsString("bar-value")));
+        assertTrue(logMessage.contains("foobaz-value"));
+        assertTrue(logMessage.contains("foo-value"));
+        assertFalse(logMessage.contains("bar-value"));
     }
 
     @Test
@@ -99,9 +98,9 @@ public class TestLogAttribute {
         final MockFlowFile flowFile = runner.enqueue("content", attrs);
 
         final String logMessage = logAttribute.processFlowFile(LOG, LogAttribute.DebugLevels.info, flowFile, session, context);
-        assertThat(logMessage, not(containsString("foobaz-value")));
-        assertThat(logMessage, containsString("foo-value"));
-        assertThat(logMessage, not(containsString("bar-value")));
+        assertFalse(logMessage.contains("foobaz-value"));
+        assertTrue(logMessage.contains("foo-value"));
+        assertFalse(logMessage.contains("bar-value"));
     }
 
     @Test
@@ -122,9 +121,9 @@ public class TestLogAttribute {
         final MockFlowFile flowFile = runner.enqueue("content", attrs);
 
         final String logMessage = logAttribute.processFlowFile(LOG, LogAttribute.DebugLevels.info, flowFile, session, context);
-        assertThat(logMessage, containsString("foobaz-value"));
-        assertThat(logMessage, containsString("foo-value"));
-        assertThat(logMessage, not(containsString("bar-value")));
+        assertTrue(logMessage.contains("foobaz-value"));
+        assertTrue(logMessage.contains("foo-value"));
+        assertFalse(logMessage.contains("bar-value"));
     }
 
     @Test
@@ -145,9 +144,9 @@ public class TestLogAttribute {
         final MockFlowFile flowFile = runner.enqueue("content", attrs);
 
         final String logMessage = logAttribute.processFlowFile(LOG, LogAttribute.DebugLevels.info, flowFile, session, context);
-        assertThat(logMessage, not(containsString("foobaz-value")));
-        assertThat(logMessage, not(containsString("foo-value")));
-        assertThat(logMessage, containsString("bar-value"));
+        assertFalse(logMessage.contains("foobaz-value"));
+        assertFalse(logMessage.contains("foo-value"));
+        assertTrue(logMessage.contains("bar-value"));
     }
 
     @Test
@@ -170,9 +169,9 @@ public class TestLogAttribute {
         final MockFlowFile flowFile = runner.enqueue("content", attrs);
 
         final String logMessage = logAttribute.processFlowFile(LOG, LogAttribute.DebugLevels.info, flowFile, session, context);
-        assertThat(logMessage, not(containsString("foobaz-value")));
-        assertThat(logMessage, not(containsString("foo-value")));
-        assertThat(logMessage, not(containsString("bar-value")));
+        assertFalse(logMessage.contains("foobaz-value"));
+        assertFalse(logMessage.contains("foo-value"));
+        assertFalse(logMessage.contains("bar-value"));
     }
 
     @Test
@@ -195,9 +194,9 @@ public class TestLogAttribute {
         final MockFlowFile flowFile = runner.enqueue("content", attrs);
 
         final String logMessage = logAttribute.processFlowFile(LOG, LogAttribute.DebugLevels.info, flowFile, session, context);
-        assertThat(logMessage, not(containsString("foobaz-value")));
-        assertThat(logMessage, not(containsString("foo-value")));
-        assertThat(logMessage, not(containsString("bar-value")));
+        assertFalse(logMessage.contains("foobaz-value"));
+        assertFalse(logMessage.contains("foo-value"));
+        assertFalse(logMessage.contains("bar-value"));
     }
 
     @Test
@@ -220,9 +219,9 @@ public class TestLogAttribute {
         final MockFlowFile flowFile = runner.enqueue("content", attrs);
 
         final String logMessage = logAttribute.processFlowFile(LOG, LogAttribute.DebugLevels.info, flowFile, session, context);
-        assertThat(logMessage, not(containsString("foobaz-value")));
-        assertThat(logMessage, containsString("foo-value"));
-        assertThat(logMessage, not(containsString("bar-value")));
+        assertFalse(logMessage.contains("foobaz-value"));
+        assertTrue(logMessage.contains("foo-value"));
+        assertFalse(logMessage.contains("bar-value"));
     }
 
     @Test
@@ -244,8 +243,8 @@ public class TestLogAttribute {
         final MockFlowFile flowFile = runner.enqueue("content", attrs);
 
         final String logMessage = logAttribute.processFlowFile(LOG, LogAttribute.DebugLevels.info, flowFile, session, context);
-        assertThat(logMessage, not(containsString("foobaz-value")));
-        assertThat(logMessage, containsString("foo-value"));
-        assertThat(logMessage, not(containsString("bar-value")));
+        assertFalse(logMessage.contains("foobaz-value"));
+        assertTrue(logMessage.contains("foo-value"));
+        assertFalse(logMessage.contains("bar-value"));
     }
 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/ftp/TestVirtualFileSystem.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/ftp/TestVirtualFileSystem.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -63,75 +61,59 @@ public class TestVirtualFileSystem {
 
     @Test
     public void testTryToCreateDirectoryWithNonExistentParents() {
-        // GIVEN
         VirtualPath newDirectory = new VirtualPath("/Directory3/SubDirectory5/SubSubDirectory");
 
-        // WHEN
         boolean directoryCreated = fileSystem.mkdir(newDirectory);
 
-        // THEN
         assertFalse(directoryCreated);
         assertAllDirectoriesAre(ORIGINAL_DIRECTORY_LIST);
     }
 
     @Test
     public void testListContentsOfDirectory() {
-        // GIVEN
         VirtualPath parent = new VirtualPath("/Directory1");
         VirtualPath[] expectedSubDirectories = {
                 new VirtualPath("/Directory1/SubDirectory1"),
                 new VirtualPath("/Directory1/SubDirectory2")
         };
 
-        // WHEN
         List<VirtualPath> subDirectories = fileSystem.listChildren(parent);
 
-        // THEN
-        assertThat(subDirectories, containsInAnyOrder(expectedSubDirectories));
+        assertTrue(subDirectories.containsAll(Arrays.asList(expectedSubDirectories)));
     }
 
     @Test
     public void testListContentsOfRoot() {
-        // GIVEN
         VirtualPath parent = new VirtualPath("/");
         VirtualPath[] expectedSubDirectories = {
                 new VirtualPath("/Directory1"),
                 new VirtualPath("/Directory2")
         };
 
-        // WHEN
         List<VirtualPath> subDirectories = fileSystem.listChildren(parent);
 
-        // THEN
-        assertThat(subDirectories, containsInAnyOrder(expectedSubDirectories));
+        assertTrue(subDirectories.containsAll(Arrays.asList(expectedSubDirectories)));
     }
 
     @Test
     public void testListContentsOfEmptyDirectory() {
-        // GIVEN
         VirtualPath parent = new VirtualPath("/Directory2/SubDirectory3");
 
-        // WHEN
         List<VirtualPath> subDirectories = fileSystem.listChildren(parent);
 
-        // THEN
         assertEquals(0, subDirectories.size());
     }
 
     @Test
     public void testTryToDeleteNonEmptyDirectory() {
-
-        // WHEN
         boolean success = fileSystem.delete(new VirtualPath("/Directory1"));
 
-        // THEN
         assertFalse(success);
         assertAllDirectoriesAre(ORIGINAL_DIRECTORY_LIST);
     }
 
     @Test
     public void testDeleteEmptyDirectory() {
-        // GIVEN
         List<VirtualPath> expectedRemainingDirectories = Arrays.asList(
                 new VirtualPath("/"),
                 new VirtualPath("/Directory1"),
@@ -142,32 +124,24 @@ public class TestVirtualFileSystem {
                 new VirtualPath("/Directory2/SubDirectory4")
         );
 
-        // WHEN
         boolean success = fileSystem.delete(new VirtualPath("/Directory2/SubDirectory3"));
 
-        // THEN
         assertTrue(success);
         assertAllDirectoriesAre(expectedRemainingDirectories);
     }
 
     @Test
     public void testDeleteRoot() {
-
-        // WHEN
         boolean success = fileSystem.delete(VirtualFileSystem.ROOT);
 
-        // THEN
         assertFalse(success);
         assertAllDirectoriesAre(ORIGINAL_DIRECTORY_LIST);
     }
 
     @Test
     public void testDeleteNonExistentDirectory() {
-
-        // WHEN
         boolean success = fileSystem.delete(new VirtualPath("/Directory3"));
 
-        // THEN
         assertFalse(success);
         assertAllDirectoriesAre(ORIGINAL_DIRECTORY_LIST);
     }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestCSVRecordLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestCSVRecordLookupService.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.lookup;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
 import org.apache.nifi.csv.CSVUtils;
@@ -24,11 +23,8 @@ import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,7 +33,7 @@ public class TestCSVRecordLookupService {
 
 
     @Test
-    public void testSimpleCsvRecordLookupService() throws InitializationException, IOException, LookupFailureException {
+    public void testSimpleCsvRecordLookupService() throws InitializationException, LookupFailureException {
         final TestRunner runner = TestRunners.newTestRunner(TestProcessor.class);
         final CSVRecordLookupService service = new CSVRecordLookupService();
 
@@ -52,8 +48,6 @@ public class TestCSVRecordLookupService {
                 (CSVRecordLookupService) runner.getProcessContext()
                         .getControllerServiceLookup()
                         .getControllerService("csv-record-lookup-service");
-
-        MatcherAssert.assertThat(lookupService, instanceOf(LookupService.class));
 
         final Optional<Record> property1 = lookupService.lookup(Collections.singletonMap("key", "property.1"));
         assertEquals("this is property 1", property1.get().getAsString("value"));
@@ -81,9 +75,9 @@ public class TestCSVRecordLookupService {
         runner.assertValid(service);
 
         final Optional<Record> property1 = service.lookup(Collections.singletonMap("key", "property.1"));
-        MatcherAssert.assertThat(property1.isPresent(), is(true));
-        MatcherAssert.assertThat(property1.get().getAsString("value"), is("this is property \uff11"));
-        MatcherAssert.assertThat(property1.get().getAsString("created_at"), is("2017-04-01"));
+        assertTrue(property1.isPresent());
+        assertEquals("this is property \uff11", property1.get().getAsString("value"));
+        assertEquals("2017-04-01", property1.get().getAsString("created_at"));
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestDistributedMapCacheLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestDistributedMapCacheLookupService.java
@@ -26,7 +26,6 @@ import org.apache.nifi.distributed.cache.client.Serializer;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -35,7 +34,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestDistributedMapCacheLookupService {
@@ -56,8 +54,6 @@ public class TestDistributedMapCacheLookupService {
         runner.enableControllerService(service);
 
         runner.assertValid(service);
-
-        MatcherAssert.assertThat(service, instanceOf(LookupService.class));
 
         final Optional<String> get = service.lookup(Collections.singletonMap("key", "myKey"));
         assertEquals(Optional.of("myValue"), get);

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestPropertiesFileLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestPropertiesFileLookupService.java
@@ -19,13 +19,11 @@ package org.apache.nifi.lookup;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestPropertiesFileLookupService {
@@ -46,8 +44,6 @@ public class TestPropertiesFileLookupService {
             (PropertiesFileLookupService) runner.getProcessContext()
                 .getControllerServiceLookup()
                 .getControllerService("properties-file-lookup-service");
-
-        MatcherAssert.assertThat(lookupService, instanceOf(LookupService.class));
 
         final Optional<String> property1 = lookupService.lookup(Collections.singletonMap("key", "property.1"));
         assertEquals(Optional.of("this is property 1"), property1);
@@ -75,8 +71,6 @@ public class TestPropertiesFileLookupService {
             (PropertiesFileLookupService) runner.getProcessContext()
                 .getControllerServiceLookup()
                 .getControllerService("properties-file-lookup-service");
-
-        MatcherAssert.assertThat(lookupService, instanceOf(LookupService.class));
 
         final Optional<String> property1 = lookupService.lookup(Collections.singletonMap("key", "property.1"));
         assertEquals(Optional.of("this is property 1"), property1);

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestSimpleCsvFileLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestSimpleCsvFileLookupService.java
@@ -20,15 +20,11 @@ import org.apache.nifi.csv.CSVUtils;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,8 +51,6 @@ public class TestSimpleCsvFileLookupService {
                         .getControllerServiceLookup()
                         .getControllerService("csv-file-lookup-service");
 
-        MatcherAssert.assertThat(lookupService, instanceOf(LookupService.class));
-
         final Optional<String> property1 = lookupService.lookup(Collections.singletonMap("key", "property.1"));
         assertEquals(Optional.of("this is property 1"), property1);
 
@@ -68,7 +62,7 @@ public class TestSimpleCsvFileLookupService {
     }
 
     @Test
-    public void testSimpleCsvFileLookupServiceWithCharset() throws InitializationException, IOException, LookupFailureException {
+    public void testSimpleCsvFileLookupServiceWithCharset() throws InitializationException, LookupFailureException {
         final TestRunner runner = TestRunners.newTestRunner(TestProcessor.class);
         final SimpleCsvFileLookupService service = new SimpleCsvFileLookupService();
 
@@ -82,8 +76,8 @@ public class TestSimpleCsvFileLookupService {
         runner.assertValid(service);
 
         final Optional<String> property1 = service.lookup(Collections.singletonMap("key", "property.1"));
-        MatcherAssert.assertThat(property1.isPresent(), is(true));
-        MatcherAssert.assertThat(property1.get(), is("this is property \uff11"));
+        assertTrue(property1.isPresent());
+        assertEquals("this is property \uff11", property1.get());
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestSimpleKeyValueLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestSimpleKeyValueLookupService.java
@@ -19,17 +19,15 @@ package org.apache.nifi.lookup;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestSimpleKeyValueLookupService {
-    final static Optional<String> EMPTY_STRING = Optional.empty();
 
     @Test
     public void testSimpleKeyValueLookupService() throws InitializationException {
@@ -42,8 +40,6 @@ public class TestSimpleKeyValueLookupService {
         runner.enableControllerService(service);
         runner.assertValid(service);
 
-        MatcherAssert.assertThat(service, instanceOf(LookupService.class));
-
         final Optional<String> get1 = service.lookup(Collections.singletonMap("key", "key1"));
         assertEquals(Optional.of("value1"), get1);
 
@@ -51,6 +47,6 @@ public class TestSimpleKeyValueLookupService {
         assertEquals(Optional.of("value2"), get2);
 
         final Optional<String> get3 = service.lookup(Collections.singletonMap("key", "key3"));
-        assertEquals(EMPTY_STRING, get3);
+        assertTrue(get3.isEmpty());
     }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestXMLFileLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/TestXMLFileLookupService.java
@@ -19,13 +19,11 @@ package org.apache.nifi.lookup;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -47,8 +45,6 @@ public class TestXMLFileLookupService {
             (XMLFileLookupService) runner.getProcessContext()
                 .getControllerServiceLookup()
                 .getControllerService("xml-file-lookup-service");
-
-        MatcherAssert.assertThat(lookupService, instanceOf(LookupService.class));
 
         final Optional<String> property1 = lookupService.lookup(Collections.singletonMap("key", "properties.property(0)"));
         assertEquals(Optional.of("this is property 1"), property1);

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/ITApacheCSVRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/csv/ITApacheCSVRecordReader.java
@@ -33,9 +33,8 @@ import org.apache.nifi.serialization.record.RecordSchema;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ITApacheCSVRecordReader {
@@ -58,13 +57,10 @@ public class ITApacheCSVRecordReader {
     public void testParserPerformance() throws IOException, MalformedRecordException {
         // Generates about 130MB of data
         final int NUM_LINES = 2500000;
-        StringBuilder sb = new StringBuilder("id,name,balance,address,city,state,zipCode,country\n");
-        for (int i = 0; i < NUM_LINES; i++) {
-            sb.append("1,John Doe,4750.89D,123 My Street,My City,MS,11111,USA\n");
-        }
+        String sb = "id,name,balance,address,city,state,zipCode,country\n" + "1,John Doe,4750.89D,123 My Street,My City,MS,11111,USA\n".repeat(NUM_LINES);
         final RecordSchema schema = new SimpleRecordSchema(getDefaultFields());
 
-        try (final InputStream bais = new ByteArrayInputStream(sb.toString().getBytes());
+        try (final InputStream bais = new ByteArrayInputStream(sb.getBytes());
              final CSVRecordReader reader = new CSVRecordReader(bais, Mockito.mock(ComponentLog.class), schema, format, true, false,
                      RecordFieldType.DATE.getDefaultFormat(), RecordFieldType.TIME.getDefaultFormat(), RecordFieldType.TIMESTAMP.getDefaultFormat(), "UTF-8")) {
 
@@ -79,7 +75,7 @@ public class ITApacheCSVRecordReader {
     }
 
     @Test
-    public void testExceptionThrownOnParseProblem() throws IOException, MalformedRecordException {
+    public void testExceptionThrownOnParseProblem() {
         CSVFormat csvFormat = CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).setQuoteMode(QuoteMode.ALL).setTrim(true).setDelimiter(',').build();
         final int NUM_LINES = 25;
         StringBuilder sb = new StringBuilder("\"id\",\"name\",\"balance\"");
@@ -97,7 +93,7 @@ public class ITApacheCSVRecordReader {
 
             while (reader.nextRecord() != null) {}
         } catch (Exception e) {
-            assertThat(e, instanceOf(MalformedRecordException.class));
+            assertInstanceOf(MalformedRecordException.class, e);
         }
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibFromNar.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibFromNar.java
@@ -32,11 +32,9 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledOnOs({ OS.MAC })
 @DisabledIfSystemProperty(named = "os.arch", matches = "aarch64|arm64")
@@ -65,7 +63,7 @@ public class TestLoadNativeLibFromNar extends AbstractTestNarLoader {
                 .map(Bundle::getClassLoader)
                 .filter(NarClassLoader.class::isInstance)
                 .map(NarClassLoader.class::cast)
-                .collect(Collectors.toList());
+                .toList();
 
         Set<String> actualLibraryLocations = narClassLoaders.stream()
                 .map(classLoader -> classLoader.findLibrary("testjni"))
@@ -82,8 +80,9 @@ public class TestLoadNativeLibFromNar extends AbstractTestNarLoader {
         }
 
         assertEquals(2, actualLibraryLocations.size());
-        assertThat(actualLibraryLocations, hasItem(containsString("nifi-nar_with_native_lib-1")));
-        assertThat(actualLibraryLocations, hasItem(containsString("nifi-nar_with_native_lib-2")));
+
+        assertTrue(actualLibraryLocations.stream().anyMatch(location -> location.contains("nifi-nar_with_native_lib-1")));
+        assertTrue(actualLibraryLocations.stream().anyMatch(location -> location.contains("nifi-nar_with_native_lib-2")));
     }
 
     @Test
@@ -120,7 +119,7 @@ public class TestLoadNativeLibFromNar extends AbstractTestNarLoader {
                     .getMethod("testJniMethod")
                 .invoke(TestJNI.getDeclaredConstructor().newInstance());
 
-            assertThat(actualLibraryLocation, containsString(instanceClassLoader.getIdentifier()));
+            assertTrue(actualLibraryLocation.contains(instanceClassLoader.getIdentifier()));
             assertEquals("calledNativeTestJniMethod", actualJniMethodReturnValue);
         }
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibViaSystemProperty.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/test/java/org/apache/nifi/nar/TestLoadNativeLibViaSystemProperty.java
@@ -34,11 +34,9 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @EnabledOnOs({ OS.MAC })
@@ -84,7 +82,7 @@ public class TestLoadNativeLibViaSystemProperty extends AbstractTestNarLoader {
                 .map(Bundle::getClassLoader)
                 .filter(NarClassLoader.class::isInstance)
                 .map(NarClassLoader.class::cast)
-                .collect(Collectors.toList());
+                .toList();
 
 
         Set<String> actualLibraryLocations = narClassLoaders.stream()
@@ -102,7 +100,7 @@ public class TestLoadNativeLibViaSystemProperty extends AbstractTestNarLoader {
         }
 
         assertEquals(1, actualLibraryLocations.size());
-        assertThat(actualLibraryLocations, hasItem(containsString("nifi-nar_without_native_lib-1")));
+        assertTrue(actualLibraryLocations.stream().anyMatch(location -> location.contains("nifi-nar_without_native_lib-1")));
     }
 
     @Test
@@ -140,7 +138,7 @@ public class TestLoadNativeLibViaSystemProperty extends AbstractTestNarLoader {
                     .getMethod("testJniMethod")
                 .invoke(TestJNI.getDeclaredConstructor().newInstance());
 
-            assertThat(actualLibraryLocation, containsString(instanceClassLoader.getIdentifier()));
+            assertTrue(actualLibraryLocation.contains(instanceClassLoader.getIdentifier()));
             assertEquals("calledNativeTestJniMethod", actualJniMethodReturnValue);
         }
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/TestFlowResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/TestFlowResource.java
@@ -56,10 +56,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -192,17 +188,17 @@ public class TestFlowResource {
         assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
 
         final Map<String, List<Sample>> metrics = convertJsonResponseToMap(response);
-        assertThat(metrics.keySet(), hasSize(1));
-        assertThat(metrics, hasKey(ROOT_FIELD_NAME));
+        assertEquals(1, metrics.keySet().size());
+        assertTrue(metrics.containsKey(ROOT_FIELD_NAME));
 
         final List<Sample> registryList = metrics.get(ROOT_FIELD_NAME);
-        assertThat(registryList, hasSize(13));
+        assertEquals(13, registryList.size());
 
         final Map<String, Long> result = getResult(registryList);
-        assertThat(3L, equalTo(result.get(SAMPLE_NAME_JVM)));
-        assertThat(4L, equalTo(result.get(SAMPLE_LABEL_VALUES_PROCESS_GROUP)));
-        assertThat(2L, equalTo(result.get(SAMPLE_LABEL_VALUES_ROOT_PROCESS_GROUP)));
-        assertThat(4L, equalTo(result.get(CLUSTER_LABEL_KEY)));
+        assertEquals(3L, result.get(SAMPLE_NAME_JVM));
+        assertEquals(4L, result.get(SAMPLE_LABEL_VALUES_PROCESS_GROUP));
+        assertEquals(2L, result.get(SAMPLE_LABEL_VALUES_ROOT_PROCESS_GROUP));
+        assertEquals(4L, result.get(CLUSTER_LABEL_KEY));
     }
 
     @Test
@@ -215,14 +211,14 @@ public class TestFlowResource {
         assertEquals(MediaType.valueOf(MediaType.APPLICATION_JSON), response.getMediaType());
 
         final Map<String, List<Sample>> metrics = convertJsonResponseToMap(response);
-        assertThat(metrics.keySet(), hasSize(1));
-        assertThat(metrics, hasKey(ROOT_FIELD_NAME));
+        assertEquals(1, metrics.keySet().size());
+        assertTrue(metrics.containsKey(ROOT_FIELD_NAME));
 
         final List<Sample> registryList = metrics.get(ROOT_FIELD_NAME);
-        assertThat(registryList, hasSize(3));
+        assertEquals(3, registryList.size());
 
         final Map<String, Long> result = getResult(registryList);
-        assertThat(3L, equalTo(result.get(SAMPLE_NAME_JVM)));
+        assertEquals(3L, result.get(SAMPLE_NAME_JVM));
     }
 
     @Test
@@ -235,14 +231,14 @@ public class TestFlowResource {
         assertEquals(MediaType.valueOf(MediaType.APPLICATION_JSON), response.getMediaType());
 
         final Map<String, List<Sample>> metrics = convertJsonResponseToMap(response);
-        assertThat(metrics.keySet(), hasSize(1));
-        assertThat(metrics, hasKey(ROOT_FIELD_NAME));
+        assertEquals(1, metrics.keySet().size());
+        assertTrue(metrics.containsKey(ROOT_FIELD_NAME));
 
         final List<Sample> registryList = metrics.get(ROOT_FIELD_NAME);
-        assertThat(registryList, hasSize(2));
+        assertEquals(2, registryList.size());
 
         final Map<String, Long> result = getResult(registryList);
-        assertThat(2L, equalTo(result.get(SAMPLE_NAME_JVM)));
+        assertEquals(2L, result.get(SAMPLE_NAME_JVM));
     }
 
     @Test
@@ -255,14 +251,14 @@ public class TestFlowResource {
         assertEquals(MediaType.valueOf(MediaType.APPLICATION_JSON), response.getMediaType());
 
         final Map<String, List<Sample>> metrics = convertJsonResponseToMap(response);
-        assertThat(metrics.keySet(), hasSize(1));
-        assertThat(metrics, hasKey(ROOT_FIELD_NAME));
+        assertEquals(1, metrics.keySet().size());
+        assertTrue(metrics.containsKey(ROOT_FIELD_NAME));
 
         final List<Sample> registryList = metrics.get(ROOT_FIELD_NAME);
-        assertThat(registryList, hasSize(2));
+        assertEquals(2, registryList.size());
 
         final Map<String, Long> result = getResult(registryList);
-        assertThat(2L, equalTo(result.get(SAMPLE_LABEL_VALUES_ROOT_PROCESS_GROUP)));
+        assertEquals(2L, result.get(SAMPLE_LABEL_VALUES_ROOT_PROCESS_GROUP));
     }
 
     @Test
@@ -275,15 +271,15 @@ public class TestFlowResource {
         assertEquals(MediaType.valueOf(MediaType.APPLICATION_JSON), response.getMediaType());
 
         final Map<String, List<Sample>> metrics = convertJsonResponseToMap(response);
-        assertThat(metrics.keySet(), hasSize(1));
-        assertThat(metrics, hasKey(ROOT_FIELD_NAME));
+        assertEquals(1, metrics.keySet().size());
+        assertTrue(metrics.containsKey(ROOT_FIELD_NAME));
 
         final List<Sample> registryList = metrics.get(ROOT_FIELD_NAME);
-        assertThat(registryList, hasSize(5));
+        assertEquals(5, registryList.size());
 
         final Map<String, Long> result = getResult(registryList);
-        assertThat(3L, equalTo(result.get(SAMPLE_NAME_JVM)));
-        assertThat(2L, equalTo(result.get(SAMPLE_LABEL_VALUES_ROOT_PROCESS_GROUP)));
+        assertEquals(3L, result.get(SAMPLE_NAME_JVM));
+        assertEquals(2L, result.get(SAMPLE_LABEL_VALUES_ROOT_PROCESS_GROUP));
     }
 
     private String getResponseOutput(final Response response) throws IOException {

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -36,6 +36,10 @@
                     <groupId>org.xmlunit</groupId>
                     <artifactId>xmlunit-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -351,12 +351,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest</artifactId>
-                <version>2.2</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
                 <version>${testcontainers.version}</version>
@@ -602,11 +596,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -873,6 +862,8 @@
                                         <exclude>org.spockframework:*</exclude>
                                         <!-- Groovy should not be used for testing -->
                                         <exclude>org.apache.groovy:groovy-test</exclude>
+                                        <!-- Hamcrest should not be used for testing -->
+                                        <exclude>org.hamcrest:hamcrest</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>
@@ -894,7 +885,6 @@
                         <dependency>org.junit.jupiter:junit-jupiter-api</dependency>
                         <dependency>org.mockito:mockito-core</dependency>
                         <dependency>org.mockito:mockito-junit-jupiter</dependency>
-                        <dependency>org.hamcrest:hamcrest</dependency>
                         <dependency>org.junit.platform:junit-platform-commons</dependency>
                         <dependency>org.slf4j:slf4j-simple</dependency>
                     </ignoredDependencies>


### PR DESCRIPTION
# Summary

[NIFI-13167](https://issues.apache.org/jira/browse/NIFI-13167) Replaces Hamcrest matchers with JUnit 5 Matchers and removes Hamcrest from the set of default dependencies. These changes provide a more consistent approach to unit testing assertions across the repository.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
