### PR TITLE
NIFI-13169: Upgrade Flyway in Registry to 10.12.0

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
@@ -297,6 +297,11 @@
             <version>${flyway.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <version>${flyway.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/db/CustomFlywayConfiguration.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/db/CustomFlywayConfiguration.java
@@ -20,10 +20,10 @@ import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.flywaydb.core.internal.database.DatabaseType;
 import org.flywaydb.core.internal.database.DatabaseTypeRegister;
-import org.flywaydb.core.internal.database.postgresql.PostgreSQLDatabaseType;
 import org.flywaydb.core.internal.jdbc.JdbcUtils;
 import org.flywaydb.database.mysql.MySQLDatabaseType;
 import org.flywaydb.database.mysql.mariadb.MariaDBDatabaseType;
+import org.flywaydb.database.postgresql.PostgreSQLDatabaseType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
@@ -56,7 +56,7 @@ public class CustomFlywayConfiguration implements FlywayConfigurationCustomizer 
 
     @Override
     public void customize(final FluentConfiguration configuration) {
-        final DatabaseType databaseType = getDatabaseType(configuration.getDataSource());
+        final DatabaseType databaseType = getDatabaseType(configuration.getDataSource(), configuration);
         LOGGER.info("Determined database type is {}", databaseType.getName());
 
         if (databaseType instanceof MySQLDatabaseType || databaseType instanceof MariaDBDatabaseType) {
@@ -87,9 +87,9 @@ public class CustomFlywayConfiguration implements FlywayConfigurationCustomizer 
      * @param dataSource the data source
      * @return the database type
      */
-    private DatabaseType getDatabaseType(final DataSource dataSource) {
+    private DatabaseType getDatabaseType(final DataSource dataSource, final org.flywaydb.core.api.configuration.Configuration configuration) {
         try (final Connection connection = dataSource.getConnection()) {
-            return DatabaseTypeRegister.getDatabaseTypeForConnection(connection);
+            return DatabaseTypeRegister.getDatabaseTypeForConnection(connection, configuration);
         } catch (SQLException e) {
             LOGGER.error(e.getMessage(), e);
             throw new FlywayException("Unable to obtain connection from Flyway DataSource", e);

--- a/nifi-registry/nifi-registry-core/nifi-registry-revision/nifi-registry-revision-spring-jdbc/src/test/java/org/apache/nifi/registry/revision/jdbc/TestJdbcRevisionManager.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-revision/nifi-registry-revision-spring-jdbc/src/test/java/org/apache/nifi/registry/revision/jdbc/TestJdbcRevisionManager.java
@@ -27,6 +27,7 @@ import org.apache.nifi.registry.revision.api.RevisionUpdate;
 import org.apache.nifi.registry.revision.api.UpdateRevisionTask;
 import org.apache.nifi.registry.revision.standard.StandardRevisionClaim;
 import org.apache.nifi.registry.revision.standard.StandardUpdateResult;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.flywaydb.core.internal.database.DatabaseType;
 import org.flywaydb.core.internal.database.DatabaseTypeRegister;
 import org.flywaydb.database.mysql.MySQLDatabaseType;
@@ -92,11 +93,11 @@ public class TestJdbcRevisionManager {
 
         // Create the REVISION table if it does not exist
         final DataSource dataSource = jdbcTemplate.getDataSource();
-        LOGGER.info("#### DataSource class is {}", new Object[]{dataSource.getClass().getCanonicalName()});
+        LOGGER.info("#### DataSource class is {}", dataSource.getClass().getCanonicalName());
 
         try (final Connection connection = dataSource.getConnection()) {
             final String createTableSql;
-            final DatabaseType databaseType = DatabaseTypeRegister.getDatabaseTypeForConnection(connection);
+            final DatabaseType databaseType = DatabaseTypeRegister.getDatabaseTypeForConnection(connection, new FluentConfiguration());
             if (databaseType.equals(new MySQLDatabaseType())) {
                 createTableSql = CREATE_TABLE_SQL_MYSQL;
             } else {

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,8 +36,8 @@
     </modules>
     <properties>
         <spring.boot.version>3.2.5</spring.boot.version>
-        <flyway.version>9.22.3</flyway.version>
-        <flyway.tests.version>9.5.0</flyway.tests.version>
+        <flyway.version>10.12.0</flyway.version>
+        <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>6.9.0.202403050737-r</jgit.version>
         <org.apache.sshd.version>2.12.1</org.apache.sshd.version>


### PR DESCRIPTION
# Summary

[NIFI-13169](https://issues.apache.org/jira/browse/NIFI-13169) Upgraded the Flyway version in NiFi Registry to 10.12.0 and made any necessary API changes. Tested buckets and flows against PostgreSQL 15.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
