### PR TITLE
NIFI-13256 Correct Example WriteHelloWorld Processor Attributes

### DIFF
--- a/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
@@ -153,10 +153,10 @@ class WriteHelloWorld(FlowFileTransform):
         version = '0.0.1-SNAPSHOT'
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        pass
 
     def transform(self, context, flowfile):
-        return FlowFileTransformResult(relationship = "success", contents = "Hello World", attributes = {"greeting", "hello"})
+        return FlowFileTransformResult(relationship = "success", contents = "Hello World", attributes = {"greeting": "hello"})
 ----
 
 The `transform` method is expected to take two arguments: the context (of type `nifiapi.properties.ProcessContext`) and


### PR DESCRIPTION
# Summary

[NIFI-13256](https://issues.apache.org/jira/browse/NIFI-13256) Corrects the `WriteHelloWorld` example Python Processor in the Python Developer Guide to define a dictionary instead of a set for FlowFile attributes.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
