### PR TITLE
NIFI-12669 Fix EvaluateXQuery processor to encode result attr correctly on Windows

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EvaluateXQuery.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EvaluateXQuery.java
@@ -368,7 +368,7 @@ public class EvaluateXQuery extends AbstractProcessor {
     private String formatItem(XdmItem item, ProcessContext context) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         writeFormattedItem(item, context, baos);
-        return baos.toString();
+        return baos.toString(StandardCharsets.UTF_8);
     }
 
     void writeFormattedItem(XdmItem item, ProcessContext context, OutputStream out) throws IOException {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestEvaluateXQuery.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestEvaluateXQuery.java
@@ -198,7 +198,7 @@ public class TestEvaluateXQuery {
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><fruit xmlns:ns=\"http://namespace/1\"><name>banana</name><color>yellow</color></fruit>",
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><fruit xmlns:ns=\"http://namespace/1\" taste=\"sweet\"><name>orange</name><color>orange</color></fruit>",
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><fruit xmlns:ns=\"http://namespace/1\"><name>blueberry</name><color>blue</color></fruit>",
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><fruit xmlns:ns=\"http://namespace/1\" taste=\"tart\"><name>raspberry</name><color>red</color></fruit>",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><fruit xmlns:ns=\"http://namespace/1\" taste=\"ÄÖÜäöüßéèóò\"><name>raspberry</name><color>red</color></fruit>",
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?><fruit xmlns:ns=\"http://namespace/1\"><name>none</name><color/></fruit>"));
 
         /* XML all matches wrapped (one result)*/
@@ -210,7 +210,7 @@ public class TestEvaluateXQuery {
                 + "<fruit xmlns:ns=\"http://namespace/1\"><name>banana</name><color>yellow</color></fruit>"
                 + "<fruit xmlns:ns=\"http://namespace/1\" taste=\"sweet\"><name>orange</name><color>orange</color></fruit>"
                 + "<fruit xmlns:ns=\"http://namespace/1\"><name>blueberry</name><color>blue</color></fruit>"
-                + "<fruit xmlns:ns=\"http://namespace/1\" taste=\"tart\"><name>raspberry</name><color>red</color></fruit>"
+                + "<fruit xmlns:ns=\"http://namespace/1\" taste=\"ÄÖÜäöüßéèóò\"><name>raspberry</name><color>red</color></fruit>"
                 + "<fruit xmlns:ns=\"http://namespace/1\"><name>none</name><color/></fruit>"
                 + "</wrap>"));
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestXml/fruit.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestXml/fruit.xml
@@ -36,7 +36,7 @@
         <name>blueberry</name>
         <color>blue</color>
     </fruit>
-    <fruit taste="tart">
+    <fruit taste="ÄÖÜäöüßéèóò">
         <name>raspberry</name>
         <color>red</color>
     </fruit>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12669](https://issues.apache.org/jira/browse/NIFI-12669)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-12669) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-12669`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-12669`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

No UI Changes

### Licensing

No new dependencies

### Documentation

No documentation changes required
