### PR TITLE
NIFI-13155: Adding revision checking in flow reducer

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/README.md
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/README.md
@@ -6,8 +6,8 @@ This module is the primary UI for NiFi. It contains the canvas and all UI's for 
 that support other UIs that intergate with this. These include documentation, data viewers, advanced configuration UIs, error handling, and Registry UIs.
 Overtime, these will all be modernized and possibly brought into this Nx repo to co-locate all the front end code.
 
-On startup, NiFi has been updated to locate the new UI and deploy it to a new context path (`/nf`). One thing to note, when using the new UI running 
-in NiFi at `/nf`, the user can log in and use the application. When logging out however, there is a hardcoded redirect that happens from the back end 
+On startup, NiFi has been updated to locate the new UI and deploy it to a new context path (`/nf`). One thing to note, when using the new UI running
+in NiFi at `/nf`, the user can log in and use the application. When logging out however, there is a hardcoded redirect that happens from the back end
 which sends the user to the old UI (`/nifi`).
 
 Once the remaining features have been implemented, the look and feel has be polished, and it is ready for release the old UI will be removed. At that time

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
@@ -67,6 +67,7 @@ export interface LoadProcessGroupResponse {
     flow: ProcessGroupFlowEntity;
     flowStatus: ControllerStatusEntity;
     controllerBulletins: ControllerBulletinsEntity;
+    connectedStateChanged: boolean;
 }
 
 export interface LoadConnectionSuccess {
@@ -538,6 +539,7 @@ export interface ComponentEntity {
     id: string;
     permissions: Permissions;
     position: Position;
+    revision: Revision;
     component: any;
 }
 
@@ -617,6 +619,8 @@ export interface ControllerBulletinsEntity {
 export interface FlowState {
     id: string;
     flow: ProcessGroupFlowEntity;
+    addedCache: string[];
+    removedCache: string[];
     flowStatus: ControllerStatusEntity;
     refreshRpgDetails: RefreshRemoteProcessGroupPollingDetailsRequest | null;
     controllerBulletins: ControllerBulletinsEntity;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/cluster-summary/cluster-summary.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/cluster-summary/cluster-summary.actions.ts
@@ -41,6 +41,8 @@ export const setDisconnectionAcknowledged = createAction(
     props<{ disconnectionAcknowledged: boolean }>()
 );
 
+export const resetConnectedStateChanged = createAction(`${CLUSTER_SUMMARY_STATE_PREFIX} Reset Connected State Changed`);
+
 export const searchCluster = createAction(
     `${CLUSTER_SUMMARY_STATE_PREFIX} Search Cluster`,
     props<{ request: ClusterSearchRequest }>()

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/cluster-summary/cluster-summary.reducer.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/cluster-summary/cluster-summary.reducer.ts
@@ -18,14 +18,17 @@
 import { createReducer, on } from '@ngrx/store';
 import { ClusterSummaryState } from './index';
 import {
+    acknowledgeClusterConnectionChange,
     loadClusterSummary,
     loadClusterSummarySuccess,
+    resetConnectedStateChanged,
     searchClusterSuccess,
     setDisconnectionAcknowledged
 } from './cluster-summary.actions';
 
 export const initialState: ClusterSummaryState = {
     disconnectionAcknowledged: false,
+    connectedStateChanged: false,
     clusterSummary: null,
     searchResults: null,
     status: 'pending'
@@ -45,6 +48,14 @@ export const clusterSummaryReducer = createReducer(
     on(searchClusterSuccess, (state, { response }) => ({
         ...state,
         searchResults: response
+    })),
+    on(acknowledgeClusterConnectionChange, (state) => ({
+        ...state,
+        connectedStateChanged: true
+    })),
+    on(resetConnectedStateChanged, (state) => ({
+        ...state,
+        connectedStateChanged: false
     })),
     on(setDisconnectionAcknowledged, (state, { disconnectionAcknowledged }) => ({
         ...state,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/cluster-summary/cluster-summary.selectors.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/cluster-summary/cluster-summary.selectors.ts
@@ -25,6 +25,11 @@ export const selectDisconnectionAcknowledged = createSelector(
     (state: ClusterSummaryState) => state.disconnectionAcknowledged
 );
 
+export const selectConnectedStateChanged = createSelector(
+    selectClusterSummaryState,
+    (state: ClusterSummaryState) => state.connectedStateChanged
+);
+
 export const selectClusterSummary = createSelector(
     selectClusterSummaryState,
     (state: ClusterSummaryState) => state.clusterSummary

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/cluster-summary/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/cluster-summary/index.ts
@@ -44,6 +44,7 @@ export interface ClusterSearchResults {
 
 export interface ClusterSummaryState {
     disconnectionAcknowledged: boolean;
+    connectedStateChanged: boolean;
     clusterSummary: ClusterSummary | null;
     searchResults: ClusterSearchResults | null;
     status: 'pending' | 'loading' | 'success';


### PR DESCRIPTION
NIFI-13155: 
- Handling newer revisions in flow reducer to ensure that the appropriate version of the component is saved in case responses are received out of order.

This addresses an issue that occurs for slow connections and there are very large flows. Under these circumstances, a user would issue a request to add or remove a component between when the canvas polling starts and completes. This can be easily simulated by adding a `delay` to the `pipe` following the API call and before `loadProcessGroupSuccess` is dispatched.

This PR additionally adds an override to skip the revision check when a nodes cluster connection state changes. This is important because the basis for component revisions changes when the node is connected to the cluster from when it's disconnected.