### PR TITLE
NIFI-13105 Implement a FlowRegistryClient that use GitHub for version…

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/registry/flow/FlowRegistryClient.java
+++ b/nifi-api/src/main/java/org/apache/nifi/registry/flow/FlowRegistryClient.java
@@ -21,6 +21,7 @@ import org.apache.nifi.components.ConfigurableComponent;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * <p>
@@ -146,7 +147,7 @@ public interface FlowRegistryClient extends ConfigurableComponent {
     FlowRegistryBucket getBucket(FlowRegistryClientConfigurationContext context, BucketLocation bucketLocation) throws FlowRegistryException, IOException;
 
     /**
-     * Registers the given RegisteredFlow into the the Flow Registry.
+     * Registers the given RegisteredFlow into the Flow Registry.
      *
      * @param context Configuration context.
      * @param flow The RegisteredFlow to add to the Registry.
@@ -252,4 +253,15 @@ public interface FlowRegistryClient extends ConfigurableComponent {
      * @throws IOException If there is issue with the communication between NiFi and the Flow Registry.
      */
     Optional<String> getLatestVersion(FlowRegistryClientConfigurationContext context, FlowLocation flowLocation) throws FlowRegistryException, IOException;
+
+    /**
+     * Generates the id for registering a flow.
+     *
+     * @param flowName the name of the flow
+     * @return the generated id
+     */
+    default String generateFlowId(final String flowName) {
+        return UUID.randomUUID().toString();
+    }
+
 }

