### PR TITLE
NIFI-13305 Upgrade HBase dependencies from 2.5.8 to 2.6.0

### DIFF
--- a/nifi-extension-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>nifi-hbase_2-client-service-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <hbase.version>2.5.8-hadoop3</hbase.version>
+        <hbase.version>2.6.0-hadoop3</hbase.version>
     </properties>
     <modules>
         <module>nifi-hbase_2-client-service</module>
@@ -46,29 +46,6 @@
     </build>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId>
-                <version>${netty.3.version}</version>
-            </dependency>
-            <!-- Override commons-beanutils -->
-            <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>1.9.4</version>
-            </dependency>
-            <!-- Override nimbus-jose-jwt 9.8.1 from hadoop-auth -->
-            <dependency>
-                <groupId>com.nimbusds</groupId>
-                <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.37.3</version>
-            </dependency>
-            <!-- Override woodstox-core 5.3.0 from HBase -->
-            <dependency>
-                <groupId>com.fasterxml.woodstox</groupId>
-                <artifactId>woodstox-core</artifactId>
-                <version>5.4.0</version>
-            </dependency>
             <!-- Override Guava 27 -->
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
# Summary

[NIFI-13305](https://issues.apache.org/jira/browse/NIFI-13305) Upgrades Apache HBase dependencies from 2.5.8 to [2.6.0](https://issues.apache.org/jira/projects/HBASE/versions/12350930), incorporating a number of bug fixes and improvements. Changes include removing dependency overrides that are no longer required based on updates in HBase 2.6.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
