### PR TITLE
NIFI-13168 Upgrade QuestDB from 7.3.7 to 7.4.2

### DIFF
--- a/nifi-extension-bundles/nifi-questdb-bundle/nifi-questdb/pom.xml
+++ b/nifi-extension-bundles/nifi-questdb-bundle/nifi-questdb/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.questdb</groupId>
             <artifactId>questdb</artifactId>
-            <version>7.3.7</version>
+            <version>7.4.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/nifi-extension-bundles/nifi-questdb-bundle/nifi-questdb/src/main/java/org/apache/nifi/questdb/embedded/CursorBasedQueryRowContext.java
+++ b/nifi-extension-bundles/nifi-questdb-bundle/nifi-questdb/src/main/java/org/apache/nifi/questdb/embedded/CursorBasedQueryRowContext.java
@@ -50,7 +50,7 @@ final class CursorBasedQueryRowContext implements QueryRowContext {
 
     @Override
     public String getString(final int position) {
-        return String.valueOf(actualRecord.getSym(position));
+        return String.valueOf(actualRecord.getSymA(position));
     }
 
     boolean hasNext() {

--- a/nifi-extension-bundles/nifi-questdb-bundle/nifi-questdb/src/main/java/org/apache/nifi/questdb/embedded/EmbeddedDatabaseManager.java
+++ b/nifi-extension-bundles/nifi-questdb-bundle/nifi-questdb/src/main/java/org/apache/nifi/questdb/embedded/EmbeddedDatabaseManager.java
@@ -178,8 +178,10 @@ final class EmbeddedDatabaseManager implements DatabaseManager {
             for (final ManagedTableDefinition tableDefinition : context.getTableDefinitions()) {
                 try {
                     final TableToken tableToken = this.engine.get().getTableTokenIfExists(tableDefinition.getName());
-                    final TableRecordMetadata metadata = this.engine.get().getSequencerMetadata(tableToken);
-                    metadata.close();
+                    if (tableToken.isWal()) {
+                        final TableRecordMetadata metadata = this.engine.get().getSequencerMetadata(tableToken);
+                        metadata.close();
+                    }
 
                     client.execute(String.format("SELECT * FROM %S LIMIT 1", tableDefinition.getName()));
                 } catch (final Exception e) {


### PR DESCRIPTION
# Summary

[NIFI-13168](https://issues.apache.org/jira/browse/NIFI-13168) Upgrades QuestDB from 7.3.7 to 7.4.2 and includes method and status check adjustments to reflect changes in the QuestDB library.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
