### PR TITLE
NIFI-13232 Add Authentication Configuration REST API method

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/AuthenticationConfigurationDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/AuthenticationConfigurationDTO.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlType;
+
+/**
+ * Authentication Configuration endpoint and status information
+ */
+@XmlType(name = "authenticationConfiguration")
+public class AuthenticationConfigurationDTO {
+
+    private boolean loginSupported;
+
+    private boolean logoutSupported;
+
+    private String loginUri;
+
+    private String logoutUri;
+
+    @Schema(
+            description = "Whether the system is configured to support login operations",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
+    public boolean isLoginSupported() {
+        return loginSupported;
+    }
+
+    public void setLoginSupported(final boolean loginSupported) {
+        this.loginSupported = loginSupported;
+    }
+
+    @Schema(
+            description = "Whether the system is configured to support logout operations based on current authentication status",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
+    public boolean isLogoutSupported() {
+        return logoutSupported;
+    }
+
+    public void setLogoutSupported(final boolean logoutSupported) {
+        this.logoutSupported = logoutSupported;
+    }
+
+    @Schema(
+            description = "Location for initiating login processing",
+            accessMode = Schema.AccessMode.READ_ONLY,
+            nullable = true
+    )
+    public String getLoginUri() {
+        return loginUri;
+    }
+
+    public void setLoginUri(final String loginUri) {
+        this.loginUri = loginUri;
+    }
+
+    @Schema(
+            description = "Location for initiating logout processing",
+            accessMode = Schema.AccessMode.READ_ONLY,
+            nullable = true
+    )
+    public String getLogoutUri() {
+        return logoutUri;
+    }
+
+    public void setLogoutUri(final String logoutUri) {
+        this.logoutUri = logoutUri;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/AuthenticationConfigurationDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/AuthenticationConfigurationDTO.java
@@ -27,8 +27,6 @@ public class AuthenticationConfigurationDTO {
 
     private boolean loginSupported;
 
-    private boolean logoutSupported;
-
     private String loginUri;
 
     private String logoutUri;
@@ -43,18 +41,6 @@ public class AuthenticationConfigurationDTO {
 
     public void setLoginSupported(final boolean loginSupported) {
         this.loginSupported = loginSupported;
-    }
-
-    @Schema(
-            description = "Whether the system is configured to support logout operations based on current authentication status",
-            accessMode = Schema.AccessMode.READ_ONLY
-    )
-    public boolean isLogoutSupported() {
-        return logoutSupported;
-    }
-
-    public void setLogoutSupported(final boolean logoutSupported) {
-        this.logoutSupported = logoutSupported;
     }
 
     @Schema(

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/AuthenticationConfigurationDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/AuthenticationConfigurationDTO.java
@@ -25,11 +25,25 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlType(name = "authenticationConfiguration")
 public class AuthenticationConfigurationDTO {
 
+    private boolean externalLoginRequired;
+
     private boolean loginSupported;
 
     private String loginUri;
 
     private String logoutUri;
+
+    @Schema(
+            description = "Whether the system requires login through an external Identity Provider",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
+    public boolean isExternalLoginRequired() {
+        return externalLoginRequired;
+    }
+
+    public void setExternalLoginRequired(final boolean externalLoginRequired) {
+        this.externalLoginRequired = externalLoginRequired;
+    }
 
     @Schema(
             description = "Whether the system is configured to support login operations",

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/AuthenticationConfigurationEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/AuthenticationConfigurationEntity.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.api.entity;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.apache.nifi.web.api.dto.AuthenticationConfigurationDTO;
+
+@XmlRootElement(name = "authenticationConfigurationEntity")
+public class AuthenticationConfigurationEntity extends Entity {
+
+    private AuthenticationConfigurationDTO authenticationConfiguration;
+
+    public AuthenticationConfigurationDTO getAuthenticationConfiguration() {
+        return authenticationConfiguration;
+    }
+
+    public void setAuthenticationConfiguration(final AuthenticationConfigurationDTO authenticationConfiguration) {
+        this.authenticationConfiguration = authenticationConfiguration;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/CurrentUserEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/CurrentUserEntity.java
@@ -31,6 +31,7 @@ public class CurrentUserEntity extends Entity {
 
     private String identity;
     private boolean anonymous;
+    private boolean logoutSupported;
 
     private PermissionsDTO provenancePermissions;
     private PermissionsDTO countersPermissions;
@@ -66,6 +67,18 @@ public class CurrentUserEntity extends Entity {
 
     public void setAnonymous(boolean anonymous) {
         this.anonymous = anonymous;
+    }
+
+    @Schema(
+            description = "Whether the system is configured to support logout operations based on current user authentication status",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
+    public boolean isLogoutSupported() {
+        return logoutSupported;
+    }
+
+    public void setLogoutSupported(final boolean logoutSupported) {
+        this.logoutSupported = logoutSupported;
     }
 
     /**

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-authorization-providers/src/main/java/org/apache/nifi/authorization/user/NiFiUserUtils.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-authorization-providers/src/main/java/org/apache/nifi/authorization/user/NiFiUserUtils.java
@@ -23,6 +23,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Utility methods for retrieving information about the current application user.
@@ -89,4 +90,27 @@ public final class NiFiUserUtils {
         return proxyChain;
     }
 
+    /**
+     * Get Authentication Credentials from the current Spring Security Context Authentication object
+     *
+     * @return Optional Credentials from Spring Security Context
+     */
+    public static Optional<Object> getAuthenticationCredentials() {
+        final Optional<Object> authenticationCredentials;
+
+        final SecurityContext securityContext = SecurityContextHolder.getContext();
+        if (securityContext == null) {
+            authenticationCredentials = Optional.empty();
+        } else {
+            final Authentication authentication = securityContext.getAuthentication();
+            if (authentication == null) {
+                authenticationCredentials = Optional.empty();
+            } else {
+                final Object credentials = authentication.getCredentials();
+                authenticationCredentials = Optional.ofNullable(credentials);
+            }
+        }
+
+        return authenticationCredentials;
+    }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiResourceConfig.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiWebApiResourceConfig.java
@@ -98,6 +98,7 @@ public class NiFiWebApiResourceConfig extends ResourceConfig {
         register(ctx.getBean("systemDiagnosticsResource"));
         register(ctx.getBean("accessResource"));
         register(ctx.getBean("accessPolicyResource"));
+        register(ctx.getBean("authenticationResource"));
         register(ctx.getBean("tenantsResource"));
         register(ctx.getBean("versionsResource"));
         register(ctx.getBean("parameterContextResource"));

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -377,6 +377,8 @@ import org.slf4j.LoggerFactory;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+import org.springframework.security.oauth2.core.OAuth2Token;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -4777,6 +4779,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         final CurrentUserEntity entity = new CurrentUserEntity();
         entity.setIdentity(user.getIdentity());
         entity.setAnonymous(user.isAnonymous());
+        entity.setLogoutSupported(isLogoutSupported());
         entity.setProvenancePermissions(dtoFactory.createPermissionsDto(authorizableLookup.getProvenance()));
         entity.setCountersPermissions(dtoFactory.createPermissionsDto(authorizableLookup.getCounters()));
         entity.setTenantsPermissions(dtoFactory.createPermissionsDto(authorizableLookup.getTenant()));
@@ -6649,6 +6652,13 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         }
 
         return propertyDescriptor;
+    }
+
+    private boolean isLogoutSupported() {
+        // Logout is supported when authenticated using a JSON Web Token
+        return NiFiUserUtils.getAuthenticationCredentials()
+                .map(credentials -> credentials instanceof OAuth2Token)
+                .orElse(false);
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AuthenticationResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AuthenticationResource.java
@@ -70,6 +70,7 @@ public class AuthenticationResource extends ApplicationResource {
     )
     public Response getAuthenticationConfiguration() {
         final AuthenticationConfigurationDTO configuration = new AuthenticationConfigurationDTO();
+        configuration.setExternalLoginRequired(authenticationConfiguration.externalLoginRequired());
         configuration.setLoginSupported(authenticationConfiguration.loginSupported());
 
         final URI configuredLoginUri = authenticationConfiguration.loginUri();

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AuthenticationResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AuthenticationResource.java
@@ -36,10 +36,6 @@ import org.apache.nifi.web.api.entity.AccessConfigurationEntity;
 import org.apache.nifi.web.api.entity.AuthenticationConfigurationEntity;
 import org.apache.nifi.web.configuration.AuthenticationConfiguration;
 import org.apache.nifi.web.util.RequestUriBuilder;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.core.OAuth2Token;
 import org.springframework.util.StringUtils;
 
 import java.net.URI;
@@ -75,7 +71,6 @@ public class AuthenticationResource extends ApplicationResource {
     public Response getAuthenticationConfiguration() {
         final AuthenticationConfigurationDTO configuration = new AuthenticationConfigurationDTO();
         configuration.setLoginSupported(authenticationConfiguration.loginSupported());
-        configuration.setLogoutSupported(isLogoutSupported());
 
         final URI configuredLoginUri = authenticationConfiguration.loginUri();
         if (configuredLoginUri != null) {
@@ -93,26 +88,6 @@ public class AuthenticationResource extends ApplicationResource {
         entity.setAuthenticationConfiguration(configuration);
 
         return generateOkResponse(entity).build();
-    }
-
-    private boolean isLogoutSupported() {
-        final boolean logoutSupported;
-
-        final SecurityContext securityContext = SecurityContextHolder.getContext();
-        if (securityContext == null) {
-            logoutSupported = false;
-        } else {
-            final Authentication authentication = securityContext.getAuthentication();
-            if (authentication == null) {
-                logoutSupported = false;
-            } else {
-                final Object credentials = authentication.getCredentials();
-                // Logout is supported when authenticated using a JSON Web Token
-                logoutSupported = credentials instanceof OAuth2Token;
-            }
-        }
-
-        return logoutSupported;
     }
 
     private String getAuthenticationUri(final URI configuredUri) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AuthenticationResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/AuthenticationResource.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.apache.nifi.cluster.coordination.ClusterCoordinator;
+import org.apache.nifi.cluster.coordination.http.replication.RequestReplicator;
+import org.apache.nifi.controller.FlowController;
+import org.apache.nifi.util.NiFiProperties;
+import org.apache.nifi.web.api.dto.AuthenticationConfigurationDTO;
+import org.apache.nifi.web.api.entity.AccessConfigurationEntity;
+import org.apache.nifi.web.api.entity.AuthenticationConfigurationEntity;
+import org.apache.nifi.web.configuration.AuthenticationConfiguration;
+import org.apache.nifi.web.util.RequestUriBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2Token;
+import org.springframework.util.StringUtils;
+
+import java.net.URI;
+import java.util.Objects;
+
+@Path("/authentication")
+@Tag(name = "Authentication")
+public class AuthenticationResource extends ApplicationResource {
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    public AuthenticationResource(
+            final AuthenticationConfiguration authenticationConfiguration,
+            final NiFiProperties properties,
+            final RequestReplicator requestReplicator,
+            final ClusterCoordinator clusterCoordinator,
+            final FlowController flowController
+    ) {
+        this.authenticationConfiguration = Objects.requireNonNull(authenticationConfiguration);
+        setProperties(properties);
+        setRequestReplicator(requestReplicator);
+        setClusterCoordinator(clusterCoordinator);
+        setFlowController(flowController);
+    }
+
+    @GET
+    @Consumes(MediaType.WILDCARD)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/configuration")
+    @Operation(
+            summary = "Retrieves the authentication configuration endpoint and status information",
+            responses = @ApiResponse(content = @Content(schema = @Schema(implementation = AccessConfigurationEntity.class)))
+    )
+    public Response getAuthenticationConfiguration() {
+        final AuthenticationConfigurationDTO configuration = new AuthenticationConfigurationDTO();
+        configuration.setLoginSupported(authenticationConfiguration.loginSupported());
+        configuration.setLogoutSupported(isLogoutSupported());
+
+        final URI configuredLoginUri = authenticationConfiguration.loginUri();
+        if (configuredLoginUri != null) {
+            final String loginUri = getAuthenticationUri(configuredLoginUri);
+            configuration.setLoginUri(loginUri);
+        }
+
+        final URI configuredLogoutUri = authenticationConfiguration.logoutUri();
+        if (configuredLogoutUri != null) {
+            final String logoutUri = getAuthenticationUri(configuredLogoutUri);
+            configuration.setLogoutUri(logoutUri);
+        }
+
+        final AuthenticationConfigurationEntity entity = new AuthenticationConfigurationEntity();
+        entity.setAuthenticationConfiguration(configuration);
+
+        return generateOkResponse(entity).build();
+    }
+
+    private boolean isLogoutSupported() {
+        final boolean logoutSupported;
+
+        final SecurityContext securityContext = SecurityContextHolder.getContext();
+        if (securityContext == null) {
+            logoutSupported = false;
+        } else {
+            final Authentication authentication = securityContext.getAuthentication();
+            if (authentication == null) {
+                logoutSupported = false;
+            } else {
+                final Object credentials = authentication.getCredentials();
+                // Logout is supported when authenticated using a JSON Web Token
+                logoutSupported = credentials instanceof OAuth2Token;
+            }
+        }
+
+        return logoutSupported;
+    }
+
+    private String getAuthenticationUri(final URI configuredUri) {
+        final RequestUriBuilder builder = RequestUriBuilder.fromHttpServletRequest(httpServletRequest);
+        builder.path(configuredUri.getPath());
+
+        final String fragment = configuredUri.getFragment();
+        if (StringUtils.hasText(fragment)) {
+            builder.fragment(fragment);
+        }
+
+        return builder.build().toString();
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/AuthenticationConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/AuthenticationConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.configuration;
+
+import java.net.URI;
+
+/**
+ * Authentication Configuration based on configured application properties
+ *
+ * @param loginSupported Whether login operations are supported
+ * @param loginUri Optional URI for login operations
+ * @param logoutUri Optional URI for logout operations
+ */
+public record AuthenticationConfiguration(
+        boolean loginSupported,
+        URI loginUri,
+        URI logoutUri
+) {
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/AuthenticationConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/AuthenticationConfiguration.java
@@ -21,11 +21,13 @@ import java.net.URI;
 /**
  * Authentication Configuration based on configured application properties
  *
+ * @param externalLoginRequired Whether login through an external Identity Provider is required
  * @param loginSupported Whether login operations are supported
  * @param loginUri Optional URI for login operations
  * @param logoutUri Optional URI for logout operations
  */
 public record AuthenticationConfiguration(
+        boolean externalLoginRequired,
         boolean loginSupported,
         URI loginUri,
         URI logoutUri

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/resources/nifi-web-api-context.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/resources/nifi-web-api-context.xml
@@ -630,6 +630,13 @@
         <constructor-arg ref="requestReplicator" />
         <constructor-arg ref="flowController" />
     </bean>
+    <bean id="authenticationResource" class="org.apache.nifi.web.api.AuthenticationResource" scope="singleton">
+        <constructor-arg ref="authenticationConfiguration"/>
+        <constructor-arg ref="nifiProperties"/>
+        <constructor-arg ref="clusterCoordinator"/>
+        <constructor-arg ref="requestReplicator" />
+        <constructor-arg ref="flowController" />
+    </bean>
     <bean id="tenantsResource" class="org.apache.nifi.web.api.TenantsResource" scope="singleton">
         <constructor-arg ref="serviceFacade"/>
         <constructor-arg ref="authorizer"/>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/WebSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/WebSecurityConfiguration.java
@@ -118,7 +118,8 @@ public class WebSecurityConfiguration {
                                 "/access/kerberos",
                                 "/access/knox/callback",
                                 "/access/knox/request",
-                                "/access/logout/complete"
+                                "/access/logout/complete",
+                                "/authentication/configuration"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/converter/StandardJwtAuthenticationConverter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/converter/StandardJwtAuthenticationConverter.java
@@ -56,7 +56,7 @@ public class StandardJwtAuthenticationConverter implements Converter<Jwt, NiFiAu
     @Override
     public NiFiAuthenticationToken convert(final Jwt jwt) {
         final NiFiUser user = getUser(jwt);
-        return new NiFiAuthenticationToken(new NiFiUserDetails(user));
+        return new NiFiAuthenticationToken(new NiFiUserDetails(user), jwt);
     }
 
     private NiFiUser getUser(final Jwt jwt) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/token/NiFiAuthenticationToken.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/token/NiFiAuthenticationToken.java
@@ -26,16 +26,34 @@ public class NiFiAuthenticationToken extends AbstractAuthenticationToken {
 
     final UserDetails nifiUserDetails;
 
-    public NiFiAuthenticationToken(final UserDetails nifiUserDetails) {
-        super(nifiUserDetails.getAuthorities());
+    private final Object credentials;
+
+    /**
+     * Token constructor with User Details and without additional credentials
+     *
+     * @param userDetails Spring Security User Details
+     */
+    public NiFiAuthenticationToken(final UserDetails userDetails) {
+        this(userDetails, userDetails.getPassword());
+    }
+
+    /**
+     * Token constructor with User Details and optional credentials from authentication processing
+     *
+     * @param userDetails Spring Security User Details
+     * @param credentials Optional credentials from authentication processing
+     */
+    public NiFiAuthenticationToken(final UserDetails userDetails, final Object credentials) {
+        super(userDetails.getAuthorities());
         super.setAuthenticated(true);
-        setDetails(nifiUserDetails);
-        this.nifiUserDetails = nifiUserDetails;
+        setDetails(userDetails);
+        this.nifiUserDetails = userDetails;
+        this.credentials = credentials;
     }
 
     @Override
     public Object getCredentials() {
-        return nifiUserDetails.getPassword();
+        return credentials;
     }
 
     @Override


### PR DESCRIPTION
# Summary

[NIFI-13232](https://issues.apache.org/jira/browse/NIFI-13232) Adds a new REST API method for returning authentication configuration details.

The purpose of the new method is to provide sufficient details for the user interface to determine when to show the login screen and when to show the logout link.

The REST API method is designed to support current authentication strategies, including username and password authentication with a Login Identity Provider, as well as single sign-on with either OIDC or SAML. The method should also return correct status when the client makes a request using mutual TLS with a client certificate. The mutual TLS scenario may require an additional field because when NiFi is running behind a reverse proxy, the proxy itself will provide a client certificate, but the client web browser should be presented with a login screen or be redirected for single sign-on.

Changes include adding a `credentials` property to the authentication token class, providing access to the JSON Web Token or Client Certificates passed during the initial authentication process.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
