### PR TITLE
NIFI-13278: Ensure 3rdpartylicenses.txt is included in resulting build artifact

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/pom.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/pom.xml
@@ -87,6 +87,13 @@
                                         <include>**/*</include>
                                     </includes>
                                 </resource>
+                                <resource>
+                                    <directory>${frontend.working.dir}/dist/nifi</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>3rdpartylicenses.txt</include>
+                                    </includes>
+                                </resource>
                             </resources>
                         </configuration>
                     </execution>


### PR DESCRIPTION
NIFI-13278:
- Ensure 3rdpartylicenses.txt is included in resulting build artifact.