### PR TITLE
NIFI-12967: Introducing Back action

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/app.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/app.component.spec.ts
@@ -19,12 +19,22 @@ import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { provideMockStore } from '@ngrx/store/testing';
+import { navigationFeatureKey } from './state/navigation';
+import * as fromNavigation from './state/navigation/navigation.reducer';
 
 describe('AppComponent', () => {
     beforeEach(() =>
         TestBed.configureTestingModule({
             imports: [RouterTestingModule, MatProgressSpinnerModule],
-            declarations: [AppComponent]
+            declarations: [AppComponent],
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [navigationFeatureKey]: fromNavigation.initialState
+                    }
+                })
+            ]
         })
     );
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/app.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/app.component.ts
@@ -24,7 +24,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { NiFiState } from './state';
 import { Store } from '@ngrx/store';
 import { BackNavigation } from './state/navigation';
-import { popBackNavigation, pushBackNavigation } from './state/navigation/navigation.actions';
+import { popBackNavigation, pushBackNavigation, resetBackNavigation } from './state/navigation/navigation.actions';
 import { filter, map, tap } from 'rxjs';
 import { concatLatestFrom } from '@ngrx/operators';
 import { selectBackNavigation } from './state/navigation/navigation.selectors';
@@ -73,9 +73,10 @@ export class AppComponent {
                         })
                     );
                 } else if (previousBackNavigation) {
-                    if (!event.url.startsWith(previousBackNavigation.routeBoundary.join('/'))) {
-                        console.log('popping...');
+                    if (extras?.state?.['executeBackNavigation']) {
                         this.store.dispatch(popBackNavigation());
+                    } else if (!event.url.startsWith(previousBackNavigation.routeBoundary.join('/'))) {
+                        this.store.dispatch(resetBackNavigation());
                     }
                 }
             });

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/app.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/app.component.ts
@@ -16,11 +16,18 @@
  */
 
 import { Component } from '@angular/core';
-import { GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationStart, Router } from '@angular/router';
+import { GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationStart, NavigationEnd, Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Storage } from './service/storage.service';
 import { ThemingService } from './service/theming.service';
 import { MatDialog } from '@angular/material/dialog';
+import { NiFiState } from './state';
+import { Store } from '@ngrx/store';
+import { BackNavigation } from './state/navigation';
+import { popBackNavigation, pushBackNavigation } from './state/navigation/navigation.actions';
+import { filter, map, tap } from 'rxjs';
+import { concatLatestFrom } from '@ngrx/operators';
+import { selectBackNavigation } from './state/navigation/navigation.selectors';
 
 @Component({
     selector: 'nifi',
@@ -35,19 +42,43 @@ export class AppComponent {
         private router: Router,
         private storage: Storage,
         private themingService: ThemingService,
-        private dialog: MatDialog
+        private dialog: MatDialog,
+        private store: Store<NiFiState>
     ) {
-        this.router.events.pipe(takeUntilDestroyed()).subscribe((event) => {
-            if (event instanceof NavigationStart) {
-                this.dialog.openDialogs.forEach((dialog) => dialog.close('ROUTED'));
-            }
-            if (event instanceof GuardsCheckStart) {
-                this.guardLoading = true;
-            }
-            if (event instanceof GuardsCheckEnd || event instanceof NavigationCancel) {
-                this.guardLoading = false;
-            }
-        });
+        this.router.events
+            .pipe(
+                takeUntilDestroyed(),
+                tap((event) => {
+                    if (event instanceof NavigationStart) {
+                        this.dialog.openDialogs.forEach((dialog) => dialog.close('ROUTED'));
+                    }
+                    if (event instanceof GuardsCheckStart) {
+                        this.guardLoading = true;
+                    }
+                    if (event instanceof GuardsCheckEnd || event instanceof NavigationCancel) {
+                        this.guardLoading = false;
+                    }
+                }),
+                filter((e) => e instanceof NavigationEnd),
+                map((e) => e as NavigationEnd),
+                concatLatestFrom(() => this.store.select(selectBackNavigation))
+            )
+            .subscribe(([event, previousBackNavigation]) => {
+                const extras = this.router.getCurrentNavigation()?.extras;
+                if (extras?.state?.['backNavigation']) {
+                    const backNavigation: BackNavigation = extras?.state?.['backNavigation'];
+                    this.store.dispatch(
+                        pushBackNavigation({
+                            backNavigation
+                        })
+                    );
+                } else if (previousBackNavigation) {
+                    if (!event.url.startsWith(previousBackNavigation.routeBoundary.join('/'))) {
+                        console.log('popping...');
+                        this.store.dispatch(popBackNavigation());
+                    }
+                }
+            });
 
         let theme = this.storage.getItem('theme');
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/app.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/app.component.ts
@@ -24,7 +24,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { NiFiState } from './state';
 import { Store } from '@ngrx/store';
 import { BackNavigation } from './state/navigation';
-import { popBackNavigation, pushBackNavigation, resetBackNavigation } from './state/navigation/navigation.actions';
+import { popBackNavigation, pushBackNavigation } from './state/navigation/navigation.actions';
 import { filter, map, tap } from 'rxjs';
 import { concatLatestFrom } from '@ngrx/operators';
 import { selectBackNavigation } from './state/navigation/navigation.selectors';
@@ -73,11 +73,11 @@ export class AppComponent {
                         })
                     );
                 } else if (previousBackNavigation) {
-                    if (extras?.state?.['executeBackNavigation']) {
-                        this.store.dispatch(popBackNavigation());
-                    } else if (!event.url.startsWith(previousBackNavigation.routeBoundary.join('/'))) {
-                        this.store.dispatch(resetBackNavigation());
-                    }
+                    this.store.dispatch(
+                        popBackNavigation({
+                            url: event.url
+                        })
+                    );
                 }
             });
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/access-policies/ui/component-access-policies/component-access-policies.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/access-policies/ui/component-access-policies/component-access-policies.component.ts
@@ -331,6 +331,7 @@ export class ComponentAccessPolicies implements OnInit, OnDestroy {
                 return 'icon-group-remote';
             case 'parameter-providers':
             case 'parameter-contexts':
+            case 'reporting-tasks':
                 return 'icon-drop';
         }
 
@@ -353,6 +354,8 @@ export class ComponentAccessPolicies implements OnInit, OnDestroy {
                 return ComponentType.RemoteProcessGroup;
             case 'parameter-contexts':
                 return 'Parameter Context';
+            case 'reporting-tasks':
+                return 'Reporting Task';
             case 'parameter-providers':
                 return ComponentType.ParameterProvider;
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-actions.service.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-actions.service.ts
@@ -229,7 +229,8 @@ export class CanvasActionsService {
                             navigateToManageComponentPolicies({
                                 request: {
                                     resource: 'process-groups',
-                                    id: extraArgs.processGroupId
+                                    id: extraArgs.processGroupId,
+                                    backNavigationContext: 'Process Group'
                                 }
                             })
                         );
@@ -239,24 +240,31 @@ export class CanvasActionsService {
                     const componentType: ComponentType = selectionData.type;
 
                     let resource = 'process-groups';
+                    let backNavigationContext = 'Process Group';
                     switch (componentType) {
                         case ComponentType.Processor:
                             resource = 'processors';
+                            backNavigationContext = 'Processor';
                             break;
                         case ComponentType.InputPort:
                             resource = 'input-ports';
+                            backNavigationContext = 'Input Port';
                             break;
                         case ComponentType.OutputPort:
                             resource = 'output-ports';
+                            backNavigationContext = 'Output Port';
                             break;
                         case ComponentType.Funnel:
                             resource = 'funnels';
+                            backNavigationContext = 'Funnel';
                             break;
                         case ComponentType.Label:
                             resource = 'labels';
+                            backNavigationContext = 'Label';
                             break;
                         case ComponentType.RemoteProcessGroup:
                             resource = 'remote-process-groups';
+                            backNavigationContext = 'Remote Process Group';
                             break;
                     }
 
@@ -264,7 +272,8 @@ export class CanvasActionsService {
                         navigateToManageComponentPolicies({
                             request: {
                                 resource,
-                                id: selectionData.id
+                                id: selectionData.id,
+                                backNavigationContext
                             }
                         })
                     );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
@@ -667,7 +667,7 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
 
                         backNavigation = {
                             route: ['/process-groups', this.canvasUtils.getProcessGroupId()],
-                            routeBoundary: ['/parameters'],
+                            routeBoundary: ['/parameter-contexts'],
                             context: 'Process Group'
                         } as BackNavigation;
                     } else {
@@ -681,7 +681,7 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
                                 ComponentType.ProcessGroup,
                                 selectionData.id
                             ],
-                            routeBoundary: ['/parameters'],
+                            routeBoundary: ['/parameter-contexts'],
                             context: 'Process Group'
                         } as BackNavigation;
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
@@ -72,6 +72,7 @@ import { CanvasView } from './canvas-view.service';
 import { CanvasActionsService } from './canvas-actions.service';
 import * as FlowActions from '../state/flow/flow.actions';
 import { DraggableBehavior } from './behavior/draggable-behavior.service';
