### PR TITLE
NIFI-13217 Adjust JavaDoc of ProcessSession to align with changed standard implementation

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/processor/ProcessSession.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/ProcessSession.java
@@ -430,7 +430,8 @@ public interface ProcessSession {
     /**
      * Removes the attribute with the given {@code key} from the given {@link FlowFile}.
      * <p>
-     * If the {@code key} is named {@code uuid}, this method will return the same FlowFile without removing any attribute.
+     * The attributes with the keys {@code uuid}, {@code path}, and {@code filename} will not be removed.
+     * If the {@code key} is one of those, this method will return the same FlowFile without removing any attribute.
      *
      * @param flowFile to update
      * @param key of attribute to remove
@@ -447,7 +448,7 @@ public interface ProcessSession {
     /**
      * Removes the attributes with the given {@code keys} from the given {@link FlowFile}.
      * <p>
-     * If the set of keys contains the value {@code uuid}, this key will be ignored.
+     * The attributes with the keys {@code uuid}, {@code path}, and {@code filename} will not be removed.
      *
      * @param flowFile to update
      * @param keys of attributes to remove
@@ -464,7 +465,7 @@ public interface ProcessSession {
     /**
      * Removes all attributes from the given {@link FlowFile} whose key matches the given pattern.
      * <p>
-     * If the pattern matches the key {@code uuid}, this key will not be removed.
+     * The attributes with the keys {@code uuid}, {@code path}, and {@code filename} will not be removed.
      *
      * @param flowFile to update
      * @param keyPattern pattern to match each {@link FlowFile} attribute against; may be null, in which case no attribute is removed


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Adjusts the JavaDoc of `ProcessSession` to align with the changes introduced to the standard implementation with [NIFI-13200](https://issues.apache.org/jira/browse/NIFI-13200) / #8791.
This behavioral change might surprise users thus it seems sensible to adjust the JavaDoc with a notice accordingly.

[NIFI-13217](https://issues.apache.org/jira/browse/NIFI-13217)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### UI Contributions

- [x] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
