### PR TITLE
NIFI-13154 Display parameter reference when used as Sensitive property value

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
@@ -34,7 +34,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * An immutable object for holding information about a type of component

--- a/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
@@ -720,15 +720,6 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
         return sensitive;
     }
 
-    // Pattern to match a parameter reference i.e. "#{anything}"
-    private static final Pattern PARAMETER_REFERENCE = Pattern.compile("^#\\{.*}$");
-
-    public static boolean isSensitiveValueSafeToDisplay(String value) {
-        // If the value is a parameter reference, then it is safe to display the parameter name.
-        // A parameter name is safe to display to users because the sensitive info is stored in the parameter value.
-        return value != null && PARAMETER_REFERENCE.matcher(value).matches();
-    }
-
     public boolean isDynamic() {
         return dynamic;
     }

--- a/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
+++ b/nifi-api/src/main/java/org/apache/nifi/components/PropertyDescriptor.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * An immutable object for holding information about a type of component
@@ -717,6 +718,15 @@ public final class PropertyDescriptor implements Comparable<PropertyDescriptor> 
 
     public boolean isSensitive() {
         return sensitive;
+    }
+
+    // Pattern to match a parameter reference i.e. "#{anything}"
+    private static final Pattern PARAMETER_REFERENCE = Pattern.compile("^#\\{.*}$");
+
+    public static boolean isSensitiveValueSafeToDisplay(String value) {
+        // If the value is a parameter reference, then it is safe to display the parameter name.
+        // A parameter name is safe to display to users because the sensitive info is stored in the parameter value.
+        return value != null && PARAMETER_REFERENCE.matcher(value).matches();
     }
 
     public boolean isDynamic() {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -4155,9 +4155,9 @@ public final class DtoFactory {
                // store the property descriptor
                dto.getDescriptors().put(descriptor.getName(), createPropertyDescriptorDto(descriptor, procNode.getProcessGroup().getIdentifier()));
 
-               // determine the property value - don't include sensitive properties
+               // determine the property value - don't include sensitive properties values (unless they are safe to display)
                String propertyValue = entry.getValue();
-               if (propertyValue != null && descriptor.isSensitive()) {
+               if (propertyValue != null && descriptor.isSensitive() && !PropertyDescriptor.isSensitiveValueSafeToDisplay(propertyValue)) {
                    propertyValue = SENSITIVE_VALUE_MASK;
                } else if (propertyValue == null && descriptor.getDefaultValue() != null) {
                    propertyValue = descriptor.getDefaultValue();

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -275,6 +275,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public final class DtoFactory {
@@ -4116,7 +4117,16 @@ public final class DtoFactory {
        return threadDumps;
    }
 
-   /**
+    // Pattern to match a parameter reference i.e. "#{anything}"
+    private static final Pattern PARAMETER_REFERENCE = Pattern.compile("^#\\{.*}$");
+
+    private boolean isSensitiveValueSafeToDisplay(String value) {
+        // If the value is a parameter reference, then it is safe to display the parameter name.
+        // A parameter name is safe to display to users because the sensitive info is stored in the parameter value.
+        return value != null && PARAMETER_REFERENCE.matcher(value).matches();
+    }
+
+    /**
     * Creates a ProcessorConfigDTO from the specified ProcessorNode.
     *
     * @param procNode node
@@ -4157,7 +4167,7 @@ public final class DtoFactory {
 
                // determine the property value - don't include sensitive properties values (unless they are safe to display)
                String propertyValue = entry.getValue();
-               if (propertyValue != null && descriptor.isSensitive() && !PropertyDescriptor.isSensitiveValueSafeToDisplay(propertyValue)) {
+               if (propertyValue != null && descriptor.isSensitive() && !isSensitiveValueSafeToDisplay(propertyValue)) {
                    propertyValue = SENSITIVE_VALUE_MASK;
                } else if (propertyValue == null && descriptor.getDefaultValue() != null) {
                    propertyValue = descriptor.getDefaultValue();

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/property-table/property-table.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/property-table/property-table.component.html
@@ -68,8 +68,10 @@
                                         isSensitiveProperty(item.descriptor) ? sensitive : nonSensitive;
                                         context: { $implicit: resolvePropertyValue(item) }
                                     "></ng-container>
-                                <ng-template #sensitive>
-                                    <div class="sensitive surface-color">Sensitive value set</div>
+                                <ng-template #sensitive let-resolvedValue>
+                                    <div class="sensitive surface-color">
+                                        {{ isSensitiveValueSafeToDisplay(resolvedValue) ? resolvedValue : 'Sensitive value set' }}
+                                    </div>
                                 </ng-template>
                                 <ng-template #nonSensitive let-resolvedValue>
                                     <ng-container

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/property-table/property-table.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/property-table/property-table.component.ts
@@ -398,6 +398,12 @@ export class PropertyTable implements AfterViewInit, ControlValueAccessor {
         return descriptor.sensitive;
     }
 
+    isSensitiveValueSafeToDisplay(rawValue: string): boolean {
+        // Return true if the sensitive value is safe to display without obfuscating it.
+        // A parameter name is safe to display to users because the sensitive info is stored in the parameter value.
+        return /^#\{.*}$/.test(rawValue);
+    }
+
     isNull(value: string): boolean {
         return value == null;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/jquery/propertytable/jquery.propertytable.js
@@ -391,7 +391,7 @@
                 // determine the value to use when populating the text field
                 if (nfCommon.isDefinedAndNotNull(item[args.column.field])) {
                     if (sensitive) {
-                        initialValue = nfCommon.config.sensitiveText;
+                        initialValue = nfCommon.isSensitiveValueSafeToDisplay(item[args.column.field]) ? item[args.column.field] : 'Sensitive value set';
                     } else {
                         initialValue = item[args.column.field];
                         isEmptyChecked = initialValue === '';
@@ -1306,7 +1306,7 @@
 
                 // determine if the property is sensitive
                 if (nfCommon.isSensitiveProperty(propertyDescriptor)) {
-                    valueMarkup = '<span class="table-cell sensitive">Sensitive value set</span>';
+                    valueMarkup = '<span class="table-cell sensitive">' + (nfCommon.isSensitiveValueSafeToDisplay(value) ? value : 'Sensitive value set') + '</span>';
                 } else {
                     var resolvedAllowableValue = false;
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/nf-common.js
@@ -1113,6 +1113,16 @@
         },
 
         /**
+         * Returns true if the sensitive value is safe to display without obfuscating it
+         *
+         * @argument {string} rawValue         The property raw value
+         */
+        isSensitiveValueSafeToDisplay: function (rawValue) {
+            // A parameter name is safe to display to users because the sensitive info is stored in the parameter value.
+            return /^#\{.*}$/.test(rawValue);
+        },
+
+        /**
          * Determines if the specified property is required.
          *
          * @param {object} propertyDescriptor           The property descriptor

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/FlowSynchronizationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/FlowSynchronizationIT.java
@@ -167,7 +167,7 @@ public class FlowSynchronizationIT extends NiFiSystemIT {
 
         assertEquals(SENSITIVE_VALUE_MASK, proc1Properties.get("Sensitive"));
         assertEquals(SENSITIVE_VALUE_MASK, proc2Properties.get("Sensitive"));
-        assertEquals(SENSITIVE_VALUE_MASK, proc3Properties.get("Sensitive"));
+        assertEquals("#{MyParameter}", proc3Properties.get("Sensitive"));
 
         // Make sure that the sensitive parameter is being referenced.
         final ParameterEntity parameter = getNifiClient().getParamContextClient(DO_NOT_REPLICATE).getParamContext(paramContext.getId(), false).getComponent().getParameters().iterator().next();


### PR DESCRIPTION
A parameter reference (containing a parameter name) is safe to display to users because the sensitive info is stored in the parameter value.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13154](https://issues.apache.org/jira/browse/NIFI-13154)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-13154) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

I tested the current and new ui with different types of values for sensitive properties. When a parameter reference 
#{parameter} is in the sensitive property value then it is displayed to the user. If anything else if the sensitive property value, then the value is obfuscated from the user with text "Sensitive value set"

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

Implemented in both the current and new UI.

- [X] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

No dependency changes.

### Documentation

No documentation changes.
