### PR TITLE
[NIFI-13277] - Make the main menu more compact in terms of spacing.

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/styles/_app.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/assets/styles/_app.scss
@@ -209,6 +209,10 @@
     .mdc-dialog__content {
         font-size: 14px !important;
     }
+
+    .mat-mdc-menu-content .mat-mdc-menu-item {
+        min-height: 2.25rem;
+    }
 }
 
 @mixin generate-material-theme($material-theme) {


### PR DESCRIPTION
[NIFI-13277](https://issues.apache.org/jira/browse/NIFI-13277)

Before:
<img width="1072" alt="Screenshot 2024-05-21 at 1 09 45 PM" src="https://github.com/apache/nifi/assets/713866/cc768394-06c6-4fba-b914-41eedb255dda">


After:
<img width="1074" alt="Screenshot 2024-05-21 at 1 08 48 PM" src="https://github.com/apache/nifi/assets/713866/5c427825-e604-455b-9e4e-a354b900837f">


With the changes, the menu (as of now) displays without the need for scrollbars until the displayable browser area gets below 570 pixels in height. Previously it needed more than 740px. I guess I'm running non-clustered... but in clustered mode there would be an extra menu item, so these numbers would be slightly bigger there.