### PR TITLE
NIFI-13157 Replaced deprecated getNextTarEntry() and getNextZipEntry() with getNextEntry().

### DIFF
--- a/c2/c2-client-bundle/c2-client-service/src/test/java/org/apache/nifi/c2/client/service/operation/TransferDebugOperationHandlerTest.java
+++ b/c2/c2-client-bundle/c2-client-service/src/test/java/org/apache/nifi/c2/client/service/operation/TransferDebugOperationHandlerTest.java
@@ -238,7 +238,7 @@ public class TransferDebugOperationHandlerTest {
         Map<String, String> fileNamesWithContents = new HashMap<>();
         try (TarArchiveInputStream tarInputStream = new TarArchiveInputStream(new GzipCompressorInputStream(new ByteArrayInputStream(bundle)))) {
             TarArchiveEntry currentEntry;
-            while ((currentEntry = tarInputStream.getNextTarEntry()) != null) {
+            while ((currentEntry = tarInputStream.getNextEntry()) != null) {
                 fileNamesWithContents.put(
                     currentEntry.getName(),
                     new BufferedReader(new InputStreamReader(tarInputStream)).lines().collect(joining(NEW_LINE)));

--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV1.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV1.java
@@ -34,7 +34,7 @@ public class FlowFileUnpackagerV1 implements FlowFileUnpackager {
     public Map<String, String> unpackageFlowFile(final InputStream in, final OutputStream out) throws IOException {
         flowFilesRead++;
         final TarArchiveInputStream tarIn = new TarArchiveInputStream(in);
-        final TarArchiveEntry attribEntry = tarIn.getNextTarEntry();
+        final TarArchiveEntry attribEntry = tarIn.getNextEntry();
         if (attribEntry == null) {
             return null;
         }
@@ -48,7 +48,7 @@ public class FlowFileUnpackagerV1 implements FlowFileUnpackager {
                     + FlowFilePackagerV1.FILENAME_ATTRIBUTES);
         }
 
-        final TarArchiveEntry contentEntry = tarIn.getNextTarEntry();
+        final TarArchiveEntry contentEntry = tarIn.getNextEntry();
 
         if (contentEntry != null && contentEntry.getName().equals(FlowFilePackagerV1.FILENAME_CONTENT)) {
             final byte[] buffer = new byte[512 << 10];//512KB

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/TarUnpackerSequenceFileWriter.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/TarUnpackerSequenceFileWriter.java
@@ -37,7 +37,7 @@ public class TarUnpackerSequenceFileWriter extends SequenceFileWriterImpl {
     protected void processInputStream(final InputStream stream, final FlowFile tarArchivedFlowFile, final Writer writer) throws IOException {
         try (final TarArchiveInputStream tarIn = new TarArchiveInputStream(new BufferedInputStream(stream))) {
             TarArchiveEntry tarEntry;
-            while ((tarEntry = tarIn.getNextTarEntry()) != null) {
+            while ((tarEntry = tarIn.getNextEntry()) != null) {
                 if (tarEntry.isDirectory()) {
                     continue;
                 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -379,7 +379,7 @@ public class UnpackContent extends AbstractProcessor {
                 int fragmentCount = 0;
                 try (final TarArchiveInputStream tarIn = new TarArchiveInputStream(new BufferedInputStream(inputStream))) {
                     TarArchiveEntry tarEntry;
-                    while ((tarEntry = tarIn.getNextTarEntry()) != null) {
+                    while ((tarEntry = tarIn.getNextEntry()) != null) {
                         if (tarEntry.isDirectory() || !fileMatches(tarEntry)) {
                             continue;
                         }
@@ -521,7 +521,7 @@ public class UnpackContent extends AbstractProcessor {
                 try (final ZipArchiveInputStream zipInputStream = new ZipArchiveInputStream(new BufferedInputStream(inputStream),
                     filenameEncoding.toString(), true, allowStoredEntriesWithDataDescriptor)) {
                     ZipArchiveEntry zipEntry;
-                    while ((zipEntry = zipInputStream.getNextZipEntry()) != null) {
+                    while ((zipEntry = zipInputStream.getNextEntry()) != null) {
                         processEntry(zipInputStream, zipEntry.isDirectory(), zipEntry.getName(), EncryptionMethod.NONE);
                     }
                 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13157](https://issues.apache.org/jira/browse/NIFI-13157)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
