### PR TITLE
NIFI-13294 Deprecate Apache Knox SSO Authentication

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -610,6 +610,8 @@ SAML authentication enables the following REST API resources for integration wit
 [[apache_knox]]
 === Apache Knox
 
+NOTE: Support for Apache Knox Single Sign-On is deprecated for removal in NiFi 2.
+
 To enable authentication via Apache Knox the following properties must be configured in _nifi.properties_.
 
 [options="header"]

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
@@ -174,6 +174,10 @@
             <artifactId>nifi-property-protection-loader</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-deprecation-log</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
         </dependency>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/KnoxAuthenticationSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/KnoxAuthenticationSecurityConfiguration.java
@@ -17,6 +17,8 @@
 package org.apache.nifi.web.security.configuration;
 
 import org.apache.nifi.authorization.Authorizer;
+import org.apache.nifi.deprecation.log.DeprecationLogger;
+import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.web.security.knox.KnoxAuthenticationFilter;
 import org.apache.nifi.web.security.knox.KnoxAuthenticationProvider;
@@ -32,6 +34,8 @@ import org.springframework.security.authentication.AuthenticationManager;
  */
 @Configuration
 public class KnoxAuthenticationSecurityConfiguration {
+    private static final DeprecationLogger deprecationLogger = DeprecationLoggerFactory.getLogger(KnoxAuthenticationSecurityConfiguration.class);
+
     private final NiFiProperties niFiProperties;
 
     private final Authorizer authorizer;
@@ -43,6 +47,10 @@ public class KnoxAuthenticationSecurityConfiguration {
     ) {
         this.niFiProperties = niFiProperties;
         this.authorizer = authorizer;
+
+        if (niFiProperties.isKnoxSsoEnabled()) {
+            deprecationLogger.warn("Support for Apache Knox Single Sign-On authentication is deprecated for removal in NiFi 2");
+        }
     }
 
     @Bean


### PR DESCRIPTION
# Summary

[NIFI-13294](https://issues.apache.org/jira/browse/NIFI-13294) Deprecates Apache Knox [Single Sign-On](https://knox.apache.org/books/knox-1-6-0/user-guide.html#SSO+Cookie+Provider) authentication for subsequent removal in NiFi 2.

OpenID Connect and SAML 2 integration provide standards-based SSO without reference to particular identity providers.

This deprecation does not impact Apache Knox [proxy gateway access](https://knox.apache.org/books/knox-1-6-0/user-guide.html#Nifi+UI) to NiFi, which continues to be supported using X.509 client certificates and the `X-ProxiedEntitiesChain` HTTP header.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