+import { BackNavigation } from '../../../state/navigation';
 
 @Injectable({ providedIn: 'root' })
 export class CanvasContextMenu implements ContextMenuDefinitionProvider {
@@ -665,22 +666,24 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
                         id = this.canvasUtils.getParameterContextId();
 
                         backNavigation = {
-                            backNavigation: ['/process-groups', this.canvasUtils.getProcessGroupId()],
+                            route: ['/process-groups', this.canvasUtils.getProcessGroupId()],
+                            routeBoundary: ['/parameters'],
                             context: 'Process Group'
-                        };
+                        } as BackNavigation;
                     } else {
                         const selectionData = selection.datum();
                         id = selectionData.parameterContext.id;
 
                         backNavigation = {
-                            backNavigation: [
+                            route: [
                                 '/process-groups',
                                 this.canvasUtils.getProcessGroupId(),
                                 ComponentType.ProcessGroup,
                                 selectionData.id
                             ],
+                            routeBoundary: ['/parameters'],
                             context: 'Process Group'
-                        };
+                        } as BackNavigation;
                     }
 
                     if (id) {
@@ -964,14 +967,15 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
                         navigateToComponentDocumentation({
                             request: {
                                 backNavigation: {
-                                    backNavigation: [
+                                    route: [
                                         '/process-groups',
                                         processGroupId,
                                         ComponentType.Processor,
                                         selectionData.id
                                     ],
+                                    routeBoundary: ['/documentation'],
                                     context: 'Processor'
-                                },
+                                } as BackNavigation,
                                 parameters: {
                                     select: selectionData.component.type,
                                     group: selectionData.component.bundle.group,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/service/canvas-context-menu.service.ts
@@ -660,18 +660,35 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
                 text: 'Parameters',
                 action: (selection: d3.Selection<any, any, any, any>) => {
                     let id;
+                    let backNavigation;
                     if (selection.empty()) {
                         id = this.canvasUtils.getParameterContextId();
+
+                        backNavigation = {
+                            backNavigation: ['/process-groups', this.canvasUtils.getProcessGroupId()],
+                            context: 'Process Group'
+                        };
                     } else {
                         const selectionData = selection.datum();
                         id = selectionData.parameterContext.id;
+
+                        backNavigation = {
+                            backNavigation: [
+                                '/process-groups',
+                                this.canvasUtils.getProcessGroupId(),
+                                ComponentType.ProcessGroup,
+                                selectionData.id
+                            ],
+                            context: 'Process Group'
+                        };
                     }
 
                     if (id) {
                         this.store.dispatch(
                             navigateToParameterContext({
                                 request: {
-                                    id
+                                    id,
+                                    backNavigation
                                 }
                             })
                         );
@@ -941,14 +958,26 @@ export class CanvasContextMenu implements ContextMenuDefinitionProvider {
                 clazz: 'fa fa-book',
                 text: 'View Documentation',
                 action: (selection: any) => {
+                    const processGroupId = this.canvasUtils.getProcessGroupId();
                     const selectionData = selection.datum();
                     this.store.dispatch(
                         navigateToComponentDocumentation({
-                            params: {
-                                select: selectionData.component.type,
-                                group: selectionData.component.bundle.group,
-                                artifact: selectionData.component.bundle.artifact,
-                                version: selectionData.component.bundle.version
+                            request: {
+                                backNavigation: {
+                                    backNavigation: [
+                                        '/process-groups',
+                                        processGroupId,
+                                        ComponentType.Processor,
+                                        selectionData.id
+                                    ],
+                                    context: 'Processor'
+                                },
+                                parameters: {
+                                    select: selectionData.component.type,
+                                    group: selectionData.component.bundle.group,
+                                    artifact: selectionData.component.bundle.artifact,
+                                    version: selectionData.component.bundle.version
+                                }
                             }
                         })
                     );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.actions.ts
@@ -78,6 +78,11 @@ export const navigateToAdvancedServiceUi = createAction(
     props<{ id: string }>()
 );
 
+export const navigateToManageComponentPolicies = createAction(
+    '[Controller Services] Navigate To Manage Component Policies',
+    props<{ id: string }>()
+);
+
 export const openConfigureControllerServiceDialog = createAction(
     '[Controller Services] Open Configure Controller Service Dialog',
     props<{ request: EditControllerServiceDialogRequest }>()

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.actions.ts
@@ -68,6 +68,11 @@ export const inlineCreateControllerServiceSuccess = createAction(
     props<{ response: CreateControllerServiceSuccess }>()
 );
 
+export const navigateToService = createAction(
+    '[Controller Services] Navigate To Service',
+    props<{ request: SelectControllerServiceRequest }>()
+);
+
 export const navigateToEditService = createAction(
     '[Controller Services] Navigate To Edit Service',
     props<{ id: string }>()

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.effects.ts
@@ -542,22 +542,26 @@ export class ControllerServicesEffects {
                 map((action) => action.response),
                 concatLatestFrom(() => this.store.select(selectCurrentProcessGroupId)),
                 tap(([response, processGroupId]) => {
-                    if (response.postUpdateNavigation && response.postUpdateNavigationBoundary) {
-                        this.router.navigate(response.postUpdateNavigation, {
-                            state: {
-                                backNavigation: {
-                                    route: [
-                                        '/process-groups',
-                                        processGroupId,
-                                        'controller-services',
-                                        response.id,
-                                        'edit'
-                                    ],
-                                    routeBoundary: response.postUpdateNavigationBoundary,
-                                    context: 'Controller Service'
-                                } as BackNavigation
-                            }
-                        });
+                    if (response.postUpdateNavigation) {
+                        if (response.postUpdateNavigationBoundary) {
+                            this.router.navigate(response.postUpdateNavigation, {
+                                state: {
+                                    backNavigation: {
+                                        route: [
+                                            '/process-groups',
+                                            processGroupId,
+                                            'controller-services',
+                                            response.id,
+                                            'edit'
+                                        ],
+                                        routeBoundary: response.postUpdateNavigationBoundary,
+                                        context: 'Controller Service'
+                                    } as BackNavigation
+                                }
+                            });
+                        } else {
+                            this.router.navigate(response.postUpdateNavigation);
+                        }
                     } else {
                         this.dialog.closeAll();
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/controller-services.effects.ts
@@ -248,6 +248,28 @@ export class ControllerServicesEffects {
         { dispatch: false }
     );
 
+    navigateToService$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ControllerServicesActions.navigateToService),
+                map((action) => action.request),
+                concatLatestFrom(() => this.store.select(selectCurrentProcessGroupId)),
+                tap(([request, processGroupId]) => {
+                    const routeBoundary: string[] = ['/process-groups', request.processGroupId, 'controller-services'];
+                    this.router.navigate([...routeBoundary, request.id], {
+                        state: {
+                            backNavigation: {
+                                route: ['/process-groups', processGroupId, 'controller-services', request.id],
+                                routeBoundary,
+                                context: 'Controller Service'
+                            } as BackNavigation
+                        }
+                    });
+                })
+            ),
+        { dispatch: false }
+    );
+
     openConfigureControllerServiceDialog$ = createEffect(
         () =>
             this.actions$.pipe(

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/controller-services/index.ts
@@ -41,12 +41,14 @@ export interface ConfigureControllerServiceRequest {
     uri: string;
     payload: any;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface ConfigureControllerServiceSuccess {
     id: string;
     controllerService: ControllerServiceEntity;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface DeleteControllerServiceRequest {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
@@ -106,6 +106,8 @@ import {
     UpdateConnectionRequest,
     UpdateConnectionSuccess,
     UpdatePositionsRequest,
+    UpdateProcessorRequest,
+    UpdateProcessorResponse,
     UploadProcessGroupRequest,
     VersionControlInformationEntity
 } from './index';
@@ -460,12 +462,12 @@ export const updateComponentFailure = createAction(
 
 export const updateProcessor = createAction(
     `${CANVAS_PREFIX} Update Processor`,
-    props<{ request: UpdateComponentRequest }>()
+    props<{ request: UpdateProcessorRequest }>()
 );
 
 export const updateProcessorSuccess = createAction(
     `${CANVAS_PREFIX} Update Processor Success`,
-    props<{ response: UpdateComponentResponse }>()
+    props<{ response: UpdateProcessorResponse }>()
 );
 
 export const updateConnection = createAction(

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -1781,22 +1781,26 @@ export class FlowEffects {
             map((action) => action.response),
             concatLatestFrom(() => this.store.select(selectCurrentProcessGroupId)),
             tap(([response, processGroupId]) => {
-                if (response.postUpdateNavigation && response.postUpdateNavigationBoundary) {
-                    this.router.navigate(response.postUpdateNavigation, {
-                        state: {
-                            backNavigation: {
-                                route: [
-                                    '/process-groups',
-                                    processGroupId,
-                                    ComponentType.Processor,
-                                    response.id,
-                                    'edit'
-                                ],
-                                routeBoundary: response.postUpdateNavigationBoundary,
-                                context: 'Processor'
-                            } as BackNavigation
-                        }
-                    });
+                if (response.postUpdateNavigation) {
+                    if (response.postUpdateNavigationBoundary) {
+                        this.router.navigate(response.postUpdateNavigation, {
+                            state: {
+                                backNavigation: {
+                                    route: [
+                                        '/process-groups',
+                                        processGroupId,
+                                        ComponentType.Processor,
+                                        response.id,
+                                        'edit'
+                                    ],
+                                    routeBoundary: response.postUpdateNavigationBoundary,
+                                    context: 'Processor'
+                                } as BackNavigation
+                            }
+                        });
+                    } else {
+                        this.router.navigate(response.postUpdateNavigation);
+                    }
                 } else {
                     this.dialog.closeAll();
                 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -1080,8 +1080,23 @@ export class FlowEffects {
             this.actions$.pipe(
                 ofType(FlowActions.navigateToQueueListing),
                 map((action) => action.request),
-                tap((request) => {
-                    this.router.navigate(['/queue', request.connectionId]);
+                concatLatestFrom(() => this.store.select(selectCurrentProcessGroupId)),
+                tap(([request, processGroupId]) => {
+                    const routeBoundary: string[] = ['/queue', request.connectionId];
+                    this.router.navigate([...routeBoundary], {
+                        state: {
+                            backNavigation: {
+                                route: [
+                                    '/process-groups',
+                                    processGroupId,
+                                    ComponentType.Connection,
+                                    request.connectionId
+                                ],
+                                routeBoundary,
+                                context: 'Connection'
+                            } as BackNavigation
+                        }
+                    });
                 })
             ),
         { dispatch: false }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -1150,8 +1150,25 @@ export class FlowEffects {
             this.actions$.pipe(
                 ofType(FlowActions.navigateToControllerServicesForProcessGroup),
                 map((action) => action.request),
-                tap((request) => {
-                    this.router.navigate(['/process-groups', request.id, 'controller-services']);
+                concatLatestFrom(() => this.store.select(selectCurrentProcessGroupId)),
+                tap(([request, processGroupId]) => {
+                    let route: string[];
+                    if (processGroupId == request.id) {
+                        route = ['/process-groups', processGroupId];
+                    } else {
+                        route = ['/process-groups', processGroupId, ComponentType.ProcessGroup, request.id];
+                    }
+
+                    const routeBoundary: string[] = ['/process-groups', request.id, 'controller-services'];
+                    this.router.navigate([...routeBoundary], {
+                        state: {
+                            backNavigation: {
+                                route,
+                                routeBoundary,
+                                context: 'Process Group'
+                            } as BackNavigation
+                        }
+                    });
                 })
             ),
         { dispatch: false }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
@@ -32,6 +32,7 @@ import {
     VersionedFlowSnapshotMetadataEntity
 } from '../../../../state/shared';
 import { HttpErrorResponse } from '@angular/common/http';
+import { BackNavigation } from '../../../../state/navigation';
 
 export const flowFeatureKey = 'flowState';
 
@@ -346,6 +347,7 @@ export interface OpenComponentDialogRequest {
 export interface NavigateToManageComponentPoliciesRequest {
     resource: string;
     id: string;
+    backNavigationContext: string;
 }
 
 export interface EditComponentDialogRequest {
@@ -373,6 +375,7 @@ export interface NavigateToQueueListing {
 
 export interface NavigateToParameterContext {
     id: string;
+    backNavigation: BackNavigation;
 }
 
 export interface EditCurrentProcessGroupRequest {
@@ -388,8 +391,7 @@ export interface EditConnectionDialogRequest extends EditComponentDialogRequest 
     };
 }
 
-export interface UpdateProcessorRequest {
-    payload: any;
+export interface UpdateProcessorRequest extends UpdateComponentRequest {
     postUpdateNavigation?: string[];
 }
 
@@ -401,7 +403,6 @@ export interface UpdateComponentRequest {
     payload: any;
     errorStrategy: 'snackbar' | 'banner';
     restoreOnFailure?: any;
-    postUpdateNavigation?: string[];
 }
 
 export interface UpdateComponentResponse {
@@ -409,6 +410,9 @@ export interface UpdateComponentResponse {
     id: string;
     type: ComponentType;
     response: any;
+}
+
+export interface UpdateProcessorResponse extends UpdateComponentResponse {
     postUpdateNavigation?: string[];
 }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/state/flow/index.ts
@@ -393,6 +393,7 @@ export interface EditConnectionDialogRequest extends EditComponentDialogRequest 
 
 export interface UpdateProcessorRequest extends UpdateComponentRequest {
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface UpdateComponentRequest {
@@ -414,6 +415,7 @@ export interface UpdateComponentResponse {
 
 export interface UpdateProcessorResponse extends UpdateComponentResponse {
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface UpdateComponentFailure {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/header/header.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/header/header.component.spec.ts
@@ -19,13 +19,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HeaderComponent } from './header.component';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../state/flow/flow.reducer';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NewCanvasItem } from './new-canvas-item/new-canvas-item.component';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatDividerModule } from '@angular/material/divider';
 import { selectControllerBulletins, selectControllerStatus } from '../../../state/flow/flow.selectors';
-import { ControllerStatus } from '../../../state/flow';
+import { ControllerStatus, flowFeatureKey } from '../../../state/flow';
 import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Component } from '@angular/core';
@@ -34,10 +33,13 @@ import { ClusterSummary } from '../../../../../state/cluster-summary';
 import { selectClusterSummary } from '../../../../../state/cluster-summary/cluster-summary.selectors';
 import { selectCurrentUser } from '../../../../../state/current-user/current-user.selectors';
 import * as fromUser from '../../../../../state/current-user/current-user.reducer';
+import * as fromNavigation from '../../../../../state/navigation/navigation.reducer';
+import * as fromFlow from '../../../state/flow/flow.reducer';
 import { selectFlowConfiguration } from '../../../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../../../state/flow-configuration/flow-configuration.reducer';
 import { selectLoginConfiguration } from '../../../../../state/login-configuration/login-configuration.selectors';
 import * as fromLoginConfiguration from '../../../../../state/login-configuration/login-configuration.reducer';
+import { navigationFeatureKey } from '../../../../../state/navigation';
 
 describe('HeaderComponent', () => {
     let component: HeaderComponent;
@@ -101,7 +103,10 @@ describe('HeaderComponent', () => {
             ],
             providers: [
                 provideMockStore({
-                    initialState,
+                    initialState: {
+                        [flowFeatureKey]: fromFlow.initialState,
+                        [navigationFeatureKey]: fromNavigation.initialState
+                    },
                     selectors: [
                         {
                             selector: selectClusterSummary,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/items/processor/edit-processor/edit-processor.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/items/processor/edit-processor/edit-processor.component.ts
@@ -301,7 +301,7 @@ export class EditProcessor extends TabbedDialog {
         );
     }
 
-    submitForm(postUpdateNavigation?: string[]) {
+    submitForm(postUpdateNavigation?: string[], postUpdateNavigationBoundary?: string[]) {
         const relationshipConfiguration: RelationshipConfiguration =
             this.editProcessorForm.get('relationshipConfiguration')?.value;
         const autoTerminated: string[] = relationshipConfiguration.relationships
@@ -357,6 +357,7 @@ export class EditProcessor extends TabbedDialog {
             type: ComponentType.Processor,
             errorStrategy: 'banner',
             postUpdateNavigation,
+            postUpdateNavigationBoundary,
             payload
         });
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/items/processor/edit-processor/edit-processor.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/items/processor/edit-processor/edit-processor.component.ts
@@ -27,6 +27,7 @@ import { MatOptionModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
 import { Observable, of } from 'rxjs';
 import {
+    ComponentType,
     InlineServiceCreationRequest,
     InlineServiceCreationResponse,
     ParameterContextEntity,
@@ -351,6 +352,10 @@ export class EditProcessor extends TabbedDialog {
         }
 
         this.editProcessor.next({
+            id: this.request.entity.id,
+            uri: this.request.entity.uri,
+            type: ComponentType.Processor,
+            errorStrategy: 'banner',
             postUpdateNavigation,
             payload
         });

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.html
@@ -50,6 +50,7 @@
                                 (viewControllerServiceDocumentation)="viewControllerServiceDocumentation($event)"
                                 (configureControllerService)="configureControllerService($event)"
                                 (openAdvancedUi)="openAdvancedUi($event)"
+                                (manageAccessPolicies)="navigateToManageComponentPolicies($event)"
                                 (enableControllerService)="enableControllerService($event)"
                                 (disableControllerService)="disableControllerService($event)"
                                 (viewStateControllerService)="viewStateControllerService($event)"

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.html
@@ -55,6 +55,7 @@
                                 (disableControllerService)="disableControllerService($event)"
                                 (viewStateControllerService)="viewStateControllerService($event)"
                                 (changeControllerServiceVersion)="changeControllerServiceVersion($event)"
+                                (goToControllerService)="navigateToControllerService($event)"
                                 (deleteControllerService)="deleteControllerService($event)"></controller-service-table>
                         </div>
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.ts
@@ -32,6 +32,7 @@ import {
     navigateToAdvancedServiceUi,
     navigateToEditService,
     navigateToManageComponentPolicies,
+    navigateToService,
     openChangeControllerServiceVersionDialog,
     openConfigureControllerServiceDialog,
     openDisableControllerServiceDialog,
@@ -202,6 +203,19 @@ export class ControllerServices implements OnDestroy {
                 id: entity.id
             })
         );
+    }
+
+    navigateToControllerService(entity: ControllerServiceEntity): void {
+        if (entity.parentGroupId) {
+            this.store.dispatch(
+                navigateToService({
+                    request: {
+                        id: entity.id,
+                        processGroupId: entity.parentGroupId
+                    }
+                })
+            );
+        }
     }
 
     navigateToManageComponentPolicies(entity: ControllerServiceEntity): void {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.ts
@@ -175,7 +175,8 @@ export class ControllerServices implements OnDestroy {
 
         if (entity.parentGroupId) {
             request.backNavigation = {
-                backNavigation: ['/process-groups', entity.parentGroupId, 'controller-services', entity.id],
+                route: ['/process-groups', entity.parentGroupId, 'controller-services', entity.id],
+                routeBoundary: ['/documentation'],
                 context: 'Controller Service'
             };
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.ts
@@ -31,6 +31,7 @@ import {
     loadControllerServices,
     navigateToAdvancedServiceUi,
     navigateToEditService,
+    navigateToManageComponentPolicies,
     openChangeControllerServiceVersionDialog,
     openConfigureControllerServiceDialog,
     openDisableControllerServiceDialog,
@@ -49,6 +50,7 @@ import { NiFiState } from '../../../../state';
 import { getComponentStateAndOpenDialog } from '../../../../state/component-state/component-state.actions';
 import { navigateToComponentDocumentation } from '../../../../state/documentation/documentation.actions';
 import { FlowConfiguration } from '../../../../state/flow-configuration';
+import { DocumentationRequest } from '../../../../state/documentation';
 
 @Component({
     selector: 'controller-services',
@@ -162,14 +164,25 @@ export class ControllerServices implements OnDestroy {
     }
 
     viewControllerServiceDocumentation(entity: ControllerServiceEntity): void {
+        const request: DocumentationRequest = {
+            parameters: {
+                select: entity.component.type,
+                group: entity.component.bundle.group,
+                artifact: entity.component.bundle.artifact,
+                version: entity.component.bundle.version
+            }
+        };
+
+        if (entity.parentGroupId) {
+            request.backNavigation = {
+                backNavigation: ['/process-groups', entity.parentGroupId, 'controller-services', entity.id],
+                context: 'Controller Service'
+            };
+        }
+
         this.store.dispatch(
             navigateToComponentDocumentation({
-                params: {
-                    select: entity.component.type,
-                    group: entity.component.bundle.group,
-                    artifact: entity.component.bundle.artifact,
-                    version: entity.component.bundle.version
-                }
+                request
             })
         );
     }
@@ -185,6 +198,14 @@ export class ControllerServices implements OnDestroy {
     openAdvancedUi(entity: ControllerServiceEntity): void {
         this.store.dispatch(
             navigateToAdvancedServiceUi({
+                id: entity.id
+            })
+        );
+    }
+
+    navigateToManageComponentPolicies(entity: ControllerServiceEntity): void {
+        this.store.dispatch(
+            navigateToManageComponentPolicies({
                 id: entity.id
             })
         );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.actions.ts
@@ -64,6 +64,11 @@ export const navigateToEditParameterContext = createAction(
     props<{ id: string }>()
 );
 
+export const navigateToManageComponentPolicies = createAction(
+    '[Parameter Context Listing] Navigate To Manage Component Policies',
+    props<{ id: string }>()
+);
+
 export const getEffectiveParameterContextAndOpenDialog = createAction(
     '[Parameter Context Listing] Get Effective Parameter Context Open Dialog',
     props<{ request: GetEffectiveParameterContext }>()

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
@@ -59,6 +59,7 @@ import { OkDialog } from '../../../../ui/common/ok-dialog/ok-dialog.component';
 import { ErrorHelper } from '../../../../service/error-helper.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MEDIUM_DIALOG, SMALL_DIALOG, XL_DIALOG } from '../../../../index';
+import { preserveCurrentBackNavigation, pushBackNavigation } from '../../../../state/navigation/navigation.actions';
 
 @Injectable()
 export class ParameterContextListingEffects {
@@ -199,6 +200,30 @@ export class ParameterContextListingEffects {
             map((action) => action.error),
             switchMap((error) => of(ErrorActions.snackBarError({ error })))
         )
+    );
+
+    navigateToManageComponentPolicies$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ParameterContextListingActions.navigateToManageComponentPolicies),
+                map((action) => action.id),
+                tap((id) => {
+                    this.store.dispatch(preserveCurrentBackNavigation());
+                    this.router
+                        .navigate(['/access-policies', 'read', 'component', 'parameter-contexts', id])
+                        .then(() => {
+                            this.store.dispatch(
+                                pushBackNavigation({
+                                    backNavigation: {
+                                        backNavigation: ['/parameter-contexts', id],
+                                        context: 'Parameter Context'
+                                    }
+                                })
+                            );
+                        });
+                })
+            ),
+        { dispatch: false }
     );
 
     navigateToEditService$ = createEffect(

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
@@ -59,7 +59,7 @@ import { OkDialog } from '../../../../ui/common/ok-dialog/ok-dialog.component';
 import { ErrorHelper } from '../../../../service/error-helper.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MEDIUM_DIALOG, SMALL_DIALOG, XL_DIALOG } from '../../../../index';
-import { preserveCurrentBackNavigation, pushBackNavigation } from '../../../../state/navigation/navigation.actions';
+import { BackNavigation } from '../../../../state/navigation';
 
 @Injectable()
 export class ParameterContextListingEffects {
@@ -208,19 +208,16 @@ export class ParameterContextListingEffects {
                 ofType(ParameterContextListingActions.navigateToManageComponentPolicies),
                 map((action) => action.id),
                 tap((id) => {
-                    this.store.dispatch(preserveCurrentBackNavigation());
-                    this.router
-                        .navigate(['/access-policies', 'read', 'component', 'parameter-contexts', id])
-                        .then(() => {
-                            this.store.dispatch(
-                                pushBackNavigation({
-                                    backNavigation: {
-                                        backNavigation: ['/parameter-contexts', id],
-                                        context: 'Parameter Context'
-                                    }
-                                })
-                            );
-                        });
+                    const routeBoundary: string[] = ['/access-policies'];
+                    this.router.navigate([...routeBoundary, 'read', 'component', 'parameter-contexts', id], {
+                        state: {
+                            backNavigation: {
+                                route: ['/parameter-contexts', id],
+                                routeBoundary,
+                                context: 'Parameter Context'
+                            } as BackNavigation
+                        }
+                    });
                 })
             ),
         { dispatch: false }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-listing.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-listing.component.html
@@ -35,7 +35,8 @@
                     [flowConfiguration]="(flowConfiguration$ | async)!"
                     (selectParameterContext)="selectParameterContext($event)"
                     (editParameterContext)="editParameterContext($event)"
-                    (deleteParameterContext)="deleteParameterContext($event)"></parameter-context-table>
+                    (deleteParameterContext)="deleteParameterContext($event)"
+                    (manageAccessPolicies)="navigateToManageComponentPolicies($event)"></parameter-context-table>
             </div>
             <div class="flex justify-between">
                 <div class="refresh-container flex items-center gap-x-2">

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-listing.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-listing.component.ts
@@ -28,6 +28,7 @@ import {
     getEffectiveParameterContextAndOpenDialog,
     loadParameterContexts,
     navigateToEditParameterContext,
+    navigateToManageComponentPolicies,
     openNewParameterContextDialog,
     promptParameterContextDeletion,
     selectParameterContext
@@ -117,6 +118,14 @@ export class ParameterContextListing implements OnInit {
                 request: {
                     parameterContext: entity
                 }
+            })
+        );
+    }
+
+    navigateToManageComponentPolicies(entity: ParameterContextEntity): void {
+        this.store.dispatch(
+            navigateToManageComponentPolicies({
+                id: entity.id
             })
         );
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-table/parameter-context-table.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-table/parameter-context-table.component.html
@@ -86,10 +86,7 @@
                                 </button>
                             }
                             @if (canManageAccessPolicies()) {
-                                <button
-                                    mat-menu-item
-                                    (click)="$event.stopPropagation()"
-                                    [routerLink]="getPolicyLink(item)">
+                                <button mat-menu-item (click)="manageAccessPoliciesClicked(item)">
                                     <i class="fa fa-key primary-color mr-2"></i>
                                     Manage Access Policies
                                 </button>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-table/parameter-context-table.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-table/parameter-context-table.component.ts
@@ -47,6 +47,7 @@ export class ParameterContextTable {
     @Output() selectParameterContext: EventEmitter<ParameterContextEntity> = new EventEmitter<ParameterContextEntity>();
     @Output() editParameterContext: EventEmitter<ParameterContextEntity> = new EventEmitter<ParameterContextEntity>();
     @Output() deleteParameterContext: EventEmitter<ParameterContextEntity> = new EventEmitter<ParameterContextEntity>();
+    @Output() manageAccessPolicies: EventEmitter<ParameterContextEntity> = new EventEmitter<ParameterContextEntity>();
 
     displayedColumns: string[] = ['name', 'provider', 'description', 'actions'];
     dataSource: MatTableDataSource<ParameterContextEntity> = new MatTableDataSource<ParameterContextEntity>();
@@ -99,6 +100,10 @@ export class ParameterContextTable {
         return this.flowConfiguration?.supportsManagedAuthorizer && this.currentUser.tenantsPermissions.canRead;
     }
 
+    manageAccessPoliciesClicked(entity: ParameterContextEntity): void {
+        this.manageAccessPolicies.next(entity);
+    }
+
     canGoToParameterProvider(entity: ParameterContextEntity): boolean {
         if (!this.canRead(entity)) {
             return false;
@@ -111,10 +116,6 @@ export class ParameterContextTable {
             return [];
         }
         return ['/settings', 'parameter-providers', entity.component.parameterProviderConfiguration.id];
-    }
-
-    getPolicyLink(entity: ParameterContextEntity): string[] {
-        return ['/access-policies', 'read', 'component', 'parameter-contexts', entity.id];
     }
 
     select(entity: ParameterContextEntity): void {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/state/queue-listing/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/state/queue-listing/index.ts
@@ -73,6 +73,7 @@ export interface LoadConnectionLabelRequest {
 }
 
 export interface LoadConnectionLabelResponse {
+    connectionId: string;
     connectionLabel: string;
 }
 
@@ -103,10 +104,15 @@ export interface FlowFileDialogRequest {
     clusterNodeId?: string;
 }
 
+export interface SelectedConnection {
+    id: string;
+    label: string;
+}
+
 export interface QueueListingState {
     activeListingRequest: ListingRequest | null;
     completedListingRequest: ListingRequest;
-    connectionLabel: string;
+    selectedConnection: SelectedConnection | null;
     loadedTimestamp: string;
     status: 'pending' | 'loading' | 'error' | 'success';
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/state/queue-listing/queue-listing.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/state/queue-listing/queue-listing.effects.ts
@@ -66,6 +66,7 @@ export class QueueListingEffects {
 
                         return QueueListingActions.loadConnectionLabelSuccess({
                             response: {
+                                connectionId: request.connectionId,
                                 connectionLabel
                             }
                         });
@@ -74,6 +75,7 @@ export class QueueListingEffects {
                         of(
                             QueueListingActions.loadConnectionLabelSuccess({
                                 response: {
+                                    connectionId: request.connectionId,
                                     connectionLabel: 'Connection'
                                 }
                             })

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/state/queue-listing/queue-listing.reducer.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/state/queue-listing/queue-listing.reducer.ts
@@ -48,7 +48,7 @@ export const initialState: QueueListingState = {
         },
         flowFileSummaries: []
     },
-    connectionLabel: 'Connection',
+    selectedConnection: null,
     loadedTimestamp: 'N/A',
     status: 'pending'
 };
@@ -57,7 +57,10 @@ export const queueListingReducer = createReducer(
     initialState,
     on(loadConnectionLabelSuccess, (state, { response }) => ({
         ...state,
-        connectionLabel: response.connectionLabel
+        selectedConnection: {
+            id: response.connectionId,
+            label: response.connectionLabel
+        }
     })),
     on(submitQueueListingRequest, (state) => ({
         ...state,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/state/queue-listing/queue-listing.selectors.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/state/queue-listing/queue-listing.selectors.ts
@@ -37,9 +37,9 @@ export const selectCompletedListingRequest = createSelector(
 
 export const selectStatus = createSelector(selectQueueListingState, (state: QueueListingState) => state.status);
 
-export const selectConnectionLabel = createSelector(
+export const selectSelectedConnection = createSelector(
     selectQueueListingState,
-    (state: QueueListingState) => state.connectionLabel
+    (state: QueueListingState) => state.selectedConnection
 );
 
 export const selectLoadedTimestamp = createSelector(

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/flowfile-table/flowfile-table.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/flowfile-table/flowfile-table.component.html
@@ -16,7 +16,7 @@
   -->
 
 <div class="flowfile-table h-full flex flex-col">
-    <h3 class="queue-listing-header primary-color">{{ connectionLabel }}</h3>
+    <h3 class="queue-listing-header primary-color">{{ selectedConnection?.label }}</h3>
     <error-banner></error-banner>
     <div class="flex justify-between mb-2">
         <div class="accent-color font-medium">
@@ -151,11 +151,18 @@
                                         View content
                                     </button>
                                 }
-                                @if (currentUser.provenancePermissions.canRead) {
+                                @if (selectedConnection && currentUser.provenancePermissions.canRead) {
                                     <button
                                         mat-menu-item
                                         [routerLink]="['/provenance']"
-                                        [queryParams]="{ flowFileUuid: item.uuid }">
+                                        [queryParams]="{ flowFileUuid: item.uuid }"
+                                        [state]="{
+                                            backNavigation: {
+                                                route: ['/queue', selectedConnection.id],
+                                                routeBoundary: ['/provenance'],
+                                                context: 'Queue'
+                                            }
+                                        }">
                                         <i class="icon icon-provenance primary-color mr-2"></i>
                                         Provenance
                                     </button>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/flowfile-table/flowfile-table.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/flowfile-table/flowfile-table.component.ts
@@ -23,7 +23,7 @@ import { ValidationErrorsTip } from '../../../../../ui/common/tooltips/validatio
 import { NiFiCommon } from '../../../../../service/nifi-common.service';
 
 import { RouterLink } from '@angular/router';
-import { FlowFileSummary, ListingRequest } from '../../../state/queue-listing';
+import { FlowFileSummary, ListingRequest, SelectedConnection } from '../../../state/queue-listing';
 import { CurrentUser } from '../../../../../state/current-user';
 import { ErrorBanner } from '../../../../../ui/common/error-banner/error-banner.component';
 import { ClusterSummary } from '../../../../../state/cluster-summary';
@@ -38,7 +38,7 @@ import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
     styleUrls: ['./flowfile-table.component.scss']
 })
 export class FlowFileTable {
-    @Input() connectionLabel!: string;
+    @Input() selectedConnection: SelectedConnection | null = null;
 
     @Input() set listingRequest(listingRequest: ListingRequest) {
         if (listingRequest.flowFileSummaries) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/queue-listing.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/queue-listing.component.html
@@ -21,7 +21,7 @@
             @if (listingRequest$ | async; as listingRequest) {
                 @if (about$ | async; as about) {
                     <flowfile-table
-                        [connectionLabel]="(connectionLabel$ | async)!"
+                        [selectedConnection]="(selectedConnection$ | async)!"
                         [listingRequest]="listingRequest"
                         [currentUser]="(currentUser$ | async)!"
                         [clusterSummary]="(clusterSummary$ | async)!"

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/queue-listing.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/queue/ui/queue-listing/queue-listing.component.ts
@@ -20,7 +20,7 @@ import { Store } from '@ngrx/store';
 import { distinctUntilChanged, filter } from 'rxjs';
 import {
     selectConnectionIdFromRoute,
-    selectConnectionLabel,
+    selectSelectedConnection,
     selectCompletedListingRequest,
     selectLoadedTimestamp,
     selectStatus
@@ -51,7 +51,7 @@ import { loadClusterSummary } from '../../../../state/cluster-summary/cluster-su
 })
 export class QueueListing implements OnInit, OnDestroy {
     status$ = this.store.select(selectStatus);
-    connectionLabel$ = this.store.select(selectConnectionLabel);
+    selectedConnection$ = this.store.select(selectSelectedConnection);
     loadedTimestamp$ = this.store.select(selectLoadedTimestamp);
     listingRequest$ = this.store.select(selectCompletedListingRequest);
     currentUser$ = this.store.select(selectCurrentUser);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/feature/settings.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/feature/settings.component.html
@@ -17,7 +17,7 @@
 
 <div class="flex flex-col h-screen justify-between">
     <header class="mb-5 nifi-header">
-        <navigation></navigation>
+        <navigation [popBackNavigationOnDestroy]="false"></navigation>
     </header>
     <div class="pb-5 px-5 flex-1 flex flex-col">
         <h3 class="primary-color">NiFi Settings</h3>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/feature/settings.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/feature/settings.component.html
@@ -17,7 +17,7 @@
 
 <div class="flex flex-col h-screen justify-between">
     <header class="mb-5 nifi-header">
-        <navigation [popBackNavigationOnDestroy]="false"></navigation>
+        <navigation></navigation>
     </header>
     <div class="pb-5 px-5 flex-1 flex flex-col">
         <h3 class="primary-color">NiFi Settings</h3>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/flow-analysis-rules.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/flow-analysis-rules.effects.ts
@@ -50,6 +50,7 @@ import {
     selectPropertyVerificationStatus
 } from '../../../../state/property-verification/property-verification.selectors';
 import { VerifyPropertiesRequestContext } from '../../../../state/property-verification';
+import { preserveCurrentBackNavigation, pushBackNavigation } from '../../../../state/navigation/navigation.actions';
 
 @Injectable()
 export class FlowAnalysisRulesEffects {
@@ -305,10 +306,30 @@ export class FlowAnalysisRulesEffects {
                             });
 
                             saveChangesDialogReference.componentInstance.no.pipe(take(1)).subscribe(() => {
-                                this.router.navigate(commands);
+                                this.store.dispatch(preserveCurrentBackNavigation());
+                                this.router.navigate(commands).then(() => {
+                                    this.store.dispatch(
+                                        pushBackNavigation({
+                                            backNavigation: {
+                                                backNavigation: ['/settings', 'flow-analysis-rules', ruleId, 'edit'],
+                                                context: 'Flow Analysis Rule'
+                                            }
+                                        })
+                                    );
+                                });
                             });
                         } else {
-                            this.router.navigate(commands);
+                            this.store.dispatch(preserveCurrentBackNavigation());
+                            this.router.navigate(commands).then(() => {
+                                this.store.dispatch(
+                                    pushBackNavigation({
+                                        backNavigation: {
+                                            backNavigation: ['/settings', 'flow-analysis-rules', ruleId, 'edit'],
+                                            context: 'Flow Analysis Rule'
+                                        }
+                                    })
+                                );
+                            });
                         }
                     };
 
@@ -392,7 +413,17 @@ export class FlowAnalysisRulesEffects {
                 map((action) => action.response),
                 tap((response) => {
                     if (response.postUpdateNavigation) {
-                        this.router.navigate(response.postUpdateNavigation);
+                        this.store.dispatch(preserveCurrentBackNavigation());
+                        this.router.navigate(response.postUpdateNavigation).then(() => {
+                            this.store.dispatch(
+                                pushBackNavigation({
+                                    backNavigation: {
+                                        backNavigation: ['/settings', 'flow-analysis-rules', response.id, 'edit'],
+                                        context: 'Flow Analysis Rule'
+                                    }
+                                })
+                            );
+                        });
                     } else {
                         this.dialog.closeAll();
                     }
@@ -423,8 +454,7 @@ export class FlowAnalysisRulesEffects {
                         FlowAnalysisRuleActions.enableFlowAnalysisRuleSuccess({
                             response: {
                                 id: request.id,
-                                flowAnalysisRule: response,
-                                postUpdateNavigation: response.postUpdateNavigation
+                                flowAnalysisRule: response
                             }
                         })
                     ),
@@ -438,20 +468,6 @@ export class FlowAnalysisRulesEffects {
                 )
             )
         )
-    );
-
-    enableFlowAnalysisRuleSuccess$ = createEffect(
-        () =>
-            this.actions$.pipe(
-                ofType(FlowAnalysisRuleActions.enableFlowAnalysisRuleSuccess),
-                map((action) => action.response),
-                tap((response) => {
-                    if (response.postUpdateNavigation) {
-                        this.router.navigate(response.postUpdateNavigation);
-                    }
-                })
-            ),
-        { dispatch: false }
     );
 
     disableFlowAnalysisRule$ = createEffect(() =>
@@ -464,8 +480,7 @@ export class FlowAnalysisRulesEffects {
                         FlowAnalysisRuleActions.disableFlowAnalysisRuleSuccess({
                             response: {
                                 id: request.id,
-                                flowAnalysisRule: response,
-                                postUpdateNavigation: response.postUpdateNavigation
+                                flowAnalysisRule: response
                             }
                         })
                     ),
@@ -479,20 +494,6 @@ export class FlowAnalysisRulesEffects {
                 )
             )
         )
-    );
-
-    disableFlowAnalysisRuleSuccess$ = createEffect(
-        () =>
-            this.actions$.pipe(
-                ofType(FlowAnalysisRuleActions.disableFlowAnalysisRuleSuccess),
-                map((action) => action.response),
-                tap((response) => {
-                    if (response.postUpdateNavigation) {
-                        this.router.navigate(response.postUpdateNavigation);
-                    }
-                })
-            ),
-        { dispatch: false }
     );
 
     openChangeFlowAnalysisRuleVersionDialog$ = createEffect(

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/flow-analysis-rules.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/flow-analysis-rules.effects.ts
@@ -416,16 +416,20 @@ export class FlowAnalysisRulesEffects {
                 ofType(FlowAnalysisRuleActions.configureFlowAnalysisRuleSuccess),
                 map((action) => action.response),
                 tap((response) => {
-                    if (response.postUpdateNavigation && response.postUpdateNavigationBoundary) {
-                        this.router.navigate(response.postUpdateNavigation, {
-                            state: {
-                                backNavigation: {
-                                    route: ['/settings', 'flow-analysis-rules', response.id, 'edit'],
-                                    routeBoundary: response.postUpdateNavigationBoundary,
-                                    context: 'Flow Analysis Rule'
-                                } as BackNavigation
-                            }
-                        });
+                    if (response.postUpdateNavigation) {
+                        if (response.postUpdateNavigationBoundary) {
+                            this.router.navigate(response.postUpdateNavigation, {
+                                state: {
+                                    backNavigation: {
+                                        route: ['/settings', 'flow-analysis-rules', response.id, 'edit'],
+                                        routeBoundary: response.postUpdateNavigationBoundary,
+                                        context: 'Flow Analysis Rule'
+                                    } as BackNavigation
+                                }
+                            });
+                        } else {
+                            this.router.navigate(response.postUpdateNavigation);
+                        }
                     } else {
                         this.dialog.closeAll();
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/index.ts
@@ -50,17 +50,20 @@ export interface ConfigureFlowAnalysisRuleRequest {
     uri: string;
     payload: any;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface ConfigureFlowAnalysisRuleSuccess {
     id: string;
     flowAnalysisRule: FlowAnalysisRuleEntity;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface UpdateFlowAnalysisRuleRequest {
     payload: any;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface EnableFlowAnalysisRuleSuccess {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/flow-analysis-rules/index.ts
@@ -66,13 +66,11 @@ export interface UpdateFlowAnalysisRuleRequest {
 export interface EnableFlowAnalysisRuleSuccess {
     id: string;
     flowAnalysisRule: FlowAnalysisRuleEntity;
-    postUpdateNavigation?: string[];
 }
 
 export interface DisableFlowAnalysisRuleSuccess {
     id: string;
     flowAnalysisRule: FlowAnalysisRuleEntity;
-    postUpdateNavigation?: string[];
 }
 
 export interface EnableFlowAnalysisRuleRequest {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/index.ts
@@ -33,12 +33,14 @@ export interface ConfigureControllerServiceRequest {
     uri: string;
     payload: any;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface ConfigureControllerServiceSuccess {
     id: string;
     controllerService: ControllerServiceEntity;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface DeleteControllerServiceRequest {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.actions.ts
@@ -81,7 +81,12 @@ export const navigateToEditService = createAction(
 );
 
 export const navigateToAdvancedServiceUi = createAction(
-    '[Controller Services] Navigate To Advanced Service UI',
+    '[Management Controller Services] Navigate To Advanced Service UI',
+    props<{ id: string }>()
+);
+
+export const navigateToManageComponentPolicies = createAction(
+    '[Management Controller Services] Navigate To Manage Component Policies',
     props<{ id: string }>()
 );
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.effects.ts
@@ -464,16 +464,20 @@ export class ManagementControllerServicesEffects {
                 ofType(ManagementControllerServicesActions.configureControllerServiceSuccess),
                 map((action) => action.response),
                 tap((response) => {
-                    if (response.postUpdateNavigation && response.postUpdateNavigationBoundary) {
-                        this.router.navigate(response.postUpdateNavigation, {
-                            state: {
-                                backNavigation: {
-                                    route: ['/settings', 'management-controller-services', response.id, 'edit'],
-                                    routeBoundary: response.postUpdateNavigationBoundary,
-                                    context: 'Controller Service'
-                                } as BackNavigation
-                            }
-                        });
+                    if (response.postUpdateNavigation) {
+                        if (response.postUpdateNavigationBoundary) {
+                            this.router.navigate(response.postUpdateNavigation, {
+                                state: {
+                                    backNavigation: {
+                                        route: ['/settings', 'management-controller-services', response.id, 'edit'],
+                                        routeBoundary: response.postUpdateNavigationBoundary,
+                                        context: 'Controller Service'
+                                    } as BackNavigation
+                                }
+                            });
+                        } else {
+                            this.router.navigate(response.postUpdateNavigation);
+                        }
                     } else {
                         this.dialog.closeAll();
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.effects.ts
@@ -56,6 +56,7 @@ import {
     selectPropertyVerificationStatus
 } from '../../../../state/property-verification/property-verification.selectors';
 import { VerifyPropertiesRequestContext } from '../../../../state/property-verification';
+import { preserveCurrentBackNavigation, pushBackNavigation } from '../../../../state/navigation/navigation.actions';
 
 @Injectable()
 export class ManagementControllerServicesEffects {
@@ -191,7 +192,41 @@ export class ManagementControllerServicesEffects {
                 ofType(ManagementControllerServicesActions.navigateToAdvancedServiceUi),
                 map((action) => action.id),
                 tap((id) => {
-                    this.router.navigate(['/settings', 'management-controller-services', id, 'advanced']);
+                    this.store.dispatch(preserveCurrentBackNavigation());
+                    this.router.navigate(['/settings', 'management-controller-services', id, 'advanced']).then(() => {
+                        this.store.dispatch(
+                            pushBackNavigation({
+                                backNavigation: {
+                                    backNavigation: ['/settings', 'management-controller-services', id],
+                                    context: 'Controller Service'
+                                }
+                            })
+                        );
+                    });
+                })
+            ),
+        { dispatch: false }
+    );
+
+    navigateToManageComponentPolicies$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ManagementControllerServicesActions.navigateToManageComponentPolicies),
+                map((action) => action.id),
+                tap((id) => {
+                    this.store.dispatch(preserveCurrentBackNavigation());
+                    this.router
+                        .navigate(['/access-policies', 'read', 'component', 'controller-services', id])
+                        .then(() => {
+                            this.store.dispatch(
+                                pushBackNavigation({
+                                    backNavigation: {
+                                        backNavigation: ['/settings', 'management-controller-services', id],
+                                        context: 'Controller Service'
+                                    }
+                                })
+                            );
+                        });
                 })
             ),
         { dispatch: false }
@@ -263,7 +298,7 @@ export class ManagementControllerServicesEffects {
                         selectPropertyVerificationStatus
                     );
 
-                    const goTo = (commands: string[], destination: string): void => {
+                    const goTo = (commands: string[], destination: string, backNavigation: boolean): void => {
                         if (editDialogReference.componentInstance.editControllerServiceForm.dirty) {
                             const saveChangesDialogReference = this.dialog.open(YesNoDialog, {
                                 ...SMALL_DIALOG,
@@ -278,23 +313,57 @@ export class ManagementControllerServicesEffects {
                             });
 
                             saveChangesDialogReference.componentInstance.no.pipe(take(1)).subscribe(() => {
-                                this.router.navigate(commands);
+                                this.router.navigate(commands).then(() => {
+                                    if (backNavigation) {
+                                        this.store.dispatch(preserveCurrentBackNavigation());
+                                        this.store.dispatch(
+                                            pushBackNavigation({
+                                                backNavigation: {
+                                                    backNavigation: [
+                                                        '/settings',
+                                                        'management-controller-services',
+                                                        serviceId,
+                                                        'edit'
+                                                    ],
+                                                    context: 'Controller Service'
+                                                }
+                                            })
+                                        );
+                                    }
+                                });
                             });
                         } else {
-                            this.router.navigate(commands);
+                            this.router.navigate(commands).then(() => {
+                                if (backNavigation) {
+                                    this.store.dispatch(preserveCurrentBackNavigation());
+                                    this.store.dispatch(
+                                        pushBackNavigation({
+                                            backNavigation: {
+                                                backNavigation: [
+                                                    '/settings',
+                                                    'management-controller-services',
+                                                    serviceId,
+                                                    'edit'
+                                                ],
+                                                context: 'Controller Service'
+                                            }
+                                        })
+                                    );
+                                }
+                            });
                         }
                     };
 
                     editDialogReference.componentInstance.goToService = (serviceId: string) => {
                         const commands: string[] = ['/settings', 'management-controller-services', serviceId];
-                        goTo(commands, 'Controller Service');
+                        goTo(commands, 'Controller Service', true);
                     };
 
                     editDialogReference.componentInstance.goToReferencingComponent = (
                         component: ControllerServiceReferencingComponent
                     ) => {
                         const route: string[] = this.getRouteForReference(component);
-                        goTo(route, component.referenceType);
+                        goTo(route, component.referenceType, false);
                     };
 
                     editDialogReference.componentInstance.createNewService =
@@ -401,7 +470,22 @@ export class ManagementControllerServicesEffects {
                 map((action) => action.response),
                 tap((response) => {
                     if (response.postUpdateNavigation) {
-                        this.router.navigate(response.postUpdateNavigation);
+                        this.store.dispatch(preserveCurrentBackNavigation());
+                        this.router.navigate(response.postUpdateNavigation).then(() => {
+                            this.store.dispatch(
+                                pushBackNavigation({
+                                    backNavigation: {
+                                        backNavigation: [
+                                            '/settings',
+                                            'management-controller-services',
+                                            response.id,
+                                            'edit'
+                                        ],
+                                        context: 'Controller Service'
+                                    }
+                                })
+                            );
+                        });
                     } else {
                         this.dialog.closeAll();
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/parameter-providers/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/parameter-providers/index.ts
@@ -167,17 +167,20 @@ export interface ConfigureParameterProviderRequest {
     uri: string;
     payload: any;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface ConfigureParameterProviderSuccess {
     id: string;
     parameterProvider: ParameterProviderEntity;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface UpdateParameterProviderRequest {
     payload: any;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface FetchParameterProviderParametersRequest {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/parameter-providers/parameter-providers.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/parameter-providers/parameter-providers.actions.ts
@@ -92,6 +92,11 @@ export const navigateToAdvancedParameterProviderUi = createAction(
     props<{ id: string }>()
 );
 
+export const navigateToManageAccessPolicies = createAction(
+    `${PARAMETER_PROVIDERS_PREFIX} Navigate To Manage Access Policies`,
+    props<{ id: string }>()
+);
+
 export const navigateToFetchParameterProvider = createAction(
     `${PARAMETER_PROVIDERS_PREFIX} Navigate To Fetch Parameter Provider`,
     props<{ id: string }>()

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/parameter-providers/parameter-providers.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/parameter-providers/parameter-providers.effects.ts
@@ -66,6 +66,7 @@ import {
     selectPropertyVerificationStatus
 } from '../../../../state/property-verification/property-verification.selectors';
 import { VerifyPropertiesRequestContext } from '../../../../state/property-verification';
+import { preserveCurrentBackNavigation, pushBackNavigation } from '../../../../state/navigation/navigation.actions';
 
 @Injectable()
 export class ParameterProvidersEffects {
@@ -257,7 +258,41 @@ export class ParameterProvidersEffects {
                 ofType(ParameterProviderActions.navigateToAdvancedParameterProviderUi),
                 map((action) => action.id),
                 tap((id) => {
-                    this.router.navigate(['settings', 'parameter-providers', id, 'advanced']);
+                    this.store.dispatch(preserveCurrentBackNavigation());
+                    this.router.navigate(['settings', 'parameter-providers', id, 'advanced']).then(() => {
+                        this.store.dispatch(
+                            pushBackNavigation({
+                                backNavigation: {
+                                    backNavigation: ['settings', 'parameter-providers', id],
+                                    context: 'Parameter Provider'
+                                }
+                            })
+                        );
+                    });
+                })
+            ),
+        { dispatch: false }
+    );
+
+    navigateToManageAccessPolicies$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ParameterProviderActions.navigateToManageAccessPolicies),
+                map((action) => action.id),
+                tap((id) => {
+                    this.store.dispatch(preserveCurrentBackNavigation());
+                    this.router
+                        .navigate(['/access-policies', 'read', 'component', 'parameter-providers', id])
+                        .then(() => {
+                            this.store.dispatch(
+                                pushBackNavigation({
+                                    backNavigation: {
+                                        backNavigation: ['/settings', 'parameter-providers', id],
+                                        context: 'Parameter Provider'
+                                    }
+                                })
+                            );
+                        });
                 })
             ),
         { dispatch: false }
@@ -349,10 +384,30 @@ export class ParameterProvidersEffects {
                             });
 
                             promptSaveDialogRef.componentInstance.no.pipe(take(1)).subscribe(() => {
-                                this.router.navigate(commands);
+                                this.store.dispatch(preserveCurrentBackNavigation());
+                                this.router.navigate(commands).then(() => {
+                                    this.store.dispatch(
+                                        pushBackNavigation({
+                                            backNavigation: {
+                                                backNavigation: ['/settings', 'parameter-providers', id, 'edit'],
+                                                context: 'Parameter Provider'
+                                            }
+                                        })
+                                    );
+                                });
                             });
                         } else {
-                            this.router.navigate(commands);
+                            this.store.dispatch(preserveCurrentBackNavigation());
+                            this.router.navigate(commands).then(() => {
+                                this.store.dispatch(
+                                    pushBackNavigation({
+                                        backNavigation: {
+                                            backNavigation: ['/settings', 'parameter-providers', id, 'edit'],
+                                            context: 'Parameter Provider'
+                                        }
+                                    })
+                                );
+                            });
                         }
                     };
 
@@ -448,7 +503,17 @@ export class ParameterProvidersEffects {
                 map((action) => action.response),
                 tap((response) => {
                     if (response.postUpdateNavigation) {
-                        this.router.navigate(response.postUpdateNavigation);
+                        this.store.dispatch(preserveCurrentBackNavigation());
+                        this.router.navigate(response.postUpdateNavigation).then(() => {
+                            this.store.dispatch(
+                                pushBackNavigation({
+                                    backNavigation: {
+                                        backNavigation: ['/settings', 'parameter-providers', response.id, 'edit'],
+                                        context: 'Parameter Provider'
+                                    }
+                                })
+                            );
+                        });
                     } else {
                         this.dialog.closeAll();
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/parameter-providers/parameter-providers.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/parameter-providers/parameter-providers.effects.ts
@@ -498,16 +498,20 @@ export class ParameterProvidersEffects {
                 ofType(ParameterProviderActions.configureParameterProviderSuccess),
                 map((action) => action.response),
                 tap((response) => {
-                    if (response.postUpdateNavigation && response.postUpdateNavigationBoundary) {
-                        this.router.navigate(response.postUpdateNavigation, {
-                            state: {
-                                backNavigation: {
-                                    route: ['/settings', 'parameter-providers', response.id, 'edit'],
-                                    routeBoundary: response.postUpdateNavigationBoundary,
-                                    context: 'Parameter Provider'
-                                } as BackNavigation
-                            }
-                        });
+                    if (response.postUpdateNavigation) {
+                        if (response.postUpdateNavigationBoundary) {
+                            this.router.navigate(response.postUpdateNavigation, {
+                                state: {
+                                    backNavigation: {
+                                        route: ['/settings', 'parameter-providers', response.id, 'edit'],
+                                        routeBoundary: response.postUpdateNavigationBoundary,
+                                        context: 'Parameter Provider'
+                                    } as BackNavigation
+                                }
+                            });
+                        } else {
+                            this.router.navigate(response.postUpdateNavigation);
+                        }
                     } else {
                         this.dialog.closeAll();
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/registry-clients/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/registry-clients/index.ts
@@ -51,12 +51,14 @@ export interface EditRegistryClientRequest {
     uri: string;
     payload: any;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface EditRegistryClientRequestSuccess {
     id: string;
     registryClient: RegistryClientEntity;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface DeleteRegistryClientRequest {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/registry-clients/registry-clients.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/registry-clients/registry-clients.effects.ts
@@ -303,16 +303,20 @@ export class RegistryClientsEffects {
                 ofType(RegistryClientsActions.configureRegistryClientSuccess),
                 map((action) => action.response),
                 tap((response) => {
-                    if (response.postUpdateNavigation && response.postUpdateNavigationBoundary) {
-                        this.router.navigate(response.postUpdateNavigation, {
-                            state: {
-                                backNavigation: {
-                                    route: ['/settings', 'registry-clients', response.id, 'edit'],
-                                    routeBoundary: response.postUpdateNavigationBoundary,
-                                    context: 'Registry Client'
-                                } as BackNavigation
-                            }
-                        });
+                    if (response.postUpdateNavigation) {
+                        if (response.postUpdateNavigationBoundary) {
+                            this.router.navigate(response.postUpdateNavigation, {
+                                state: {
+                                    backNavigation: {
+                                        route: ['/settings', 'registry-clients', response.id, 'edit'],
+                                        routeBoundary: response.postUpdateNavigationBoundary,
+                                        context: 'Registry Client'
+                                    } as BackNavigation
+                                }
+                            });
+                        } else {
+                            this.router.navigate(response.postUpdateNavigation);
+                        }
                     } else {
                         this.dialog.closeAll();
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/registry-clients/registry-clients.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/registry-clients/registry-clients.effects.ts
@@ -37,6 +37,7 @@ import * as ErrorActions from '../../../../state/error/error.actions';
 import { ErrorHelper } from '../../../../service/error-helper.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { LARGE_DIALOG, MEDIUM_DIALOG, SMALL_DIALOG } from '../../../../index';
+import { preserveCurrentBackNavigation, pushBackNavigation } from '../../../../state/navigation/navigation.actions';
 
 @Injectable()
 export class RegistryClientsEffects {
@@ -209,10 +210,35 @@ export class RegistryClientsEffects {
                             });
 
                             saveChangesDialogReference.componentInstance.no.pipe(take(1)).subscribe(() => {
-                                this.router.navigate(commands);
+                                this.store.dispatch(preserveCurrentBackNavigation());
+                                this.router.navigate(commands).then(() => {
+                                    this.store.dispatch(
+                                        pushBackNavigation({
+                                            backNavigation: {
+                                                backNavigation: [
+                                                    '/settings',
+                                                    'registry-clients',
+                                                    registryClientId,
+                                                    'edit'
+                                                ],
+                                                context: 'Registry Client'
+                                            }
+                                        })
+                                    );
+                                });
                             });
                         } else {
-                            this.router.navigate(commands);
+                            this.store.dispatch(preserveCurrentBackNavigation());
+                            this.router.navigate(commands).then(() => {
+                                this.store.dispatch(
+                                    pushBackNavigation({
+                                        backNavigation: {
+                                            backNavigation: ['/settings', 'registry-clients', registryClientId, 'edit'],
+                                            context: 'Registry Client'
+                                        }
+                                    })
+                                );
+                            });
                         }
                     };
 
@@ -285,7 +311,17 @@ export class RegistryClientsEffects {
                 map((action) => action.response),
                 tap((response) => {
                     if (response.postUpdateNavigation) {
-                        this.router.navigate(response.postUpdateNavigation);
+                        this.store.dispatch(preserveCurrentBackNavigation());
+                        this.router.navigate(response.postUpdateNavigation).then(() => {
+                            this.store.dispatch(
+                                pushBackNavigation({
+                                    backNavigation: {
+                                        backNavigation: ['/settings', 'registry-clients', response.id, 'edit'],
+                                        context: 'Registry Client'
+                                    }
+                                })
+                            );
+                        });
                     } else {
                         this.dialog.closeAll();
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/index.ts
@@ -50,24 +50,20 @@ export interface ConfigureReportingTaskRequest {
     uri: string;
     payload: any;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface ConfigureReportingTaskSuccess {
     id: string;
     reportingTask: ReportingTaskEntity;
     postUpdateNavigation?: string[];
-}
-
-export interface ConfigureReportingTaskRequest {
-    id: string;
-    uri: string;
-    payload: any;
-    postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface UpdateReportingTaskRequest {
     payload: any;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface EditReportingTaskDialogRequest {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.actions.ts
@@ -89,6 +89,11 @@ export const navigateToAdvancedReportingTaskUi = createAction(
     props<{ id: string }>()
 );
 
+export const navigateToManageAccessPolicies = createAction(
+    '[Reporting Tasks] Navigate To Manage Access Policies',
+    props<{ id: string }>()
+);
+
 export const startReportingTask = createAction(
     '[Reporting Tasks] Start Reporting Task',
     props<{ request: StartReportingTaskRequest }>()

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.effects.ts
@@ -454,16 +454,20 @@ export class ReportingTasksEffects {
                 ofType(ReportingTaskActions.configureReportingTaskSuccess),
                 map((action) => action.response),
                 tap((response) => {
-                    if (response.postUpdateNavigation && response.postUpdateNavigationBoundary) {
-                        this.router.navigate(response.postUpdateNavigation, {
-                            state: {
-                                backNavigation: {
-                                    route: ['/settings', 'reporting-tasks', response.id, 'edit'],
-                                    routeBoundary: response.postUpdateNavigationBoundary,
-                                    context: 'Reporting Task'
-                                } as BackNavigation
-                            }
-                        });
+                    if (response.postUpdateNavigation) {
+                        if (response.postUpdateNavigationBoundary) {
+                            this.router.navigate(response.postUpdateNavigation, {
+                                state: {
+                                    backNavigation: {
+                                        route: ['/settings', 'reporting-tasks', response.id, 'edit'],
+                                        routeBoundary: response.postUpdateNavigationBoundary,
+                                        context: 'Reporting Task'
+                                    } as BackNavigation
+                                }
+                            });
+                        } else {
+                            this.router.navigate(response.postUpdateNavigation);
+                        }
                     } else {
                         this.dialog.closeAll();
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.effects.ts
@@ -29,9 +29,9 @@ import { ReportingTaskService } from '../../service/reporting-task.service';
 import { CreateReportingTask } from '../../ui/reporting-tasks/create-reporting-task/create-reporting-task.component';
 import { Router } from '@angular/router';
 import { selectSaving } from '../management-controller-services/management-controller-services.selectors';
-import { OpenChangeComponentVersionDialogRequest, UpdateControllerServiceRequest } from '../../../../state/shared';
+import { OpenChangeComponentVersionDialogRequest } from '../../../../state/shared';
 import { EditReportingTask } from '../../ui/reporting-tasks/edit-reporting-task/edit-reporting-task.component';
-import { CreateReportingTaskSuccess, EditReportingTaskDialogRequest } from './index';
+import { CreateReportingTaskSuccess, EditReportingTaskDialogRequest, UpdateReportingTaskRequest } from './index';
 import { ManagementControllerServiceService } from '../../service/management-controller-service.service';
 import { PropertyTableHelperService } from '../../../../service/property-table-helper.service';
 import * as ErrorActions from '../../../../state/error/error.actions';
@@ -50,7 +50,7 @@ import {
     selectPropertyVerificationStatus
 } from '../../../../state/property-verification/property-verification.selectors';
 import { VerifyPropertiesRequestContext } from '../../../../state/property-verification';
-import { preserveCurrentBackNavigation, pushBackNavigation } from '../../../../state/navigation/navigation.actions';
+import { BackNavigation } from '../../../../state/navigation';
 
 @Injectable()
 export class ReportingTasksEffects {
@@ -235,16 +235,15 @@ export class ReportingTasksEffects {
                 ofType(ReportingTaskActions.navigateToAdvancedReportingTaskUi),
                 map((action) => action.id),
                 tap((id) => {
-                    this.store.dispatch(preserveCurrentBackNavigation());
-                    this.router.navigate(['/settings', 'reporting-tasks', id, 'advanced']).then(() => {
-                        this.store.dispatch(
-                            pushBackNavigation({
-                                backNavigation: {
-                                    backNavigation: ['/settings', 'reporting-tasks', id],
-                                    context: 'Reporting Task'
-                                }
-                            })
-                        );
+                    const routeBoundary: string[] = ['/settings', 'reporting-tasks', id, 'advanced'];
+                    this.router.navigate([...routeBoundary], {
+                        state: {
+                            backNavigation: {
+                                route: ['/settings', 'reporting-tasks', id],
+                                routeBoundary,
+                                context: 'Reporting Task'
+                            } as BackNavigation
+                        }
                     });
                 })
             ),
@@ -257,16 +256,15 @@ export class ReportingTasksEffects {
                 ofType(ReportingTaskActions.navigateToManageAccessPolicies),
                 map((action) => action.id),
                 tap((id) => {
-                    this.store.dispatch(preserveCurrentBackNavigation());
-                    this.router.navigate(['/access-policies', 'read', 'component', 'reporting-tasks', id]).then(() => {
-                        this.store.dispatch(
-                            pushBackNavigation({
-                                backNavigation: {
-                                    backNavigation: ['/settings', 'reporting-tasks', id],
-                                    context: 'Reporting Task'
-                                }
-                            })
-                        );
+                    const routeBoundary = ['/access-policies'];
+                    this.router.navigate([...routeBoundary, 'read', 'component', 'reporting-tasks', id], {
+                        state: {
+                            backNavigation: {
+                                route: ['/settings', 'reporting-tasks', id],
+                                routeBoundary,
+                                context: 'Reporting Task'
+                            } as BackNavigation
+                        }
                     });
                 })
             ),
@@ -335,7 +333,7 @@ export class ReportingTasksEffects {
                         selectPropertyVerificationStatus
                     );
 
-                    const goTo = (commands: string[], destination: string): void => {
+                    const goTo = (commands: string[], destination: string, commandBoundary: string[]): void => {
                         if (editDialogReference.componentInstance.editReportingTaskForm.dirty) {
                             const saveChangesDialogReference = this.dialog.open(YesNoDialog, {
                                 ...SMALL_DIALOG,
@@ -346,40 +344,37 @@ export class ReportingTasksEffects {
                             });
 
                             saveChangesDialogReference.componentInstance.yes.pipe(take(1)).subscribe(() => {
-                                editDialogReference.componentInstance.submitForm(commands);
+                                editDialogReference.componentInstance.submitForm(commands, commandBoundary);
                             });
 
                             saveChangesDialogReference.componentInstance.no.pipe(take(1)).subscribe(() => {
-                                this.store.dispatch(preserveCurrentBackNavigation());
-                                this.router.navigate(commands).then(() => {
-                                    this.store.dispatch(
-                                        pushBackNavigation({
-                                            backNavigation: {
-                                                backNavigation: ['/settings', 'reporting-tasks', taskId, 'edit'],
-                                                context: 'Reporting Task'
-                                            }
-                                        })
-                                    );
+                                this.router.navigate(commands, {
+                                    state: {
+                                        backNavigation: {
+                                            route: ['/settings', 'reporting-tasks', taskId, 'edit'],
+                                            routeBoundary: commandBoundary,
+                                            context: 'Reporting Task'
+                                        } as BackNavigation
+                                    }
                                 });
                             });
                         } else {
-                            this.store.dispatch(preserveCurrentBackNavigation());
-                            this.router.navigate(commands).then(() => {
-                                this.store.dispatch(
-                                    pushBackNavigation({
-                                        backNavigation: {
-                                            backNavigation: ['/settings', 'reporting-tasks', taskId, 'edit'],
-                                            context: 'Reporting Task'
-                                        }
-                                    })
-                                );
+                            this.router.navigate(commands, {
+                                state: {
+                                    backNavigation: {
+                                        route: ['/settings', 'reporting-tasks', taskId, 'edit'],
+                                        routeBoundary: commandBoundary,
+                                        context: 'Reporting Task'
+                                    } as BackNavigation
+                                }
                             });
                         }
                     };
 
                     editDialogReference.componentInstance.goToService = (serviceId: string) => {
-                        const commands: string[] = ['/settings', 'management-controller-services', serviceId];
-                        goTo(commands, 'Controller Service');
+                        const commandBoundary: string[] = ['/settings', 'management-controller-services'];
+                        const commands: string[] = [...commandBoundary, serviceId];
+                        goTo(commands, 'Controller Service', commandBoundary);
                     };
 
                     editDialogReference.componentInstance.createNewService =
@@ -391,14 +386,16 @@ export class ReportingTasksEffects {
 
                     editDialogReference.componentInstance.editReportingTask
                         .pipe(takeUntil(editDialogReference.afterClosed()))
-                        .subscribe((updateControllerServiceRequest: UpdateControllerServiceRequest) => {
+                        .subscribe((updateReportingTaskRequest: UpdateReportingTaskRequest) => {
                             this.store.dispatch(
                                 ReportingTaskActions.configureReportingTask({
                                     request: {
                                         id: request.reportingTask.id,
                                         uri: request.reportingTask.uri,
-                                        payload: updateControllerServiceRequest.payload,
-                                        postUpdateNavigation: updateControllerServiceRequest.postUpdateNavigation
+                                        payload: updateReportingTaskRequest.payload,
+                                        postUpdateNavigation: updateReportingTaskRequest.postUpdateNavigation,
+                                        postUpdateNavigationBoundary:
+                                            updateReportingTaskRequest.postUpdateNavigationBoundary
                                     }
                                 })
                             );
@@ -434,7 +431,8 @@ export class ReportingTasksEffects {
                             response: {
                                 id: request.id,
                                 reportingTask: response,
-                                postUpdateNavigation: request.postUpdateNavigation
+                                postUpdateNavigation: request.postUpdateNavigation,
+                                postUpdateNavigationBoundary: request.postUpdateNavigationBoundary
                             }
                         })
                     ),
@@ -456,17 +454,15 @@ export class ReportingTasksEffects {
                 ofType(ReportingTaskActions.configureReportingTaskSuccess),
                 map((action) => action.response),
                 tap((response) => {
-                    if (response.postUpdateNavigation) {
-                        this.store.dispatch(preserveCurrentBackNavigation());
-                        this.router.navigate(response.postUpdateNavigation).then(() => {
-                            this.store.dispatch(
-                                pushBackNavigation({
-                                    backNavigation: {
-                                        backNavigation: ['/settings', 'reporting-tasks', response.id, 'edit'],
-                                        context: 'Reporting Task'
-                                    }
-                                })
-                            );
+                    if (response.postUpdateNavigation && response.postUpdateNavigationBoundary) {
+                        this.router.navigate(response.postUpdateNavigation, {
+                            state: {
+                                backNavigation: {
+                                    route: ['/settings', 'reporting-tasks', response.id, 'edit'],
+                                    routeBoundary: response.postUpdateNavigationBoundary,
+                                    context: 'Reporting Task'
+                                } as BackNavigation
+                            }
                         });
                     } else {
                         this.dialog.closeAll();

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/state/reporting-tasks/reporting-tasks.effects.ts
@@ -50,6 +50,7 @@ import {
     selectPropertyVerificationStatus
 } from '../../../../state/property-verification/property-verification.selectors';
 import { VerifyPropertiesRequestContext } from '../../../../state/property-verification';
+import { preserveCurrentBackNavigation, pushBackNavigation } from '../../../../state/navigation/navigation.actions';
 
 @Injectable()
 export class ReportingTasksEffects {
@@ -234,7 +235,39 @@ export class ReportingTasksEffects {
                 ofType(ReportingTaskActions.navigateToAdvancedReportingTaskUi),
                 map((action) => action.id),
                 tap((id) => {
-                    this.router.navigate(['/settings', 'reporting-tasks', id, 'advanced']);
+                    this.store.dispatch(preserveCurrentBackNavigation());
+                    this.router.navigate(['/settings', 'reporting-tasks', id, 'advanced']).then(() => {
+                        this.store.dispatch(
+                            pushBackNavigation({
+                                backNavigation: {
+                                    backNavigation: ['/settings', 'reporting-tasks', id],
+                                    context: 'Reporting Task'
+                                }
+                            })
+                        );
+                    });
+                })
+            ),
+        { dispatch: false }
+    );
+
+    navigateToManageAccessPolicies$ = createEffect(
+        () =>
+            this.actions$.pipe(
+                ofType(ReportingTaskActions.navigateToManageAccessPolicies),
+                map((action) => action.id),
+                tap((id) => {
+                    this.store.dispatch(preserveCurrentBackNavigation());
+                    this.router.navigate(['/access-policies', 'read', 'component', 'reporting-tasks', id]).then(() => {
+                        this.store.dispatch(
+                            pushBackNavigation({
+                                backNavigation: {
+                                    backNavigation: ['/settings', 'reporting-tasks', id],
+                                    context: 'Reporting Task'
+                                }
+                            })
+                        );
+                    });
                 })
             ),
         { dispatch: false }
@@ -317,10 +350,30 @@ export class ReportingTasksEffects {
                             });
 
                             saveChangesDialogReference.componentInstance.no.pipe(take(1)).subscribe(() => {
-                                this.router.navigate(commands);
+                                this.store.dispatch(preserveCurrentBackNavigation());
+                                this.router.navigate(commands).then(() => {
+                                    this.store.dispatch(
+                                        pushBackNavigation({
+                                            backNavigation: {
+                                                backNavigation: ['/settings', 'reporting-tasks', taskId, 'edit'],
+                                                context: 'Reporting Task'
+                                            }
+                                        })
+                                    );
+                                });
                             });
                         } else {
-                            this.router.navigate(commands);
+                            this.store.dispatch(preserveCurrentBackNavigation());
+                            this.router.navigate(commands).then(() => {
+                                this.store.dispatch(
+                                    pushBackNavigation({
+                                        backNavigation: {
+                                            backNavigation: ['/settings', 'reporting-tasks', taskId, 'edit'],
+                                            context: 'Reporting Task'
+                                        }
+                                    })
+                                );
+                            });
                         }
                     };
 
@@ -404,7 +457,17 @@ export class ReportingTasksEffects {
                 map((action) => action.response),
                 tap((response) => {
                     if (response.postUpdateNavigation) {
-                        this.router.navigate(response.postUpdateNavigation);
+                        this.store.dispatch(preserveCurrentBackNavigation());
+                        this.router.navigate(response.postUpdateNavigation).then(() => {
+                            this.store.dispatch(
+                                pushBackNavigation({
+                                    backNavigation: {
+                                        backNavigation: ['/settings', 'reporting-tasks', response.id, 'edit'],
+                                        context: 'Reporting Task'
+                                    }
+                                })
+                            );
+                        });
                     } else {
                         this.dialog.closeAll();
                     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/edit-flow-analysis-rule/edit-flow-analysis-rule.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/edit-flow-analysis-rule/edit-flow-analysis-rule.component.ts
@@ -140,7 +140,7 @@ export class EditFlowAnalysisRule extends TabbedDialog {
         return this.nifiCommon.formatBundle(entity.component.bundle);
     }
 
-    submitForm(postUpdateNavigation?: string[]) {
+    submitForm(postUpdateNavigation?: string[], postUpdateNavigationBoundary?: string[]) {
         const payload: any = {
             revision: this.client.getRevision(this.request.flowAnalysisRule),
             disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged(),
@@ -164,7 +164,8 @@ export class EditFlowAnalysisRule extends TabbedDialog {
 
         this.editFlowAnalysisRule.next({
             payload,
-            postUpdateNavigation
+            postUpdateNavigation,
+            postUpdateNavigationBoundary
         });
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.ts
@@ -111,11 +111,17 @@ export class FlowAnalysisRules implements OnInit, OnDestroy {
     viewFlowAnalysisRuleDocumentation(entity: FlowAnalysisRuleEntity): void {
         this.store.dispatch(
             navigateToComponentDocumentation({
-                params: {
-                    select: entity.component.type,
-                    group: entity.component.bundle.group,
-                    artifact: entity.component.bundle.artifact,
-                    version: entity.component.bundle.version
+                request: {
+                    backNavigation: {
+                        backNavigation: ['/settings', 'flow-analysis-rules', entity.id],
+                        context: 'Flow Analysis Rule'
+                    },
+                    parameters: {
+                        select: entity.component.type,
+                        group: entity.component.bundle.group,
+                        artifact: entity.component.bundle.artifact,
+                        version: entity.component.bundle.version
+                    }
                 }
             })
         );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/flow-analysis-rules/flow-analysis-rules.component.ts
@@ -113,7 +113,8 @@ export class FlowAnalysisRules implements OnInit, OnDestroy {
             navigateToComponentDocumentation({
                 request: {
                     backNavigation: {
-                        backNavigation: ['/settings', 'flow-analysis-rules', entity.id],
+                        route: ['/settings', 'flow-analysis-rules', entity.id],
+                        routeBoundary: ['/documentation'],
                         context: 'Flow Analysis Rule'
                     },
                     parameters: {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.html
@@ -42,6 +42,7 @@
                         (selectControllerService)="selectControllerService($event)"
                         (viewControllerServiceDocumentation)="viewControllerServiceDocumentation($event)"
                         (configureControllerService)="configureControllerService($event)"
+                        (manageAccessPolicies)="navigateToManageComponentPolicies($event)"
                         (openAdvancedUi)="openAdvancedUi($event)"
                         (enableControllerService)="enableControllerService($event)"
                         (disableControllerService)="disableControllerService($event)"

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.ts
@@ -28,6 +28,7 @@ import {
     loadManagementControllerServices,
     navigateToAdvancedServiceUi,
     navigateToEditService,
+    navigateToManageComponentPolicies,
     openChangeMgtControllerServiceVersionDialog,
     openConfigureControllerServiceDialog,
     openDisableControllerServiceDialog,
@@ -47,6 +48,7 @@ import { selectFlowConfiguration } from '../../../../state/flow-configuration/fl
 import { CurrentUser } from '../../../../state/current-user';
 import { getComponentStateAndOpenDialog } from '../../../../state/component-state/component-state.actions';
 import { navigateToComponentDocumentation } from '../../../../state/documentation/documentation.actions';
+import { popBackNavigation } from '../../../../state/navigation/navigation.actions';
 
 @Component({
     selector: 'management-controller-services',
@@ -114,11 +116,17 @@ export class ManagementControllerServices implements OnInit, OnDestroy {
     viewControllerServiceDocumentation(entity: ControllerServiceEntity): void {
         this.store.dispatch(
             navigateToComponentDocumentation({
-                params: {
-                    select: entity.component.type,
-                    group: entity.component.bundle.group,
-                    artifact: entity.component.bundle.artifact,
-                    version: entity.component.bundle.version
+                request: {
+                    backNavigation: {
+                        backNavigation: ['/settings', 'management-controller-services', entity.id],
+                        context: 'Controller Service'
+                    },
+                    parameters: {
+                        select: entity.component.type,
+                        group: entity.component.bundle.group,
+                        artifact: entity.component.bundle.artifact,
+                        version: entity.component.bundle.version
+                    }
                 }
             })
         );
@@ -127,6 +135,14 @@ export class ManagementControllerServices implements OnInit, OnDestroy {
     configureControllerService(entity: ControllerServiceEntity): void {
         this.store.dispatch(
             navigateToEditService({
+                id: entity.id
+            })
+        );
+    }
+
+    navigateToManageComponentPolicies(entity: ControllerServiceEntity): void {
+        this.store.dispatch(
+            navigateToManageComponentPolicies({
                 id: entity.id
             })
         );
@@ -214,5 +230,6 @@ export class ManagementControllerServices implements OnInit, OnDestroy {
 
     ngOnDestroy(): void {
         this.store.dispatch(resetManagementControllerServicesState());
+        this.store.dispatch(popBackNavigation());
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/management-controller-services/management-controller-services.component.ts
@@ -48,7 +48,6 @@ import { selectFlowConfiguration } from '../../../../state/flow-configuration/fl
 import { CurrentUser } from '../../../../state/current-user';
 import { getComponentStateAndOpenDialog } from '../../../../state/component-state/component-state.actions';
 import { navigateToComponentDocumentation } from '../../../../state/documentation/documentation.actions';
-import { popBackNavigation } from '../../../../state/navigation/navigation.actions';
 
 @Component({
     selector: 'management-controller-services',
@@ -118,7 +117,8 @@ export class ManagementControllerServices implements OnInit, OnDestroy {
             navigateToComponentDocumentation({
                 request: {
                     backNavigation: {
-                        backNavigation: ['/settings', 'management-controller-services', entity.id],
+                        route: ['/settings', 'management-controller-services', entity.id],
+                        routeBoundary: ['/documentation'],
                         context: 'Controller Service'
                     },
                     parameters: {
@@ -230,6 +230,5 @@ export class ManagementControllerServices implements OnInit, OnDestroy {
 
     ngOnDestroy(): void {
         this.store.dispatch(resetManagementControllerServicesState());
-        this.store.dispatch(popBackNavigation());
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/edit-parameter-provider/edit-parameter-provider.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/edit-parameter-provider/edit-parameter-provider.component.ts
@@ -129,7 +129,7 @@ export class EditParameterProvider extends TabbedDialog {
         return this.nifiCommon.formatBundle(entity.component.bundle);
     }
 
-    submitForm(postUpdateNavigation?: string[]) {
+    submitForm(postUpdateNavigation?: string[], postUpdateNavigationBoundary?: string[]) {
         const payload: any = {
             revision: this.client.getRevision(this.request.parameterProvider),
             disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged(),
@@ -151,7 +151,8 @@ export class EditParameterProvider extends TabbedDialog {
 
         this.editParameterProvider.next({
             payload,
-            postUpdateNavigation
+            postUpdateNavigation,
+            postUpdateNavigationBoundary
         });
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers-table/parameter-providers-table.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers-table/parameter-providers-table.component.html
@@ -134,10 +134,7 @@
                                         </button>
                                     }
                                     @if (canManageAccessPolicies()) {
-                                        <button
-                                            mat-menu-item
-                                            (click)="$event.stopPropagation()"
-                                            [routerLink]="getPolicyLink(item)">
+                                        <button mat-menu-item (click)="manageAccessPoliciesClicked(item)">
                                             <i class="fa fa-key primary-color mr-2"></i>
                                             Manage Access Policies
                                         </button>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers-table/parameter-providers-table.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers-table/parameter-providers-table.component.ts
@@ -212,7 +212,7 @@ export class ParameterProvidersTable {
         this.deleteParameterProvider.next(entity);
     }
 
-    getPolicyLink(entity: ParameterProviderEntity): string[] {
-        return ['/access-policies', 'read', 'component', 'parameter-providers', entity.id];
+    manageAccessPoliciesClicked(entity: ParameterProviderEntity) {
+        this.manageAccessPolicies.next(entity);
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers.component.html
@@ -43,6 +43,7 @@
                         (deleteParameterProvider)="deleteParameterProvider($event)"
                         (configureParameterProvider)="openConfigureParameterProviderDialog($event)"
                         (openAdvancedUi)="openAdvancedUi($event)"
+                        (manageAccessPolicies)="navigateToManageAccessPolicies($event)"
                         (fetchParameterProvider)="fetchParameterProviderParameters($event)"
                         (viewParameterProviderDocumentation)="viewParameterProviderDocumentation($event)"
                         (selectParameterProvider)="selectParameterProvider($event)"></parameter-providers-table>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers.component.ts
@@ -150,7 +150,8 @@ export class ParameterProviders implements OnInit, OnDestroy {
             navigateToComponentDocumentation({
                 request: {
                     backNavigation: {
-                        backNavigation: ['/settings', 'parameter-providers', parameterProvider.id],
+                        route: ['/settings', 'parameter-providers', parameterProvider.id],
+                        routeBoundary: ['/documentation'],
                         context: 'Parameter Provider'
                     },
                     parameters: {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/parameter-providers/parameter-providers.component.ts
@@ -137,14 +137,28 @@ export class ParameterProviders implements OnInit, OnDestroy {
         );
     }
 
+    navigateToManageAccessPolicies(parameterProvider: ParameterProviderEntity) {
+        this.store.dispatch(
+            ParameterProviderActions.navigateToManageAccessPolicies({
+                id: parameterProvider.id
+            })
+        );
+    }
+
     viewParameterProviderDocumentation(parameterProvider: ParameterProviderEntity): void {
         this.store.dispatch(
             navigateToComponentDocumentation({
-                params: {
-                    select: parameterProvider.component.type,
-                    group: parameterProvider.component.bundle.group,
-                    artifact: parameterProvider.component.bundle.artifact,
-                    version: parameterProvider.component.bundle.version
+                request: {
+                    backNavigation: {
+                        backNavigation: ['/settings', 'parameter-providers', parameterProvider.id],
+                        context: 'Parameter Provider'
+                    },
+                    parameters: {
+                        select: parameterProvider.component.type,
+                        group: parameterProvider.component.bundle.group,
+                        artifact: parameterProvider.component.bundle.artifact,
+                        version: parameterProvider.component.bundle.version
+                    }
                 }
             })
         );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/registry-clients/edit-registry-client/edit-registry-client.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/registry-clients/edit-registry-client/edit-registry-client.component.ts
@@ -105,7 +105,7 @@ export class EditRegistryClient extends TabbedDialog {
         return this.nifiCommon.formatType(entity.component);
     }
 
-    submitForm(postUpdateNavigation?: string[]) {
+    submitForm(postUpdateNavigation?: string[], postUpdateNavigationBoundary?: string[]) {
         const payload: any = {
             revision: this.client.getRevision(this.request.registryClient),
             disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged(),
@@ -132,7 +132,8 @@ export class EditRegistryClient extends TabbedDialog {
             id: this.request.registryClient.id,
             uri: this.request.registryClient.uri,
             payload,
-            postUpdateNavigation
+            postUpdateNavigation,
+            postUpdateNavigationBoundary
         });
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/edit-reporting-task/edit-reporting-task.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/edit-reporting-task/edit-reporting-task.component.ts
@@ -179,7 +179,7 @@ export class EditReportingTask extends TabbedDialog {
         return this.nifiCommon.formatBundle(entity.component.bundle);
     }
 
-    submitForm(postUpdateNavigation?: string[]) {
+    submitForm(postUpdateNavigation?: string[], postUpdateNavigationBoundary?: string[]) {
         const payload: any = {
             revision: this.client.getRevision(this.request.reportingTask),
             disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged(),
@@ -204,7 +204,8 @@ export class EditReportingTask extends TabbedDialog {
 
         this.editReportingTask.next({
             payload,
-            postUpdateNavigation
+            postUpdateNavigation,
+            postUpdateNavigationBoundary
         });
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-task-table/reporting-task-table.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-task-table/reporting-task-table.component.html
@@ -160,10 +160,7 @@
                                 </button>
                             }
                             @if (canManageAccessPolicies()) {
-                                <button
-                                    mat-menu-item
-                                    (click)="$event.stopPropagation()"
-                                    [routerLink]="getPolicyLink(item)">
+                                <button mat-menu-item (click)="managedAccessPoliciesClicked(item)">
                                     <i class="fa fa-key primary-color mr-2"></i>
                                     Manage Access Policies
                                 </button>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-task-table/reporting-task-table.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-task-table/reporting-task-table.component.ts
@@ -55,6 +55,7 @@ export class ReportingTaskTable {
     @Output() startReportingTask: EventEmitter<ReportingTaskEntity> = new EventEmitter<ReportingTaskEntity>();
     @Output() configureReportingTask: EventEmitter<ReportingTaskEntity> = new EventEmitter<ReportingTaskEntity>();
     @Output() openAdvancedUi: EventEmitter<ReportingTaskEntity> = new EventEmitter<ReportingTaskEntity>();
+    @Output() manageAccessPolicies: EventEmitter<ReportingTaskEntity> = new EventEmitter<ReportingTaskEntity>();
     @Output() viewStateReportingTask: EventEmitter<ReportingTaskEntity> = new EventEmitter<ReportingTaskEntity>();
     @Output() stopReportingTask: EventEmitter<ReportingTaskEntity> = new EventEmitter<ReportingTaskEntity>();
     @Output() changeReportingTaskVersion: EventEmitter<ReportingTaskEntity> = new EventEmitter<ReportingTaskEntity>();
@@ -253,8 +254,8 @@ export class ReportingTaskTable {
         return this.flowConfiguration.supportsManagedAuthorizer && this.currentUser.tenantsPermissions.canRead;
     }
 
-    getPolicyLink(entity: ReportingTaskEntity): string[] {
-        return ['/access-policies', 'read', 'component', 'reporting-tasks', entity.id];
+    managedAccessPoliciesClicked(entity: ReportingTaskEntity): void {
+        this.manageAccessPolicies.next(entity);
     }
 
     select(entity: ReportingTaskEntity): void {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.html
@@ -38,6 +38,7 @@
                         [flowConfiguration]="(flowConfiguration$ | async)!"
                         (configureReportingTask)="configureReportingTask($event)"
                         (openAdvancedUi)="openAdvancedUi($event)"
+                        (manageAccessPolicies)="navigateToManageAccessPolicies($event)"
                         (viewStateReportingTask)="viewStateReportingTask($event)"
                         (selectReportingTask)="selectReportingTask($event)"
                         (viewReportingTaskDocumentation)="viewReportingTaskDocumentation($event)"

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.ts
@@ -30,6 +30,7 @@ import {
     loadReportingTasks,
     navigateToAdvancedReportingTaskUi,
     navigateToEditReportingTask,
+    navigateToManageAccessPolicies,
     openChangeReportingTaskVersionDialog,
     openConfigureReportingTaskDialog,
     openNewReportingTaskDialog,
@@ -119,14 +120,28 @@ export class ReportingTasks implements OnInit, OnDestroy {
         );
     }
 
+    navigateToManageAccessPolicies(entity: ReportingTaskEntity): void {
+        this.store.dispatch(
+            navigateToManageAccessPolicies({
+                id: entity.id
+            })
+        );
+    }
+
     viewReportingTaskDocumentation(entity: ReportingTaskEntity): void {
         this.store.dispatch(
             navigateToComponentDocumentation({
-                params: {
-                    select: entity.component.type,
-                    group: entity.component.bundle.group,
-                    artifact: entity.component.bundle.artifact,
-                    version: entity.component.bundle.version
+                request: {
+                    backNavigation: {
+                        backNavigation: ['/settings', 'reporting-tasks', entity.id],
+                        context: 'Reporting Task'
+                    },
+                    parameters: {
+                        select: entity.component.type,
+                        group: entity.component.bundle.group,
+                        artifact: entity.component.bundle.artifact,
+                        version: entity.component.bundle.version
+                    }
                 }
             })
         );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/settings/ui/reporting-tasks/reporting-tasks.component.ts
@@ -133,7 +133,8 @@ export class ReportingTasks implements OnInit, OnDestroy {
             navigateToComponentDocumentation({
                 request: {
                     backNavigation: {
-                        backNavigation: ['/settings', 'reporting-tasks', entity.id],
+                        route: ['/settings', 'reporting-tasks', entity.id],
+                        routeBoundary: ['/documentation'],
                         context: 'Reporting Task'
                     },
                     parameters: {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/documentation/documentation.effects.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/documentation/documentation.effects.ts
@@ -20,16 +20,12 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import * as DocumentationActions from './documentation.actions';
 import { map, tap } from 'rxjs';
 import { Router } from '@angular/router';
-import { Store } from '@ngrx/store';
-import { NiFiState } from '../index';
-import { preserveCurrentBackNavigation, pushBackNavigation } from '../navigation/navigation.actions';
 
 @Injectable()
 export class DocumentationEffects {
     constructor(
         private actions$: Actions,
-        private router: Router,
-        private store: Store<NiFiState>
+        private router: Router
     ) {}
 
     navigateToComponentDocumentation$ = createEffect(
@@ -38,10 +34,9 @@ export class DocumentationEffects {
                 ofType(DocumentationActions.navigateToComponentDocumentation),
                 map((action) => action.request),
                 tap((request) => {
-                    this.store.dispatch(preserveCurrentBackNavigation());
-                    this.router.navigate(['/documentation']).then(() => {
-                        if (request.backNavigation) {
-                            this.store.dispatch(pushBackNavigation({ backNavigation: request.backNavigation }));
+                    this.router.navigate(['/documentation'], {
+                        state: {
+                            backNavigation: request.backNavigation
                         }
                     });
                 })

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/index.ts
@@ -43,6 +43,8 @@ import { loginConfigurationFeatureKey, LoginConfigurationState } from './login-c
 import { loginConfigurationReducer } from './login-configuration/login-configuration.reducer';
 import { propertyVerificationFeatureKey, PropertyVerificationState } from './property-verification';
 import { propertyVerificationReducer } from './property-verification/property-verification.reducer';
+import { navigationFeatureKey, NavigationState } from './navigation';
+import { navigationReducer } from './navigation/navigation.reducer';
 
 export interface NiFiState {
     [DEFAULT_ROUTER_FEATURENAME]: RouterReducerState;
@@ -50,6 +52,7 @@ export interface NiFiState {
     [currentUserFeatureKey]: CurrentUserState;
     [extensionTypesFeatureKey]: ExtensionTypesState;
     [aboutFeatureKey]: AboutState;
+    [navigationFeatureKey]: NavigationState;
     [flowConfigurationFeatureKey]: FlowConfigurationState;
     [loginConfigurationFeatureKey]: LoginConfigurationState;
     [statusHistoryFeatureKey]: StatusHistoryState;
@@ -67,6 +70,7 @@ export const rootReducers: ActionReducerMap<NiFiState> = {
     [currentUserFeatureKey]: currentUserReducer,
     [extensionTypesFeatureKey]: extensionTypesReducer,
     [aboutFeatureKey]: aboutReducer,
+    [navigationFeatureKey]: navigationReducer,
     [flowConfigurationFeatureKey]: flowConfigurationReducer,
     [loginConfigurationFeatureKey]: loginConfigurationReducer,
     [statusHistoryFeatureKey]: statusHistoryReducer,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/index.ts
@@ -18,11 +18,11 @@
 export const navigationFeatureKey = 'navigation';
 
 export interface BackNavigation {
-    backNavigation: string[];
+    route: string[];
+    routeBoundary: string[];
     context: string;
 }
 
 export interface NavigationState {
     backNavigations: BackNavigation[];
-    preserveState: boolean;
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/index.ts
@@ -15,19 +15,14 @@
  * limitations under the License.
  */
 
-import { BackNavigation } from '../navigation';
+export const navigationFeatureKey = 'navigation';
 
-export const documentationFeatureKey = 'documentation';
-
-export interface DocumentationRequest {
-    backNavigation?: BackNavigation;
-    parameters: DocumentationParameters;
+export interface BackNavigation {
+    backNavigation: string[];
+    context: string;
 }
 
-export interface DocumentationParameters {
-    [key: string]: string;
-}
-
-export interface DocumentationState {
-    documentationParameters: DocumentationParameters | null;
+export interface NavigationState {
+    backNavigations: BackNavigation[];
+    preserveState: boolean;
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.actions.ts
@@ -24,3 +24,5 @@ export const pushBackNavigation = createAction(
 );
 
 export const popBackNavigation = createAction('[Navigation] Pop Back Navigation');
+
+export const resetBackNavigation = createAction('[Navigation] Reset Back Navigation');

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.actions.ts
@@ -18,14 +18,6 @@
 import { createAction, props } from '@ngrx/store';
 import { BackNavigation } from './index';
 
-/**
- * The preserveCurrentBackNavigation should be used prior to navigating where a new Back Navigation will be pushed
- * after routing completes. This is needed because by default the Back Navigation will be popped when the Navigation
- * bar is destroy. By preserve the current Back Navigation, the current Back Navigation will not be popped allowing
- * for multiple Back Navigation to be possible.
- */
-export const preserveCurrentBackNavigation = createAction('[Navigation] Preserve Current Back Navigation');
-
 export const pushBackNavigation = createAction(
     '[Navigation] Push Back Navigation',
     props<{ backNavigation: BackNavigation }>()

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.actions.ts
@@ -16,13 +16,19 @@
  */
 
 import { createAction, props } from '@ngrx/store';
-import { DocumentationRequest } from './index';
+import { BackNavigation } from './index';
 
-export const navigateToComponentDocumentation = createAction(
-    '[Documentation] Navigate To Component Documentation',
-    props<{
-        request: DocumentationRequest;
-    }>()
+/**
+ * The preserveCurrentBackNavigation should be used prior to navigating where a new Back Navigation will be pushed
+ * after routing completes. This is needed because by default the Back Navigation will be popped when the Navigation
+ * bar is destroy. By preserve the current Back Navigation, the current Back Navigation will not be popped allowing
+ * for multiple Back Navigation to be possible.
+ */
+export const preserveCurrentBackNavigation = createAction('[Navigation] Preserve Current Back Navigation');
+
+export const pushBackNavigation = createAction(
+    '[Navigation] Push Back Navigation',
+    props<{ backNavigation: BackNavigation }>()
 );
 
-export const clearDocumentationParameters = createAction('[Documentation] Clear Documentation Parameters');
+export const popBackNavigation = createAction('[Navigation] Pop Back Navigation');

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.actions.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.actions.ts
@@ -23,6 +23,4 @@ export const pushBackNavigation = createAction(
     props<{ backNavigation: BackNavigation }>()
 );
 
-export const popBackNavigation = createAction('[Navigation] Pop Back Navigation');
-
-export const resetBackNavigation = createAction('[Navigation] Reset Back Navigation');
+export const popBackNavigation = createAction('[Navigation] Pop Back Navigation', props<{ url: string }>());

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.reducer.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.reducer.ts
@@ -16,21 +16,32 @@
  */
 
 import { createReducer, on } from '@ngrx/store';
-import { DocumentationState } from './index';
-import { clearDocumentationParameters, navigateToComponentDocumentation } from './documentation.actions';
+import { NavigationState } from './index';
+import { popBackNavigation, preserveCurrentBackNavigation, pushBackNavigation } from './navigation.actions';
+import { produce } from 'immer';
 
-export const initialState: DocumentationState = {
-    documentationParameters: null
+export const initialState: NavigationState = {
+    backNavigations: [],
+    preserveState: false
 };
 
-export const documentationReducer = createReducer(
+export const navigationReducer = createReducer(
     initialState,
-    on(navigateToComponentDocumentation, (state, { request }) => ({
+    on(preserveCurrentBackNavigation, (state) => ({
         ...state,
-        documentationParameters: request.parameters
+        preserveState: true
     })),
-    on(clearDocumentationParameters, (state) => ({
-        ...state,
-        documentationParameters: null
-    }))
+    on(pushBackNavigation, (state, { backNavigation }) => {
+        return produce(state, (draftState) => {
+            draftState.backNavigations.push(backNavigation);
+        });
+    }),
+    on(popBackNavigation, (state) => {
+        return produce(state, (draftState) => {
+            if (draftState.backNavigations.length > 0 && !draftState.preserveState) {
+                draftState.backNavigations.pop();
+            }
+            draftState.preserveState = false;
+        });
+    })
 );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.reducer.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.reducer.ts
@@ -28,7 +28,14 @@ export const navigationReducer = createReducer(
     initialState,
     on(pushBackNavigation, (state, { backNavigation }) => {
         return produce(state, (draftState) => {
-            draftState.backNavigations.push(backNavigation);
+            if (draftState.backNavigations.length > 0) {
+                const currentBackNavigation = draftState.backNavigations[draftState.backNavigations.length - 1];
+                if (routesNotEqual(currentBackNavigation.route, backNavigation.route)) {
+                    draftState.backNavigations.push(backNavigation);
+                }
+            } else {
+                draftState.backNavigations.push(backNavigation);
+            }
         });
     }),
     on(popBackNavigation, (state) => {
@@ -42,3 +49,17 @@ export const navigationReducer = createReducer(
         ...initialState
     }))
 );
+
+function routesNotEqual(route1: string[], route2: string[]) {
+    if (route1.length !== route2.length) {
+        return true;
+    }
+
+    for (let i = 0; i < route1.length; i++) {
+        if (route1[i] !== route2[i]) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.reducer.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.reducer.ts
@@ -17,20 +17,15 @@
 
 import { createReducer, on } from '@ngrx/store';
 import { NavigationState } from './index';
-import { popBackNavigation, preserveCurrentBackNavigation, pushBackNavigation } from './navigation.actions';
+import { popBackNavigation, pushBackNavigation } from './navigation.actions';
 import { produce } from 'immer';
 
 export const initialState: NavigationState = {
-    backNavigations: [],
-    preserveState: false
+    backNavigations: []
 };
 
 export const navigationReducer = createReducer(
     initialState,
-    on(preserveCurrentBackNavigation, (state) => ({
-        ...state,
-        preserveState: true
-    })),
     on(pushBackNavigation, (state, { backNavigation }) => {
         return produce(state, (draftState) => {
             draftState.backNavigations.push(backNavigation);
@@ -38,10 +33,9 @@ export const navigationReducer = createReducer(
     }),
     on(popBackNavigation, (state) => {
         return produce(state, (draftState) => {
-            if (draftState.backNavigations.length > 0 && !draftState.preserveState) {
+            if (draftState.backNavigations.length > 0) {
                 draftState.backNavigations.pop();
             }
-            draftState.preserveState = false;
         });
     })
 );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.reducer.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.reducer.ts
@@ -17,7 +17,7 @@
 
 import { createReducer, on } from '@ngrx/store';
 import { NavigationState } from './index';
-import { popBackNavigation, pushBackNavigation } from './navigation.actions';
+import { popBackNavigation, pushBackNavigation, resetBackNavigation } from './navigation.actions';
 import { produce } from 'immer';
 
 export const initialState: NavigationState = {
@@ -37,5 +37,8 @@ export const navigationReducer = createReducer(
                 draftState.backNavigations.pop();
             }
         });
-    })
+    }),
+    on(resetBackNavigation, () => ({
+        ...initialState
+    }))
 );

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.selectors.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/navigation/navigation.selectors.ts
@@ -15,19 +15,15 @@
  * limitations under the License.
  */
 
-import { BackNavigation } from '../navigation';
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { navigationFeatureKey, NavigationState } from './index';
 
-export const documentationFeatureKey = 'documentation';
+export const selectNavigationState = createFeatureSelector<NavigationState>(navigationFeatureKey);
 
-export interface DocumentationRequest {
-    backNavigation?: BackNavigation;
-    parameters: DocumentationParameters;
-}
+export const selectBackNavigation = createSelector(selectNavigationState, (state: NavigationState) => {
+    if (state.backNavigations.length > 0) {
+        return state.backNavigations[state.backNavigations.length - 1];
+    }
 
-export interface DocumentationParameters {
-    [key: string]: string;
-}
-
-export interface DocumentationState {
-    documentationParameters: DocumentationParameters | null;
-}
+    return null;
+});

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/shared/index.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/state/shared/index.ts
@@ -135,6 +135,7 @@ export interface EditControllerServiceDialogRequest {
 export interface UpdateControllerServiceRequest {
     payload: any;
     postUpdateNavigation?: string[];
+    postUpdateNavigationBoundary?: string[];
 }
 
 export interface SetEnableControllerServiceDialogRequest {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/advanced-ui/advanced-ui.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/advanced-ui/advanced-ui.component.spec.ts
@@ -21,16 +21,18 @@ import { AdvancedUi } from './advanced-ui.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Component } from '@angular/core';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../state/documentation/documentation.reducer';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { selectCurrentUser } from '../../../state/current-user/current-user.selectors';
 import * as fromUser from '../../../state/current-user/current-user.reducer';
+import * as fromNavigation from '../../../state/navigation/navigation.reducer';
 import { selectClusterSummary } from '../../../state/cluster-summary/cluster-summary.selectors';
 import * as fromClusterSummary from '../../../state/cluster-summary/cluster-summary.reducer';
 import { selectFlowConfiguration } from '../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../state/flow-configuration/flow-configuration.reducer';
 import { selectLoginConfiguration } from '../../../state/login-configuration/login-configuration.selectors';
 import * as fromLoginConfiguration from '../../../state/login-configuration/login-configuration.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
+import { navigationFeatureKey } from '../../../state/navigation';
 
 describe('AdvancedUi', () => {
     let component: AdvancedUi;
@@ -48,7 +50,10 @@ describe('AdvancedUi', () => {
             imports: [AdvancedUi, HttpClientTestingModule, RouterTestingModule, MockNavigation],
             providers: [
                 provideMockStore({
-                    initialState,
+                    initialState: {
+                        [currentUserFeatureKey]: fromUser.initialState,
+                        [navigationFeatureKey]: fromNavigation.initialState
+                    },
                     selectors: [
                         {
                             selector: selectCurrentUser,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/context-menu/context-menu.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/context-menu/context-menu.component.html
@@ -28,8 +28,10 @@
                 @if (hasSubMenu(item)) {
                     @if (menuComponent.menu; as subMenu) {
                         <button class="context-menu-item pl-1 pr-1 pt-2 pb-2" cdkMenuItem [cdkMenuTriggerFor]="subMenu">
-                            <div class="context-menu-item-img" [class]="item.clazz"></div>
-                            <div class="context-menu-item-text surface-contrast">{{ item.text }}</div>
+                            <div class="flex gap-x-1">
+                                <div class="context-menu-item-img" [class]="item.clazz"></div>
+                                <div class="context-menu-item-text surface-contrast">{{ item.text }}</div>
+                            </div>
                             <div class="context-menu-group-item-img fa fa-caret-right"></div>
                         </button>
                     }
@@ -42,7 +44,7 @@
                         class="context-menu-item pl-1 pr-1 pt-2 pb-2 flex justify-between"
                         (click)="menuItemClicked(item, $event)"
                         cdkMenuItem>
-                        <div class="flex">
+                        <div class="flex gap-x-1">
                             <div class="context-menu-item-img" [class]="item.clazz"></div>
                             <div class="context-menu-item-text surface-contrast">{{ item.text }}</div>
                         </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.html
@@ -173,7 +173,7 @@
                                     </button>
                                 }
                             } @else {
-                                <button mat-menu-item [routerLink]="getServiceLink(item)">
+                                <button mat-menu-item (click)="goToControllerServiceClicked(item)">
                                     <i class="fa fa-long-arrow-right primary-color mr-2"></i>
                                     Go To
                                 </button>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.html
@@ -167,10 +167,7 @@
                                     </button>
                                 }
                                 @if (canManageAccessPolicies()) {
-                                    <button
-                                        mat-menu-item
-                                        (click)="$event.stopPropagation()"
-                                        [routerLink]="getPolicyLink(item)">
+                                    <button mat-menu-item (click)="manageAccessPoliciesClicked(item)">
                                         <i class="fa fa-key primary-color mr-2"></i>
                                         Manage Access Policies
                                     </button>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.ts
@@ -87,6 +87,8 @@ export class ControllerServiceTable {
         new EventEmitter<ControllerServiceEntity>();
     @Output() changeControllerServiceVersion: EventEmitter<ControllerServiceEntity> =
         new EventEmitter<ControllerServiceEntity>();
+    @Output() goToControllerService: EventEmitter<ControllerServiceEntity> =
+        new EventEmitter<ControllerServiceEntity>();
 
     protected readonly TextTip = TextTip;
     protected readonly BulletinsTip = BulletinsTip;
@@ -192,12 +194,8 @@ export class ControllerServiceTable {
         return this.canRead(entity) ? this.nifiCommon.formatBundle(entity.component.bundle) : '';
     }
 
-    getServiceLink(entity: ControllerServiceEntity): string[] {
-        if (entity.parentGroupId == null) {
-            return ['/settings', 'management-controller-services', entity.id];
-        } else {
-            return ['/process-groups', entity.parentGroupId, 'controller-services', entity.id];
-        }
+    goToControllerServiceClicked(entity: ControllerServiceEntity): void {
+        this.goToControllerService.next(entity);
     }
 
     isDisabled(entity: ControllerServiceEntity): boolean {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/controller-service-table/controller-service-table.component.ts
@@ -77,6 +77,7 @@ export class ControllerServiceTable {
         new EventEmitter<ControllerServiceEntity>();
     @Output() configureControllerService: EventEmitter<ControllerServiceEntity> =
         new EventEmitter<ControllerServiceEntity>();
+    @Output() manageAccessPolicies: EventEmitter<ControllerServiceEntity> = new EventEmitter<ControllerServiceEntity>();
     @Output() openAdvancedUi: EventEmitter<ControllerServiceEntity> = new EventEmitter<ControllerServiceEntity>();
     @Output() enableControllerService: EventEmitter<ControllerServiceEntity> =
         new EventEmitter<ControllerServiceEntity>();
@@ -259,6 +260,10 @@ export class ControllerServiceTable {
         this.deleteControllerService.next(entity);
     }
 
+    manageAccessPoliciesClicked(entity: ControllerServiceEntity): void {
+        this.manageAccessPolicies.next(entity);
+    }
+
     changeVersionClicked(entity: ControllerServiceEntity) {
         this.changeControllerServiceVersion.next(entity);
     }
@@ -273,10 +278,6 @@ export class ControllerServiceTable {
 
     canManageAccessPolicies(): boolean {
         return this.flowConfiguration.supportsManagedAuthorizer && this.currentUser.tenantsPermissions.canRead;
-    }
-
-    getPolicyLink(entity: ControllerServiceEntity): string[] {
-        return ['/access-policies', 'read', 'component', 'controller-services', entity.id];
     }
 
     select(entity: ControllerServiceEntity): void {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/edit-controller-service/edit-controller-service.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/controller-service/edit-controller-service/edit-controller-service.component.ts
@@ -166,7 +166,7 @@ export class EditControllerService extends TabbedDialog {
         return this.nifiCommon.formatBundle(entity.component.bundle);
     }
 
-    submitForm(postUpdateNavigation?: string[]) {
+    submitForm(postUpdateNavigation?: string[], postUpdateNavigationBoundary?: string[]) {
         const payload: any = {
             revision: this.client.getRevision(this.request.controllerService),
             disconnectedNodeAcknowledged: this.clusterConnectionService.isDisconnectionAcknowledged(),
@@ -188,7 +188,8 @@ export class EditControllerService extends TabbedDialog {
 
         this.editControllerService.next({
             payload,
-            postUpdateNavigation
+            postUpdateNavigation,
+            postUpdateNavigationBoundary
         });
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.html
@@ -193,7 +193,7 @@
     </nav>
     @if (backNavigation(); as navigation) {
         <div class="pl-2 py-2">
-            <a [routerLink]="navigation.route"
+            <a [routerLink]="navigation.route" [state]="{ executeBackNavigation: true }"
                 ><i class="fa fa-arrow-left primary-color mr-2"></i>Back to {{ navigation.context }}</a
             >
         </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.html
@@ -15,178 +15,187 @@
   ~ limitations under the License.
   -->
 
-<nav class="nifi-navigation select-none">
-    <div class="flex justify-between items-center h-16 pl-4">
-        <div class="flex">
-            <div class="h-16 w-28 mr-6 relative">
-                <img
-                    ngSrc="assets/icons/nifi-logo.svg"
-                    fill
-                    priority
-                    alt="NiFi Logo"
-                    class="pointer"
-                    [routerLink]="getCanvasLink()" />
-            </div>
-            <ng-content></ng-content>
-        </div>
-        @if (currentUser(); as user) {
-            <div class="flex justify-between items-center gap-x-1">
-                <div class="flex flex-col justify-between items-end gap-y-1">
-                    @if (!user.anonymous) {
-                        <div class="current-user">{{ user.identity }}</div>
-                    }
-                    @if (allowLogin(user)) {
-                        <a href="#">log in</a>
-                    }
-                    @if (user.logoutSupported) {
-                        <a (click)="logout()">log out</a>
-                    }
+<div class="flex flex-col">
+    <nav class="nifi-navigation select-none">
+        <div class="flex justify-between items-center h-16 pl-4">
+            <div class="flex">
+                <div class="h-16 w-28 mr-6 relative">
+                    <img
+                        ngSrc="assets/icons/nifi-logo.svg"
+                        fill
+                        priority
+                        alt="NiFi Logo"
+                        class="pointer"
+                        [routerLink]="getCanvasLink()" />
                 </div>
-                <button
-                    mat-button
-                    [matMenuTriggerFor]="globalMenu"
-                    class="h-16 w-16 flex items-center justify-center icon global-menu">
-                    <i class="fa fa-navicon"></i>
-                </button>
-                <mat-menu #globalMenu="matMenu" xPosition="before">
-                    <button mat-menu-item class="global-menu-item" [routerLink]="getCanvasLink()">
-                        <i class="icon icon-drop primary-color mr-2"></i>
-                        Canvas
-                    </button>
-                    <mat-divider></mat-divider>
-                    <button mat-menu-item class="global-menu-item" [routerLink]="['/summary']">
-                        <i class="fa fa-table primary-color mr-2"></i>
-                        Summary
-                    </button>
+                <ng-content></ng-content>
+            </div>
+            @if (currentUser(); as user) {
+                <div class="flex justify-between items-center gap-x-1">
+                    <div class="flex flex-col justify-between items-end gap-y-1">
+                        @if (!user.anonymous) {
+                            <div class="current-user">{{ user.identity }}</div>
+                        }
+                        @if (allowLogin(user)) {
+                            <a href="#">log in</a>
+                        }
+                        @if (user.logoutSupported) {
+                            <a (click)="logout()">log out</a>
+                        }
+                    </div>
                     <button
-                        mat-menu-item
-                        class="global-menu-item"
-                        [routerLink]="['/counters']"
-                        [disabled]="!user.countersPermissions.canRead">
-                        <i class="icon icon-counter primary-color mr-2"></i>
-                        Counter
+                        mat-button
+                        [matMenuTriggerFor]="globalMenu"
+                        class="h-16 w-16 flex items-center justify-center icon global-menu">
+                        <i class="fa fa-navicon"></i>
                     </button>
-                    <button mat-menu-item class="global-menu-item" [routerLink]="['/bulletins']">
-                        <i class="fa fa-sticky-note-o primary-color mr-2"></i>
-                        Bulletin Board
-                    </button>
-                    <mat-divider></mat-divider>
-                    <button
-                        mat-menu-item
-                        class="global-menu-item"
-                        [routerLink]="['/provenance']"
-                        [disabled]="!user.provenancePermissions.canRead">
-                        <i class="icon icon-provenance primary-color mr-2"></i>
-                        Data Provenance
-                    </button>
-                    <mat-divider></mat-divider>
-                    <button
-                        mat-menu-item
-                        class="global-menu-item"
-                        [routerLink]="['/settings']"
-                        [disabled]="!user.controllerPermissions.canRead">
-                        <i class="fa fa-wrench primary-color mr-2"></i>
-                        Controller Settings
-                    </button>
-                    <button mat-menu-item class="global-menu-item" [routerLink]="['/parameter-contexts']">
-                        <i class="fa mr-2"></i>
-                        Parameter Contexts
-                    </button>
-                    @if (clusterSummary()?.clustered) {
+                    <mat-menu #globalMenu="matMenu" xPosition="before">
+                        <button mat-menu-item class="global-menu-item" [routerLink]="getCanvasLink()">
+                            <i class="icon icon-drop primary-color mr-2"></i>
+                            Canvas
+                        </button>
+                        <mat-divider></mat-divider>
+                        <button mat-menu-item class="global-menu-item" [routerLink]="['/summary']">
+                            <i class="fa fa-table primary-color mr-2"></i>
+                            Summary
+                        </button>
                         <button
                             mat-menu-item
                             class="global-menu-item"
-                            [disabled]="!user.controllerPermissions.canRead"
-                            [routerLink]="['/cluster']">
-                            <i class="fa fa-cubes primary-color mr-2"></i>
-                            Cluster
+                            [routerLink]="['/counters']"
+                            [disabled]="!user.countersPermissions.canRead">
+                            <i class="icon icon-counter primary-color mr-2"></i>
+                            Counter
                         </button>
-                    }
-                    <button mat-menu-item class="global-menu-item" [routerLink]="['/flow-configuration-history']">
-                        <i class="fa fa-history primary-color mr-2"></i>
-                        Flow Configuration History
-                    </button>
-                    <button mat-menu-item class="global-menu-item" (click)="viewNodeStatusHistory()">
-                        <i class="fa fa-area-chart primary-color mr-2"></i>
-                        Node Status History
-                    </button>
-                    <button
-                        mat-menu-item
-                        class="global-menu-item"
-                        [disabled]="!user.systemPermissions.canRead"
-                        (click)="viewSystemDiagnostics()">
-                        <i class="fa mr-2"></i>
-                        System Diagnostics
-                    </button>
-                    @if (flowConfiguration(); as flowConfig) {
-                        @if (flowConfig.supportsManagedAuthorizer) {
-                            <mat-divider></mat-divider>
+                        <button mat-menu-item class="global-menu-item" [routerLink]="['/bulletins']">
+                            <i class="fa fa-sticky-note-o primary-color mr-2"></i>
+                            Bulletin Board
+                        </button>
+                        <mat-divider></mat-divider>
+                        <button
+                            mat-menu-item
+                            class="global-menu-item"
+                            [routerLink]="['/provenance']"
+                            [disabled]="!user.provenancePermissions.canRead">
+                            <i class="icon icon-provenance primary-color mr-2"></i>
+                            Data Provenance
+                        </button>
+                        <mat-divider></mat-divider>
+                        <button
+                            mat-menu-item
+                            class="global-menu-item"
+                            [routerLink]="['/settings']"
+                            [disabled]="!user.controllerPermissions.canRead">
+                            <i class="fa fa-wrench primary-color mr-2"></i>
+                            Controller Settings
+                        </button>
+                        <button mat-menu-item class="global-menu-item" [routerLink]="['/parameter-contexts']">
+                            <i class="fa mr-2"></i>
+                            Parameter Contexts
+                        </button>
+                        @if (clusterSummary()?.clustered) {
                             <button
                                 mat-menu-item
                                 class="global-menu-item"
-                                [routerLink]="['/users']"
-                                [disabled]="!user.tenantsPermissions.canRead">
-                                <i class="fa fa-users primary-color mr-2"></i>
-                                Users
+                                [disabled]="!user.controllerPermissions.canRead"
+                                [routerLink]="['/cluster']">
+                                <i class="fa fa-cubes primary-color mr-2"></i>
+                                Cluster
                             </button>
-                            <button
-                                mat-menu-item
-                                class="global-menu-item"
-                                [routerLink]="['/access-policies', 'global']"
-                                [disabled]="
-                                    !user.tenantsPermissions.canRead ||
-                                    !user.policiesPermissions.canRead ||
-                                    !user.policiesPermissions.canWrite
-                                ">
-                                <i class="fa fa-key primary-color mr-2"></i>
-                                Policies
-                            </button>
-                            <mat-divider></mat-divider>
                         }
-                    }
-                    <button mat-menu-item class="global-menu-item" [routerLink]="['/documentation']">
-                        <i class="fa fa-question-circle primary-color mr-2"></i>
-                        Help
-                    </button>
-                    <button mat-menu-item class="global-menu-item" (click)="viewAbout()">
-                        <i class="fa fa-info-circle primary-color mr-2"></i>
-                        About
-                    </button>
-                    <button mat-menu-item [matMenuTriggerFor]="theming">
-                        <i class="fa mr-2"></i>
-                        Appearance
-                    </button>
-                </mat-menu>
-                <mat-menu #theming="matMenu" xPosition="before">
-                    <button mat-menu-item class="global-menu-item" (click)="toggleTheme(LIGHT_THEME)">
-                        @if (theme === LIGHT_THEME) {
-                            <i class="fa fa-check primary-color mr-2"></i>
-                        }
-                        @if (theme !== LIGHT_THEME) {
+                        <button mat-menu-item class="global-menu-item" [routerLink]="['/flow-configuration-history']">
+                            <i class="fa fa-history primary-color mr-2"></i>
+                            Flow Configuration History
+                        </button>
+                        <button mat-menu-item class="global-menu-item" (click)="viewNodeStatusHistory()">
+                            <i class="fa fa-area-chart primary-color mr-2"></i>
+                            Node Status History
+                        </button>
+                        <button
+                            mat-menu-item
+                            class="global-menu-item"
+                            [disabled]="!user.systemPermissions.canRead"
+                            (click)="viewSystemDiagnostics()">
                             <i class="fa mr-2"></i>
+                            System Diagnostics
+                        </button>
+                        @if (flowConfiguration(); as flowConfig) {
+                            @if (flowConfig.supportsManagedAuthorizer) {
+                                <mat-divider></mat-divider>
+                                <button
+                                    mat-menu-item
+                                    class="global-menu-item"
+                                    [routerLink]="['/users']"
+                                    [disabled]="!user.tenantsPermissions.canRead">
+                                    <i class="fa fa-users primary-color mr-2"></i>
+                                    Users
+                                </button>
+                                <button
+                                    mat-menu-item
+                                    class="global-menu-item"
+                                    [routerLink]="['/access-policies', 'global']"
+                                    [disabled]="
+                                        !user.tenantsPermissions.canRead ||
+                                        !user.policiesPermissions.canRead ||
+                                        !user.policiesPermissions.canWrite
+                                    ">
+                                    <i class="fa fa-key primary-color mr-2"></i>
+                                    Policies
+                                </button>
+                                <mat-divider></mat-divider>
+                            }
                         }
-                        Light
-                    </button>
-                    <button mat-menu-item class="global-menu-item" (click)="toggleTheme(DARK_THEME)">
-                        @if (theme === DARK_THEME) {
-                            <i class="fa fa-check primary-color mr-2"></i>
-                        }
-                        @if (theme !== DARK_THEME) {
+                        <button mat-menu-item class="global-menu-item" [routerLink]="['/documentation']">
+                            <i class="fa fa-question-circle primary-color mr-2"></i>
+                            Help
+                        </button>
+                        <button mat-menu-item class="global-menu-item" (click)="viewAbout()">
+                            <i class="fa fa-info-circle primary-color mr-2"></i>
+                            About
+                        </button>
+                        <button mat-menu-item [matMenuTriggerFor]="theming">
                             <i class="fa mr-2"></i>
-                        }
-                        Dark
-                    </button>
-                    <button mat-menu-item class="global-menu-item" (click)="toggleTheme(OS_SETTING)">
-                        @if (theme === OS_SETTING || theme === null) {
-                            <i class="fa fa-check primary-color mr-2"></i>
-                        }
-                        @if (theme !== OS_SETTING && theme !== null) {
-                            <i class="fa mr-2"></i>
-                        }
-                        Device
-                    </button>
-                </mat-menu>
-            </div>
-        }
-    </div>
-</nav>
+                            Appearance
+                        </button>
+                    </mat-menu>
+                    <mat-menu #theming="matMenu" xPosition="before">
+                        <button mat-menu-item class="global-menu-item" (click)="toggleTheme(LIGHT_THEME)">
+                            @if (theme === LIGHT_THEME) {
+                                <i class="fa fa-check primary-color mr-2"></i>
+                            }
+                            @if (theme !== LIGHT_THEME) {
+                                <i class="fa mr-2"></i>
+                            }
+                            Light
+                        </button>
+                        <button mat-menu-item class="global-menu-item" (click)="toggleTheme(DARK_THEME)">
+                            @if (theme === DARK_THEME) {
+                                <i class="fa fa-check primary-color mr-2"></i>
+                            }
+                            @if (theme !== DARK_THEME) {
+                                <i class="fa mr-2"></i>
+                            }
+                            Dark
+                        </button>
+                        <button mat-menu-item class="global-menu-item" (click)="toggleTheme(OS_SETTING)">
+                            @if (theme === OS_SETTING || theme === null) {
+                                <i class="fa fa-check primary-color mr-2"></i>
+                            }
+                            @if (theme !== OS_SETTING && theme !== null) {
+                                <i class="fa mr-2"></i>
+                            }
+                            Device
+                        </button>
+                    </mat-menu>
+                </div>
+            }
+        </div>
+    </nav>
+    @if (backNavigation(); as navigation) {
+        <div class="pl-2 py-2">
+            <a [routerLink]="navigation.backNavigation"
+                ><i class="fa fa-arrow-left primary-color mr-2"></i>Back to {{ navigation.context }}</a
+            >
+        </div>
+    }
+</div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.html
@@ -193,7 +193,7 @@
     </nav>
     @if (backNavigation(); as navigation) {
         <div class="pl-2 py-2">
-            <a [routerLink]="navigation.backNavigation"
+            <a [routerLink]="navigation.route"
                 ><i class="fa fa-arrow-left primary-color mr-2"></i>Back to {{ navigation.context }}</a
             >
         </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.html
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.html
@@ -193,9 +193,10 @@
     </nav>
     @if (backNavigation(); as navigation) {
         <div class="pl-2 py-2">
-            <a [routerLink]="navigation.route" [state]="{ executeBackNavigation: true }"
-                ><i class="fa fa-arrow-left primary-color mr-2"></i>Back to {{ navigation.context }}</a
-            >
+            <a [routerLink]="navigation.route">
+                <i class="fa fa-arrow-left primary-color mr-2"></i>
+                Back to {{ navigation.context }}
+            </a>
         </div>
     }
 </div>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.spec.ts
@@ -19,17 +19,19 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { Navigation } from './navigation.component';
 import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../state/current-user/current-user.reducer';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { selectCurrentUser } from '../../../state/current-user/current-user.selectors';
 import * as fromUser from '../../../state/current-user/current-user.reducer';
+import * as fromNavigation from '../../../state/navigation/navigation.reducer';
 import { selectClusterSummary } from '../../../state/cluster-summary/cluster-summary.selectors';
 import * as fromClusterSummary from '../../../state/cluster-summary/cluster-summary.reducer';
 import { selectFlowConfiguration } from '../../../state/flow-configuration/flow-configuration.selectors';
 import * as fromFlowConfiguration from '../../../state/flow-configuration/flow-configuration.reducer';
 import { selectLoginConfiguration } from '../../../state/login-configuration/login-configuration.selectors';
 import * as fromLoginConfiguration from '../../../state/login-configuration/login-configuration.reducer';
+import { currentUserFeatureKey } from '../../../state/current-user';
+import { navigationFeatureKey } from '../../../state/navigation';
 
 describe('Navigation', () => {
     let component: Navigation;
@@ -40,7 +42,10 @@ describe('Navigation', () => {
             imports: [Navigation, HttpClientTestingModule, RouterTestingModule],
             providers: [
                 provideMockStore({
-                    initialState,
+                    initialState: {
+                        [currentUserFeatureKey]: fromUser.initialState,
+                        [navigationFeatureKey]: fromNavigation.initialState
+                    },
                     selectors: [
                         {
                             selector: selectCurrentUser,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AsyncPipe, NgOptimizedImage } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDividerModule } from '@angular/material/divider';
@@ -47,7 +47,6 @@ import {
 import { selectClusterSummary } from '../../../state/cluster-summary/cluster-summary.selectors';
 import { selectLoginConfiguration } from '../../../state/login-configuration/login-configuration.selectors';
 import { selectBackNavigation } from '../../../state/navigation/navigation.selectors';
-import { popBackNavigation } from '../../../state/navigation/navigation.actions';
 
 @Component({
     selector: 'navigation',
@@ -79,8 +78,6 @@ export class Navigation implements OnInit, OnDestroy {
     clusterSummary = this.store.selectSignal(selectClusterSummary);
     backNavigation = this.store.selectSignal(selectBackNavigation);
 
-    @Input() popBackNavigationOnDestroy: boolean = true;
-
     constructor(
         private store: Store<NiFiState>,
         private storage: Storage,
@@ -109,9 +106,6 @@ export class Navigation implements OnInit, OnDestroy {
     ngOnDestroy(): void {
         this.store.dispatch(stopCurrentUserPolling());
         this.store.dispatch(stopClusterSummaryPolling());
-        if (this.popBackNavigationOnDestroy) {
-            this.store.dispatch(popBackNavigation());
-        }
     }
 
     allowLogin(user: CurrentUser): boolean {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/ui/common/navigation/navigation.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { AsyncPipe, NgOptimizedImage } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDividerModule } from '@angular/material/divider';
@@ -46,6 +46,8 @@ import {
 } from '../../../state/cluster-summary/cluster-summary.actions';
 import { selectClusterSummary } from '../../../state/cluster-summary/cluster-summary.selectors';
 import { selectLoginConfiguration } from '../../../state/login-configuration/login-configuration.selectors';
+import { selectBackNavigation } from '../../../state/navigation/navigation.selectors';
+import { popBackNavigation } from '../../../state/navigation/navigation.actions';
 
 @Component({
     selector: 'navigation',
@@ -70,10 +72,14 @@ export class Navigation implements OnInit, OnDestroy {
     LIGHT_THEME: string = LIGHT_THEME;
     DARK_THEME: string = DARK_THEME;
     OS_SETTING: string = OS_SETTING;
+
     currentUser = this.store.selectSignal(selectCurrentUser);
     flowConfiguration = this.store.selectSignal(selectFlowConfiguration);
     loginConfiguration = this.store.selectSignal(selectLoginConfiguration);
     clusterSummary = this.store.selectSignal(selectClusterSummary);
+    backNavigation = this.store.selectSignal(selectBackNavigation);
+
+    @Input() popBackNavigationOnDestroy: boolean = true;
 
     constructor(
         private store: Store<NiFiState>,
@@ -103,6 +109,9 @@ export class Navigation implements OnInit, OnDestroy {
     ngOnDestroy(): void {
         this.store.dispatch(stopCurrentUserPolling());
         this.store.dispatch(stopClusterSummaryPolling());
+        if (this.popBackNavigationOnDestroy) {
+            this.store.dispatch(popBackNavigation());
+        }
     }
 
     allowLogin(user: CurrentUser): boolean {


### PR DESCRIPTION
NIFI-12967:
- Adding support for navigating back to the users previous location in certain circumstances like going to a Controller Service, managing access policies, going to parameters, viewing documentation, opening advanced UIs, and viewing data provenance.
- Cleaning unnecessary instances of postUpdateNavigation.

The scenarios mentioned in the commit message above have a slightly different UX from the existing application. In the old UI, these actions would open in a large modal on top of the current component. When the user was done they could return to where they were by closing the modal. In the new UI, the user currently needs to use their browser back button as the application did not directly offer a back option. This PR introduces that back option but only in the cases identified above. Scenarios outside of this (other links in the application like Referencing Components) are not included here but could be considered in the future as a further improvement over the old UI.