--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -872,6 +872,12 @@ language governing permissions and limitations under the License. -->
             <version>2.0.0-SNAPSHOT</version>
             <type>nar</type>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-github-nar</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
         <!-- AspectJ library needed by the Java Agent used for native library loading (see bootstrap.conf) -->
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/pom.xml
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <!--
+      Licensed to the Apache Software Foundation (ASF) under one or more
+      contributor license agreements.  See the NOTICE file distributed with
+      this work for additional information regarding copyright ownership.
+      The ASF licenses this file to You under the Apache License, Version 2.0
+      (the "License"); you may not use this file except in compliance with
+      the License.  You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+    -->
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-github-bundle</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>nifi-github-extensions</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>${github-api.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/FlowSnapshotSerializer.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/FlowSnapshotSerializer.java
@@ -1,0 +1,34 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.nifi.github;
+
+import org.apache.nifi.registry.flow.RegisteredFlowSnapshot;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Serializer for flow snapshots.
+ */
+public interface FlowSnapshotSerializer {
+
+    String serialize(final RegisteredFlowSnapshot flowSnapshot) throws IOException;
+
+    RegisteredFlowSnapshot deserialize(final InputStream inputStream) throws IOException;
+
+}

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubAuthenticationType.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubAuthenticationType.java
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.nifi.github;
+
+/**
+ * Enumeration of authentication types for the GitHub client.
+ */
+public enum GitHubAuthenticationType {
+
+    NONE,
+    PERSONAL_ACCESS_TOKEN,
+    APP_INSTALLATION_TOKEN;
+
+}

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubCreateContentRequest.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubCreateContentRequest.java
@@ -1,0 +1,101 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.nifi.github;
+
+import java.util.Objects;
+
+public class GitHubCreateContentRequest {
+
+    private final String branch;
+    private final String path;
+    private final String content;
+    private final String message;
+    private final String existingContentSha;
+
+    private GitHubCreateContentRequest(final Builder builder) {
+        this.branch = Objects.requireNonNull(builder.branch);
+        this.path = Objects.requireNonNull(builder.path);
+        this.content = Objects.requireNonNull(builder.content);
+        this.message = Objects.requireNonNull(builder.message);
+        // Will be null for create, and populated for update
+        this.existingContentSha = builder.existingContentSha;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getExistingContentSha() {
+        return existingContentSha;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String branch;
+        private String path;
+        private String content;
+        private String message;
+        private String existingContentSha;
+
+        public Builder branch(final String branch) {
+            this.branch = branch;
+            return this;
+        }
+
+        public Builder path(final String path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder content(final String content) {
+            this.content = content;
+            return this;
+        }
+
+        public Builder message(final String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder existingContentSha(final String existingSha) {
+            this.existingContentSha = existingSha;
+            return this;
+        }
+
+        public GitHubCreateContentRequest build() {
+            return new GitHubCreateContentRequest(this);
+        }
+    }
+}

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubCreateContentRequest.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubCreateContentRequest.java
@@ -1,19 +1,19 @@
 /*
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  *
  */
 

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubRepositoryClient.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubRepositoryClient.java
@@ -141,19 +141,20 @@ public class GitHubRepositoryClient {
      * @throws IOException if an I/O error happens calling GitHub
      * @throws FlowRegistryException if a non I/O error happens calling GitHub
      */
-    public GHContentUpdateResponse createContent(final GitHubCreateContentRequest request) throws IOException, FlowRegistryException {
+    public String createContent(final GitHubCreateContentRequest request) throws IOException, FlowRegistryException {
         final String branch = request.getBranch();
         final String resolvedPath = getResolvedPath(request.getPath());
         LOGGER.debug("Creating content at path [{}] on branch [{}] in repo [{}] ", resolvedPath, branch, repository.getName());
         return execute(() -> {
             try {
-                return repository.createContent()
+                final GHContentUpdateResponse response = repository.createContent()
                         .branch(branch)
                         .path(resolvedPath)
                         .content(request.getContent())
                         .message(request.getMessage())
                         .sha(request.getExistingContentSha())
                         .commit();
+                return response.getCommit().getSha();
             } catch (final FileNotFoundException fnf) {
                 throwPathOrBranchNotFound(fnf, resolvedPath, branch);
                 return null;

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubRepositoryClient.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubRepositoryClient.java
@@ -1,19 +1,19 @@
 /*
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  *
  */
 
@@ -50,34 +50,32 @@ public class GitHubRepositoryClient {
 
     private final GHRepository repository;
     private final String repoPath;
-    private final boolean authenticationPresent;
+    private final GitHubAuthenticationType authenticationType;
 
     private GitHubRepositoryClient(final Builder builder) throws IOException {
         final GitHubBuilder gitHubBuilder = new GitHubBuilder().withEndpoint(builder.apiUrl);
 
-        final String accessToken = builder.accessToken;
-        if (accessToken != null) {
-            gitHubBuilder.withOAuthToken(accessToken);
-            authenticationPresent = true;
-        } else {
-            authenticationPresent = false;
+        authenticationType = builder.authenticationType;
+        switch (authenticationType) {
+            case PERSONAL_ACCESS_TOKEN -> gitHubBuilder.withOAuthToken(builder.personalAccessToken);
+            case APP_INSTALLATION_TOKEN -> gitHubBuilder.withAppInstallationToken(builder.appInstallationToken);
         }
 
         final GitHub gitHub = gitHubBuilder.build();
         try {
             repository = gitHub.getRepository(builder.repoOwner + "/" + builder.repoName);
         } catch (final IOException e) {
-            LOGGER.error("Unable to access GitHub repository [{}] due to: {}", builder.repoName, e.getMessage(), e);
+            LOGGER.error("Unable to access GitHub repository [{}]", builder.repoName, e);
             throw e;
         }
         repoPath = builder.repoPath;
     }
 
     /**
-     * @return true if the client is configured with credentials to authenticate
+     * @return the authentication type this client is configured with
      */
-    public boolean isAuthenticationPresent() {
-        return authenticationPresent;
+    public GitHubAuthenticationType getAuthenticationType() {
+        return authenticationType;
     }
 
     /**
@@ -356,7 +354,9 @@ public class GitHubRepositoryClient {
     public static class Builder {
 
         private String apiUrl;
-        private String accessToken;
+        private GitHubAuthenticationType authenticationType;
+        private String personalAccessToken;
+        private String appInstallationToken;
         private String repoOwner;
         private String repoName;
         private String repoPath;
@@ -366,8 +366,18 @@ public class GitHubRepositoryClient {
             return this;
         }
 
-        public Builder accessToken(final String accessToken) {
-            this.accessToken = accessToken;
+        public Builder authenticationType(final GitHubAuthenticationType authenticationType) {
+            this.authenticationType = authenticationType;
+            return this;
+        }
+
+        public Builder personalAccessToken(final String personalAccessToken) {
+            this.personalAccessToken = personalAccessToken;
+            return this;
+        }
+
+        public Builder appInstallationToken(final String appInstallationToken) {
+            this.appInstallationToken = appInstallationToken;
             return this;
         }
 

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/JacksonFlowSnapshotSerializer.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/JacksonFlowSnapshotSerializer.java
@@ -1,0 +1,58 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.nifi.github;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
+import org.apache.nifi.registry.flow.RegisteredFlowSnapshot;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Implementation of {@link FlowSnapshotSerializer} that is Jackson's ObjectMapper.
+ */
+public class JacksonFlowSnapshotSerializer implements FlowSnapshotSerializer {
+
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
+            .serializationInclusion(JsonInclude.Include.NON_NULL)
+            .defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+            .annotationIntrospector(new JakartaXmlBindAnnotationIntrospector(TypeFactory.defaultInstance()))
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .addModule(new VersionedComponentModule())
+            .build();
+
+    @Override
+    public String serialize(final RegisteredFlowSnapshot flowSnapshot) throws IOException {
+        return OBJECT_MAPPER.writeValueAsString(flowSnapshot);
+    }
+
+    @Override
+    public RegisteredFlowSnapshot deserialize(final InputStream inputStream) throws IOException {
+        return OBJECT_MAPPER.readValue(inputStream, RegisteredFlowSnapshot.class);
+    }
+
+}

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/VersionedComponentModule.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/VersionedComponentModule.java
@@ -1,0 +1,64 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.nifi.github;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import org.apache.nifi.flow.ConnectableComponent;
+import org.apache.nifi.flow.VersionedComponent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Jackson Module to customize serialization of versioned component objects.
+ */
+public class VersionedComponentModule extends SimpleModule {
+
+    private static final Set<String> EXCLUDE_JSON_FIELDS = Set.of("instanceIdentifier", "instanceGroupId");
+
+    @Override
+    public void setupModule(final SetupContext context) {
+        super.setupModule(context);
+        context.addBeanSerializerModifier(new VersionedComponentBeanSerializerModifier());
+    }
+
+    private static class VersionedComponentBeanSerializerModifier extends BeanSerializerModifier {
+        @Override
+        public List<BeanPropertyWriter> changeProperties(final SerializationConfig config, final BeanDescription beanDesc, final List<BeanPropertyWriter> beanProperties) {
+            if (!VersionedComponent.class.isAssignableFrom(beanDesc.getBeanClass())
+                    && !ConnectableComponent.class.isAssignableFrom(beanDesc.getBeanClass())) {
+                return super.changeProperties(config, beanDesc, beanProperties);
+            }
+
+            final List<BeanPropertyWriter> includedProperties = new ArrayList<>();
+            for (final BeanPropertyWriter property : beanProperties) {
+                if (!EXCLUDE_JSON_FIELDS.contains(property.getName())) {
+                    includedProperties.add(property);
+                }
+            }
+            return includedProperties;
+        }
+    }
+}

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/VersionedComponentModule.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/VersionedComponentModule.java
@@ -1,19 +1,19 @@
 /*
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one or more
- *  * contributor license agreements.  See the NOTICE file distributed with
- *  * this work for additional information regarding copyright ownership.
- *  * The ASF licenses this file to You under the Apache License, Version 2.0
- *  * (the "License"); you may not use this file except in compliance with
- *  * the License.  You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  *
  */
 

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/resources/META-INF/services/org.apache.nifi.registry.flow.FlowRegistryClient
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/resources/META-INF/services/org.apache.nifi.registry.flow.FlowRegistryClient
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.github.GitHubFlowRegistryClient

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/test/java/org/apache/nifi/github/GitHubFlowRegistryClientTest.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/test/java/org/apache/nifi/github/GitHubFlowRegistryClientTest.java
@@ -1,0 +1,202 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.nifi.github;
+
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.flow.VersionedProcessGroup;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.registry.flow.FlowRegistryBucket;
+import org.apache.nifi.registry.flow.FlowRegistryClientConfigurationContext;
+import org.apache.nifi.registry.flow.FlowRegistryClientInitializationContext;
+import org.apache.nifi.registry.flow.FlowRegistryException;
+import org.apache.nifi.registry.flow.RegisterAction;
+import org.apache.nifi.registry.flow.RegisteredFlow;
+import org.apache.nifi.registry.flow.RegisteredFlowSnapshot;
+import org.apache.nifi.registry.flow.RegisteredFlowSnapshotMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class GitHubFlowRegistryClientTest {
+
+    static final String DEFAULT_REPO_PATH = "some-path";
+    static final String DEFAULT_REPO_BRANCH = "some-branch";
+
+    private GitHubRepositoryClient repositoryClient;
+    private FlowSnapshotSerializer flowSnapshotSerializer;
+    private GitHubFlowRegistryClient flowRegistryClient;
+    private FlowRegistryClientConfigurationContext clientConfigurationContext;
+    private ComponentLog componentLog;
+
+    @BeforeEach
+    public void setup() throws IOException, FlowRegistryException {
+        repositoryClient = mock(GitHubRepositoryClient.class);
+        flowSnapshotSerializer = mock(FlowSnapshotSerializer.class);
+        flowRegistryClient = new TestableGitHubRepositoryClient(repositoryClient, flowSnapshotSerializer);
+
+        clientConfigurationContext = mock(FlowRegistryClientConfigurationContext.class);
+        componentLog = mock(ComponentLog.class);
+
+        final FlowRegistryClientInitializationContext initializationContext = mock(FlowRegistryClientInitializationContext.class);
+        when(initializationContext.getLogger()).thenReturn(componentLog);
+        flowRegistryClient.initialize(initializationContext);
+
+        when(repositoryClient.getCanRead()).thenReturn(true);
+        when(repositoryClient.getCanWrite()).thenReturn(true);
+        when(repositoryClient.getTopLevelDirectoryNames(anyString())).thenReturn(Set.of("existing-bucket"));
+    }
+
+    @Test
+    public void testRegisterFlow() throws IOException, FlowRegistryException {
+        setupClientConfigurationContextWithDefaults();
+
+        final String serializedSnapshotContent = "placeholder";
+        when(flowSnapshotSerializer.serialize(any(RegisteredFlowSnapshot.class))).thenReturn(serializedSnapshotContent);
+
+        final RegisteredFlow incomingFlow = createIncomingRegisteredFlow();
+        final RegisteredFlow resultFlow = flowRegistryClient.registerFlow(clientConfigurationContext, incomingFlow);
+        assertEquals(incomingFlow.getIdentifier(), resultFlow.getIdentifier());
+        assertEquals(incomingFlow.getName(), resultFlow.getName());
+        assertEquals(incomingFlow.getBucketIdentifier(), resultFlow.getBucketIdentifier());
+        assertEquals(incomingFlow.getBucketName(), resultFlow.getBucketName());
+        assertEquals(incomingFlow.getBranch(), resultFlow.getBranch());
+
+        final ArgumentCaptor<GitHubCreateContentRequest> argumentCaptor = ArgumentCaptor.forClass(GitHubCreateContentRequest.class);
+        verify(repositoryClient).createContent(argumentCaptor.capture());
+
+        final GitHubCreateContentRequest capturedArgument = argumentCaptor.getValue();
+        assertEquals(incomingFlow.getBranch(), capturedArgument.getBranch());
+        assertEquals(GitHubFlowRegistryClient.SNAPSHOT_FILE_PATH_FORMAT.formatted(incomingFlow.getBucketIdentifier(), incomingFlow.getIdentifier()), capturedArgument.getPath());
+        assertEquals(serializedSnapshotContent, capturedArgument.getContent());
+        assertNull(capturedArgument.getExistingContentSha());
+    }
+
+    @Test
+    public void testRegisterFlowSnapshot() throws IOException, FlowRegistryException {
+        setupClientConfigurationContextWithDefaults();
+
+        final RegisteredFlow incomingFlow = createIncomingRegisteredFlow();
+
+        final RegisteredFlowSnapshotMetadata incomingMetadata = new RegisteredFlowSnapshotMetadata();
+        incomingMetadata.setBranch(incomingFlow.getBranch());
+        incomingMetadata.setBucketIdentifier(incomingFlow.getBucketIdentifier());
+        incomingMetadata.setFlowIdentifier(incomingFlow.getIdentifier());
+        incomingMetadata.setComments("Unit test");
+
+        final RegisteredFlowSnapshot incomingSnapshot = new RegisteredFlowSnapshot();
+        incomingSnapshot.setFlow(incomingFlow);
+        incomingSnapshot.setSnapshotMetadata(incomingMetadata);
+        incomingSnapshot.setFlowContents(new VersionedProcessGroup());
+
+        final String snapshotFilePath = GitHubFlowRegistryClient.SNAPSHOT_FILE_PATH_FORMAT.formatted(incomingFlow.getBucketIdentifier(), incomingFlow.getIdentifier());
+        when(repositoryClient.getContentFromBranch(snapshotFilePath, DEFAULT_REPO_BRANCH)).thenReturn(new ByteArrayInputStream(new byte[0]));
+        when(flowSnapshotSerializer.deserialize(any(InputStream.class))).thenReturn(incomingSnapshot);
+
+        final String serializedSnapshotContent = "placeholder";
+        when(flowSnapshotSerializer.serialize(any(RegisteredFlowSnapshot.class))).thenReturn(serializedSnapshotContent);
+
+        final String commitSha = "commitSha";
+        when(repositoryClient.createContent(any(GitHubCreateContentRequest.class))).thenReturn(commitSha);
+
+        final RegisteredFlowSnapshot resultSnapshot = flowRegistryClient.registerFlowSnapshot(clientConfigurationContext, incomingSnapshot, RegisterAction.COMMIT);
+        assertNotNull(resultSnapshot);
+
+        final RegisteredFlow resultFlow = resultSnapshot.getFlow();
+        assertNotNull(resultFlow);
+        assertEquals(incomingFlow.getIdentifier(), resultFlow.getIdentifier());
+        assertEquals(incomingFlow.getName(), resultFlow.getName());
+        assertEquals(incomingFlow.getBucketIdentifier(), resultFlow.getBucketIdentifier());
+        assertEquals(incomingFlow.getBucketName(), resultFlow.getBucketName());
+        assertEquals(incomingFlow.getBranch(), resultFlow.getBranch());
+
+        final RegisteredFlowSnapshotMetadata resultMetadata = resultSnapshot.getSnapshotMetadata();
+        assertNotNull(resultMetadata);
+        assertEquals(incomingMetadata.getBranch(), resultMetadata.getBranch());
+        assertEquals(incomingMetadata.getBucketIdentifier(), resultMetadata.getBucketIdentifier());
+        assertEquals(incomingMetadata.getFlowIdentifier(), resultMetadata.getFlowIdentifier());
+        assertEquals(incomingMetadata.getComments(), resultMetadata.getComments());
+
+        final FlowRegistryBucket resultBucket = resultSnapshot.getBucket();
+        assertNotNull(resultBucket);
+        assertEquals(incomingMetadata.getBucketIdentifier(), resultBucket.getIdentifier());
+        assertEquals(incomingMetadata.getBucketIdentifier(), resultBucket.getName());
+    }
+
+    private RegisteredFlow createIncomingRegisteredFlow() {
+        final RegisteredFlow incomingFlow = new RegisteredFlow();
+        incomingFlow.setIdentifier("Flow1");
+        incomingFlow.setName("Flow1");
+        incomingFlow.setBucketIdentifier("Bucket1");
+        incomingFlow.setBucketName("Bucket1");
+        incomingFlow.setBranch(DEFAULT_REPO_BRANCH);
+        return incomingFlow;
+    }
+
+    private void setupClientConfigurationContext(final String repoPath, final String branch) {
+        final PropertyValue repoPathPropertyValue = createMockPropertyValue(repoPath);
+        when(clientConfigurationContext.getProperty(GitHubFlowRegistryClient.REPOSITORY_PATH)).thenReturn(repoPathPropertyValue);
+
+        final PropertyValue branchPropertyValue = createMockPropertyValue(branch);
+        when(clientConfigurationContext.getProperty(GitHubFlowRegistryClient.REPOSITORY_BRANCH)).thenReturn(branchPropertyValue);
+    }
+
+    private void setupClientConfigurationContextWithDefaults() {
+        setupClientConfigurationContext(DEFAULT_REPO_PATH, DEFAULT_REPO_BRANCH);
+    }
+
+    private PropertyValue createMockPropertyValue(final String value) {
+        final PropertyValue propertyValue = mock(PropertyValue.class);
+        when(propertyValue.getValue()).thenReturn(value);
+        return propertyValue;
+    }
+
+    private static class TestableGitHubRepositoryClient extends GitHubFlowRegistryClient {
+        private final GitHubRepositoryClient repositoryClient;
+        private final FlowSnapshotSerializer flowSnapshotSerializer;
+
+        public TestableGitHubRepositoryClient(final GitHubRepositoryClient repositoryClient, final FlowSnapshotSerializer flowSnapshotSerializer) {
+            this.repositoryClient = repositoryClient;
+            this.flowSnapshotSerializer = flowSnapshotSerializer;
+        }
+
+        @Override
+        protected GitHubRepositoryClient createRepositoryClient(final FlowRegistryClientConfigurationContext context) throws IOException, FlowRegistryException {
+            return repositoryClient;
+        }
+
+        @Override
+        protected FlowSnapshotSerializer createFlowSnapshotSerializer(final FlowRegistryClientInitializationContext initializationContext) {
+            return flowSnapshotSerializer;
+        }
+    }
+
+}

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-nar/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-github-bundle</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-github-nar</artifactId>
+    <packaging>nar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-github-extensions</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-shared-nar</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/nifi-extension-bundles/nifi-github-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-github-bundle/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>nifi-standard-shared-bom</artifactId>
+        <groupId>org.apache.nifi</groupId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../nifi-standard-shared-bundle/nifi-standard-shared-bom</relativePath>
+    </parent>
+
+    <artifactId>nifi-github-bundle</artifactId>
+    <packaging>pom</packaging>
+
+    <properties>
+        <github-api.version>1.321</github-api.version>
+    </properties>
+
+    <modules>
+        <module>nifi-github-extensions</module>
+        <module>nifi-github-nar</module>
+    </modules>
+</project>

--- a/nifi-extension-bundles/pom.xml
+++ b/nifi-extension-bundles/pom.xml
@@ -104,5 +104,6 @@
         <module>nifi-jolt-bundle</module>
         <module>nifi-questdb-bundle</module>
         <module>nifi-protobuf-bundle</module>
+        <module>nifi-github-bundle</module>
     </modules>
 </project>

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/FlowAnalyzingRegistryClientNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/FlowAnalyzingRegistryClientNode.java
@@ -462,6 +462,11 @@ public final class FlowAnalyzingRegistryClientNode implements FlowRegistryClient
     }
 
     @Override
+    public String generateFlowId(final String flowName) throws IOException, FlowRegistryException {
+        return node.generateFlowId(flowName);
+    }
+
+    @Override
     public void setComponent(final LoggableComponent<FlowRegistryClient> component) {
         node.setComponent(component);
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardFlowRegistryClientNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardFlowRegistryClientNode.java
@@ -285,6 +285,11 @@ public final class StandardFlowRegistryClientNode extends AbstractComponentNode 
     }
 
     @Override
+    public String generateFlowId(final String flowName) throws IOException, FlowRegistryException {
+        return execute(() -> client.get().getComponent().generateFlowId(flowName));
+    }
+
+    @Override
     public void setComponent(final LoggableComponent<FlowRegistryClient> component) {
         client.set(component);
     }
@@ -299,7 +304,7 @@ public final class StandardFlowRegistryClientNode extends AbstractComponentNode 
             }
 
             final List<String> validationProblems = validationResults.stream()
-                .map(e -> e.getExplanation())
+                .map(ValidationResult::getExplanation)
                 .collect(Collectors.toList());
 
             throw new FlowRegistryInvalidException(validationProblems);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/registry/flow/FlowRegistryClientNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/registry/flow/FlowRegistryClientNode.java
@@ -63,5 +63,7 @@ public interface FlowRegistryClientNode extends ComponentNode {
     Set<RegisteredFlowSnapshotMetadata> getFlowVersions(FlowRegistryClientUserContext context, FlowLocation flowLocation) throws FlowRegistryException, IOException;
     Optional<String> getLatestVersion(FlowRegistryClientUserContext context, FlowLocation flowLocation) throws FlowRegistryException, IOException;
 
+    String generateFlowId(String flowName) throws IOException, FlowRegistryException;
+
     void setComponent(LoggableComponent<FlowRegistryClient> component);
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -3276,7 +3276,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         final FlowRegistryBranch defaultBranch = flowRegistryDAO.getDefaultBranchForUser(clientUserContext, registryClientId);
         return flowRegistryDAO.getFlowVersionsForUser(clientUserContext, registryClientId, defaultBranch.getName(), bucketId, flowId).stream()
                 .map(md -> createVersionedFlowSnapshotMetadataEntity(registryClientId, md))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     @Override
@@ -5021,7 +5021,6 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         final Map<String, ParameterProviderReference> parameterProviderReferences = new HashMap<>();
         final Map<String, VersionedParameterContext> parameterContexts = createVersionedParameterContexts(processGroup, parameterProviderReferences);
 
-        final String flowId = versionedFlowDto.getFlowId() == null ? UUID.randomUUID().toString() : versionedFlowDto.getFlowId();
         final String registryId = requestEntity.getVersionedFlow().getRegistryId();
 
         final String selectedBranch;
@@ -5040,7 +5039,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         versionedFlow.setDescription(versionedFlowDto.getDescription());
         versionedFlow.setLastModifiedTimestamp(versionedFlow.getCreatedTimestamp());
         versionedFlow.setName(versionedFlowDto.getFlowName());
-        versionedFlow.setIdentifier(flowId);
+        versionedFlow.setIdentifier(versionedFlowDto.getFlowId());
 
         // Add the Versioned Flow and first snapshot to the Flow Registry
         final RegisteredFlowSnapshot registeredSnapshot;
@@ -5069,7 +5068,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
             // then we need to capture the created versioned flow information as a partial successful result.
             if (registerNewFlow) {
                 try {
-                    final FlowLocation flowLocation = new FlowLocation(selectedBranch, versionedFlowDto.getBucketId(), flowId);
+                    final FlowLocation flowLocation = new FlowLocation(selectedBranch, versionedFlowDto.getBucketId(), registeredFlow.getIdentifier());
                     final FlowRegistryClientNode flowRegistryClientNode = flowRegistryDAO.getFlowRegistryClient(registryId);
                     flowRegistryClientNode.deregisterFlow(FlowRegistryClientContextFactory.getContextForUser(NiFiUserUtils.getNiFiUser()), flowLocation);
                 } catch (final IOException | FlowRegistryException e2) {
@@ -5357,6 +5356,8 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         }
 
         try {
+            final String generatedId = registry.generateFlowId(flow.getName());
+            flow.setIdentifier(generatedId);
             return registry.registerFlow(FlowRegistryClientContextFactory.getContextForUser(NiFiUserUtils.getNiFiUser()), flow);
         } catch (final IOException | FlowRegistryException e) {
             throw new NiFiCoreException("Failed to register flow with Flow Registry due to " + e.getMessage(), e);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -394,7 +394,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/VersionsResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/VersionsResource.java
@@ -1247,7 +1247,7 @@ public class VersionsResource extends FlowUpdateResource<VersionControlInformati
 
         final RegisteredFlowSnapshotMetadata metadata = flowSnapshot.getSnapshotMetadata();
         final VersionControlInformationDTO versionControlInfo = new VersionControlInformationDTO();
-        versionControlInfo.setBranch(requestVci.getBranch());
+        versionControlInfo.setBranch(metadata.getBranch());
         versionControlInfo.setBucketId(metadata.getBucketIdentifier());
         versionControlInfo.setBucketName(bucket.getName());
         versionControlInfo.setFlowDescription(flow.getDescription());

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardFlowRegistryDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardFlowRegistryDAO.java
@@ -198,7 +198,12 @@ public class StandardFlowRegistryDAO extends ComponentDAO implements FlowRegistr
 
             final FlowLocation flowLocation = new FlowLocation(branch, bucketId, flowId);
             final Set<RegisteredFlowSnapshotMetadata> flowVersions = flowRegistry.getFlowVersions(context, flowLocation);
-            final Set<RegisteredFlowSnapshotMetadata> sortedFlowVersions = new TreeSet<>(Comparator.comparingLong(RegisteredFlowSnapshotMetadata::getTimestamp));
+
+            // if somehow the timestamp of two versions is exactly the same, then we use version as a secondary comparison,
+            // otherwise one of the objects won't be added to the set since compareTo returns 0 indicating it already exists
+            final Set<RegisteredFlowSnapshotMetadata> sortedFlowVersions = new TreeSet<>(
+                    Comparator.comparingLong(RegisteredFlowSnapshotMetadata::getTimestamp)
+                            .thenComparing(RegisteredFlowSnapshotMetadata::getVersion));
             sortedFlowVersions.addAll(flowVersions);
             return sortedFlowVersions;
         } catch (final IOException | FlowRegistryException ioe) {


### PR DESCRIPTION
…ing flows

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13105](https://issues.apache.org/jira/browse/NIFI-13105)

This PR adds a new `FlowRegistryClient` that uses `GitHub` API to version control flows. Currently the client is configured with the repo information, including a branch and optional path in the repo to use, otherwise the root of the repo is used. 

Buckets are directories underneath the location in the repo. The client will check for a bucket named `Default`, and if it does not exist it will be created. Additional buckets can be created by adding additional directories to the repo outside of NiFi. 

The branch is planned to become part of the version control screens when saving/importing which is tracked by. [NIFI-13127](https://issues.apache.org/jira/browse/NIFI-13127). Until then, the branch that is configured in the client will be used for all operations, so in order to work on different branches, it currently requires creating separate registry clients pointing at the same repo, but different branches.

It is also possible to import flows from a public repo that you don't have permissions to by not providing an access token. This will allow import and change version, but attempting to save a change will result in a "not found" exception which is GitHub's behavior when you specify a branch or file that you don't have access to, even though it may be in the repo.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
