### PR TITLE
NIFI-13210 Add CODECOV_TOKEN to GitHub Workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -187,8 +187,10 @@ jobs:
           ${{ env.MAVEN_PROJECTS }}
       - name: Codecov
         uses: codecov/codecov-action@v4
+        if: github.repository_owner == 'apache'
         with:
           files: ./nifi-code-coverage/target/site/jacoco-aggregate/jacoco.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Test Reports
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
# Summary

[NIFI-13210](https://issues.apache.org/jira/browse/NIFI-13210) Adds the `CODECOV_TOKEN` secret reference to the Codecov reporting step in the GitHub workflow, enabling code coverage reporting following Apache infrastructure updates in [INFRA-25778](https://issues.apache.org/jira/browse/INFRA-25778).

Codecov Action version 4 requires a token for coverage reporting.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
