### PR TITLE
NIFI-13284: Only saving canvas routes that are not edit or history

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.ts
@@ -102,7 +102,9 @@ export class Canvas implements OnInit, OnDestroy {
             .select(selectUrl)
             .pipe(takeUntilDestroyed())
             .subscribe((route) => {
-                this.storage.setItem('current-canvas-route', route);
+                if (!route.endsWith('/edit') && !route.endsWith('/history')) {
+                    this.storage.setItem('current-canvas-route', route);
+                }
             });
 
         // load the process group from the route


### PR DESCRIPTION
NIFI-13284:
- Only saving canvas routes that are not edit or history.