### PR TITLE
NIFI-13255 Replaced deprecated io.netty.handler.ssl.JdkSslContext constructor with API suggested replacement

### DIFF
--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/src/main/java/org/apache/nifi/graph/TinkerpopClientService.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/src/main/java/org/apache/nifi/graph/TinkerpopClientService.java
@@ -21,7 +21,9 @@ import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyShell;
 import groovy.lang.Script;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import io.netty.handler.ssl.JdkSslContext;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.nifi.annotation.behavior.RequiresInstanceClassLoading;
@@ -334,9 +336,14 @@ public class TinkerpopClientService extends AbstractControllerService implements
     protected Cluster.Builder setupSSL(ConfigurationContext context, Cluster.Builder builder) {
         if (context.getProperty(SSL_CONTEXT_SERVICE).isSet()) {
             SSLContextService service = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextService.class);
+            ApplicationProtocolConfig applicationProtocolConfig = new ApplicationProtocolConfig(ApplicationProtocolConfig.Protocol.NONE,
+                    ApplicationProtocolConfig.SelectorFailureBehavior.FATAL_ALERT, ApplicationProtocolConfig.SelectedListenerFailureBehavior.FATAL_ALERT);
+            JdkSslContext jdkSslContext = new JdkSslContext(service.createContext(), true, null,
+                    IdentityCipherSuiteFilter.INSTANCE, applicationProtocolConfig, ClientAuth.NONE, null, false);
+
             builder
                     .enableSsl(true)
-                    .sslContext(new JdkSslContext(service.createContext(), true, ClientAuth.NONE));
+                    .sslContext(jdkSslContext);
             usesSSL = true;
         }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13255](https://issues.apache.org/jira/browse/NIFI-13255)
The [source code](https://github.com/netty/netty/blob/43455dfe98202b8dc63d89ac3f04027c3e8f9f54/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java#L203C5-L208C6) to the deprecated `io.netty.handler.ssl.JdkSslContext` constructor shows it delegates to the 8 argument constructor which is not deprecated. 
```
@Deprecated
    public JdkSslContext(SSLContext sslContext, boolean isClient,
                         ClientAuth clientAuth) {
        this(sslContext, isClient, null, IdentityCipherSuiteFilter.INSTANCE,
                JdkDefaultApplicationProtocolNegotiator.INSTANCE, clientAuth, null, false);
    }
```
The current code had to switch to the 8 argument constructor but functionally the only part which had to be swapped out was the deprecated `JdkDefaultApplicationProtocolNegotiator.INSTANCE` for an instance of `io.netty.handler.ssl.ApplicationProtocolConfig`. I had tried to pick values when configuring an instance of `io.netty.handler.ssl.ApplicationProtocolConfig` which seemed to align to what `JdkDefaultApplicationProtocolNegotiator` offered but the review of this PR has to confirm this. There is no unit test which exercises this.


# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
