### PR TITLE
NIFI-13296 Deprecate Kerberos SPNEGO Authentication

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -3308,6 +3308,9 @@ supports different strategies, including *cookie* and *route* options.
 
 [[kerberos_service]]
 == Kerberos Service
+
+NOTE: Support for Kerberos SPNEGO authentication is deprecated for removal in NiFi 2.
+
 NiFi can be configured to use Kerberos SPNEGO (or "Kerberos Service") for authentication. In this scenario, users will hit the REST endpoint `/access/kerberos` and the server will respond with a `401` status code and the challenge response header `WWW-Authenticate: Negotiate`. This communicates to the browser to use the GSS-API and load the user's Kerberos ticket and provide it as a Base64-encoded header value in the subsequent request. It will be of the form `Authorization: Negotiate YII...`. NiFi will attempt to validate this ticket with the KDC. If it is successful, the user's _principal_ will be returned as the identity, and the flow will follow login/credential authentication, in that a JWT will be issued in the response to prevent the unnecessary overhead of Kerberos authentication on every subsequent request. If the ticket cannot be validated, it will return with the appropriate error response code. The user will then be able to provide their Kerberos credentials to the login form if the `KerberosLoginIdentityProvider` has been configured. See <<kerberos_login_identity_provider>> login identity provider for more details.
 
 NiFi will only respond to Kerberos SPNEGO negotiation over an HTTPS connection, as unsecured requests are never authenticated.

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/KerberosAuthenticationSecurityConfiguration.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/KerberosAuthenticationSecurityConfiguration.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.web.security.configuration;
 
+import org.apache.nifi.deprecation.log.DeprecationLogger;
+import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.web.security.kerberos.KerberosService;
 import org.apache.nifi.web.security.spring.KerberosServiceFactoryBean;
@@ -28,6 +30,8 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class KerberosAuthenticationSecurityConfiguration {
+    private static final DeprecationLogger deprecationLogger = DeprecationLoggerFactory.getLogger(KerberosAuthenticationSecurityConfiguration.class);
+
     private final NiFiProperties niFiProperties;
 
     @Autowired
@@ -35,6 +39,10 @@ public class KerberosAuthenticationSecurityConfiguration {
             final NiFiProperties niFiProperties
     ) {
         this.niFiProperties = niFiProperties;
+
+        if (niFiProperties.isKerberosSpnegoSupportEnabled()) {
+            deprecationLogger.warn("Support for Kerberos SPNEGO authentication is deprecated for removal in NiFi 2");
+        }
     }
 
     @Bean


### PR DESCRIPTION
# Summary

[NIFI-13296](https://issues.apache.org/jira/browse/NIFI-13296) Deprecates Kerberos [SPNEGO](https://en.wikipedia.org/wiki/SPNEGO) authentication for subsequent removal in NiFi 2. This deprecation applies to framework-level configuration as opposed to username and password-based authentication using the Kerberos Login Identity Provider.

Kerberos SPNEGO authentication requires non-standard [client browser configuration](https://docs.spring.io/spring-security-kerberos/docs/current/reference/html/browserspnegoconfig.html) that is specific to particular host addresses, whereas standards-based Single Sign-On integration using OpenID Connect or SAML 2 does not have similar constraints.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
