### PR TITLE
NIFI-13265 Removed the instantiation of Object arrays for arguments in ComponentLog log and org.slf4j.Logger statements.

### DIFF
--- a/minifi/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/util/LogUtil.java
+++ b/minifi/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/util/LogUtil.java
@@ -49,7 +49,7 @@ public class LogUtil {
                     .collect(Collectors.toList());
         }
         DockerPort dockerPort = container.port(8000);
-        logger.info("Connecting to external port {} for docker internal port of {}", new Object[]{dockerPort.getExternalPort(), dockerPort.getInternalPort()});
+        logger.info("Connecting to external port {} for docker internal port of {}", dockerPort.getExternalPort(), dockerPort.getInternalPort());
         URL url = URI.create("http://" + dockerPort.getIp() + ":" + dockerPort.getExternalPort()).toURL();
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
         try (InputStream inputStream = urlConnection.getInputStream();

--- a/nifi-commons/nifi-security-identity/src/main/java/org/apache/nifi/authorization/util/IdentityMappingUtil.java
+++ b/nifi-commons/nifi-security-identity/src/main/java/org/apache/nifi/authorization/util/IdentityMappingUtil.java
@@ -84,7 +84,7 @@ public class IdentityMappingUtil {
                 final String identityPattern = properties.getProperty(propertyName);
 
                 if (StringUtils.isBlank(identityPattern)) {
-                    LOGGER.warn("{} Mapping property {} was found, but was empty", new Object[] {getSubject.get(), propertyName});
+                    LOGGER.warn("{} Mapping property {} was found, but was empty", getSubject.get(), propertyName);
                     continue;
                 }
 
@@ -92,8 +92,7 @@ public class IdentityMappingUtil {
                 final String identityValue = properties.getProperty(identityValueProperty);
 
                 if (StringUtils.isBlank(identityValue)) {
-                    LOGGER.warn("{} Mapping property {} was found, but corresponding value {} was not found",
-                            new Object[] {getSubject.get(), propertyName, identityValueProperty});
+                    LOGGER.warn("{} Mapping property {} was found, but corresponding value {} was not found", getSubject.get(), propertyName, identityValueProperty);
                     continue;
                 }
 
@@ -101,7 +100,7 @@ public class IdentityMappingUtil {
                 String rawIdentityTransform = properties.getProperty(identityTransformProperty);
 
                 if (StringUtils.isBlank(rawIdentityTransform)) {
-                    LOGGER.debug("{} Mapping property {} was found, but no transform was present. Using NONE.", new Object[] {getSubject.get(), propertyName});
+                    LOGGER.debug("{} Mapping property {} was found, but no transform was present. Using NONE.", getSubject.get(), propertyName);
                     rawIdentityTransform = Transform.NONE.name();
                 }
 
@@ -110,15 +109,14 @@ public class IdentityMappingUtil {
                     identityTransform = Transform.valueOf(rawIdentityTransform);
                 } catch (final IllegalArgumentException iae) {
                     LOGGER.warn("{} Mapping property {} was found, but corresponding transform {} was not valid. Allowed values {}",
-                            new Object[] {getSubject.get(), propertyName, rawIdentityTransform, StringUtils.join(Transform.values(), ", ")});
+                            getSubject.get(), propertyName, rawIdentityTransform, StringUtils.join(Transform.values(), ", "));
                     continue;
                 }
 
                 final IdentityMapping identityMapping = new IdentityMapping(key, Pattern.compile(identityPattern), identityValue, identityTransform);
                 mappings.add(identityMapping);
 
-                LOGGER.debug("Found {} Mapping with key = {}, pattern = {}, value = {}, transform = {}",
-                        new Object[] {getSubject.get(), key, identityPattern, identityValue, rawIdentityTransform});
+                LOGGER.debug("Found {} Mapping with key = {}, pattern = {}, value = {}, transform = {}", getSubject.get(), key, identityPattern, identityValue, rawIdentityTransform);
             }
         }
 

--- a/nifi-commons/nifi-security-kerberos/src/main/java/org/apache/nifi/security/krb/KerberosAction.java
+++ b/nifi-commons/nifi-security-kerberos/src/main/java/org/apache/nifi/security/krb/KerberosAction.java
@@ -55,7 +55,7 @@ public class KerberosAction<T> {
         if (!kerberosUser.isLoggedIn()) {
             try {
                 kerberosUser.login();
-                logger.info("Successful login for {}", new Object[]{kerberosUser.getPrincipal()});
+                logger.info("Successful login for {}", kerberosUser.getPrincipal());
             } catch (final KerberosLoginException e) {
                 throw new ProcessException("Login failed due to: " + e.getMessage(), e);
             }

--- a/nifi-commons/nifi-socket-utils/src/main/java/org/apache/nifi/io/nio/ChannelDispatcher.java
+++ b/nifi-commons/nifi-socket-utils/src/main/java/org/apache/nifi/io/nio/ChannelDispatcher.java
@@ -71,7 +71,7 @@ public final class ChannelDispatcher implements Runnable {
                 selectServerSocketKeys();
                 selectSocketChannelKeys();
             } catch (final Exception ex) {
-                LOGGER.warn("Key selection failed: {} Normal during shutdown.", new Object[]{ex});
+                LOGGER.warn("Key selection failed: Normal during shutdown.", ex);
             }
         }
     }

--- a/nifi-commons/nifi-write-ahead-log/src/main/java/org/apache/nifi/wali/HashMapSnapshot.java
+++ b/nifi-commons/nifi-write-ahead-log/src/main/java/org/apache/nifi/wali/HashMapSnapshot.java
@@ -155,8 +155,7 @@ public class HashMapSnapshot<T> implements WriteAheadSnapshot<T>, RecordLookup<T
             }
             this.swapLocations.addAll(swapLocations);
 
-            logger.info("{} restored {} Records and {} Swap Files from Snapshot, ending with Transaction ID {}",
-                new Object[] {this, numRecords, swapLocations.size(), maxTransactionId});
+            logger.info("{} restored {} Records and {} Swap Files from Snapshot, ending with Transaction ID {}", this, numRecords, swapLocations.size(), maxTransactionId);
 
             return new StandardSnapshotRecovery<>(recordMap, swapLocations, snapshotFile, maxTransactionId);
         }

--- a/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/main/java/org/apache/nifi/jasn1/StandardRecordModelIteratorProvider.java
+++ b/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/main/java/org/apache/nifi/jasn1/StandardRecordModelIteratorProvider.java
@@ -89,7 +89,7 @@ public class StandardRecordModelIteratorProvider implements RecordModelIteratorP
 
         try {
             final int decode = model.decode(inputStream);
-            logger.debug("Decoded {} bytes into {}", new Object[]{decode, model.getClass()});
+            logger.debug("Decoded {} bytes into {}", decode, model.getClass());
         } catch (IOException e) {
             throw new RuntimeException("Failed to decode " + rootClass.getCanonicalName(), e);
         }

--- a/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/main/java/org/apache/nifi/processors/avro/ExtractAvroMetadata.java
+++ b/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/main/java/org/apache/nifi/processors/avro/ExtractAvroMetadata.java
@@ -210,7 +210,7 @@ public class ExtractAvroMetadata extends AbstractProcessor {
                 }
             });
         } catch (final ProcessException pe) {
-            getLogger().error("Failed to extract Avro metadata for {} due to {}; transferring to failure", new Object[] {flowFile, pe});
+            getLogger().error("Transferring to failure since failed to extract Avro metadata for {}", flowFile, pe);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
@@ -446,7 +446,7 @@ public class FetchS3Object extends AbstractS3Processor {
 
         session.transfer(flowFile, REL_SUCCESS);
         final long transferMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-        getLogger().info("Successfully retrieved S3 Object for {} in {} millis; routing to success", new Object[]{flowFile, transferMillis});
+        getLogger().info("Successfully retrieved S3 Object for {} in {} millis; routing to success", flowFile, transferMillis);
         session.getProvenanceReporter().fetch(flowFile, url, transferMillis);
     }
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -367,12 +367,10 @@ public class PutS3Object extends AbstractS3Processor {
             return null;
         }
         if (localUploadExistsInS3(s3, bucket, currState)) {
-            getLogger().info("Local state for {} loaded with uploadId {} and {} partETags",
-                    new Object[]{s3ObjectKey, currState.getUploadId(), currState.getPartETags().size()});
+            getLogger().info("Local state for {} loaded with uploadId {} and {} partETags", s3ObjectKey, currState.getUploadId(), currState.getPartETags().size());
             return currState;
         } else {
-            getLogger().info("Local state for {} with uploadId {} does not exist in S3, deleting local state",
-                    new Object[]{s3ObjectKey, currState.getUploadId()});
+            getLogger().info("Local state for {} with uploadId {} does not exist in S3, deleting local state", s3ObjectKey, currState.getUploadId());
             persistLocalState(s3ObjectKey, null);
             return null;
         }
@@ -387,8 +385,7 @@ public class PutS3Object extends AbstractS3Processor {
             try (final FileInputStream fis = new FileInputStream(persistenceFile)) {
                 props.load(fis);
             } catch (IOException ioe) {
-                getLogger().warn("Failed to recover local state for {} due to {}. Assuming no local state and " +
-                        "restarting upload.", new Object[]{s3ObjectKey, ioe.getMessage()});
+                getLogger().warn("Assuming no local state and restarting upload since failed to recover local state for {}", s3ObjectKey, ioe);
                 return null;
             }
             if (props.containsKey(s3ObjectKey)) {
@@ -397,7 +394,7 @@ public class PutS3Object extends AbstractS3Processor {
                     try {
                         return new MultipartState(localSerialState);
                     } catch (final RuntimeException rte) {
-                        getLogger().warn("Failed to recover local state for {} due to corrupt data in state.", new Object[]{s3ObjectKey, rte.getMessage()});
+                        getLogger().warn("Failed to recover local state for {} due to corrupt data in state.", s3ObjectKey, rte);
                         return null;
                     }
                 }
@@ -431,16 +428,14 @@ public class PutS3Object extends AbstractS3Processor {
             try (final FileOutputStream fos = new FileOutputStream(persistenceFile)) {
                 props.store(fos, null);
             } catch (IOException ioe) {
-                getLogger().error("Could not store state {} due to {}.",
-                        new Object[]{persistenceFile.getAbsolutePath(), ioe.getMessage()});
+                getLogger().error("Could not store state {}", persistenceFile.getAbsolutePath(), ioe);
             }
         } else {
             if (persistenceFile.exists()) {
                 try {
                     Files.delete(persistenceFile.toPath());
                 } catch (IOException ioe) {
-                    getLogger().error("Could not remove state file {} due to {}.",
-                            new Object[]{persistenceFile.getAbsolutePath(), ioe.getMessage()});
+                    getLogger().error("Could not remove state file {}", persistenceFile.getAbsolutePath(), ioe);
                 }
             }
         }
@@ -458,8 +453,7 @@ public class PutS3Object extends AbstractS3Processor {
             try (final FileInputStream fis = new FileInputStream(persistenceFile)) {
                 props.load(fis);
             } catch (final IOException ioe) {
-                getLogger().warn("Failed to ageoff remove local state due to {}",
-                        new Object[]{ioe.getMessage()});
+                getLogger().warn("Failed to ageoff remove local state", ioe);
                 return;
             }
             for (Entry<Object, Object> entry: props.entrySet()) {
@@ -468,13 +462,11 @@ public class PutS3Object extends AbstractS3Processor {
                 if (localSerialState != null) {
                     final MultipartState state = new MultipartState(localSerialState);
                     if (state.getTimestamp() < ageCutoff) {
-                        getLogger().warn("Removing local state for {} due to exceeding ageoff time",
-                                new Object[]{key});
+                        getLogger().warn("Removing local state for {} due to exceeding ageoff time", key);
                         try {
                             removeLocalState(key);
                         } catch (final IOException ioe) {
-                            getLogger().warn("Failed to remove local state for {} due to {}",
-                                    new Object[]{key, ioe.getMessage()});
+                            getLogger().warn("Failed to remove local state for {}", key, ioe);
 
                         }
                     }
@@ -734,15 +726,14 @@ public class PutS3Object extends AbstractS3Processor {
                             }
                             getLogger().info("Success initiating upload flowfile={} available={} position={} " +
                                             "length={} bucket={} key={} uploadId={}",
-                                    new Object[]{ffFilename, in.available(), currentState.getFilePosition(),
-                                            currentState.getContentLength(), bucket, key,
-                                            currentState.getUploadId()});
+                                    ffFilename, in.available(), currentState.getFilePosition(),
+                                    currentState.getContentLength(), bucket, key,
+                                    currentState.getUploadId());
                             if (initiateResult.getUploadId() != null) {
                                 attributes.put(S3_UPLOAD_ID_ATTR_KEY, initiateResult.getUploadId());
                             }
                         } catch (AmazonClientException e) {
-                            getLogger().info("Failure initiating upload flowfile={} bucket={} key={} reason={}",
-                                    new Object[]{ffFilename, bucket, key, e.getMessage()});
+                            getLogger().info("Failure initiating upload flowfile={} bucket={} key={}", ffFilename, bucket, key, e);
                             throw (e);
                         }
                     } else {
@@ -750,16 +741,11 @@ public class PutS3Object extends AbstractS3Processor {
                             try {
                                 final long skipped = in.skip(currentState.getFilePosition());
                                 if (skipped != currentState.getFilePosition()) {
-                                    getLogger().info("Failure skipping to resume upload flowfile={} " +
-                                                    "bucket={} key={} position={} skipped={}",
-                                            new Object[]{ffFilename, bucket, key,
-                                                    currentState.getFilePosition(), skipped});
+                                    getLogger().info("Failure skipping to resume upload flowfile={} bucket={} key={} position={} skipped={}",
+                                            ffFilename, bucket, key, currentState.getFilePosition(), skipped);
                                 }
                             } catch (Exception e) {
-                                getLogger().info("Failure skipping to resume upload flowfile={} bucket={} " +
-                                                "key={} position={} reason={}",
-                                        new Object[]{ffFilename, bucket, key, currentState.getFilePosition(),
-                                                e.getMessage()});
+                                getLogger().info("Failure skipping to resume upload flowfile={} bucket={} key={} position={}", ffFilename, bucket, key, currentState.getFilePosition(), e);
                                 throw (new ProcessException(e));
                             }
                         }
@@ -805,12 +791,10 @@ public class PutS3Object extends AbstractS3Processor {
                             } catch (IOException e) {
                                 // in case of the last part, the stream is already closed
                             }
-                            getLogger().info("Success uploading part flowfile={} part={} available={} " +
-                                    "etag={} uploadId={}", new Object[]{ffFilename, part, available,
-                                    uploadPartResult.getETag(), currentState.getUploadId()});
+                            getLogger().info("Success uploading part flowfile={} part={} available={} etag={} uploadId={}",
+                                    ffFilename, part, available, uploadPartResult.getETag(), currentState.getUploadId());
                         } catch (AmazonClientException e) {
-                            getLogger().info("Failure uploading part flowfile={} part={} bucket={} key={} " +
-                                    "reason={}", new Object[]{ffFilename, part, bucket, key, e.getMessage()});
+                            getLogger().info("Failure uploading part flowfile={} part={} bucket={} key={}", ffFilename, part, bucket, key, e);
                             throw (e);
                         }
                     }
@@ -825,7 +809,7 @@ public class PutS3Object extends AbstractS3Processor {
                         CompleteMultipartUploadResult completeResult =
                                 s3.completeMultipartUpload(completeRequest);
                         getLogger().info("Success completing upload flowfile={} etag={} uploadId={}",
-                                new Object[]{ffFilename, completeResult.getETag(), currentState.getUploadId()});
+                                ffFilename, completeResult.getETag(), currentState.getUploadId());
                         if (completeResult.getVersionId() != null) {
                             attributes.put(S3_VERSION_ATTR_KEY, completeResult.getVersionId());
                         }
@@ -848,8 +832,8 @@ public class PutS3Object extends AbstractS3Processor {
                         }
                         attributes.put(S3_API_METHOD_ATTR_KEY, S3_API_METHOD_MULTIPARTUPLOAD);
                     } catch (AmazonClientException e) {
-                        getLogger().info("Failure completing upload flowfile={} bucket={} key={} reason={}",
-                                new Object[]{ffFilename, bucket, key, e.getMessage()});
+                        getLogger().info("Failure completing upload flowfile={} bucket={} key={}",
+                                ffFilename, bucket, key, e);
                         throw (e);
                     }
                 }
@@ -866,12 +850,11 @@ public class PutS3Object extends AbstractS3Processor {
             final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
             session.getProvenanceReporter().send(flowFile, url, millis);
 
-            getLogger().info("Successfully put {} to Amazon S3 in {} milliseconds", new Object[]{ff, millis});
+            getLogger().info("Successfully put {} to Amazon S3 in {} milliseconds", ff, millis);
             try {
                 removeLocalState(cacheKey);
             } catch (IOException e) {
-                getLogger().info("Error trying to delete key {} from cache: {}",
-                        new Object[]{cacheKey, e.getMessage()});
+                getLogger().info("Error trying to delete key {} from cache:", cacheKey, e);
             }
 
         } catch (final ProcessException | AmazonClientException | IOException e) {
@@ -925,12 +908,10 @@ public class PutS3Object extends AbstractS3Processor {
                     getLogger().warn("AccessDenied checking S3 Multipart Upload list for {}: {} " +
                             "** The configured user does not have the s3:ListBucketMultipartUploads permission " +
                             "for this bucket, S3 ageoff cannot occur without this permission.  Next ageoff check " +
-                            "time is being advanced by interval to prevent checking on every upload **",
-                            new Object[]{bucket, e.getMessage()});
+                            "time is being advanced by interval to prevent checking on every upload **", bucket, e.getMessage());
                     lastS3AgeOff.set(System.currentTimeMillis());
                 } else {
-                    getLogger().error("Error checking S3 Multipart Upload list for {}: {}",
-                            new Object[]{bucket, e.getMessage()});
+                    getLogger().error("Error checking S3 Multipart Upload list for {}:", bucket, e);
                 }
             } finally {
                 s3BucketLock.unlock();

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -911,7 +911,7 @@ public class PutS3Object extends AbstractS3Processor {
                             "time is being advanced by interval to prevent checking on every upload **", bucket, e.getMessage());
                     lastS3AgeOff.set(System.currentTimeMillis());
                 } else {
-                    getLogger().error("Error checking S3 Multipart Upload list for {}:", bucket, e);
+                    getLogger().error("Error checking S3 Multipart Upload list for {}", bucket, e);
                 }
             } finally {
                 s3BucketLock.unlock();

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sns/PutSNS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sns/PutSNS.java
@@ -162,7 +162,7 @@ public class PutSNS extends AbstractAwsSyncProcessor<SnsClient, SnsClientBuilder
         }
 
         if (flowFile.getSize() > MAX_SIZE) {
-            getLogger().error("Cannot publish {} to SNS because its size exceeds Amazon SNS's limit of 256KB; routing to failure", new Object[]{flowFile});
+            getLogger().error("Cannot publish {} to SNS because its size exceeds Amazon SNS's limit of 256KB; routing to failure", flowFile);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/DeleteSQS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/DeleteSQS.java
@@ -109,10 +109,10 @@ public class DeleteSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuil
                 throw new ProcessException(response.failed().get(0).toString());
             }
 
-            getLogger().info("Successfully deleted message from SQS for {}", new Object[] {flowFile});
+            getLogger().info("Successfully deleted message from SQS for {}", flowFile);
             session.transfer(flowFile, REL_SUCCESS);
         } catch (final Exception e) {
-            getLogger().error("Failed to delete message from SQS due to {}", new Object[] {e});
+            getLogger().error("Failed to delete message from SQS", e);
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/GetSQS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/GetSQS.java
@@ -160,7 +160,7 @@ public class GetSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
         try {
             response = client.receiveMessage(request);
         } catch (final Exception e) {
-            getLogger().error("Failed to receive messages from Amazon SQS due to {}", new Object[]{e});
+            getLogger().error("Failed to receive messages from Amazon SQS", e);
             context.yield();
             return;
         }
@@ -196,7 +196,7 @@ public class GetSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
             session.transfer(flowFile, REL_SUCCESS);
             session.getProvenanceReporter().receive(flowFile, queueUrl);
 
-            getLogger().info("Successfully received {} from Amazon SQS", new Object[]{flowFile});
+            getLogger().info("Successfully received {} from Amazon SQS", flowFile);
         }
 
         if (autoDelete) {
@@ -223,8 +223,7 @@ public class GetSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
         try {
             client.deleteMessageBatch(deleteRequest);
         } catch (final Exception e) {
-            getLogger().error("Received {} messages from Amazon SQS but failed to delete the messages; these messages"
-                + " may be duplicated. Reason for deletion failure: {}", new Object[]{messages.size(), e});
+            getLogger().error("Received {} messages from Amazon SQS but failed to delete the messages; these messages may be duplicated. Reason for deletion failure: ", messages.size(), e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/GetSQS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/GetSQS.java
@@ -223,7 +223,7 @@ public class GetSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
         try {
             client.deleteMessageBatch(deleteRequest);
         } catch (final Exception e) {
-            getLogger().error("Received {} messages from Amazon SQS but failed to delete the messages; these messages may be duplicated. Reason for deletion failure: ", messages.size(), e);
+            getLogger().error("Received {} messages from Amazon SQS but failed to delete the messages; these messages may be duplicated", messages.size(), e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/AbstractEmailProcessor.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/AbstractEmailProcessor.java
@@ -414,7 +414,7 @@ abstract class AbstractEmailProcessor<T extends AbstractMailReceiver> extends Ab
         }
 
         processSession.getProvenanceReporter().receive(flowFile, this.displayUrl, "Received message from " + fromAddressesString, executionDuration);
-        this.getLogger().info("Successfully received {} from {} in {} millis", new Object[]{flowFile, fromAddressesString, executionDuration});
+        this.getLogger().info("Successfully received {} from {} in {} millis", flowFile, fromAddressesString, executionDuration);
         processSession.transfer(flowFile, REL_SUCCESS);
 
     }

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/ISPEnrichIP.java
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/ISPEnrichIP.java
@@ -70,8 +70,7 @@ public class ISPEnrichIP extends AbstractEnrichIP {
 
         if (StringUtils.isEmpty(ipAttributeName)) {
             session.transfer(flowFile, REL_NOT_FOUND);
-            getLogger().warn("FlowFile '{}' attribute '{}' was empty. Routing to failure",
-                    new Object[]{flowFile, IP_ADDRESS_ATTRIBUTE.getDisplayName()});
+            getLogger().warn("FlowFile '{}' attribute '{}' was empty. Routing to failure", flowFile, IP_ADDRESS_ATTRIBUTE.getDisplayName());
             return;
         }
 

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/enrich/AbstractEnrichProcessor.java
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/enrich/AbstractEnrichProcessor.java
@@ -239,8 +239,8 @@ public abstract class AbstractEnrichProcessor extends AbstractProcessor {
                         results.put(key, row);
                     }
                 } catch (IndexOutOfBoundsException e) {
-                    getLogger().warn("Could not find capture group {} while processing result. You may want to review your " +
-                            "Regular Expression to match against the content \"{}\"", new Object[]{lookupKey, rawResult});
+                    getLogger().warn("Could not find capture group {} while processing result. You may want to review your Regular Expression to match against the content \"{}\"",
+                            lookupKey, rawResult);
                 }
             }
             break;

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/enrich/QueryDNS.java
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/enrich/QueryDNS.java
@@ -258,7 +258,7 @@ public class QueryDNS extends AbstractEnrichProcessor {
             attrs = ictx.getAttributes(queryInput, new String[]{queryType});
             return attrs;
         } catch ( NameNotFoundException e) {
-            getLogger().debug("Resolution for domain {} failed due to {}", new Object[]{queryInput, e});
+            getLogger().debug("Resolution for domain {} failed", queryInput, e);
             attrs = new BasicAttributes(queryType, "NXDOMAIN", true);
             return attrs;
         }

--- a/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/main/java/org/apache/nifi/processors/evtx/ParseEvtx.java
+++ b/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/main/java/org/apache/nifi/processors/evtx/ParseEvtx.java
@@ -147,7 +147,7 @@ public class ParseEvtx extends AbstractProcessor {
         if (basename.endsWith(EVTX_EXTENSION)) {
             return basename.substring(0, basename.length() - EVTX_EXTENSION.length());
         } else {
-            logger.warn("Trying to parse file without .evtx extension {} from flowfile {}", new Object[]{basename, flowFile});
+            logger.warn("Trying to parse file without .evtx extension {} from flowfile {}", basename, flowFile);
             return basename;
         }
     }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-bin-manager/src/main/java/org/apache/nifi/processor/util/bin/BinFiles.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-bin-manager/src/main/java/org/apache/nifi/processor/util/bin/BinFiles.java
@@ -181,8 +181,7 @@ public abstract class BinFiles extends AbstractSessionFactoryProcessor {
             getLogger().debug("Binned {} FlowFiles", binningResult.getFlowFilesBinned());
         } else {
             binningResult = BinningResult.EMPTY;
-            getLogger().debug("Will not bin any FlowFiles because {} bins already exist;"
-                + "will wait until bins have been emptied before any more are created", new Object[] {totalBinCount});
+            getLogger().debug("Will not bin any FlowFiles because {} bins already exist; will wait until bins have been emptied before any more are created", totalBinCount);
         }
 
         if (!isScheduled()) {
@@ -235,7 +234,7 @@ public abstract class BinFiles extends AbstractSessionFactoryProcessor {
             try {
                 binProcessingResult = this.processBin(bin, context);
             } catch (final ProcessException e) {
-                logger.error("Failed to process bundle of {} files due to {}", new Object[] {bin.getContents().size(), e});
+                logger.error("Failed to process bundle of {} files", bin.getContents().size(), e);
 
                 final ProcessSession binSession = bin.getSession();
                 for (final FlowFile flowFile : bin.getContents()) {
@@ -244,7 +243,7 @@ public abstract class BinFiles extends AbstractSessionFactoryProcessor {
                 binSession.commitAsync();
                 continue;
             } catch (final Exception e) {
-                logger.error("Failed to process bundle of {} files due to {}; rolling back sessions", new Object[] {bin.getContents().size(), e});
+                logger.error("Rolling back sessions since failed to process bundle of {} files", bin.getContents().size(), e);
 
                 bin.getSession().rollback();
                 continue;

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventBatchingProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventBatchingProcessor.java
@@ -97,14 +97,14 @@ public abstract class AbstractListenEventBatchingProcessor<E extends Event> exte
 
             if (flowFile.getSize() == 0L || events.size() == 0) {
                 session.remove(flowFile);
-                getLogger().debug("No data written to FlowFile from batch {}; removing FlowFile", new Object[] {entry.getKey()});
+                getLogger().debug("No data written to FlowFile from batch {}; removing FlowFile", entry.getKey());
                 continue;
             }
 
             final Map<String, String> attributes = getAttributes(entry.getValue());
             flowFile = session.putAllAttributes(flowFile, attributes);
 
-            getLogger().debug("Transferring {} to success", new Object[] {flowFile});
+            getLogger().debug("Transferring {} to success", flowFile);
             session.transfer(flowFile, REL_SUCCESS);
             session.adjustCounter("FlowFiles Transferred to Success", 1L, false);
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/GetFileTransfer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/GetFileTransfer.java
@@ -130,10 +130,10 @@ public abstract class GetFileTransfer extends AbstractProcessor {
                     try {
                         transfer.close();
                     } catch (final IOException e1) {
-                        logger.warn("Unable to close connection due to {}", new Object[]{e1});
+                        logger.warn("Unable to close connection", e1);
                     }
 
-                    logger.error("Unable to fetch listing from remote server due to {}", new Object[]{e});
+                    logger.error("Unable to fetch listing from remote server", e);
                     return;
                 }
             } finally {
@@ -149,7 +149,7 @@ public abstract class GetFileTransfer extends AbstractProcessor {
                 try {
                     transfer.close();
                 } catch (final IOException e1) {
-                    logger.warn("Unable to close connection due to {}", new Object[]{e1});
+                    logger.warn("Unable to close connection", e1);
                 }
             }
             return;
@@ -205,17 +205,16 @@ public abstract class GetFileTransfer extends AbstractProcessor {
 
                     session.getProvenanceReporter().receive(flowFile, transfer.getProtocolName() + "://" + hostname + "/" + file.getFullPathFileName(), millis);
                     session.transfer(flowFile, REL_SUCCESS);
-                    logger.info("Successfully retrieved {} from {} in {} milliseconds at a rate of {} and transferred to success",
-                        new Object[]{flowFile, hostname, millis, dataRate});
+                    logger.info("Successfully retrieved {} from {} in {} milliseconds at a rate of {} and transferred to success", flowFile, hostname, millis, dataRate);
 
                     flowFilesReceived.put(flowFile, file.getFullPathFileName());
                 } catch (final IOException e) {
                     context.yield();
-                    logger.error("Unable to retrieve file {} due to {}", new Object[]{file.getFullPathFileName(), e});
+                    logger.error("Unable to retrieve file {}", file.getFullPathFileName(), e);
                     try {
                         transfer.close();
                     } catch (IOException e1) {
-                        logger.warn("Unable to close connection to remote host due to {}", new Object[]{e1});
+                        logger.warn("Unable to close connection to remote host", e1);
                     }
 
                     session.rollback();
@@ -269,7 +268,7 @@ public abstract class GetFileTransfer extends AbstractProcessor {
         try {
             transfer.close();
         } catch (final IOException e) {
-            getLogger().warn("Failed to close connection to {} due to {}", new Object[]{hostname, e});
+            getLogger().warn("Failed to close connection to {}", hostname, e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/PutFileTransfer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/PutFileTransfer.java
@@ -138,7 +138,7 @@ public abstract class PutFileTransfer<T extends FileTransfer> extends AbstractPr
                     final String dataRate = stopWatch.calculateDataRate(flowFile.getSize());
                     final long millis = stopWatch.getDuration(TimeUnit.MILLISECONDS);
                     logger.info("Successfully transferred {} to {} on remote host {} in {} milliseconds at a rate of {}",
-                            new Object[]{flowFile, fullPathRef.get(), hostname, millis, dataRate});
+                            flowFile, fullPathRef.get(), hostname, millis, dataRate);
 
                     String fullPathWithSlash = fullPathRef.get();
                     if (!fullPathWithSlash.startsWith("/")) {
@@ -160,17 +160,17 @@ public abstract class PutFileTransfer<T extends FileTransfer> extends AbstractPr
                     && ((flowFile = session.get()) != null));
         } catch (final IOException e) {
             context.yield();
-            logger.error("Unable to transfer {} to remote host {} due to {}", new Object[]{flowFile, hostname, e});
+            logger.error("Unable to transfer {} to remote host {} ", flowFile, hostname, e);
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         } catch (final FlowFileAccessException e) {
             context.yield();
-            logger.error("Unable to transfer {} to remote host {} due to {}", new Object[]{flowFile, hostname, e.getCause()});
+            logger.error("Unable to transfer {} to remote host {}", flowFile, hostname, e.getCause());
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         } catch (final ProcessException e) {
             context.yield();
-            logger.error("Unable to transfer {} to remote host {} due to {}: {}; routing to failure", new Object[]{flowFile, hostname, e, e.getCause()});
+            logger.error("Routing to failure since unable to transfer {} to remote host {}", flowFile, hostname, e.getCause());
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
         }
@@ -195,7 +195,7 @@ public abstract class PutFileTransfer<T extends FileTransfer> extends AbstractPr
         if (rejectZeroByteFiles) {
             final long sizeInBytes = flowFile.getSize();
             if (sizeInBytes == 0) {
-                logger.warn("Rejecting {} because it is zero bytes", new Object[]{flowFile});
+                logger.warn("Rejecting {} because it is zero bytes", flowFile);
                 return new ConflictResult(REL_REJECT, false, fileName, true);
             }
         }
@@ -211,26 +211,25 @@ public abstract class PutFileTransfer<T extends FileTransfer> extends AbstractPr
         }
 
         if (remoteFileInfo.isDirectory()) {
-            logger.warn("Resolving conflict by rejecting {} due to conflicting filename with a directory or file already on remote server", new Object[]{flowFile});
+            logger.warn("Resolving conflict by rejecting {} due to conflicting filename with a directory or file already on remote server", flowFile);
             return new ConflictResult(REL_REJECT, false, fileName, false);
         }
 
-        logger.info("Discovered a filename conflict on the remote server for {} so handling using configured Conflict Resolution of {}",
-                new Object[]{flowFile, conflictResolutionType});
+        logger.info("Discovered a filename conflict on the remote server for {} so handling using configured Conflict Resolution of {}", flowFile, conflictResolutionType);
 
         switch (conflictResolutionType.toUpperCase()) {
             case FileTransfer.CONFLICT_RESOLUTION_REJECT:
                 destinationRelationship = REL_REJECT;
                 transferFile = false;
                 penalizeFile = false;
-                logger.warn("Resolving conflict by rejecting {} due to conflicting filename with a directory or file already on remote server", new Object[]{flowFile});
+                logger.warn("Resolving conflict by rejecting {} due to conflicting filename with a directory or file already on remote server", flowFile);
                 break;
             case FileTransfer.CONFLICT_RESOLUTION_REPLACE:
                 transfer.deleteFile(flowFile, path, fileName);
                 destinationRelationship = REL_SUCCESS;
                 transferFile = true;
                 penalizeFile = false;
-                logger.info("Resolving filename conflict for {} with remote server by deleting remote file and replacing with flow file", new Object[]{flowFile});
+                logger.info("Resolving filename conflict for {} with remote server by deleting remote file and replacing with flow file", flowFile);
                 break;
             case FileTransfer.CONFLICT_RESOLUTION_RENAME:
                 boolean uniqueNameGenerated = false;
@@ -241,7 +240,7 @@ public abstract class PutFileTransfer<T extends FileTransfer> extends AbstractPr
                     uniqueNameGenerated = (renamedFileInfo == null);
                     if (uniqueNameGenerated) {
                         fileName = possibleFileName;
-                        logger.info("Attempting to resolve filename conflict for {} on the remote server by using a newly generated filename of: {}", new Object[]{flowFile, fileName});
+                        logger.info("Attempting to resolve filename conflict for {} on the remote server by using a newly generated filename of: {}", flowFile, fileName);
                         destinationRelationship = REL_SUCCESS;
                         transferFile = true;
                         penalizeFile = false;
@@ -259,13 +258,13 @@ public abstract class PutFileTransfer<T extends FileTransfer> extends AbstractPr
                 destinationRelationship = REL_SUCCESS;
                 transferFile = false;
                 penalizeFile = false;
-                logger.info("Resolving conflict for {}  by not transferring file and and still considering the process a success.", new Object[]{flowFile});
+                logger.info("Resolving conflict for {}  by not transferring file and and still considering the process a success.", flowFile);
                 break;
             case FileTransfer.CONFLICT_RESOLUTION_FAIL:
                 destinationRelationship = REL_FAILURE;
                 transferFile = false;
                 penalizeFile = true;
-                logger.warn("Resolved filename conflict for {} as configured by routing to FAILURE relationship.", new Object[]{flowFile});
+                logger.warn("Resolved filename conflict for {} as configured by routing to FAILURE relationship.", flowFile);
             default:
                 break;
         }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
@@ -364,7 +364,7 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
                 hdfsResources.set(resources);
             }
         } catch (Exception ex) {
-            getLogger().error("HDFS Configuration error - {}", new Object[]{ex});
+            getLogger().error("HDFS Configuration error -", ex);
             hdfsResources.set(EMPTY_HDFS_RESOURCES);
             throw ex;
         }
@@ -473,7 +473,7 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
             }
             fs = getFileSystemAsUser(config, ugi);
         }
-        getLogger().debug("resetHDFSResources UGI [{}], KerberosUser [{}]", new Object[]{ugi, kerberosUser});
+        getLogger().debug("resetHDFSResources UGI [{}], KerberosUser [{}]", ugi, kerberosUser);
 
         final Path workingDir = fs.getWorkingDirectory();
         getLogger().info("Initialized a new HDFS File System with working dir: {} default block size: {} default replication: {} config: {}",

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
@@ -364,7 +364,7 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
                 hdfsResources.set(resources);
             }
         } catch (Exception ex) {
-            getLogger().error("HDFS Configuration error -", ex);
+            getLogger().error("HDFS Configuration failed", ex);
             hdfsResources.set(EMPTY_HDFS_RESOURCES);
             throw ex;
         }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-listed-entity/src/main/java/org/apache/nifi/processor/util/list/AbstractListProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-listed-entity/src/main/java/org/apache/nifi/processor/util/list/AbstractListProcessor.java
@@ -898,7 +898,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
             }
 
             if (processedNewFiles) {
-                getLogger().info("Successfully created listing with {} new objects", new Object[]{entitiesListed});
+                getLogger().info("Successfully created listing with {} new objects", entitiesListed);
                 session.commitAsync();
             }
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-listed-entity/src/main/java/org/apache/nifi/processor/util/list/ListedEntityTracker.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-listed-entity/src/main/java/org/apache/nifi/processor/util/list/ListedEntityTracker.java
@@ -211,14 +211,14 @@ public class ListedEntityTracker<T extends ListableEntity> {
 
     private void persistListedEntities(Map<String, ListedEntity> listedEntities) throws IOException {
         final String cacheKey = getCacheKey();
-        logger.debug("Persisting listed entities: {}={}", new Object[]{cacheKey, listedEntities});
+        logger.debug("Persisting listed entities: {}={}", cacheKey, listedEntities);
         mapCacheClient.put(cacheKey, listedEntities, stringSerializer, listedEntitiesSerializer);
     }
 
     private Map<String, ListedEntity> fetchListedEntities() throws IOException {
         final String cacheKey = getCacheKey();
         final Map<String, ListedEntity> listedEntities = mapCacheClient.get(cacheKey, stringSerializer, listedEntitiesDeserializer);
-        logger.debug("Fetched listed entities: {}={}", new Object[]{cacheKey, listedEntities});
+        logger.debug("Fetched listed entities: {}={}", cacheKey, listedEntities);
         return listedEntities;
     }
 
@@ -226,7 +226,7 @@ public class ListedEntityTracker<T extends ListableEntity> {
         alreadyListedEntities = null;
         if (mapCacheClient != null) {
             final String cacheKey = getCacheKey();
-            logger.debug("Removing listed entities from cache storage: {}", new Object[]{cacheKey});
+            logger.debug("Removing listed entities from cache storage: {}", cacheKey);
             mapCacheClient.remove(cacheKey, stringSerializer);
         }
     }
@@ -281,27 +281,27 @@ public class ListedEntityTracker<T extends ListableEntity> {
             final String identifier = entity.getIdentifier();
 
             if (entity.getTimestamp() < minTimestampToList) {
-                logger.trace("Skipped {} having older timestamp than the minTimestampToList {}.", new Object[]{identifier, entity.getTimestamp(), minTimestampToList});
+                logger.trace("Skipped {} having older timestamp {} than the minTimestampToList {}.", identifier, entity.getTimestamp(), minTimestampToList);
                 return false;
             }
 
             final ListedEntity alreadyListedEntity = alreadyListedEntities.get(identifier);
             if (alreadyListedEntity == null) {
-                logger.trace("Picked {} being newly found.", new Object[]{identifier});
+                logger.trace("Picked {} being newly found.", identifier);
                 return true;
             }
 
             if (entity.getTimestamp() > alreadyListedEntity.getTimestamp()) {
-                logger.trace("Picked {} having newer timestamp {} than {}.", new Object[]{identifier, entity.getTimestamp(), alreadyListedEntity.getTimestamp()});
+                logger.trace("Picked {} having newer timestamp {} than {}.", identifier, entity.getTimestamp(), alreadyListedEntity.getTimestamp());
                 return true;
             }
 
             if (entity.getSize() != alreadyListedEntity.getSize()) {
-                logger.trace("Picked {} having different size {} than {}.", new Object[]{identifier, entity.getSize(), alreadyListedEntity.getSize()});
+                logger.trace("Picked {} having different size {} than {}.", identifier, entity.getSize(), alreadyListedEntity.getSize());
                 return true;
             }
 
-            logger.trace("Skipped {}, not changed.", new Object[]{identifier, entity.getTimestamp(), minTimestampToList});
+            logger.trace("Skipped {}, not changed.", identifier);
             return false;
         }).collect(Collectors.toList());
 
@@ -334,8 +334,8 @@ public class ListedEntityTracker<T extends ListableEntity> {
         // In case persisting listed entities failure, same entities may be listed again, but better than not listing.
         session.commitAsync(() -> {
             try {
-                logger.debug("Removed old entities count: {}, Updated entities count: {}", new Object[]{oldEntityIds.size(), updatedEntities.size()});
-                logger.trace("Removed old entities: {}, Updated entities: {}", new Object[]{oldEntityIds, updatedEntities});
+                logger.debug("Removed old entities count: {}, Updated entities count: {}", oldEntityIds.size(), updatedEntities.size());
+                logger.trace("Removed old entities: {}, Updated entities: {}", oldEntityIds, updatedEntities);
 
                 persistListedEntities(alreadyListedEntities);
             } catch (IOException e) {

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-put-pattern/src/main/java/org/apache/nifi/processor/util/pattern/PartialFunctions.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-put-pattern/src/main/java/org/apache/nifi/processor/util/pattern/PartialFunctions.java
@@ -120,7 +120,7 @@ public class PartialFunctions {
             onTrigger.execute(session);
             session.commitAsync();
         } catch (final Throwable t) {
-            logger.error("{} failed to process due to {}; rolling back session", new Object[]{onTrigger, t});
+            logger.error("Rolling back session since {} failed to process", onTrigger, t);
             rollbackSession.rollback(session, t);
             throw t;
         }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractFetchHDFSRecord.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractFetchHDFSRecord.java
@@ -235,22 +235,22 @@ public abstract class AbstractFetchHDFSRecord extends AbstractHadoopProcessor {
 
                 final Path qualifiedPath = path.makeQualified(fileSystem.getUri(), fileSystem.getWorkingDirectory());
                 successFlowFile = session.putAttribute(successFlowFile, HADOOP_FILE_URL_ATTRIBUTE, qualifiedPath.toString());
-                getLogger().info("Successfully received content from {} for {} in {} milliseconds", new Object[] {qualifiedPath, successFlowFile, stopWatch.getDuration()});
+                getLogger().info("Successfully received content from {} for {} in {} milliseconds", qualifiedPath, successFlowFile, stopWatch.getDuration());
                 session.getProvenanceReporter().fetch(successFlowFile, qualifiedPath.toString(), stopWatch.getDuration(TimeUnit.MILLISECONDS));
                 session.transfer(successFlowFile, REL_SUCCESS);
                 session.remove(originalFlowFile);
                 return null;
 
             } catch (final FileNotFoundException | AccessControlException e) {
-                getLogger().error("Failed to retrieve content from {} for {} due to {}; routing to failure", new Object[] {filenameValue, originalFlowFile, e});
+                getLogger().error("Routing to failure since failed to retrieve content from {} for {}", filenameValue, originalFlowFile, e);
                 final FlowFile failureFlowFile = session.putAttribute(originalFlowFile, FETCH_FAILURE_REASON_ATTR, e.getMessage() == null ? e.toString() : e.getMessage());
                 session.transfer(failureFlowFile, REL_FAILURE);
             } catch (final IOException | FlowFileAccessException e) {
-                getLogger().error("Failed to retrieve content from {} for {} due to {}; routing to retry", new Object[] {filenameValue, originalFlowFile, e});
+                getLogger().error("Routing to retry since failed to retrieve content from {} for {}", filenameValue, originalFlowFile, e);
                 session.transfer(session.penalize(originalFlowFile), REL_RETRY);
                 context.yield();
             } catch (final Throwable t) {
-                getLogger().error("Failed to retrieve content from {} for {} due to {}; routing to failure", new Object[] {filenameValue, originalFlowFile, t});
+                getLogger().error("Routing to failure since failed to retrieve content from {} for {}", filenameValue, originalFlowFile, t);
                 final FlowFile failureFlowFile = session.putAttribute(originalFlowFile, FETCH_FAILURE_REASON_ATTR, t.getMessage() == null ? t.toString() : t.getMessage());
                 session.transfer(failureFlowFile, REL_FAILURE);
             }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractPutHDFSRecord.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractPutHDFSRecord.java
@@ -298,7 +298,7 @@ public abstract class AbstractPutHDFSRecord extends AbstractHadoopProcessor {
                 // if the tempFile or destFile already exist, and overwrite is set to false, then transfer to failure
                 if (destinationOrTempExists && !shouldOverwrite) {
                     session.transfer(session.penalize(putFlowFile), REL_FAILURE);
-                    getLogger().warn("penalizing {} and routing to failure because file with same name already exists", new Object[]{putFlowFile});
+                    getLogger().warn("penalizing {} and routing to failure because file with same name already exists", putFlowFile);
                     return null;
                 }
 
@@ -353,8 +353,7 @@ public abstract class AbstractPutHDFSRecord extends AbstractHadoopProcessor {
                 // If destination file already exists, resolve that based on processor configuration
                 if (destinationExists && shouldOverwrite) {
                     if (fileSystem.delete(destFile, false)) {
-                        getLogger().info("deleted {} in order to replace with the contents of {}",
-                                new Object[]{destFile, putFlowFile});
+                        getLogger().info("deleted {} in order to replace with the contents of {}", destFile, putFlowFile);
                     }
                 }
 
@@ -362,7 +361,7 @@ public abstract class AbstractPutHDFSRecord extends AbstractHadoopProcessor {
                 rename(fileSystem, tempFile, destFile);
                 changeOwner(fileSystem, destFile, remoteOwner, remoteGroup);
 
-                getLogger().info("Wrote {} to {} in {} milliseconds at a rate of {}", new Object[]{putFlowFile, destFile, millis, dataRate});
+                getLogger().info("Wrote {} to {} in {} milliseconds at a rate of {}", putFlowFile, destFile, millis, dataRate);
 
                 putFlowFile = postProcess(context, session, putFlowFile, destFile);
 
@@ -384,12 +383,12 @@ public abstract class AbstractPutHDFSRecord extends AbstractHadoopProcessor {
 
             } catch (IOException | FlowFileAccessException e) {
                 deleteQuietly(fileSystem, tempDotCopyFile);
-                getLogger().error("Failed to write due to {}", new Object[]{e});
+                getLogger().error("Failed to write", e);
                 session.transfer(session.penalize(putFlowFile), REL_RETRY);
                 context.yield();
             } catch (Throwable t) {
                 deleteQuietly(fileSystem, tempDotCopyFile);
-                getLogger().error("Failed to write due to {}", new Object[]{t});
+                getLogger().error("Failed to write", t);
                 session.transfer(putFlowFile, REL_FAILURE);
             }
 
@@ -449,7 +448,7 @@ public abstract class AbstractPutHDFSRecord extends AbstractHadoopProcessor {
             try {
                 fileSystem.delete(file, false);
             } catch (Exception e) {
-                getLogger().error("Unable to remove file {} due to {}", new Object[]{file, e});
+                getLogger().error("Unable to remove file {}", file, e);
             }
         }
     }
@@ -469,7 +468,7 @@ public abstract class AbstractPutHDFSRecord extends AbstractHadoopProcessor {
                 fileSystem.setOwner(path, remoteOwner, remoteGroup);
             }
         } catch (Exception e) {
-            getLogger().warn("Could not change owner or group of {} on due to {}", new Object[]{path, e});
+            getLogger().warn("Could not change owner or group of {} on", path, e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonPathRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonPathRowRecordReader.java
@@ -107,7 +107,7 @@ public class JsonPathRowRecordReader extends AbstractJsonRowRecordReader {
             try {
                 value = ctx.read(jsonPath);
             } catch (final PathNotFoundException pnfe) {
-                logger.debug("Evaluated JSONPath Expression {} but the path was not found; will use a null value", new Object[] {entry.getValue()});
+                logger.debug("Evaluated JSONPath Expression {} but the path was not found; will use a null value", entry.getValue());
                 value = null;
             }
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/record/listen/SocketChannelRecordReaderDispatcher.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/main/java/org/apache/nifi/record/listen/SocketChannelRecordReaderDispatcher.java
@@ -87,14 +87,14 @@ public class SocketChannelRecordReaderDispatcher implements Runnable, Closeable 
                 if (currentConnections.incrementAndGet() > maxConnections) {
                     currentConnections.decrementAndGet();
                     final String remoteAddress = remoteSocketAddress == null ? "null" : remoteSocketAddress.toString();
-                    logger.warn("Rejecting connection from {} because max connections has been met", new Object[]{remoteAddress});
+                    logger.warn("Rejecting connection from {} because max connections has been met", remoteAddress);
                     IOUtils.closeQuietly(socketChannel);
                     continue;
                 }
 
                 if (logger.isDebugEnabled()) {
                     final String remoteAddress = remoteSocketAddress == null ? "null" : remoteSocketAddress.toString();
-                    logger.debug("Accepted connection from {}", new Object[]{remoteAddress});
+                    logger.debug("Accepted connection from {}", remoteAddress);
                 }
 
                 // create a StandardSocketChannelRecordReader or an SSLSocketChannelRecordReader based on presence of SSLContext

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-reporting-utils/src/main/java/org/apache/nifi/reporting/util/provenance/ProvenanceEventConsumer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-reporting-utils/src/main/java/org/apache/nifi/reporting/util/provenance/ProvenanceEventConsumer.java
@@ -181,11 +181,11 @@ public class ProvenanceEventConsumer {
             if (currMaxId < (firstEventId - 1)) {
                 if (BEGINNING_OF_STREAM.getValue().equals(startPositionValue)) {
                     logger.warn("Current provenance max id is {} which is less than what was stored in state as the last queried event, which was {}. This means the provenance restarted its " +
-                            "ids. Restarting querying from the beginning.", new Object[]{currMaxId, firstEventId});
+                            "ids. Restarting querying from the beginning.", currMaxId, firstEventId);
                     firstEventId = -1;
                 } else {
                     logger.warn("Current provenance max id is {} which is less than what was stored in state as the last queried event, which was {}. This means the provenance restarted its " +
-                            "ids. Restarting querying from the latest event in the Provenance Repository.", new Object[]{currMaxId, firstEventId});
+                            "ids. Restarting querying from the latest event in the Provenance Repository.", currMaxId, firstEventId);
                     firstEventId = currMaxId;
                 }
             }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/ConsumeGCPubSub.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/ConsumeGCPubSub.java
@@ -134,7 +134,7 @@ public class ConsumeGCPubSub extends AbstractGCPubSubWithProxyProcessor {
             subscriber = getSubscriber(context);
         } catch (IOException e) {
             storedException.set(e);
-            getLogger().error("Failed to create Google Cloud Subscriber due to {}", new Object[]{e});
+            getLogger().error("Failed to create Google Cloud Subscriber", e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PublishGCPubSub.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PublishGCPubSub.java
@@ -444,7 +444,7 @@ public class PublishGCPubSub extends AbstractGCPubSubWithProxyProcessor {
                 publisher.shutdown();
             }
         } catch (Exception e) {
-            getLogger().warn("Failed to gracefully shutdown the Google Cloud PubSub Publisher due to {}", new Object[]{e});
+            getLogger().warn("Failed to gracefully shutdown the Google Cloud PubSub Publisher", e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/DeleteGCSObject.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/DeleteGCSObject.java
@@ -132,6 +132,6 @@ public class DeleteGCSObject extends AbstractGCSProcessor {
 
         session.transfer(flowFile, REL_SUCCESS);
         final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-        getLogger().info("Successfully deleted GCS Object for {} in {} millis; routing to success", new Object[]{flowFile, millis});
+        getLogger().info("Successfully deleted GCS Object for {} in {} millis; routing to success", flowFile, millis);
     }
 }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/FetchGCSObject.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/FetchGCSObject.java
@@ -303,7 +303,7 @@ public class FetchGCSObject extends AbstractGCSProcessor {
         session.transfer(flowFile, REL_SUCCESS);
 
         final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-        getLogger().info("Successfully retrieved GCS Object for {} in {} millis; routing to success", new Object[]{flowFile, millis});
+        getLogger().info("Successfully retrieved GCS Object for {} in {} millis; routing to success", flowFile, millis);
 
         final String transitUri = getTransitUri(storage.getOptions().getHost(), bucketName, key);
         session.getProvenanceReporter().fetch(flowFile, transitUri, millis);
@@ -328,7 +328,7 @@ public class FetchGCSObject extends AbstractGCSProcessor {
         }
         if (rangeStart > 0 && rangeStart >= blob.getSize()) {
             if (getLogger().isDebugEnabled()) {
-                getLogger().debug("Start position: {}, blob size: {}", new Object[] {rangeStart, blob.getSize()});
+                getLogger().debug("Start position: {}, blob size: {}", rangeStart, blob.getSize());
             }
             throw new StorageException(416, "The range specified is not valid for the blob " + blob.getBlobId()
                     + ". Range Start is beyond the end of the blob.");

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/PutGCSObject.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/PutGCSObject.java
@@ -534,8 +534,7 @@ public class PutGCSObject extends AbstractGCSProcessor {
 
             final String transitUri = getTransitUri(storage.getOptions().getHost(), bucket, key);
             session.getProvenanceReporter().send(flowFile, transitUri, millis);
-            getLogger().info("Successfully put {} to Google Cloud Storage in {} milliseconds",
-                    new Object[]{ff, millis});
+            getLogger().info("Successfully put {} to Google Cloud Storage in {} milliseconds", ff, millis);
 
         } catch (final ProcessException | StorageException | IOException e) {
             getLogger().error("Failed to put {} to Google Cloud Storage due to {}", flowFile, e.getMessage(), e);

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-processors/src/main/java/org/apache/nifi/processors/graph/ExecuteGraphQueryRecord.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-processors/src/main/java/org/apache/nifi/processors/graph/ExecuteGraphQueryRecord.java
@@ -239,7 +239,7 @@ public class ExecuteGraphQueryRecord extends  AbstractGraphExecutor {
 
                     dynamicPropertyMap.putAll(input.getAttributes());
                     if (getLogger().isDebugEnabled()) {
-                        getLogger().debug("Dynamic Properties: {}", new Object[]{dynamicPropertyMap});
+                        getLogger().debug("Dynamic Properties: {}", dynamicPropertyMap);
                     }
                     List<Map<String, Object>> graphResponses = new ArrayList<>(executeQuery(recordScript, dynamicPropertyMap));
 

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/src/main/java/org/apache/nifi/graph/Neo4JCypherClientService.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/src/main/java/org/apache/nifi/graph/Neo4JCypherClientService.java
@@ -238,8 +238,7 @@ public class Neo4JCypherClientService extends AbstractControllerService implemen
             getLogger().error("Error while getting connection " + e.getLocalizedMessage(), e);
             throw new ProcessException("Error while getting connection" + e.getLocalizedMessage(), e);
         }
-        getLogger().info("Neo4JCypherExecutor connection created for url {}",
-                new Object[] {connectionUrl});
+        getLogger().info("Neo4JCypherExecutor connection created for url {}", connectionUrl);
     }
 
     @OnDisabled

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/flow/resource/hadoop/HDFSExternalResourceProvider.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/flow/resource/hadoop/HDFSExternalResourceProvider.java
@@ -226,11 +226,11 @@ public class HDFSExternalResourceProvider implements ExternalResourceProvider {
             fs = getFileSystemAsUser(config, ugi);
         }
 
-        LOGGER.debug("resetHDFSResources UGI [{}], KerberosUser [{}]", new Object[]{ugi, kerberosUser});
+        LOGGER.debug("resetHDFSResources UGI [{}], KerberosUser [{}]", ugi, kerberosUser);
 
         final Path workingDir = fs.getWorkingDirectory();
         LOGGER.debug("Initialized a new HDFS File System with working dir: {} default block size: {} default replication: {} config: {}",
-                new Object[]{workingDir, fs.getDefaultBlockSize(workingDir), fs.getDefaultReplication(workingDir), config.toString()});
+                workingDir, fs.getDefaultBlockSize(workingDir), fs.getDefaultReplication(workingDir), config);
 
         if (!fs.exists(sourceDirectory)) {
             throw new IllegalArgumentException("Source directory is not existing");

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/CreateHadoopSequenceFile.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/CreateHadoopSequenceFile.java
@@ -137,9 +137,7 @@ public class CreateHadoopSequenceFile extends AbstractHadoopProcessor {
                         packagingFormat = ZIP_FORMAT;
                         break;
                     default:
-                        getLogger().warn(
-                                "Cannot unpack {} because its mime.type attribute is set to '{}', which is not a format that can be unpacked",
-                                new Object[]{flowFile, mimeType});
+                        getLogger().warn("Cannot unpack {} because its mime.type attribute is set to '{}', which is not a format that can be unpacked", flowFile, mimeType);
                 }
             }
         }
@@ -180,7 +178,7 @@ public class CreateHadoopSequenceFile extends AbstractHadoopProcessor {
             flowFile = sequenceFileWriter.writeSequenceFile(flowFile, session, configuration, compressionType, codec);
             session.getProvenanceReporter().modifyContent(flowFile, stopWatch.getElapsed(TimeUnit.MILLISECONDS));
             session.transfer(flowFile, RELATIONSHIP_SUCCESS);
-            getLogger().info("Transferred flowfile {} to {}", new Object[]{flowFile, RELATIONSHIP_SUCCESS});
+            getLogger().info("Transferred flowfile {} to {}", flowFile, RELATIONSHIP_SUCCESS);
         } catch (ProcessException e) {
             getLogger().error("Failed to create Sequence File. Transferring {} to 'failure'", flowFile, e);
             session.transfer(flowFile, RELATIONSHIP_FAILURE);

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
@@ -173,7 +173,7 @@ public class DeleteHDFS extends AbstractHadoopProcessor {
                             flowFile = session.putAllAttributes(flowFile, attributes);
 
                             fileSystem.delete(path, isRecursive(context, session));
-                            getLogger().debug("For flowfile {} Deleted file at path {} with name {}", new Object[]{originalFlowFile, path.getParent().toString(), path.getName()});
+                            getLogger().debug("For flowfile {} Deleted file at path {} with name {}", originalFlowFile, path.getParent(), path.getName());
                             final Path qualifiedPath = path.makeQualified(fileSystem.getUri(), fileSystem.getWorkingDirectory());
                             flowFile = session.putAttribute(flowFile, HADOOP_FILE_URL_ATTRIBUTE, qualifiedPath.toString());
                             session.getProvenanceReporter().invokeRemoteProcess(flowFile, qualifiedPath.toString());

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/FetchHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/FetchHDFS.java
@@ -133,7 +133,7 @@ public class FetchHDFS extends AbstractHadoopProcessor {
         try {
             path = getNormalizedPath(getPath(context, flowFile));
         } catch (IllegalArgumentException e) {
-            getLogger().error("Routing to failure since failed to retrieve content from {} for {}", filenameValue, flowFile, e);
+            getLogger().error("Failed to retrieve content from {} for {}", filenameValue, flowFile, e);
             flowFile = session.putAttribute(flowFile, getAttributePrefix() + ".failure.reason", e.getMessage());
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, getFailureRelationship());
@@ -181,7 +181,7 @@ public class FetchHDFS extends AbstractHadoopProcessor {
                 session.getProvenanceReporter().fetch(outgoingFlowFile, qualifiedPath.toString(), stopWatch.getDuration(TimeUnit.MILLISECONDS));
                 session.transfer(outgoingFlowFile, getSuccessRelationship());
             } catch (final FileNotFoundException | AccessControlException e) {
-                getLogger().error("Routing to failure since failed to retrieve content from {} for {}", qualifiedPath, outgoingFlowFile, e);
+                getLogger().error("Failed to retrieve content from {} for {}", qualifiedPath, outgoingFlowFile, e);
                 outgoingFlowFile = session.putAttribute(outgoingFlowFile, getAttributePrefix() + ".failure.reason", e.getMessage());
                 outgoingFlowFile = session.penalize(outgoingFlowFile);
                 session.transfer(outgoingFlowFile, getFailureRelationship());

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/FetchHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/FetchHDFS.java
@@ -133,7 +133,7 @@ public class FetchHDFS extends AbstractHadoopProcessor {
         try {
             path = getNormalizedPath(getPath(context, flowFile));
         } catch (IllegalArgumentException e) {
-            getLogger().error("Failed to retrieve content from {} for {} due to {}; routing to failure", new Object[] {filenameValue, flowFile, e});
+            getLogger().error("Routing to failure since failed to retrieve content from {} for {}", filenameValue, flowFile, e);
             flowFile = session.putAttribute(flowFile, getAttributePrefix() + ".failure.reason", e.getMessage());
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, getFailureRelationship());
@@ -181,7 +181,7 @@ public class FetchHDFS extends AbstractHadoopProcessor {
                 session.getProvenanceReporter().fetch(outgoingFlowFile, qualifiedPath.toString(), stopWatch.getDuration(TimeUnit.MILLISECONDS));
                 session.transfer(outgoingFlowFile, getSuccessRelationship());
             } catch (final FileNotFoundException | AccessControlException e) {
-                getLogger().error("Failed to retrieve content from {} for {} due to {}; routing to failure", new Object[]{qualifiedPath, outgoingFlowFile, e});
+                getLogger().error("Routing to failure since failed to retrieve content from {} for {}", qualifiedPath, outgoingFlowFile, e);
                 outgoingFlowFile = session.putAttribute(outgoingFlowFile, getAttributePrefix() + ".failure.reason", e.getMessage());
                 outgoingFlowFile = session.penalize(outgoingFlowFile);
                 session.transfer(outgoingFlowFile, getFailureRelationship());

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFS.java
@@ -286,7 +286,7 @@ public class GetHDFS extends AbstractHadoopProcessor {
                             }
                         }
                     } catch (Exception e) {
-                        getLogger().warn("Could not add to processing queue due to {}", new Object[]{e});
+                        getLogger().warn("Could not add to processing queue", e);
                     } finally {
                         queueLock.unlock();
                     }
@@ -433,7 +433,7 @@ public class GetHDFS extends AbstractHadoopProcessor {
                 final boolean directoryExists = getUserGroupInformation().doAs((PrivilegedExceptionAction<Boolean>) () -> hdfs.exists(directoryPath));
                 if (!directoryExists) {
                     context.yield();
-                    getLogger().warn("The directory {} does not exist.", new Object[]{directoryPath});
+                    getLogger().warn("The directory {} does not exist.", directoryPath);
                 } else {
                     // get listing
                     listing = selectFiles(hdfs, directoryPath, null);

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSFileInfo.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSFileInfo.java
@@ -330,7 +330,7 @@ public class GetHDFSFileInfo extends AbstractHadoopProcessor {
         } catch (final Exception e) {
             // Catch GSSExceptions and reset the resources
             if (!handleAuthErrors(e, session, context, new GSSExceptionRollbackYieldSessionHandler())) {
-                getLogger().error("Failed to perform listing of HDFS due to {}", new Object[]{e});
+                getLogger().error("Failed to perform listing of HDFS", e);
                 ff = session.putAttribute(ff, "hdfs.status", "Failed due to: " + e);
                 session.transfer(ff, REL_FAILURE);
             }

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSSequenceFile.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSSequenceFile.java
@@ -128,9 +128,8 @@ public class GetHDFSSequenceFile extends GetHDFS {
                 if (totalSize > 0) {
                     final String dataRate = stopWatch.calculateDataRate(totalSize);
                     final long millis = stopWatch.getDuration(TimeUnit.MILLISECONDS);
-                    logger.info("Created {} flowFiles from SequenceFile {}. Ingested in {} milliseconds at a rate of {}", new Object[]{
-                        flowFiles.size(), file.toUri().toASCIIString(), millis, dataRate});
-                    logger.info("Transferred flowFiles {}  to success", new Object[]{flowFiles});
+                    logger.info("Created {} flowFiles from SequenceFile {}. Ingested in {} milliseconds at a rate of {}", flowFiles.size(), file.toUri().toASCIIString(), millis, dataRate);
+                    logger.info("Transferred flowFiles {}  to success", flowFiles);
                     session.transfer(flowFiles, REL_SUCCESS);
                 }
             }

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/KeyValueReader.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/KeyValueReader.java
@@ -68,7 +68,7 @@ public class KeyValueReader implements SequenceFileReader<Set<FlowFile>> {
         final KeyValueWriterCallback callback = new KeyValueWriterCallback(reader);
         final String inputfileName = file.getName() + "." + System.nanoTime() + ".";
         int counter = 0;
-        LOG.debug("Read from SequenceFile: {} ", new Object[]{file});
+        LOG.debug("Read from SequenceFile: {} ", file);
         try {
             while (reader.next(key)) {
                 String fileName = key.toString();
@@ -89,7 +89,7 @@ public class KeyValueReader implements SequenceFileReader<Set<FlowFile>> {
                     flowFile = session.write(flowFile, callback);
                     flowFiles.add(flowFile);
                 } catch (ProcessException e) {
-                    LOG.error("Could not write to flowfile {}", new Object[]{flowFile}, e);
+                    LOG.error("Could not write to flowfile {}", flowFile, e);
                     session.remove(flowFile);
                 }
                 key.clear();

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/KeyValueReader.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/KeyValueReader.java
@@ -68,7 +68,7 @@ public class KeyValueReader implements SequenceFileReader<Set<FlowFile>> {
         final KeyValueWriterCallback callback = new KeyValueWriterCallback(reader);
         final String inputfileName = file.getName() + "." + System.nanoTime() + ".";
         int counter = 0;
-        LOG.debug("Read from SequenceFile: {} ", file);
+        LOG.debug("Read from SequenceFile: {}", file);
         try {
             while (reader.next(key)) {
                 String fileName = key.toString();

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/MoveHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/MoveHDFS.java
@@ -306,7 +306,7 @@ public class MoveHDFS extends AbstractHadoopProcessor {
             }
         } catch (IOException e) {
             context.yield();
-            getLogger().warn("Error while retrieving list of files due to {}", new Object[]{e});
+            getLogger().warn("Error while retrieving list of files", e);
             return;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -446,7 +446,7 @@ public class MoveHDFS extends AbstractHadoopProcessor {
                     if (causeOptional.isPresent()) {
                         throw new UncheckedIOException(new IOException(causeOptional.get()));
                     }
-                    getLogger().error("Failed to rename on HDFS due to {}", new Object[]{t});
+                    getLogger().error("Failed to rename on HDFS", t);
                     session.transfer(session.penalize(flowFile), REL_FAILURE);
                     context.yield();
                 }

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
@@ -513,10 +513,10 @@ public class PutHDFS extends AbstractHadoopProcessor {
                         try {
                             hdfs.delete(tempDotCopyFile, false);
                         } catch (Exception e) {
-                            getLogger().error("Unable to remove temporary file {} due to {}", new Object[]{tempDotCopyFile, e});
+                            getLogger().error("Unable to remove temporary file {}", tempDotCopyFile, e);
                         }
                     }
-                    getLogger().error("Failed to write to HDFS due to {}", new Object[]{t});
+                    getLogger().error("Failed to write to HDFS", t);
                     session.transfer(session.penalize(putFlowFile), getFailureRelationship());
                     context.yield();
                 }
@@ -593,7 +593,7 @@ public class PutHDFS extends AbstractHadoopProcessor {
                 hdfs.setOwner(name, owner, group);
             }
         } catch (Exception e) {
-            getLogger().warn("Could not change owner or group of {} on HDFS due to {}", new Object[]{name, e});
+            getLogger().warn("Could not change owner or group of {} on HDFS", name, e);
         }
     }
 }

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/TarUnpackerSequenceFileWriter.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/TarUnpackerSequenceFileWriter.java
@@ -45,7 +45,7 @@ public class TarUnpackerSequenceFileWriter extends SequenceFileWriterImpl {
                 final long fileSize = tarEntry.getSize();
                 final InputStreamWritable inStreamWritable = new InputStreamWritable(tarIn, (int) fileSize);
                 writer.append(new Text(key), inStreamWritable);
-                logger.debug("Appending FlowFile {} to Sequence File", new Object[]{key});
+                logger.debug("Appending FlowFile {} to Sequence File", key);
             }
         }
     }

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/ValueReader.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/ValueReader.java
@@ -64,7 +64,7 @@ public class ValueReader implements SequenceFileReader<Set<FlowFile>> {
         final SequenceFile.Reader reader = new SequenceFile.Reader(configuration, Reader.file(fileSystem.makeQualified(file)));
         final String inputfileName = file.getName() + "." + System.nanoTime() + ".";
         int counter = 0;
-        LOG.debug("Reading from sequence file {}", new Object[]{file});
+        LOG.debug("Reading from sequence file {}", file);
         final OutputStreamWritableCallback writer = new OutputStreamWritableCallback(reader);
         Text key = new Text();
         try {
@@ -85,7 +85,7 @@ public class ValueReader implements SequenceFileReader<Set<FlowFile>> {
                     flowFile = session.write(flowFile, writer);
                     flowFiles.add(flowFile);
                 } catch (ProcessException e) {
-                    LOG.error("Could not write to flowfile {}", new Object[]{flowFile}, e);
+                    LOG.error("Could not write to flowfile {}", flowFile, e);
                     session.remove(flowFile);
                 }
                 key.clear();

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/ZipUnpackerSequenceFileWriter.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/ZipUnpackerSequenceFileWriter.java
@@ -48,7 +48,7 @@ public class ZipUnpackerSequenceFileWriter extends SequenceFileWriterImpl {
                 long fileSize = zipEntry.getSize();
                 final InputStreamWritable inStreamWritable = new InputStreamWritable(zipIn, (int) fileSize);
                 writer.append(new Text(key), inStreamWritable);
-                logger.debug("Appending FlowFile {} to Sequence File", new Object[]{key});
+                logger.debug("Appending FlowFile {} to Sequence File", key);
             }
         }
     }

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/inotify/GetHDFSEvents.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/inotify/GetHDFSEvents.java
@@ -193,7 +193,7 @@ public class GetHDFSEvents extends AbstractHadoopProcessor {
                     List<FlowFile> flowFiles = new ArrayList<>(eventBatch.getEvents().length);
                     for (Event e : eventBatch.getEvents()) {
                         if (toProcessEvent(context, e)) {
-                            getLogger().debug("Creating flow file for event: {}.", new Object[]{e});
+                            getLogger().debug("Creating flow file for event: {}.", e);
                             final String path = getPath(e);
 
                             FlowFile flowFile = session.create();
@@ -214,7 +214,7 @@ public class GetHDFSEvents extends AbstractHadoopProcessor {
                     for (FlowFile flowFile : flowFiles) {
                         final String path = flowFile.getAttribute(EventAttributes.EVENT_PATH);
                         final String transitUri = path.startsWith("/") ? "hdfs:/" + path : "hdfs://" + path;
-                        getLogger().debug("Transferring flow file {} and creating provenance event with URI {}.", new Object[]{flowFile, transitUri});
+                        getLogger().debug("Transferring flow file {} and creating provenance event with URI {}.", flowFile, transitUri);
                         session.transfer(flowFile, REL_SUCCESS);
                         session.getProvenanceReporter().receive(flowFile, transitUri);
                     }
@@ -223,7 +223,7 @@ public class GetHDFSEvents extends AbstractHadoopProcessor {
                 lastTxId = eventBatch.getTxid();
             }
         } catch (IOException | InterruptedException e) {
-            getLogger().error("Unable to get notification information: {}", new Object[]{e});
+            getLogger().error("Unable to get notification information:", e);
             context.yield();
             return;
         } catch (MissingEventsException e) {
@@ -231,7 +231,7 @@ public class GetHDFSEvents extends AbstractHadoopProcessor {
             // org.apache.hadoop.hdfs.client.HdfsAdmin#getInotifyEventStrea API. It suggests tuning a couple parameters if this API is used.
             lastTxId = -1L;
             getLogger().error("Unable to get notification information. Setting transaction id to -1. This may cause some events to get missed. " +
-                    "Please see javadoc for org.apache.hadoop.hdfs.client.HdfsAdmin#getInotifyEventStream: {}", new Object[]{e});
+                    "Please see javadoc for org.apache.hadoop.hdfs.client.HdfsAdmin#getInotifyEventStream:", e);
         }
 
         updateClusterStateForTxId(session);
@@ -250,7 +250,7 @@ public class GetHDFSEvents extends AbstractHadoopProcessor {
                     getLogger().debug("Failed to poll for event batch. Reached max retry times.", e);
                     throw e;
                 } else {
-                    getLogger().debug("Attempt {} failed to poll for event batch. Retrying.", new Object[]{i});
+                    getLogger().debug("Attempt {} failed to poll for event batch. Retrying.", i);
                 }
             }
         }

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/inotify/GetHDFSEvents.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/inotify/GetHDFSEvents.java
@@ -223,7 +223,7 @@ public class GetHDFSEvents extends AbstractHadoopProcessor {
                 lastTxId = eventBatch.getTxid();
             }
         } catch (IOException | InterruptedException e) {
-            getLogger().error("Unable to get notification information:", e);
+            getLogger().error("Unable to get notification information", e);
             context.yield();
             return;
         } catch (MissingEventsException e) {
@@ -231,7 +231,7 @@ public class GetHDFSEvents extends AbstractHadoopProcessor {
             // org.apache.hadoop.hdfs.client.HdfsAdmin#getInotifyEventStrea API. It suggests tuning a couple parameters if this API is used.
             lastTxId = -1L;
             getLogger().error("Unable to get notification information. Setting transaction id to -1. This may cause some events to get missed. " +
-                    "Please see javadoc for org.apache.hadoop.hdfs.client.HdfsAdmin#getInotifyEventStream:", e);
+                    "Please see javadoc for org.apache.hadoop.hdfs.client.HdfsAdmin#getInotifyEventStream", e);
         }
 
         updateClusterStateForTxId(session);

--- a/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/AbstractPutHBase.java
+++ b/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/AbstractPutHBase.java
@@ -228,7 +228,7 @@ public abstract class AbstractPutHBase extends AbstractProcessor {
             } catch (final Exception e) {
                 getLogger().error(e.getMessage(), e);
                 for (PutFlowFile putFlowFile : entry.getValue()) {
-                    getLogger().error("Routing to failure since failed to send {} to HBase due to ", putFlowFile.getFlowFile(), e);
+                    getLogger().error("Failed to send {} to HBase ", putFlowFile.getFlowFile(), e);
                     final FlowFile failure = session.penalize(putFlowFile.getFlowFile());
                     session.transfer(failure, REL_FAILURE);
                 }

--- a/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/AbstractPutHBase.java
+++ b/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/AbstractPutHBase.java
@@ -193,14 +193,14 @@ public abstract class AbstractPutHBase extends AbstractProcessor {
                 session.transfer(flowFile, REL_FAILURE);
             } else if (!putFlowFile.isValid()) {
                 if (StringUtils.isBlank(putFlowFile.getTableName())) {
-                    getLogger().error("Missing table name for FlowFile {}; routing to failure", new Object[]{flowFile});
+                    getLogger().error("Missing table name for FlowFile {}; routing to failure", flowFile);
                 } else if (null == putFlowFile.getRow()) {
-                    getLogger().error("Missing row id for FlowFile {}; routing to failure", new Object[]{flowFile});
+                    getLogger().error("Missing row id for FlowFile {}; routing to failure", flowFile);
                 } else if (putFlowFile.getColumns() == null || putFlowFile.getColumns().isEmpty()) {
-                    getLogger().error("No columns provided for FlowFile {}; routing to failure", new Object[]{flowFile});
+                    getLogger().error("No columns provided for FlowFile {}; routing to failure", flowFile);
                 } else {
                     // really shouldn't get here, but just in case
-                    getLogger().error("Failed to produce a put for FlowFile {}; routing to failure", new Object[]{flowFile});
+                    getLogger().error("Failed to produce a put for FlowFile {}; routing to failure", flowFile);
                 }
                 session.transfer(flowFile, REL_FAILURE);
             } else {
@@ -213,7 +213,7 @@ public abstract class AbstractPutHBase extends AbstractProcessor {
             }
         }
 
-        getLogger().debug("Sending {} FlowFiles to HBase in {} put operations", new Object[]{flowFiles.size(), tablePuts.size()});
+        getLogger().debug("Sending {} FlowFiles to HBase in {} put operations", flowFiles.size(), tablePuts.size());
 
         final long start = System.nanoTime();
         final List<PutFlowFile> successes = new ArrayList<>();
@@ -228,7 +228,7 @@ public abstract class AbstractPutHBase extends AbstractProcessor {
             } catch (final Exception e) {
                 getLogger().error(e.getMessage(), e);
                 for (PutFlowFile putFlowFile : entry.getValue()) {
-                    getLogger().error("Failed to send {} to HBase due to {}; routing to failure", new Object[]{putFlowFile.getFlowFile(), e});
+                    getLogger().error("Routing to failure since failed to send {} to HBase due to ", putFlowFile.getFlowFile(), e);
                     final FlowFile failure = session.penalize(putFlowFile.getFlowFile());
                     session.transfer(failure, REL_FAILURE);
                 }
@@ -236,7 +236,7 @@ public abstract class AbstractPutHBase extends AbstractProcessor {
         }
 
         final long sendMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-        getLogger().debug("Sent {} FlowFiles to HBase successfully in {} milliseconds", new Object[]{successes.size(), sendMillis});
+        getLogger().debug("Sent {} FlowFiles to HBase successfully in {} milliseconds", successes.size(), sendMillis);
 
         for (PutFlowFile putFlowFile : successes) {
             session.transfer(putFlowFile.getFlowFile(), REL_SUCCESS);

--- a/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/FetchHBaseRow.java
+++ b/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/FetchHBaseRow.java
@@ -236,14 +236,14 @@ public class FetchHBaseRow extends AbstractProcessor implements VisibilityFetchS
 
         final String tableName = context.getProperty(TABLE_NAME).evaluateAttributeExpressions(flowFile).getValue();
         if (StringUtils.isBlank(tableName)) {
-            getLogger().error("Table Name is blank or null for {}, transferring to failure", new Object[] {flowFile});
+            getLogger().error("Table Name is blank or null for {}, transferring to failure", flowFile);
             session.transfer(session.penalize(flowFile), REL_FAILURE);
             return;
         }
 
         final String rowId = context.getProperty(ROW_ID).evaluateAttributeExpressions(flowFile).getValue();
         if (StringUtils.isBlank(rowId)) {
-            getLogger().error("Row Identifier is blank or null for {}, transferring to failure", new Object[] {flowFile});
+            getLogger().error("Row Identifier is blank or null for {}, transferring to failure", flowFile);
             session.transfer(session.penalize(flowFile), REL_FAILURE);
             return;
         }
@@ -265,20 +265,20 @@ public class FetchHBaseRow extends AbstractProcessor implements VisibilityFetchS
         try {
             hBaseClientService.scan(tableName, rowIdBytes, rowIdBytes, columns, authorizations, handler);
         } catch (Exception e) {
-            getLogger().error("Unable to fetch row {} from  {} due to {}", new Object[] {rowId, tableName, e});
+            getLogger().error("Unable to fetch row {} from {}", rowId, tableName, e);
             session.transfer(handler.getFlowFile(), REL_FAILURE);
             return;
         }
 
         FlowFile handlerFlowFile = handler.getFlowFile();
         if (!handler.handledRow()) {
-            getLogger().debug("Row {} not found in {}, transferring to not found", new Object[] {rowId, tableName});
+            getLogger().debug("Row {} not found in {}, transferring to not found", rowId, tableName);
             session.transfer(handlerFlowFile, REL_NOT_FOUND);
             return;
         }
 
         if (getLogger().isDebugEnabled()) {
-            getLogger().debug("Fetched {} from {} with row id {}", new Object[]{handlerFlowFile, tableName, rowId});
+            getLogger().debug("Fetched {} from {} with row id {}", handlerFlowFile, tableName, rowId);
         }
 
         final Map<String, String> attributes = new HashMap<>();

--- a/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/GetHBase.java
+++ b/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/GetHBase.java
@@ -285,7 +285,7 @@ public class GetHBase extends AbstractProcessor implements VisibilityFetchSuppor
                     if (allSeen) {
                         // we have already seen all of the cells for this row. We do not want to
                         // include this cell in our output.
-                        getLogger().debug("all cells for row {} have already been seen", new Object[] {rowKeyString});
+                        getLogger().debug("all cells for row {} have already been seen", rowKeyString);
                         return;
                     }
                 }
@@ -324,7 +324,7 @@ public class GetHBase extends AbstractProcessor implements VisibilityFetchSuppor
 
                 session.getProvenanceReporter().receive(flowFile, hBaseClientService.toTransitUri(tableName, rowKeyString));
                 session.transfer(flowFile, REL_SUCCESS);
-                getLogger().debug("Received {} from HBase with row key {}", new Object[]{flowFile, rowKeyString});
+                getLogger().debug("Received {} from HBase with row key {}", flowFile, rowKeyString);
 
                 // we could potentially have a huge number of rows. If we get to 500, go ahead and commit the
                 // session so that we can avoid buffering tons of FlowFiles without ever sending any out.

--- a/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseJSON.java
+++ b/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseJSON.java
@@ -196,7 +196,7 @@ public class PutHBaseJSON extends AbstractPutHBase {
         final JsonNode rootNode = rootNodeRef.get();
 
         if (rootNode.isArray()) {
-            getLogger().error("Root node of JSON must be a single document, found array for {}; routing to failure", new Object[]{flowFile});
+            getLogger().error("Root node of JSON must be a single document, found array for {}; routing to failure", flowFile);
             return null;
         }
 
@@ -211,7 +211,7 @@ public class PutHBaseJSON extends AbstractPutHBase {
 
             final JsonNode fieldNode = rootNode.get(fieldName);
             if (fieldNode.isNull()) {
-                getLogger().debug("Skipping {} because value was null", new Object[]{fieldName});
+                getLogger().debug("Skipping {} because value was null", fieldName);
             } else if (fieldNode.isValueNode()) {
                 // for a value node we need to determine if we are storing the bytes of a string, or the bytes of actual types
                 if (STRING_ENCODING_VALUE.equals(fieldEncodingStrategy)) {
@@ -224,10 +224,10 @@ public class PutHBaseJSON extends AbstractPutHBase {
                 // for non-null, non-value nodes, determine what to do based on the handling strategy
                 switch (complexFieldStrategy) {
                     case FAIL_VALUE:
-                        getLogger().error("Complex value found for {}; routing to failure", new Object[]{fieldName});
+                        getLogger().error("Complex value found for {}; routing to failure", fieldName);
                         return null;
                     case WARN_VALUE:
-                        getLogger().warn("Complex value found for {}; skipping", new Object[]{fieldName});
+                        getLogger().warn("Complex value found for {}; skipping", fieldName);
                         break;
                     case TEXT_VALUE:
                         // use toString() here because asText() is only guaranteed to be supported on value nodes
@@ -266,7 +266,7 @@ public class PutHBaseJSON extends AbstractPutHBase {
         // log an error message so the user can see what the field names were and return null so it gets routed to failure
         if (extractRowId && rowIdHolder.get() == null) {
             final String fieldNameStr = StringUtils.join(rootNode.fieldNames(), ",");
-            getLogger().error("Row ID field named '{}' not found in field names '{}'; routing to failure", new Object[] {rowFieldName, fieldNameStr});
+            getLogger().error("Row ID field named '{}' not found in field names '{}'; routing to failure", rowFieldName, fieldNameStr);
             return null;
         }
 

--- a/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseRecord.java
+++ b/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseRecord.java
@@ -361,10 +361,10 @@ public class PutHBaseRecord extends AbstractPutHBase {
     private byte[] handleComplexField(Record record, String field, String complexFieldStrategy) throws PutCreationFailedInvokedException {
         switch (complexFieldStrategy) {
             case FAIL_VALUE:
-                getLogger().error("Complex value found for {}; routing to failure", new Object[]{field});
+                getLogger().error("Complex value found for {}; routing to failure", field);
                 throw new PutCreationFailedInvokedException(String.format("Complex value found for %s; routing to failure", field));
             case WARN_VALUE:
-                getLogger().warn("Complex value found for {}; skipping", new Object[]{field});
+                getLogger().warn("Complex value found for {}; skipping", field);
                 return null;
             case TEXT_VALUE:
                 final String value = record.getAsString(field);

--- a/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/ScanHBase.java
+++ b/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/ScanHBase.java
@@ -334,7 +334,7 @@ public class ScanHBase extends AbstractProcessor implements VisibilityFetchSuppo
         try {
             final String tableName = context.getProperty(TABLE_NAME).evaluateAttributeExpressions(flowFile).getValue();
             if (StringUtils.isBlank(tableName)) {
-                getLogger().error("Table Name is blank or null for {}, transferring to failure", new Object[] {flowFile});
+                getLogger().error("Table Name is blank or null for {}, transferring to failure", flowFile);
                 session.transfer(session.penalize(flowFile), REL_FAILURE);
                 return;
             }
@@ -369,11 +369,11 @@ public class ScanHBase extends AbstractProcessor implements VisibilityFetchSuppo
             }
 
             if (timerangeMin == null && timerangeMax != null) {
-                getLogger().error("Time range min value cannot be blank when max value provided for {}, transferring to failure", new Object[] {flowFile});
+                getLogger().error("Time range min value cannot be blank when max value provided for {}, transferring to failure", flowFile);
                 session.transfer(session.penalize(flowFile), REL_FAILURE);
                 return;
             } else if (timerangeMin != null && timerangeMax == null) {
-                getLogger().error("Time range max value cannot be blank when min value provided for {}, transferring to failure", new Object[] {flowFile});
+                getLogger().error("Time range max value cannot be blank when min value provided for {}, transferring to failure", flowFile);
                 session.transfer(session.penalize(flowFile), REL_FAILURE);
                 return;
             }
@@ -408,7 +408,7 @@ public class ScanHBase extends AbstractProcessor implements VisibilityFetchSuppo
                 if (handler.getFlowFile() != null) {
                     session.remove(handler.getFlowFile());
                 }
-                getLogger().error("Unable to fetch rows from HBase table {} due to {}", new Object[] {tableName, e});
+                getLogger().error("Unable to fetch rows from HBase table {}", tableName, e);
                 flowFile = session.putAttribute(flowFile, "scanhbase.results.found", Boolean.toString(handler.isHandledAny()));
                 session.transfer(flowFile, REL_FAILURE);
                 return;

--- a/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
+++ b/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
@@ -196,9 +196,9 @@ public class ExtractHL7Attributes extends AbstractProcessor {
             final Message message = parser.parse(hl7Text);
             final Map<String, String> attributes = getAttributes(message, useSegmentNames, parseSegmentFields);
             flowFile = session.putAllAttributes(flowFile, attributes);
-            getLogger().debug("Added the following attributes for {}: {}", new Object[]{flowFile, attributes});
+            getLogger().debug("Added the following attributes for {}: {}", flowFile, attributes);
         } catch (final HL7Exception e) {
-            getLogger().error("Failed to extract attributes from {} due to {}", new Object[]{flowFile, e});
+            getLogger().error("Failed to extract attributes from {}", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }

--- a/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/RouteHL7.java
+++ b/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/RouteHL7.java
@@ -169,7 +169,7 @@ public class RouteHL7 extends AbstractProcessor {
             final Message hapiMessage = parser.parse(hl7Text);
             message = new HapiMessage(hapiMessage);
         } catch (final Exception e) {
-            getLogger().error("Failed to parse {} as HL7 due to {}; routing to failure", new Object[]{flowFile, e});
+            getLogger().error("Routing to failure  since failed to parse {} as HL7", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }
@@ -191,7 +191,7 @@ public class RouteHL7 extends AbstractProcessor {
         }
 
         session.transfer(flowFile, REL_ORIGINAL);
-        getLogger().info("Routed a copy of {} to {} relationships: {}", new Object[]{flowFile, matchingRels.size(), matchingRels});
+        getLogger().info("Routed a copy of {} to {} relationships: {}", flowFile, matchingRels.size(), matchingRels);
     }
 
     private static class HL7QueryValidator implements Validator {

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryHandler.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryHandler.java
@@ -71,12 +71,12 @@ public class JndiJmsConnectionFactoryHandler extends CachedJMSConnectionFactoryH
     private ConnectionFactory lookupConnectionFactory() {
         try {
             final String factoryName = context.getProperty(JNDI_CONNECTION_FACTORY_NAME).evaluateAttributeExpressions().getValue().trim();
-            logger.debug("Looking up Connection Factory with name [{}]", new Object[] {factoryName});
+            logger.debug("Looking up Connection Factory with name [{}]", factoryName);
 
             final Context initialContext = createInitialContext();
             final Object factoryObject = initialContext.lookup(factoryName);
 
-            logger.debug("Obtained {} from JNDI", new Object[] {factoryObject});
+            logger.debug("Obtained {} from JNDI", factoryObject);
 
             if (factoryObject == null) {
                 throw new ProcessException("Got a null Factory Object from JNDI");
@@ -114,7 +114,7 @@ public class JndiJmsConnectionFactoryHandler extends CachedJMSConnectionFactoryH
             }
         });
 
-        logger.debug("Creating Initial Context using JNDI Environment {}", new Object[] {env});
+        logger.debug("Creating Initial Context using JNDI Environment {}", env);
 
         final Context initialContext = new InitialContext(env);
         return initialContext;

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSPublisher.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/JMSPublisher.java
@@ -42,7 +42,7 @@ class JMSPublisher extends JMSWorker {
 
     JMSPublisher(CachingConnectionFactory connectionFactory, JmsTemplate jmsTemplate, ComponentLog processLog) {
         super(connectionFactory, jmsTemplate, processLog);
-        processLog.debug("Created Message Publisher for {}", new Object[] {jmsTemplate});
+        processLog.debug("Created Message Publisher for {}", jmsTemplate);
     }
 
     void publish(String destinationName, byte[] messageBytes) {
@@ -140,7 +140,7 @@ class JMSPublisher extends JMSWorker {
     }
 
     private void logUnbuildableDestination(String destinationName, String headerName) {
-        this.processLog.warn("Failed to determine destination type from destination name '{}'. The '{}' header will not be set.", new Object[] {destinationName, headerName});
+        this.processLog.warn("Failed to determine destination type from destination name '{}'. The '{}' header will not be set.", destinationName, headerName);
     }
 
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumerPartitionsUtil.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumerPartitionsUtil.java
@@ -42,7 +42,7 @@ public class ConsumerPartitionsUtil {
             return null;
         }
 
-        logger.info("Found the following mapping of hosts to partitions: {}", new Object[] {hostnameToPartitionString});
+        logger.info("Found the following mapping of hosts to partitions: {}", hostnameToPartitionString);
 
         // Determine the partitions based on hostname/IP.
         int[] partitionsForThisHost = getPartitionsForThisHost(partitionsByHost);

--- a/nifi-extension-bundles/nifi-language-translation-bundle/nifi-yandex-processors/src/main/java/org/apache/nifi/processors/yandex/YandexTranslate.java
+++ b/nifi-extension-bundles/nifi-language-translation-bundle/nifi-yandex-processors/src/main/java/org/apache/nifi/processors/yandex/YandexTranslate.java
@@ -263,14 +263,14 @@ public class YandexTranslate extends AbstractProcessor {
         try {
             response = invocation.invoke();
         } catch (final Exception e) {
-            getLogger().error("Failed to make request to Yandex to transate text for {} due to {}; routing to comms.failure", new Object[]{flowFile, e});
+            getLogger().error("Routing to {} since failed to make request to Yandex to translate text for {}", REL_COMMS_FAILURE, flowFile, e);
             session.transfer(flowFile, REL_COMMS_FAILURE);
             return;
         }
 
         if (response.getStatus() != Response.Status.OK.getStatusCode()) {
-            getLogger().error("Failed to translate text using Yandex for {}; response was {}: {}; routing to {}", new Object[]{
-                    flowFile, response.getStatus(), response.getStatusInfo().getReasonPhrase(), REL_TRANSLATION_FAILED.getName()});
+            getLogger().error("Failed to translate text using Yandex for {}; response was {}: {}; routing to {}", flowFile,
+                    response.getStatus(), response.getStatusInfo().getReasonPhrase(), REL_TRANSLATION_FAILED.getName());
             flowFile = session.putAttribute(flowFile, "yandex.translate.failure.reason", response.getStatusInfo().getReasonPhrase());
             session.transfer(flowFile, REL_TRANSLATION_FAILED);
             return;

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ExtractImageMetadata.java
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ExtractImageMetadata.java
@@ -142,7 +142,7 @@ public class ExtractImageMetadata extends AbstractProcessor {
 
             session.transfer(flowfile, SUCCESS);
         } catch (ProcessException e) {
-            logger.error("Failed to extract image metadata from {} due to {}", new Object[]{flowfile, e});
+            logger.error("Failed to extract image metadata from {}", flowfile, e);
             session.transfer(flowfile, FAILURE);
         }
     }

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/media/ExtractMediaMetadata.java
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/media/ExtractMediaMetadata.java
@@ -201,7 +201,7 @@ public class ExtractMediaMetadata extends AbstractProcessor {
             session.transfer(flowFile, SUCCESS);
             session.getProvenanceReporter().modifyAttributes(flowFile, "media attributes extracted");
         } catch (ProcessException e) {
-            logger.error("Failed to extract media metadata from {} due to {}", new Object[]{flowFile, e});
+            logger.error("Failed to extract media metadata from {}", flowFile, e);
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, FAILURE);
         }

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongo.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongo.java
@@ -224,7 +224,7 @@ public class GetMongo extends AbstractMongoQueryProcessor {
                             writeBatch(buildBatch(batch, jsonTypeSetting, usePrettyPrint), input, context, session, attributes, REL_SUCCESS);
                             batch = new ArrayList<>();
                         } catch (Exception e) {
-                            logger.error("Error building batch due to {}", new Object[] {e});
+                            logger.error("Error building batch", e);
                         }
                     }
                     sent++;
@@ -234,7 +234,7 @@ public class GetMongo extends AbstractMongoQueryProcessor {
                     try {
                         writeBatch(buildBatch(batch, jsonTypeSetting, usePrettyPrint), input, context, session, attributes, REL_SUCCESS);
                     } catch (Exception e) {
-                        logger.error("Error building batch due to {}", new Object[] {e});
+                        logger.error("Error building batch", e);
                     }
                 }
             } else {

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongo.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongo.java
@@ -207,7 +207,7 @@ public class PutMongo extends AbstractMongoProcessor {
 
             if (MODE_INSERT.equalsIgnoreCase(mode)) {
                 collection.insertOne((Document) doc);
-                logger.info("inserted {} into MongoDB", new Object[] {flowFile});
+                logger.info("inserted {} into MongoDB", flowFile);
             } else {
                 // update
                 final boolean upsert = context.getProperty(UPSERT).asBoolean();
@@ -229,7 +229,7 @@ public class PutMongo extends AbstractMongoProcessor {
                     update.remove(updateKey);
                     collection.updateOne(query, update, new UpdateOptions().upsert(upsert));
                 }
-                logger.info("updated {} into MongoDB", new Object[] {flowFile});
+                logger.info("updated {} into MongoDB", flowFile);
             }
 
             session.getProvenanceReporter().send(flowFile, getURI(context));

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoRecord.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoRecord.java
@@ -269,7 +269,7 @@ public class PutMongoRecord extends AbstractMongoProcessor {
             if (!error) {
                 session.getProvenanceReporter().send(flowFile, clientService.getURI(), String.format("Written %d documents to MongoDB.", written));
                 session.transfer(flowFile, REL_SUCCESS);
-                getLogger().info("Written {} records into MongoDB", new Object[]{written});
+                getLogger().info("Written {} records into MongoDB", written);
             }
         }
     }

--- a/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/ParseNetflowv5.java
+++ b/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/ParseNetflowv5.java
@@ -125,10 +125,10 @@ public class ParseNetflowv5 extends AbstractProcessor {
         try {
             processedRecord = parser.parse(buffer);
             if (logger.isDebugEnabled()) {
-                logger.debug("Parsed {} records from the packet", new Object[] {processedRecord});
+                logger.debug("Parsed {} records from the packet", processedRecord);
             }
         } catch (Throwable e) {
-            logger.error("Parser returned unexpected Exception {} while processing {}; routing to failure", new Object[] {e, flowFile});
+            logger.error("Routing to failure since while processing {}, parser returned unexpected Exception", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }
@@ -151,7 +151,7 @@ public class ParseNetflowv5 extends AbstractProcessor {
             session.adjustCounter("Records Processed", processedRecord, false);
         } catch (Exception e) {
             // The flowfile has failed parsing & validation, routing to failure
-            logger.error("Failed to parse {} as a netflowv5 message due to {}; routing to failure", new Object[] {flowFile, e});
+            logger.error("Routing to failure since failed to parse {} as a netflowv5 message", flowFile, e);
 
             // Create a provenance event recording the routing to failure
             session.transfer(flowFile, REL_FAILURE);

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/processors/parquet/ConvertAvroToParquet.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/processors/parquet/ConvertAvroToParquet.java
@@ -180,7 +180,7 @@ public class ConvertAvroToParquet extends AbstractProcessor {
             session.getProvenanceReporter().modifyContent(putFlowFile, "Converted " + totalRecordCount.get() + " records", System.currentTimeMillis() - startTime);
 
         } catch (final ProcessException pe) {
-            getLogger().error("Failed to convert {} from Avro to Parquet due to {}; transferring to failure", new Object[]{flowFile, pe});
+            getLogger().error("Transferring to failure since failed to convert {} from Avro to Parquet", flowFile, pe);
             session.transfer(flowFile, FAILURE);
         }
 

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedTransformRecord.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedTransformRecord.java
@@ -220,7 +220,7 @@ public class ScriptedTransformRecord extends ScriptedRecordProcessor {
             session.transfer(flowFile, REL_SUCCESS);
 
             final long transformCount = counts.getRecordCount() - counts.getDroppedCount();
-            getLogger().info("Successfully transformed {} Records and dropped {} Records for {}", new Object[] {transformCount, counts.getDroppedCount(), flowFile});
+            getLogger().info("Successfully transformed {} Records and dropped {} Records for {}", transformCount, counts.getDroppedCount(), flowFile);
             session.adjustCounter("Records Transformed", transformCount, true);
             session.adjustCounter("Records Dropped", counts.getDroppedCount(), true);
 
@@ -246,7 +246,7 @@ public class ScriptedTransformRecord extends ScriptedRecordProcessor {
 
         // If a null value was returned, drop the Record
         if (returnValue == null) {
-            getLogger().trace("Script returned null for Record {} [{}] so will drop Record from {}", new Object[]{index, inputRecord, flowFile});
+            getLogger().trace("Script returned null for Record {} [{}] so will drop Record from {}", index, inputRecord, flowFile);
             counts.incrementDroppedCount();
             return;
         }
@@ -254,7 +254,7 @@ public class ScriptedTransformRecord extends ScriptedRecordProcessor {
         // If a single Record was returned, write it out
         if (returnValue instanceof Record) {
             final Record transformedRecord = (Record) returnValue;
-            getLogger().trace("Successfully transformed Record {} from {} to {} for {}", new Object[]{index, inputRecord, transformedRecord, flowFile});
+            getLogger().trace("Successfully transformed Record {} from {} to {} for {}", index, inputRecord, transformedRecord, flowFile);
             recordWriteAction.write(transformedRecord);
             return;
         }
@@ -262,7 +262,7 @@ public class ScriptedTransformRecord extends ScriptedRecordProcessor {
         // If a Collection was returned, ensure that every element in the collection is a Record and write them out
         if (returnValue instanceof Collection) {
             final Collection<?> collection = (Collection<?>) returnValue;
-            getLogger().trace("Successfully transformed Record {} from {} to {} for {}", new Object[]{index, inputRecord, collection, flowFile});
+            getLogger().trace("Successfully transformed Record {} from {} to {} for {}", index, inputRecord, collection, flowFile);
 
             for (final Object element : collection) {
                 if (!(element instanceof Record)) {

--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteMetricsReportingTask.java
+++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteMetricsReportingTask.java
@@ -214,7 +214,7 @@ public class SiteToSiteMetricsReportingTask extends AbstractSiteToSiteReportingT
                 transaction.complete();
 
                 final long transferMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-                getLogger().info("Successfully sent metrics to destination in {}ms; Transaction ID = {}", new Object[]{transferMillis, transactionId});
+                getLogger().info("Successfully sent metrics to destination in {}ms; Transaction ID = {}", transferMillis, transactionId);
             } catch (final Exception e) {
                 if (transaction != null) {
                     transaction.error();

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/GetSmbFile.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/GetSmbFile.java
@@ -554,7 +554,7 @@ public class GetSmbFile extends AbstractProcessor {
                     }
                 }
         } catch (Exception e) {
-            logger.error("Could not establish smb connection because of error {}", new Object[]{e});
+            logger.error("Could not establish smb connection", e);
             context.yield();
             smbClient.getServerList().unregister(hostname);
         }

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/PutSmbFile.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/PutSmbFile.java
@@ -271,10 +271,10 @@ public class PutSmbFile extends AbstractProcessor {
         Collections.reverse(paths);
         for (String path : paths) {
             if (!share.folderExists(path)) {
-                logger.debug("Creating folder {}", new Object[]{path});
+                logger.debug("Creating folder {}", path);
                 share.mkdir(path);
             } else {
-                logger.debug("Folder already exists {}. Moving on", new Object[]{path});
+                logger.debug("Folder already exists {}. Moving on", path);
             }
         }
     }
@@ -287,7 +287,7 @@ public class PutSmbFile extends AbstractProcessor {
             return;
         }
         final ComponentLog logger = getLogger();
-        logger.debug("Processing next {} flowfiles", new Object[]{flowFiles.size()});
+        logger.debug("Processing next {} flowfiles", flowFiles.size());
 
         final String hostname = context.getProperty(HOSTNAME).getValue();
         final String shareName = context.getProperty(SHARE).getValue();
@@ -330,9 +330,7 @@ public class PutSmbFile extends AbstractProcessor {
                 final Boolean createMissingDirectories = context.getProperty(CREATE_DIRS).asBoolean();
                 if (!createMissingDirectories && !share.folderExists(destinationFileParentDirectory)) {
                     flowFile = session.penalize(flowFile);
-                    logger.warn(
-                        "Penalizing {} and routing to failure as configured because the destination directory ({}) doesn't exist",
-                        new Object[]{flowFile, destinationFileParentDirectory});
+                    logger.warn("Penalizing {} and routing to failure as configured because the destination directory ({}) doesn't exist", flowFile, destinationFileParentDirectory);
                     session.transfer(flowFile, REL_FAILURE);
                     continue;
                 } else if (!share.folderExists(destinationFileParentDirectory)) {
@@ -344,11 +342,11 @@ public class PutSmbFile extends AbstractProcessor {
                 if (share.fileExists(destinationFullPath)) {
                     if (conflictResolution.equals(IGNORE_RESOLUTION)) {
                         session.transfer(flowFile, REL_SUCCESS);
-                        logger.info("Transferring {} to success as configured because file with same name already exists", new Object[]{flowFile});
+                        logger.info("Transferring {} to success as configured because file with same name already exists", flowFile);
                         continue;
                     } else if (conflictResolution.equals(FAIL_RESOLUTION)) {
                         flowFile = session.penalize(flowFile);
-                        logger.warn("Penalizing {} and routing to failure as configured because file with the same name already exists", new Object[]{flowFile});
+                        logger.warn("Penalizing {} and routing to failure as configured because file with the same name already exists", flowFile);
                         session.transfer(flowFile, REL_FAILURE);
                         continue;
                     }
@@ -376,7 +374,7 @@ public class PutSmbFile extends AbstractProcessor {
                 } catch (Exception e) {
                     flowFile = session.penalize(flowFile);
                     session.transfer(flowFile, REL_FAILURE);
-                    logger.error("Cannot transfer the file. Penalizing {} and routing to 'failure' because of error {}", new Object[]{flowFile, e});
+                    logger.error("Cannot transfer the file. Penalizing {} and routing to 'failure'", flowFile, e);
                     continue;
                 }
 
@@ -398,7 +396,7 @@ public class PutSmbFile extends AbstractProcessor {
                     } catch (Exception e) {
                         flowFile = session.penalize(flowFile);
                         session.transfer(flowFile, REL_FAILURE);
-                        logger.error("Cannot rename the file. Penalizing {} and routing to 'failure' because of error {}", new Object[]{flowFile, e});
+                        logger.error("Cannot rename the file. Penalizing {} and routing to 'failure'", flowFile, e);
                         continue;
                     }
                 }
@@ -412,7 +410,7 @@ public class PutSmbFile extends AbstractProcessor {
             }
         } catch (Exception e) {
             session.transfer(flowFiles, REL_FAILURE);
-            logger.error("Could not establish smb connection because of error {}", new Object[]{e});
+            logger.error("Could not establish smb connection", e);
             smbClient.getServerList().unregister(hostname);
         }
     }

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunkHTTP.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunkHTTP.java
@@ -179,7 +179,7 @@ public class PutSplunkHTTP extends SplunkAPICall {
                         success = true;
                     } else {
                         flowFile = session.putAttribute(flowFile, "splunk.response.code", String.valueOf(successResponse.getCode()));
-                        getLogger().error("Putting data into Splunk was not successful: ({}) {}", new Object[] {successResponse.getCode(), successResponse.getText()});
+                        getLogger().error("Putting data into Splunk was not successful: ({}) {}", successResponse.getCode(), successResponse.getText());
                     }
 
                     break;
@@ -195,7 +195,7 @@ public class PutSplunkHTTP extends SplunkAPICall {
 
             if (responseMessage != null) {
                 try {
-                    getLogger().error("The response content is: {}", new Object[]{IOUtils.toString(responseMessage.getContent(), "UTF-8")});
+                    getLogger().error("The response content is: {}", IOUtils.toString(responseMessage.getContent(), "UTF-8"));
                 } catch (final IOException ioException) {
                     getLogger().error("An error occurred during reading response content!");
                 }

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/QuerySplunkIndexingStatus.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/QuerySplunkIndexingStatus.java
@@ -209,7 +209,7 @@ public class QuerySplunkIndexingStatus extends SplunkAPICall {
                     }
                 });
             } else {
-                getLogger().error("Query index status was not successful because of ({}) {}", new Object[] {responseMessage.getStatus(), responseMessage.getContent()});
+                getLogger().error("Query index status was not successful because of ({}) {}", responseMessage.getStatus(), responseMessage.getContent());
                 context.yield();
                 session.transfer(undetermined.values(), RELATIONSHIP_UNDETERMINED);
             }

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/SplunkAPICall.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/SplunkAPICall.java
@@ -218,7 +218,7 @@ abstract class SplunkAPICall extends AbstractProcessor {
             return splunkService.send(endpoint, request);
             //Catch Stale connection exception, reinitialize, and retry
         } catch (final HttpException e) {
-            getLogger().error("Splunk request status code: {}. Retrying the request.", new Object[] {e.getStatus()});
+            getLogger().error("Splunk request status code: {}. Retrying the request.", e.getStatus());
             splunkService.logout();
             splunkService = getSplunkService(splunkServiceArguments);
             return splunkService.send(endpoint, request);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractQueryDatabaseTable.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractQueryDatabaseTable.java
@@ -377,7 +377,7 @@ public abstract class AbstractQueryDatabaseTable extends AbstractDatabaseFetchPr
 
             st.setQueryTimeout(queryTimeout); // timeout in seconds
             if (logger.isDebugEnabled()) {
-                logger.debug("Executing query {}", new Object[] {selectQuery});
+                logger.debug("Executing query {}", selectQuery);
             }
 
             final boolean originalAutoCommit = con.getAutoCommit();
@@ -520,7 +520,7 @@ public abstract class AbstractQueryDatabaseTable extends AbstractDatabaseFetchPr
                 // Update the state
                 session.setState(statePropertyMap, Scope.CLUSTER);
             } catch (IOException ioe) {
-                getLogger().error("{} failed to update State Manager, maximum observed values will not be recorded", new Object[]{this, ioe});
+                getLogger().error("{} failed to update State Manager, maximum observed values will not be recorded", this, ioe);
             }
 
             session.commitAsync();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CompressContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CompressContent.java
@@ -263,15 +263,14 @@ public class CompressContent extends AbstractProcessor {
         if (compressionFormatValue.equals(COMPRESSION_FORMAT_ATTRIBUTE)) {
             final String mimeType = flowFile.getAttribute(CoreAttributes.MIME_TYPE.key());
             if (mimeType == null) {
-                logger.error("No {} attribute exists for {}; routing to failure", new Object[]{CoreAttributes.MIME_TYPE.key(), flowFile});
+                logger.error("No {} attribute exists for {}; routing to failure", CoreAttributes.MIME_TYPE.key(), flowFile);
                 session.transfer(flowFile, REL_FAILURE);
                 return;
             }
 
             compressionFormatValue = compressionFormatMimeTypeMap.get(mimeType);
             if (compressionFormatValue == null) {
-                logger.info("Mime Type of {} is '{}', which does not indicate a supported Compression Format; routing to success without decompressing",
-                    new Object[]{flowFile, mimeType});
+                logger.info("Mime Type of {} is '{}', which does not indicate a supported Compression Format; routing to success without decompressing", flowFile, mimeType);
                 session.transfer(flowFile, REL_SUCCESS);
                 return;
             }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CryptographicHashContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CryptographicHashContent.java
@@ -120,7 +120,7 @@ public class CryptographicHashContent extends AbstractProcessor {
 
         // Determine the algorithm to use
         final String algorithmName = context.getProperty(HASH_ALGORITHM).getValue();
-        logger.debug("Using algorithm {}", new Object[]{algorithmName});
+        logger.debug("Using algorithm {}", algorithmName);
         HashAlgorithm algorithm = HashAlgorithm.fromName(algorithmName);
 
         if (flowFile.getSize() == 0) {
@@ -129,13 +129,13 @@ public class CryptographicHashContent extends AbstractProcessor {
                 session.transfer(flowFile, REL_FAILURE);
                 return;
             } else {
-                logger.debug("Flowfile content is empty; hashing with {} anyway", new Object[]{algorithmName});
+                logger.debug("Flowfile content is empty; hashing with {} anyway", algorithmName);
             }
         }
 
         // Generate a hash with the configured algorithm for the content
         // and create a new attribute with the configured name
-        logger.debug("Generating {} hash of content", new Object[]{algorithmName});
+        logger.debug("Generating {} hash of content", algorithmName);
         final AtomicReference<String> hashValueHolder = new AtomicReference<>(null);
 
         try {
@@ -144,17 +144,17 @@ public class CryptographicHashContent extends AbstractProcessor {
 
             // Determine the destination attribute name
             final String attributeName = "content_" + algorithmName;
-            logger.debug("Writing {} hash to attribute '{}'", new Object[]{algorithmName, attributeName});
+            logger.debug("Writing {} hash to attribute '{}'", algorithmName, attributeName);
 
             // Write the attribute
             flowFile = session.putAttribute(flowFile, attributeName, hashValueHolder.get());
-            logger.info("Successfully added attribute '{}' to {} with a value of {}; routing to success", new Object[]{attributeName, flowFile, hashValueHolder.get()});
+            logger.info("Successfully added attribute '{}' to {} with a value of {}; routing to success", attributeName, flowFile, hashValueHolder.get());
 
             // Update provenance and route to success
             session.getProvenanceReporter().modifyAttributes(flowFile);
             session.transfer(flowFile, REL_SUCCESS);
         } catch (ProcessException e) {
-            logger.error("Failed to process {} due to {}; routing to failure", new Object[]{flowFile, e});
+            logger.error("Routing to failure since failed to process {}", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
         }
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DetectDuplicate.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DetectDuplicate.java
@@ -163,7 +163,7 @@ public class DetectDuplicate extends AbstractProcessor {
         final ComponentLog logger = getLogger();
         final String cacheKey = context.getProperty(CACHE_ENTRY_IDENTIFIER).evaluateAttributeExpressions(flowFile).getValue();
         if (StringUtils.isBlank(cacheKey)) {
-            logger.error("FlowFile {} has no attribute for given Cache Entry Identifier", new Object[]{flowFile});
+            logger.error("FlowFile {} has no attribute for given Cache Entry Identifier", flowFile);
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
             return;
@@ -187,7 +187,7 @@ public class DetectDuplicate extends AbstractProcessor {
             boolean duplicate = originalCacheValue != null;
             if (duplicate && durationMS != null && (now >= originalCacheValue.getEntryTimeMS() + durationMS)) {
                 boolean status = cache.remove(cacheKey, keySerializer);
-                logger.debug("Removal of expired cached entry with key {} returned {}", new Object[]{cacheKey, status});
+                logger.debug("Removal of expired cached entry with key {} returned {}", cacheKey, status);
 
                 // both should typically result in duplicate being false...but, better safe than sorry
                 if (shouldCacheIdentifier) {
@@ -202,18 +202,18 @@ public class DetectDuplicate extends AbstractProcessor {
                 String originalFlowFileDescription = originalCacheValue.getDescription();
                 flowFile = session.putAttribute(flowFile, ORIGINAL_DESCRIPTION_ATTRIBUTE_NAME, originalFlowFileDescription);
                 session.transfer(flowFile, REL_DUPLICATE);
-                logger.info("Found {} to be a duplicate of FlowFile with description {}", new Object[]{flowFile, originalFlowFileDescription});
+                logger.info("Found {} to be a duplicate of FlowFile with description {}", flowFile, originalFlowFileDescription);
                 session.adjustCounter("Duplicates Detected", 1L, false);
             } else {
                 session.getProvenanceReporter().route(flowFile, REL_NON_DUPLICATE);
                 session.transfer(flowFile, REL_NON_DUPLICATE);
-                logger.info("Could not find a duplicate entry in cache for {}; routing to non-duplicate", new Object[]{flowFile});
+                logger.info("Could not find a duplicate entry in cache for {}; routing to non-duplicate", flowFile);
                 session.adjustCounter("Non-Duplicate Files Processed", 1L, false);
             }
         } catch (final IOException e) {
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
-            logger.error("Unable to communicate with cache when processing {} due to {}", new Object[]{flowFile, e});
+            logger.error("Unable to communicate with cache when processing {}", flowFile, e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EnforceOrder.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EnforceOrder.java
@@ -481,7 +481,7 @@ public class EnforceOrder extends AbstractProcessor {
 
                     } else {
                         final String msg = String.format("Skipped, FlowFile order was %d but current target is %d", order, targetOrder.get());
-                        logger.warn(msg + ". {}", new Object[]{f});
+                        logger.warn("{}. {}", msg, f);
                         transferResult(f, REL_SKIPPED, msg, targetOrder.get());
                     }
 
@@ -521,9 +521,9 @@ public class EnforceOrder extends AbstractProcessor {
 
         private void transferToFailure(final FlowFile flowFile, final String message, final Throwable cause) {
             if (cause != null) {
-                getLogger().warn(message + " {}", flowFile, cause);
+                getLogger().warn("{} {}", message, flowFile, cause);
             } else {
-                getLogger().warn(message + " {}", new Object[]{flowFile});
+                getLogger().warn("{} {}", message, flowFile);
             }
             transferResult(flowFile, REL_FAILURE, message, null);
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteProcess.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteProcess.java
@@ -244,7 +244,7 @@ public class ExecuteProcess extends AbstractProcessor {
             try {
                 longRunningProcess = launchProcess(context, commandStrings, batchNanos, proxyOut);
             } catch (final IOException ioe) {
-                getLogger().error("Failed to create process due to {}", new Object[] {ioe});
+                getLogger().error("Failed to create process", ioe);
                 context.yield();
                 return;
             }
@@ -277,7 +277,7 @@ public class ExecuteProcess extends AbstractProcessor {
                         } catch (final InterruptedException ie) {
                             // Ignore
                         } catch (final ExecutionException ee) {
-                            getLogger().error("Process execution failed due to {}", new Object[] {ee.getCause()});
+                            getLogger().error("Process execution failed", ee.getCause());
                         }
                     } else {
                         // wait the allotted amount of time.
@@ -350,7 +350,7 @@ public class ExecuteProcess extends AbstractProcessor {
             builder.environment().putAll(environment);
         }
 
-        getLogger().info("Start creating new Process > {} ", new Object[] {commandStrings});
+        getLogger().info("Start creating new Process > {} ", commandStrings);
         this.externalProcess = builder.redirectErrorStream(redirectErrorStream).start();
 
         // Submit task to read error stream from process
@@ -423,7 +423,7 @@ public class ExecuteProcess extends AbstractProcessor {
                         // In the future consider exposing it via configuration.
                         boolean terminated = externalProcess.waitFor(1000, TimeUnit.MILLISECONDS);
                         int exitCode = terminated ? externalProcess.exitValue() : -9999;
-                        getLogger().info("Process finished with exit code {} ", new Object[] {exitCode});
+                        getLogger().info("Process finished with exit code {} ", exitCode);
                     } catch (InterruptedException e1) {
                         Thread.currentThread().interrupt();
                     }
@@ -454,7 +454,7 @@ public class ExecuteProcess extends AbstractProcessor {
         public void setDelegate(final OutputStream delegate) {
             lock.lock();
             try {
-                logger.trace("Switching delegate from {} to {}", new Object[]{this.delegate, delegate});
+                logger.trace("Switching delegate from {} to {}", this.delegate, delegate);
                 this.delegate = delegate;
             } finally {
                 lock.unlock();
@@ -475,7 +475,7 @@ public class ExecuteProcess extends AbstractProcessor {
             try {
                 while (true) {
                     if (delegate != null) {
-                        logger.trace("Writing to {}", new Object[]{delegate});
+                        logger.trace("Writing to {}", delegate);
 
                         delegate.write(b);
                         return;
@@ -496,7 +496,7 @@ public class ExecuteProcess extends AbstractProcessor {
             try {
                 while (true) {
                     if (delegate != null) {
-                        logger.trace("Writing to {}", new Object[]{delegate});
+                        logger.trace("Writing to {}", delegate);
                         delegate.write(b, off, len);
                         return;
                     } else {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExtractText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExtractText.java
@@ -472,10 +472,10 @@ public class ExtractText extends AbstractProcessor {
             flowFile = session.putAllAttributes(flowFile, regexResults);
             session.getProvenanceReporter().modifyAttributes(flowFile);
             session.transfer(flowFile, REL_MATCH);
-            logger.info("Matched {} Regular Expressions and added attributes to FlowFile {}", new Object[]{regexResults.size(), flowFile});
+            logger.info("Matched {} Regular Expressions and added attributes to FlowFile {}", regexResults.size(), flowFile);
         } else {
             session.transfer(flowFile, REL_NO_MATCH);
-            logger.info("Did not match any Regular Expressions for  FlowFile {}", new Object[]{flowFile});
+            logger.info("Did not match any Regular Expressions for  FlowFile {}", flowFile);
         }
 
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchDistributedMapCache.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchDistributedMapCache.java
@@ -202,7 +202,7 @@ public class FetchDistributedMapCache extends AbstractProcessor {
         final String cacheKey = context.getProperty(PROP_CACHE_ENTRY_IDENTIFIER).evaluateAttributeExpressions(flowFile).getValue();
         // This block retains the previous behavior when only one Cache Entry Identifier was allowed, so as not to change the expected error message
         if (StringUtils.isBlank(cacheKey)) {
-            logger.error("FlowFile {} has no attribute for given Cache Entry Identifier", new Object[]{flowFile});
+            logger.error("FlowFile {} has no attribute for given Cache Entry Identifier", flowFile);
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
             return;
@@ -211,7 +211,7 @@ public class FetchDistributedMapCache extends AbstractProcessor {
         for (int i = 0; i < cacheKeys.size(); i++) {
             if (StringUtils.isBlank(cacheKeys.get(i))) {
                 // Log first missing identifier, route to failure, and return
-                logger.error("FlowFile {} has no attribute for Cache Entry Identifier in position {}", new Object[]{flowFile, i});
+                logger.error("FlowFile {} has no attribute for Cache Entry Identifier in position {}", flowFile, i);
                 flowFile = session.penalize(flowFile);
                 session.transfer(flowFile, REL_FAILURE);
                 return;
@@ -234,7 +234,7 @@ public class FetchDistributedMapCache extends AbstractProcessor {
                 final byte[] cacheValue = cacheValueEntry.getValue();
 
                 if (cacheValue == null) {
-                    logger.info("Could not find an entry in cache for {}; routing to not-found", new Object[]{flowFile});
+                    logger.info("Could not find an entry in cache for {}; routing to not-found", flowFile);
                     notFound = true;
                     break;
                 } else {
@@ -262,9 +262,9 @@ public class FetchDistributedMapCache extends AbstractProcessor {
                     }
 
                     if (putInAttribute) {
-                        logger.info("Found a cache key of {} and added an attribute to {} with it's value.", new Object[]{cacheKey, flowFile});
+                        logger.info("Found a cache key of {} and added an attribute to {} with it's value.", cacheKey, flowFile);
                     } else {
-                        logger.info("Found a cache key of {} and replaced the contents of {} with it's value.", new Object[]{cacheKey, flowFile});
+                        logger.info("Found a cache key of {} and replaced the contents of {} with it's value.", cacheKey, flowFile);
                     }
                 }
             }
@@ -277,7 +277,7 @@ public class FetchDistributedMapCache extends AbstractProcessor {
         } catch (final IOException e) {
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
-            logger.error("Unable to communicate with cache when processing {} due to {}", new Object[]{flowFile, e});
+            logger.error("Unable to communicate with cache when processing {}", flowFile, e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
@@ -252,7 +252,7 @@ public class FetchFile extends AbstractProcessor {
             session.transfer(session.penalize(flowFile), REL_FAILURE);
             return;
         } else if (!Files.exists(filePath)) {
-            getLogger().log(levelFileNotFound, "Could not fetch file {} from file system for {} because the file does not exist; routing to not.found", new Object[] {file, flowFile});
+            getLogger().log(levelFileNotFound, "Could not fetch file {} from file system for {} because the file does not exist; routing to not.found", file, flowFile);
             session.getProvenanceReporter().route(flowFile, REL_NOT_FOUND);
             session.transfer(session.penalize(flowFile), REL_NOT_FOUND);
             return;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
@@ -380,7 +380,7 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
                 final Integer queryTimeout = context.getProperty(QUERY_TIMEOUT).evaluateAttributeExpressions(fileToProcess).asTimePeriod(TimeUnit.SECONDS).intValue();
                 st.setQueryTimeout(queryTimeout); // timeout in seconds
 
-                logger.debug("Executing {}", new Object[]{selectQuery});
+                logger.debug("Executing {}", selectQuery);
                 ResultSet resultSet;
 
                 resultSet = st.executeQuery(selectQuery);
@@ -536,12 +536,12 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
                 }
             } catch (SQLException e) {
                 if (fileToProcess != null) {
-                    logger.error("Unable to execute SQL select query {} due to {}, routing {} to failure", new Object[]{selectQuery, e, fileToProcess});
+                    logger.error("Routing {} to failure since unable to execute SQL select query {}", fileToProcess, selectQuery, e);
                     fileToProcess = session.putAttribute(fileToProcess, "generatetablefetch.sql.error", e.getMessage());
                     session.transfer(fileToProcess, REL_FAILURE);
 
                 } else {
-                    logger.error("Unable to execute SQL select query {} due to {}", new Object[]{selectQuery, e});
+                    logger.error("Unable to execute SQL select query {}", selectQuery, e);
                     throw new ProcessException(e);
                 }
             }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpResponse.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpResponse.java
@@ -142,7 +142,7 @@ public class HandleHttpResponse extends AbstractProcessor {
 
         final String statusCodeValue = context.getProperty(STATUS_CODE).evaluateAttributeExpressions(flowFile).getValue();
         if (!isNumber(statusCodeValue)) {
-            getLogger().error("Failed to respond to HTTP request for {} because status code was '{}', which is not a valid number", new Object[]{flowFile, statusCodeValue});
+            getLogger().error("Failed to respond to HTTP request for {} because status code was '{}', which is not a valid number", flowFile, statusCodeValue);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }
@@ -190,16 +190,16 @@ public class HandleHttpResponse extends AbstractProcessor {
             session.exportTo(flowFile, response.getOutputStream());
             response.flushBuffer();
         } catch (final ProcessException e) {
-            getLogger().error("Failed to respond to HTTP request for {} due to {}", new Object[]{flowFile, e});
+            getLogger().error("Failed to respond to HTTP request for {}", flowFile, e);
             try {
                 contextMap.complete(contextIdentifier);
             } catch (final RuntimeException ce) {
-                getLogger().error("Failed to complete HTTP Transaction for {} due to {}", new Object[]{flowFile, ce});
+                getLogger().error("Failed to complete HTTP Transaction for {}", flowFile, ce);
             }
             session.transfer(flowFile, REL_FAILURE);
             return;
         } catch (final Exception e) {
-            getLogger().error("Failed to respond to HTTP request for {} due to {}", new Object[]{flowFile, e});
+            getLogger().error("Failed to respond to HTTP request for {}", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }
@@ -207,13 +207,13 @@ public class HandleHttpResponse extends AbstractProcessor {
         try {
             contextMap.complete(contextIdentifier);
         } catch (final RuntimeException ce) {
-            getLogger().error("Failed to complete HTTP Transaction for {} due to {}", new Object[]{flowFile, ce});
+            getLogger().error("Failed to complete HTTP Transaction for {}", flowFile, ce);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }
 
         session.getProvenanceReporter().send(flowFile, HTTPUtils.getURI(flowFile.getAttributes()), stopWatch.getElapsed(TimeUnit.MILLISECONDS));
-        getLogger().info("Successfully responded to HTTP Request for {} with status code {}", new Object[]{flowFile, statusCode});
+        getLogger().info("Successfully responded to HTTP Request for {} with status code {}", flowFile, statusCode);
         session.transfer(flowFile, REL_SUCCESS);
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/JoinEnrichment.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/JoinEnrichment.java
@@ -509,7 +509,7 @@ public class JoinEnrichment extends BinFiles {
             try {
                 binProcessingResult = this.processBin(bin, context);
             } catch (final ProcessException e) {
-                logger.error("Failed to process bundle of {} files due to {}", new Object[] {bin.getContents().size(), e});
+                logger.error("Failed to process bundle of {} files", bin.getContents().size(), e);
 
                 final ProcessSession binSession = bin.getSession();
                 for (final FlowFile flowFile : bin.getContents()) {
@@ -518,7 +518,7 @@ public class JoinEnrichment extends BinFiles {
                 binSession.commitAsync();
                 continue;
             } catch (final Exception e) {
-                logger.error("Failed to process bundle of {} files due to {}; rolling back sessions", new Object[] {bin.getContents().size(), e});
+                logger.error("Rolling back sessions since failed to process bundle of {} files", bin.getContents().size(), e);
 
                 bin.getSession().rollback();
                 continue;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListDatabaseTables.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListDatabaseTables.java
@@ -341,21 +341,21 @@ public class ListDatabaseTables extends AbstractProcessor {
                     }
 
                     if (refreshTable) {
-                        logger.info("Found {}: {}", new Object[] {tableType, fqn});
+                        logger.info("Found {}: {}", tableType, fqn);
                         final Map<String, String> tableInformation = new HashMap<>();
 
                         if (includeCount) {
                             try (Statement st = con.createStatement()) {
                                 final String countQuery = "SELECT COUNT(1) FROM " + fqn;
 
-                                logger.debug("Executing query: {}", new Object[] {countQuery});
+                                logger.debug("Executing query: {}", countQuery);
                                 try (ResultSet countResult = st.executeQuery(countQuery)) {
                                     if (countResult.next()) {
                                         tableInformation.put(DB_TABLE_COUNT, Long.toString(countResult.getLong(1)));
                                     }
                                 }
                             } catch (final SQLException se) {
-                                logger.error("Couldn't get row count for {}", new Object[] {fqn});
+                                logger.error("Couldn't get row count for {}", fqn);
                                 continue;
                             }
                         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -475,7 +475,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
                 });
             } catch (IOException ioe) {
                 // well then this FlowFile gets none of these attributes
-                getLogger().warn("Error collecting attributes for file {}, message is {}", new Object[] {absPathString, ioe.getMessage()});
+                getLogger().warn("Error collecting attributes for file {}", absPathString, ioe);
             }
         }
 
@@ -588,7 +588,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
                     if (Files.isReadable(dir)) {
                         return FileVisitResult.CONTINUE;
                     } else {
-                        getLogger().debug("The following directory is not readable: {}", new Object[]{dir.toString()});
+                        getLogger().debug("The following directory is not readable: {}", dir);
                         return FileVisitResult.SKIP_SUBTREE;
                     }
                 }
@@ -615,10 +615,10 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
                 @Override
                 public FileVisitResult visitFileFailed(final Path path, final IOException e) {
                     if (e instanceof AccessDeniedException) {
-                        getLogger().debug("The following file is not readable: {}", new Object[]{path.toString()});
+                        getLogger().debug("The following file is not readable: {}", path);
                         return FileVisitResult.SKIP_SUBTREE;
                     } else {
-                        getLogger().error("Error during visiting file {}: {}", path.toString(), e.getMessage(), e);
+                        getLogger().error("Error during visiting file {}: ", path, e);
                         return FileVisitResult.TERMINATE;
                     }
                 }
@@ -635,7 +635,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
 
             final long millis = System.currentTimeMillis() - start;
 
-            getLogger().debug("Took {} milliseconds to perform listing and gather {} entries", new Object[] {millis, result.size()});
+            getLogger().debug("Took {} milliseconds to perform listing and gather {} entries", millis, result.size());
             return result;
         } catch (final ProcessorStoppedException pse) {
             getLogger().info("Processor was stopped so will not complete listing of Files");
@@ -924,7 +924,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
 
         @Override
         public synchronized void purgeTimingInfo(final long cutoff) {
-            logger.debug("Purging any entries from Performance Tracker that is older than {}", new Object[] {new Date(cutoff)});
+            logger.debug("Purging any entries from Performance Tracker that is older than {}", new Date(cutoff));
             final Iterator<Map.Entry<Tuple<String, String>, TimingInfo>> itr = directoryToTimingInfo.entrySet().iterator();
 
             int purgedCount = 0;
@@ -945,7 +945,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
             }
 
             this.earliestTimestamp = earliestTimestamp;
-            logger.debug("Purged {} entries from Performance Tracker; now holding {} entries", new Object[] {purgedCount, directoryToTimingInfo.size()});
+            logger.debug("Purged {} entries from Performance Tracker; now holding {} entries", purgedCount, directoryToTimingInfo.size());
         }
 
         @Override
@@ -1065,7 +1065,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
             }
 
             if (logger.isTraceEnabled()) {
-                logger.trace("Performing operation {} on {} took {} milliseconds", new Object[] {operation, getFullPath(), duration});
+                logger.trace("Performing operation {} on {} took {} milliseconds", operation, getFullPath(), duration);
             }
         }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -618,7 +618,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
                         getLogger().debug("The following file is not readable: {}", path);
                         return FileVisitResult.SKIP_SUBTREE;
                     } else {
-                        getLogger().error("Error during visiting file {}: ", path, e);
+                        getLogger().error("Error during visiting file {}", path, e);
                         return FileVisitResult.TERMINATE;
                     }
                 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
@@ -382,7 +382,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
             toShutdown.destroy();
             clearInit();
         } catch (final Exception ex) {
-            getLogger().warn("unable to cleanly shutdown embedded server due to {}", new Object[] {ex});
+            getLogger().warn("unable to cleanly shutdown embedded server", ex);
             this.server = null;
         }
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCPRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCPRecord.java
@@ -343,7 +343,7 @@ public class ListenTCPRecord extends AbstractProcessor {
         }
 
         if (socketRecordReader.isClosed()) {
-            getLogger().warn("Unable to read records from {}, socket already closed", new Object[] {getRemoteAddress(socketRecordReader)});
+            getLogger().warn("Unable to read records from {}, socket already closed", getRemoteAddress(socketRecordReader));
             IOUtils.closeQuietly(socketRecordReader); // still need to call close so the overall count is decremented
             return;
         }
@@ -390,7 +390,7 @@ public class ListenTCPRecord extends AbstractProcessor {
                 }
 
                 if (record == null) {
-                    getLogger().debug("No records available from {}, closing connection", new Object[]{getRemoteAddress(socketRecordReader)});
+                    getLogger().debug("No records available from {}, closing connection", getRemoteAddress(socketRecordReader));
                     IOUtils.closeQuietly(socketRecordReader);
                     session.remove(flowFile);
                     return;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LookupAttribute.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LookupAttribute.java
@@ -225,7 +225,7 @@ public class LookupAttribute extends AbstractProcessor {
                 matched = putAttribute(attributeName, attributeValue, attributes, includeEmptyValues, logger) || matched;
 
                 if (!matched && logger.isDebugEnabled()) {
-                    logger.debug("No such value for key: {}", new Object[]{lookupKey});
+                    logger.debug("No such value for key: {}", lookupKey);
                 }
             }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LookupRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LookupRecord.java
@@ -435,7 +435,7 @@ public class LookupRecord extends AbstractProcessor {
                 try {
                     writer.close();
                 } catch (final IOException ioe) {
-                    getLogger().warn("Failed to close Writer for {}", new Object[] {childFlowFile});
+                    getLogger().warn("Failed to close Writer for {}", childFlowFile);
                 }
 
                 final Map<String, String> attributes = new HashMap<>();
@@ -452,7 +452,7 @@ public class LookupRecord extends AbstractProcessor {
             }
 
         } catch (final Exception e) {
-            getLogger().error("Failed to process {}", new Object[]{flowFile, e});
+            getLogger().error("Failed to process {}", flowFile, e);
 
             for (final Relationship relationship : lookupContext.getRelationshipsUsed()) {
                 final RecordSetWriter writer = lookupContext.getExistingRecordWriterForRelationship(relationship);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
@@ -539,7 +539,7 @@ public class MergeContent extends BinFiles {
             // Fail the flow files and commit them
             if (error != null) {
                 final String binDescription = contents.size() <= 10 ? contents.toString() : contents.size() + " FlowFiles";
-                getLogger().error(error + "; routing {} to failure", new Object[]{binDescription});
+                getLogger().error("{}; routing {} to failure", error, binDescription);
                 binSession.transfer(contents, REL_FAILURE);
                 binSession.commitAsync();
 
@@ -568,7 +568,7 @@ public class MergeContent extends BinFiles {
 
         final String inputDescription = contents.size() < 10 ? contents.toString() : contents.size() + " FlowFiles";
 
-        getLogger().info("Merged {} into {}. Reason for merging: {}", new Object[] {inputDescription, bundle, bin.getEvictionReason()});
+        getLogger().info("Merged {} into {}. Reason for merging: {}", inputDescription, bundle, bin.getEvictionReason());
 
         binSession.transfer(bundle, REL_MERGED);
         binProcessingResult.getAttributes().put(MERGE_UUID_ATTRIBUTE, bundle.getAttribute(CoreAttributes.UUID.key()));

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ModifyBytes.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ModifyBytes.java
@@ -143,7 +143,7 @@ public class ModifyBytes extends AbstractProcessor {
             });
         }
 
-        logger.info("Transferred {} to 'success'", new Object[]{ff});
+        logger.info("Transferred {} to 'success'", ff);
         session.getProvenanceReporter().modifyContent(ff, stopWatch.getElapsed(TimeUnit.MILLISECONDS));
         session.transfer(ff, REL_SUCCESS);
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Notify.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Notify.java
@@ -213,7 +213,7 @@ public class Notify extends AbstractProcessor {
 
             // if the computed value is null, or empty, we transfer the flow file to failure relationship
             if (StringUtils.isBlank(signalId)) {
-                logger.error("FlowFile {} has no attribute for given Release Signal Identifier", new Object[] {flowFile});
+                logger.error("FlowFile {} has no attribute for given Release Signal Identifier", flowFile);
                 // set 'notified' attribute
                 session.transfer(session.putAttribute(flowFile, NOTIFIED_ATTRIBUTE_NAME, String.valueOf(false)), REL_FAILURE);
                 continue;
@@ -251,7 +251,7 @@ public class Notify extends AbstractProcessor {
             signalBuffer.flowFiles.add(flowFile);
 
             if (logger.isDebugEnabled()) {
-                logger.debug("Cached release signal identifier {} counterName {} from FlowFile {}", new Object[] {signalId, counterName, flowFile});
+                logger.debug("Cached release signal identifier {} counterName {} from FlowFile {}", signalId, counterName, flowFile);
             }
 
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseCEF.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseCEF.java
@@ -274,7 +274,7 @@ public class ParseCEF extends AbstractProcessor {
         // ParCEFone returns null every time it cannot parse an
         // event, so we test
         if (event == null) {
-            getLogger().error("Failed to parse {} as a CEF message: it does not conform to the CEF standard; routing to failure", new Object[] {flowFile});
+            getLogger().error("Failed to parse {} as a CEF message: it does not conform to the CEF standard; routing to failure", flowFile);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseSyslog.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseSyslog.java
@@ -132,13 +132,13 @@ public class ParseSyslog extends AbstractProcessor {
         try {
             event = parser.parseEvent(buffer, null);
         } catch (final ProcessException pe) {
-            getLogger().error("Failed to parse {} as a Syslog message due to {}; routing to failure", new Object[] {flowFile, pe});
+            getLogger().error("Routing to failure since failed to parse {} as a Syslog message", flowFile, pe);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }
 
         if (event == null || !event.isValid()) {
-            getLogger().error("Failed to parse {} as a Syslog message: it does not conform to any of the RFC formats supported; routing to failure", new Object[] {flowFile});
+            getLogger().error("Failed to parse {} as a Syslog message: it does not conform to any of the RFC formats supported; routing to failure", flowFile);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PartitionRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PartitionRecord.java
@@ -219,7 +219,7 @@ public class PartitionRecord extends AbstractProcessor {
                     prop -> prop.getName(),
                     prop -> getRecordPath(context, prop, flowFile)));
         } catch (final Exception e) {
-            getLogger().error("Failed to compile RecordPath for {}; routing to failure", new Object[] {flowFile, e});
+            getLogger().error("Failed to compile RecordPath for {}; routing to failure", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }
@@ -301,14 +301,14 @@ public class PartitionRecord extends AbstractProcessor {
                 try {
                     writer.close();
                 } catch (final IOException e1) {
-                    getLogger().warn("Failed to close Record Writer for {}; some resources may not be cleaned up appropriately", new Object[] {flowFile, e1});
+                    getLogger().warn("Failed to close Record Writer for {}; some resources may not be cleaned up appropriately", flowFile, e1);
                 }
 
                 session.remove(valueMap.getFlowFile());
             }
 
 
-            getLogger().error("Failed to partition {}", new Object[] {flowFile, e});
+            getLogger().error("Failed to partition {}", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDistributedMapCache.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDistributedMapCache.java
@@ -161,7 +161,7 @@ public class PutDistributedMapCache extends AbstractProcessor {
 
         // if the computed value is null, or empty, we transfer the flow file to failure relationship
         if (StringUtils.isBlank(cacheKey)) {
-            logger.error("FlowFile {} has no attribute for given Cache Entry Identifier", new Object[] {flowFile});
+            logger.error("FlowFile {} has no attribute for given Cache Entry Identifier", flowFile);
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
             return;
@@ -177,13 +177,13 @@ public class PutDistributedMapCache extends AbstractProcessor {
 
             // too big flow file
             if (flowFileSize > maxCacheEntrySize) {
-                logger.warn("Flow file {} size {} exceeds the max cache entry size ({} B).", new Object[] {flowFile, flowFileSize, maxCacheEntrySize});
+                logger.warn("Flow file {} size {} exceeds the max cache entry size ({} B).", flowFile, flowFileSize, maxCacheEntrySize);
                 session.transfer(flowFile, REL_FAILURE);
                 return;
             }
 
             if (flowFileSize == 0) {
-                logger.warn("Flow file {} is empty, there is nothing to cache.", new Object[] {flowFile});
+                logger.warn("Flow file {} is empty, there is nothing to cache.", flowFile);
                 session.transfer(flowFile, REL_FAILURE);
                 return;
 
@@ -218,7 +218,7 @@ public class PutDistributedMapCache extends AbstractProcessor {
         } catch (final IOException e) {
             flowFile = session.penalize(flowFile);
             session.transfer(flowFile, REL_FAILURE);
-            logger.error("Unable to communicate with cache when processing {} due to {}", new Object[] {flowFile, e});
+            logger.error("Unable to communicate with cache when processing {}", flowFile, e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFile.java
@@ -251,7 +251,7 @@ public class PutFile extends AbstractProcessor {
                         } catch (Exception e) {
                             flowFile = session.penalize(flowFile);
                             session.transfer(flowFile, REL_FAILURE);
-                            logger.error("Could not set create directory with permissions {} because {}", new Object[]{permissions, e});
+                            logger.error("Could not set create directory with permissions {}", permissions, e);
                             return;
                         }
                     } else {
@@ -268,7 +268,7 @@ public class PutFile extends AbstractProcessor {
                                     UserPrincipalLookupService lookupService = currentPath.getFileSystem().getUserPrincipalLookupService();
                                     Files.setOwner(currentPath, lookupService.lookupPrincipalByName(owner));
                                 } catch (Exception e) {
-                                    logger.warn("Could not set directory owner to {} because {}", new Object[]{owner, e});
+                                    logger.warn("Could not set directory owner to {}", owner, e);
                                 }
                             }
                             if (chGroup) {
@@ -277,7 +277,7 @@ public class PutFile extends AbstractProcessor {
                                     PosixFileAttributeView view = Files.getFileAttributeView(currentPath, PosixFileAttributeView.class);
                                     view.setGroup(lookupService.lookupPrincipalByGroupName(group));
                                 } catch (Exception e) {
-                                    logger.warn("Could not set file group to {} because {}", new Object[]{group, e});
+                                    logger.warn("Could not set file group to {}", group, e);
                                 }
                             }
                             currentPath = currentPath.getParent();
@@ -286,8 +286,8 @@ public class PutFile extends AbstractProcessor {
                 } else {
                     flowFile = session.penalize(flowFile);
                     session.transfer(flowFile, REL_FAILURE);
-                    logger.error("Penalizing {} and routing to 'failure' because the output directory {} does not exist and Processor is "
-                            + "configured not to create missing directories", new Object[]{flowFile, rootDirPath});
+                    logger.error("Penalizing {} and routing to 'failure' because the output directory {} does not exist and Processor is configured not to create missing directories",
+                            flowFile, rootDirPath);
                     return;
                 }
             }
@@ -302,8 +302,8 @@ public class PutFile extends AbstractProcessor {
 
                 if (numFiles >= maxDestinationFiles) {
                     flowFile = session.penalize(flowFile);
-                    logger.warn("Penalizing {} and routing to 'failure' because the output directory {} has {} files, which exceeds the "
-                            + "configured maximum number of files", new Object[]{flowFile, finalCopyFileDir, numFiles});
+                    logger.warn("Penalizing {} and routing to 'failure' because the output directory {} has {} files, which exceeds the configured maximum number of files",
+                            flowFile, finalCopyFileDir, numFiles);
                     session.transfer(flowFile, REL_FAILURE);
                     return;
                 }
@@ -313,15 +313,15 @@ public class PutFile extends AbstractProcessor {
                 switch (conflictResponse) {
                     case REPLACE_RESOLUTION:
                         Files.delete(finalCopyFile);
-                        logger.info("Deleted {} as configured in order to replace with the contents of {}", new Object[]{finalCopyFile, flowFile});
+                        logger.info("Deleted {} as configured in order to replace with the contents of {}", finalCopyFile, flowFile);
                         break;
                     case IGNORE_RESOLUTION:
                         session.transfer(flowFile, REL_SUCCESS);
-                        logger.info("Transferring {} to success because file with same name already exists", new Object[]{flowFile});
+                        logger.info("Transferring {} to success because file with same name already exists", flowFile);
                         return;
                     case FAIL_RESOLUTION:
                         flowFile = session.penalize(flowFile);
-                        logger.warn("Penalizing {} and routing to failure as configured because file with the same name already exists", new Object[]{flowFile});
+                        logger.warn("Penalizing {} and routing to failure as configured because file with the same name already exists", flowFile);
                         session.transfer(flowFile, REL_FAILURE);
                         return;
                     default:
@@ -337,7 +337,7 @@ public class PutFile extends AbstractProcessor {
                     final OffsetDateTime fileModifyTime = OffsetDateTime.parse(lastModifiedTime, DATE_TIME_FORMATTER);
                     dotCopyFile.toFile().setLastModified(fileModifyTime.toInstant().toEpochMilli());
                 } catch (Exception e) {
-                    logger.warn("Could not set file lastModifiedTime to {} because {}", new Object[]{lastModifiedTime, e});
+                    logger.warn("Could not set file lastModifiedTime to {}", lastModifiedTime, e);
                 }
             }
 
@@ -348,7 +348,7 @@ public class PutFile extends AbstractProcessor {
                         Files.setPosixFilePermissions(dotCopyFile, PosixFilePermissions.fromString(perms));
                     }
                 } catch (Exception e) {
-                    logger.warn("Could not set file permissions to {} because {}", new Object[]{permissions, e});
+                    logger.warn("Could not set file permissions to {}", permissions, e);
                 }
             }
 
@@ -357,7 +357,7 @@ public class PutFile extends AbstractProcessor {
                     UserPrincipalLookupService lookupService = dotCopyFile.getFileSystem().getUserPrincipalLookupService();
                     Files.setOwner(dotCopyFile, lookupService.lookupPrincipalByName(owner));
                 } catch (Exception e) {
-                    logger.warn("Could not set file owner to {} because {}", new Object[]{owner, e});
+                    logger.warn("Could not set file owner to {}", owner, e);
                 }
             }
 
@@ -367,7 +367,7 @@ public class PutFile extends AbstractProcessor {
                     PosixFileAttributeView view = Files.getFileAttributeView(dotCopyFile, PosixFileAttributeView.class);
                     view.setGroup(lookupService.lookupPrincipalByGroupName(group));
                 } catch (Exception e) {
-                    logger.warn("Could not set file group to {} because {}", new Object[]{group, e});
+                    logger.warn("Could not set file group to {}", group, e);
                 }
             }
 
@@ -382,11 +382,11 @@ public class PutFile extends AbstractProcessor {
 
             if (!renamed) {
                 if (Files.exists(dotCopyFile) && dotCopyFile.toFile().delete()) {
-                    logger.debug("Deleted dot copy file {}", new Object[]{dotCopyFile});
+                    logger.debug("Deleted dot copy file {}", dotCopyFile);
                 }
                 throw new ProcessException("Could not rename: " + dotCopyFile);
             } else {
-                logger.info("Produced copy of {} at location {}", new Object[]{flowFile, finalCopyFile});
+                logger.info("Produced copy of {} at location {}", flowFile, finalCopyFile);
             }
 
             session.getProvenanceReporter().send(flowFile, finalCopyFile.toFile().toURI().toString(), stopWatch.getElapsed(TimeUnit.MILLISECONDS));
@@ -396,12 +396,12 @@ public class PutFile extends AbstractProcessor {
                 try {
                     Files.deleteIfExists(tempDotCopyFile);
                 } catch (final Exception e) {
-                    logger.error("Unable to remove temporary file {} due to {}", new Object[]{tempDotCopyFile, e});
+                    logger.error("Unable to remove temporary file {}", tempDotCopyFile, e);
                 }
             }
 
             flowFile = session.penalize(flowFile);
-            logger.error("Penalizing {} and transferring to failure due to {}", new Object[]{flowFile, t});
+            logger.error("Penalizing {} and transferring to failure", flowFile, t);
             session.transfer(flowFile, REL_FAILURE);
         }
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceText.java
@@ -423,11 +423,11 @@ public class ReplaceText extends AbstractProcessor {
         } catch (StackOverflowError e) {
             // Some regular expressions can produce many matches on large input data size using recursive code
             // do not log the StackOverflowError stack trace
-            logger.info("Transferred {} to 'failure' due to {}", new Object[] {flowFile, e.toString()});
+            logger.info("Transferred {} to 'failure'", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
             return;
         } catch (BufferOverflowException e) {
-            logger.warn("Transferred {} to 'failure' due to {}", new Object[] {flowFile, e.toString()});
+            logger.warn("Transferred {} to 'failure'", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
             return;
         } catch (IllegalAttributeException | AttributeExpressionLanguageException e) {
@@ -436,7 +436,7 @@ public class ReplaceText extends AbstractProcessor {
             return;
         }
 
-        logger.info("Transferred {} to 'success'", new Object[] {flowFile});
+        logger.info("Transferred {} to 'success'", flowFile);
         session.getProvenanceReporter().modifyContent(flowFile, stopWatch.getElapsed(TimeUnit.MILLISECONDS));
         session.transfer(flowFile, REL_SUCCESS);
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
@@ -207,7 +207,7 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
 
             flowFile = session.write(flowFile, new ReplaceTextCallback(context, flowFile, maxBufferSize));
 
-            logger.info("Transferred {} to 'success'", new Object[]{flowFile});
+            logger.info("Transferred {} to 'success'", flowFile);
             session.getProvenanceReporter().modifyContent(flowFile, stopWatch.getElapsed(TimeUnit.MILLISECONDS));
             session.transfer(flowFile, REL_SUCCESS);
         }
@@ -254,21 +254,21 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
                         if (file.lastModified() > lastModified.get()) {
                             lastModified.getAndSet(file.lastModified());
                             try (FileInputStream is = new FileInputStream(file)) {
-                                logger.info("Reloading mapping file: {}", new Object[]{fileName});
+                                logger.info("Reloading mapping file: {}", fileName);
 
                                 final Map<String, String> mapping = loadMappingFile(is);
                                 final ConfigurationState newState = new ConfigurationState(mapping);
                                 configurationStateRef.set(newState);
                             } catch (IOException e) {
-                                logger.error("Error reading mapping file: {}", new Object[]{e.getMessage()});
+                                logger.error("Error reading mapping file: ", e);
                             }
                         }
                     } else {
-                        logger.error("Mapping file does not exist or is not readable: {}", new Object[]{fileName});
+                        logger.error("Mapping file does not exist or is not readable: {}", fileName);
                     }
                 }
             } catch (Exception e) {
-                logger.error("Error loading mapping file: {}", new Object[]{e.getMessage()});
+                logger.error("Error loading mapping file: ", e);
             } finally {
                 processorLock.unlock();
             }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
@@ -260,7 +260,7 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
                                 final ConfigurationState newState = new ConfigurationState(mapping);
                                 configurationStateRef.set(newState);
                             } catch (IOException e) {
-                                logger.error("Error reading mapping file: ", e);
+                                logger.error("Error reading mapping file", e);
                             }
                         }
                     } else {
@@ -268,7 +268,7 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
                     }
                 }
             } catch (Exception e) {
-                logger.error("Error loading mapping file: ", e);
+                logger.error("Error loading mapping file", e);
             } finally {
                 processorLock.unlock();
             }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RetryFlowFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RetryFlowFile.java
@@ -248,10 +248,8 @@ public class RetryFlowFile extends AbstractProcessor {
             LogLevel reuseLogLevel = LogLevel.DEBUG;
             switch (reuseMode) {
                 case "fail":
-                    getLogger().error("FlowFile {} was previously retried with the same attribute by a " +
-                            "different processor. Route to 'failure'", new Object[]{flowfile});
-                    getLogger().debug("Current Processor: {}, Previous Processor: {}, Previous Retry: {}",
-                            new Object[]{currentInstanceUUID, lastRetriedByUUID, currentRetry - 1});
+                    getLogger().error("FlowFile {} was previously retried with the same attribute by a different processor. Route to 'failure'", flowfile);
+                    getLogger().debug("Current Processor: {}, Previous Processor: {}, Previous Retry: {}", currentInstanceUUID, lastRetriedByUUID, currentRetry - 1);
                     session.transfer(flowfile, FAILURE);
                     return;
                 case "warn":
@@ -259,10 +257,8 @@ public class RetryFlowFile extends AbstractProcessor {
                 case "reset":
                     getLogger().log(reuseLogLevel, "FlowFile {} was previously retried with the same attribute " +
                                     "by a different processor. Reset the current retry count to '1'. Consider " +
-                                    "changing the retry attribute for this processor.",
-                            new Object[]{flowfile});
-                    getLogger().debug("Current Processor: {}, Previous Processor: {}, Previous Retry: {}",
-                            new Object[]{currentInstanceUUID, lastRetriedByUUID, currentRetry});
+                                    "changing the retry attribute for this processor.", flowfile);
+                    getLogger().debug("Current Processor: {}, Previous Processor: {}, Previous Retry: {}", currentInstanceUUID, lastRetriedByUUID, currentRetry);
                     currentRetry = 1;
                     break;
             }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteOnAttribute.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteOnAttribute.java
@@ -290,7 +290,7 @@ public class RouteOnAttribute extends AbstractProcessor {
             if (!descriptor.isDynamic()) {
                 continue;
             }
-            getLogger().debug("Adding new dynamic property: {}", new Object[]{descriptor});
+            getLogger().debug("Adding new dynamic property: {}", descriptor);
             newPropertyMap.put(new Relationship.Builder().name(descriptor.getName()).build(), context.getProperty(descriptor));
         }
 
@@ -341,7 +341,7 @@ public class RouteOnAttribute extends AbstractProcessor {
         }
 
         if (destinationRelationships.isEmpty()) {
-            logger.info("Routing {} to unmatched", new Object[] {flowFile});
+            logger.info("Routing {} to unmatched", flowFile);
             flowFile = session.putAttribute(flowFile, ROUTE_ATTRIBUTE_KEY, REL_NO_MATCH.getName());
             session.getProvenanceReporter().route(flowFile, REL_NO_MATCH);
             session.transfer(flowFile, REL_NO_MATCH);
@@ -359,14 +359,14 @@ public class RouteOnAttribute extends AbstractProcessor {
 
             // now transfer any clones generated
             for (final Map.Entry<Relationship, FlowFile> entry : transferMap.entrySet()) {
-                logger.info("Cloned {} into {} and routing clone to relationship {}", new Object[] {flowFile, entry.getValue(), entry.getKey()});
+                logger.info("Cloned {} into {} and routing clone to relationship {}", flowFile, entry.getValue(), entry.getKey());
                 FlowFile updatedFlowFile = session.putAttribute(entry.getValue(), ROUTE_ATTRIBUTE_KEY, entry.getKey().getName());
                 session.getProvenanceReporter().route(updatedFlowFile, entry.getKey());
                 session.transfer(updatedFlowFile, entry.getKey());
             }
 
             //now transfer the original flow file
-            logger.info("Routing {} to {}", new Object[]{flowFile, firstRelationship});
+            logger.info("Routing {} to {}", flowFile, firstRelationship);
             session.getProvenanceReporter().route(flowFile, firstRelationship);
             flowFile = session.putAttribute(flowFile, ROUTE_ATTRIBUTE_KEY, firstRelationship.getName());
             session.transfer(flowFile, firstRelationship);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteOnContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteOnContent.java
@@ -220,7 +220,7 @@ public class RouteOnContent extends AbstractProcessor {
                 flowFile = session.putAttribute(flowFile, ROUTE_ATTRIBUTE_KEY, REL_NO_MATCH.getName());
                 session.transfer(flowFile, REL_NO_MATCH);
                 session.getProvenanceReporter().route(flowFile, REL_NO_MATCH);
-                logger.info("Routing {} to 'unmatched'", new Object[]{flowFile});
+                logger.info("Routing {} to 'unmatched'", flowFile);
             } else {
                 final Relationship firstRelationship = destinations.iterator().next();
                 destinations.remove(firstRelationship);
@@ -230,13 +230,13 @@ public class RouteOnContent extends AbstractProcessor {
                     clone = session.putAttribute(clone, ROUTE_ATTRIBUTE_KEY, relationship.getName());
                     session.getProvenanceReporter().route(clone, relationship);
                     session.transfer(clone, relationship);
-                    logger.info("Cloning {} to {} and routing clone to {}", new Object[]{flowFile, clone, relationship});
+                    logger.info("Cloning {} to {} and routing clone to {}", flowFile, clone, relationship);
                 }
 
                 flowFile = session.putAttribute(flowFile, ROUTE_ATTRIBUTE_KEY, firstRelationship.getName());
                 session.getProvenanceReporter().route(flowFile, firstRelationship);
                 session.transfer(flowFile, firstRelationship);
-                logger.info("Routing {} to {}", new Object[]{flowFile, firstRelationship});
+                logger.info("Routing {} to {}", flowFile, firstRelationship);
             }
         }
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteText.java
@@ -347,7 +347,7 @@ public class RouteText extends AbstractProcessor {
             if (!descriptor.isDynamic()) {
                 continue;
             }
-            getLogger().debug("Adding new dynamic property: {}", new Object[] {descriptor});
+            getLogger().debug("Adding new dynamic property: {}", descriptor);
             newPropertyMap.put(new Relationship.Builder().name(descriptor.getName()).build(), context.getProperty(descriptor));
         }
 
@@ -538,7 +538,7 @@ public class RouteText extends AbstractProcessor {
                 attributes.put(ROUTE_ATTRIBUTE_KEY, relationship.getName());
                 attributes.put(GROUP_ATTRIBUTE_KEY, StringUtils.join(group.getCapturedValues(), ", "));
 
-                logger.info("Created {} from {}; routing to relationship {}", new Object[] {flowFile, originalFlowFile, relationship.getName()});
+                logger.info("Created {} from {}; routing to relationship {}", flowFile, originalFlowFile, relationship.getName());
                 FlowFile updatedFlowFile = session.putAllAttributes(flowFile, attributes);
                 session.getProvenanceReporter().route(updatedFlowFile, entry.getKey());
                 session.transfer(updatedFlowFile, entry.getKey());
@@ -547,7 +547,7 @@ public class RouteText extends AbstractProcessor {
 
         // now transfer the original flow file
         FlowFile flowFile = originalFlowFile;
-        logger.info("Routing {} to {}", new Object[] {flowFile, REL_ORIGINAL});
+        logger.info("Routing {} to {}", flowFile, REL_ORIGINAL);
         session.getProvenanceReporter().route(originalFlowFile, REL_ORIGINAL);
         flowFile = session.putAttribute(flowFile, ROUTE_ATTRIBUTE_KEY, REL_ORIGINAL.getName());
         session.transfer(flowFile, REL_ORIGINAL);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ScanAttribute.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ScanAttribute.java
@@ -210,7 +210,7 @@ public class ScanAttribute extends AbstractProcessor {
             final Relationship relationship = matched ? REL_MATCHED : REL_UNMATCHED;
             session.getProvenanceReporter().route(flowFile, relationship);
             session.transfer(flowFile, relationship);
-            logger.info("Transferred {} to {}", new Object[]{flowFile, relationship});
+            logger.info("Transferred {} to {}", flowFile, relationship);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ScanContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ScanContent.java
@@ -163,7 +163,7 @@ public class ScanContent extends AbstractProcessor {
 
                     search.initializeDictionary(terms);
                     searchRef.set(search);
-                    logger.info("Loaded search dictionary from {}", new Object[]{context.getProperty(DICTIONARY).getValue()});
+                    logger.info("Loaded search dictionary from {}", context.getProperty(DICTIONARY).getValue());
                     return true;
                 }
             } finally {
@@ -232,12 +232,12 @@ public class ScanContent extends AbstractProcessor {
 
         final SearchTerm<byte[]> matchingTerm = termRef.get();
         if (matchingTerm == null) {
-            logger.info("Routing {} to 'unmatched'", new Object[]{flowFile});
+            logger.info("Routing {} to 'unmatched'", flowFile);
             session.getProvenanceReporter().route(flowFile, REL_NO_MATCH);
             session.transfer(flowFile, REL_NO_MATCH);
         } else {
             final String matchingTermString = matchingTerm.toString(UTF8);
-            logger.info("Routing {} to 'matched' because it matched term {}", new Object[]{flowFile, matchingTermString});
+            logger.info("Routing {} to 'matched' because it matched term {}", flowFile, matchingTermString);
             flowFile = session.putAttribute(flowFile, MATCH_ATTRIBUTE_KEY, matchingTermString);
             session.getProvenanceReporter().route(flowFile, REL_MATCH);
             session.transfer(flowFile, REL_MATCH);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SegmentContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SegmentContent.java
@@ -167,9 +167,9 @@ public class SegmentContent extends AbstractProcessor {
         session.transfer(flowFile, REL_ORIGINAL);
 
         if (totalSegments <= 10) {
-            getLogger().info("Segmented {} into {} segments: {}", new Object[]{flowFile, totalSegments, segmentSet});
+            getLogger().info("Segmented {} into {} segments: {}", flowFile, totalSegments, segmentSet);
         } else {
-            getLogger().info("Segmented {} into {} segments", new Object[]{flowFile, totalSegments});
+            getLogger().info("Segmented {} into {} segments", flowFile, totalSegments);
         }
     }
 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitContent.java
@@ -208,7 +208,7 @@ public class SplitContent extends AbstractProcessor {
 
         final byte[] byteSequence = this.byteSequence.get();
         if (byteSequence == null) {   // should never happen. But just in case...
-            logger.error("{} Unable to obtain Byte Sequence", new Object[]{this});
+            logger.error("{} Unable to obtain Byte Sequence", this);
             session.rollback();
             return;
         }
@@ -261,7 +261,7 @@ public class SplitContent extends AbstractProcessor {
             FlowFile clone = session.clone(flowFile);
             // finishFragmentAttributes performs .clear() so List must be mutable
             splitList.add(clone);
-            logger.info("Found no match for {}; transferring original 'original' and transferring clone {} to 'splits'", new Object[]{flowFile, clone});
+            logger.info("Found no match for {}; transferring original 'original' and transferring clone {} to 'splits'", flowFile, clone);
         } else {
             for (final Tuple<Long, Long> tuple : splits) {
                 long offset = tuple.getKey();
@@ -293,9 +293,9 @@ public class SplitContent extends AbstractProcessor {
         session.transfer(flowFile, REL_ORIGINAL);
 
         if (splitList.size() > 10) {
-            logger.info("Split {} into {} files", new Object[]{flowFile, splitList.size()});
+            logger.info("Split {} into {} files", flowFile, splitList.size());
         } else {
-            logger.info("Split {} into {} files: {}", new Object[]{flowFile, splitList.size(), splitList});
+            logger.info("Split {} into {} files: {}", flowFile, splitList.size(), splitList);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitJson.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitJson.java
@@ -189,7 +189,7 @@ public class SplitJson extends AbstractJsonPathProcessor {
         try {
             documentContext = validateAndEstablishJsonContext(processSession, original, jsonPathConfiguration);
         } catch (InvalidJsonException e) {
-            logger.error("FlowFile {} did not have valid JSON content.", new Object[]{original});
+            logger.error("FlowFile {} did not have valid JSON content.", original);
             processSession.transfer(original, REL_FAILURE);
             return;
         }
@@ -200,13 +200,13 @@ public class SplitJson extends AbstractJsonPathProcessor {
         try {
             jsonPathResult = documentContext.read(jsonPath);
         } catch (PathNotFoundException e) {
-            logger.warn("JsonPath {} could not be found for FlowFile {}", new Object[]{jsonPath.getPath(), original});
+            logger.warn("JsonPath {} could not be found for FlowFile {}", jsonPath.getPath(), original);
             processSession.transfer(original, REL_FAILURE);
             return;
         }
 
         if (!(jsonPathResult instanceof List)) {
-            logger.error("The evaluated value {} of {} was not a JSON Array compatible type and cannot be split.", new Object[]{jsonPathResult, jsonPath.getPath()});
+            logger.error("The evaluated value {} of {} was not a JSON Array compatible type and cannot be split.", jsonPathResult, jsonPath.getPath());
             processSession.transfer(original, REL_FAILURE);
             return;
         }
@@ -233,6 +233,6 @@ public class SplitJson extends AbstractJsonPathProcessor {
 
         original = copyAttributesToOriginal(processSession, original, fragmentId, resultList.size());
         processSession.transfer(original, REL_ORIGINAL);
-        logger.info("Split {} into {} FlowFiles", new Object[]{original, resultList.size()});
+        logger.info("Split {} into {} FlowFiles", original, resultList.size());
     }
 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitRecord.java
@@ -198,7 +198,7 @@ public class SplitRecord extends AbstractProcessor {
                 }
             });
         } catch (final ProcessException pe) {
-            getLogger().error("Failed to split {}", new Object[] {original, pe});
+            getLogger().error("Failed to split", original, pe);
             session.remove(splits);
             session.transfer(original, REL_FAILURE);
             return;
@@ -211,7 +211,7 @@ public class SplitRecord extends AbstractProcessor {
             session.putAttribute(split, FRAGMENT_COUNT, String.valueOf(splits.size()));
         }
         session.transfer(splits, REL_SPLITS);
-        getLogger().info("Successfully split {} into {} FlowFiles, each containing up to {} records", new Object[] {original, splits.size(), maxRecords});
+        getLogger().info("Successfully split {} into {} FlowFiles, each containing up to {} records", original, splits.size(), maxRecords);
     }
 
 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitText.java
@@ -344,7 +344,7 @@ public class SplitText extends AbstractProcessor {
             }
         }
 
-        getLogger().info("Split {} into {} FlowFiles{}", new Object[] {sourceFlowFile, splitFlowFiles.size(), headerFlowFile == null ? " containing headers." : "."});
+        getLogger().info("Split {} into {} FlowFiles{}", sourceFlowFile, splitFlowFiles.size(), headerFlowFile == null ? " containing headers." : ".");
         if (headerFlowFile != null) {
             processSession.remove(headerFlowFile);
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
@@ -1260,7 +1260,7 @@ public class TailFile extends AbstractProcessor {
         try {
             reader = FileChannel.open(file.toPath(), StandardOpenOption.READ);
         } catch (final IOException ioe) {
-            getLogger().warn("Unable to open file {}; will attempt to access file again after the configured Yield Duration has elapsed: ", file, ioe);
+            getLogger().warn("Unable to open file {}; will attempt to access file again after the configured Yield Duration has elapsed", file, ioe);
             return null;
         }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
@@ -439,7 +439,7 @@ public class TailFile extends AbstractProcessor {
             migratedStatesMap.put(MAP_PREFIX + "0." + TailFileState.StateKeys.LENGTH, statesMap.get(TailFileState.StateKeys.POSITION));
             statesMap = Collections.unmodifiableMap(migratedStatesMap);
 
-            getLogger().info("statesMap has been migrated. {}", new Object[]{migratedStatesMap});
+            getLogger().info("statesMap has been migrated. {}", migratedStatesMap);
         }
 
         initStates(filesToTail, statesMap, false, startPosition);
@@ -615,7 +615,7 @@ public class TailFile extends AbstractProcessor {
                         getLogger().debug("When recovering state, checksum of tailed file matches the stored checksum. Will resume where left off.");
                         tailFile = existingTailFile;
                         reader = FileChannel.open(tailFile.toPath(), StandardOpenOption.READ);
-                        getLogger().debug("Created FileChannel {} for {} in recoverState", new Object[]{reader, tailFile});
+                        getLogger().debug("Created FileChannel {} for {} in recoverState", reader, tailFile);
 
                         reader.position(position);
                     } else {
@@ -626,7 +626,7 @@ public class TailFile extends AbstractProcessor {
             } else {
                 // fewer bytes than our position, so we know we weren't already reading from this file. Keep reader at a position of 0.
                 getLogger().debug("When recovering state, existing file to tail is only {} bytes but position flag is {}; "
-                        + "this indicates that the file has rotated. Will begin tailing current file from beginning.", new Object[]{existingTailFile.length(), position});
+                        + "this indicates that the file has rotated. Will begin tailing current file from beginning.", existingTailFile.length(), position);
             }
 
             states.get(filePath).setState(new TailFileState(filePath, tailFile, reader, position, timestamp, length, checksum, ByteBuffer.allocate(preAllocatedBufferSize)));
@@ -634,7 +634,7 @@ public class TailFile extends AbstractProcessor {
             resetState(filePath);
         }
 
-        getLogger().debug("Recovered state {}", new Object[]{states.get(filePath).getState()});
+        getLogger().debug("Recovered state {}", states.get(filePath).getState());
     }
 
     private void resetState(final String filePath) {
@@ -667,7 +667,7 @@ public class TailFile extends AbstractProcessor {
 
         try {
             reader.close();
-            getLogger().debug("Closed FileChannel {}", new Object[]{reader});
+            getLogger().debug("Closed FileChannel {}", reader);
         } catch (final IOException ioe) {
             getLogger().warn("Failed to close file handle during cleanup");
         }
@@ -784,7 +784,7 @@ public class TailFile extends AbstractProcessor {
 
                 try {
                     final FileChannel fileChannel = FileChannel.open(file.toPath(), StandardOpenOption.READ);
-                    getLogger().debug("Created FileChannel {} for {}", new Object[]{fileChannel, file});
+                    getLogger().debug("Created FileChannel {} for {}", fileChannel, file);
 
                     final Checksum checksum = new CRC32();
                     final long position = file.length();
@@ -892,9 +892,9 @@ public class TailFile extends AbstractProcessor {
             // Since file has rotated, we close the reader, create a new one, and then reset our state.
             try {
                 reader.close();
-                getLogger().debug("Closed FileChannel {}", new Object[]{reader, reader});
+                getLogger().debug("Closed FileChannel {}", reader);
             } catch (final IOException ioe) {
-                getLogger().warn("Failed to close reader for {} due to {}", new Object[]{file, ioe});
+                getLogger().warn("Failed to close reader for {}", file, ioe);
             }
 
             reader = createReader(file, 0L);
@@ -1021,7 +1021,7 @@ public class TailFile extends AbstractProcessor {
      */
     private long readLines(final FileChannel reader, final ByteBuffer buffer, final OutputStream out, final Checksum checksum,
                            Boolean reReadOnNul, final boolean readFully) throws IOException {
-        getLogger().debug("Reading lines starting at position {}", new Object[]{reader.position()});
+        getLogger().debug("Reading lines starting at position {}", reader.position());
 
         try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             long pos = reader.position();
@@ -1080,7 +1080,7 @@ public class TailFile extends AbstractProcessor {
             }
 
             if (rePos < reader.position()) {
-                getLogger().debug("Read {} lines; repositioning reader from {} to {}", new Object[]{linesRead, pos, rePos});
+                getLogger().debug("Read {} lines; repositioning reader from {} to {}", linesRead, pos, rePos);
                 reader.position(rePos); // Ensure we can re-read if necessary
             }
 
@@ -1181,7 +1181,7 @@ public class TailFile extends AbstractProcessor {
 
                 if (file.lastModified() < minTimestamp) {
                     getLogger().debug("Found rolled off file {} but its last modified timestamp is before the cutoff (Last Mod = {}, Cutoff = {}) so will not consume it",
-                            new Object[]{file, lastMod, minTimestamp});
+                            file, lastMod, minTimestamp);
 
                     continue;
                 } else if (file.equals(tailFile)) {
@@ -1236,7 +1236,7 @@ public class TailFile extends AbstractProcessor {
                         || TailFileState.StateKeys.FILENAME.equals(key)
                         || TailFileState.StateKeys.POSITION.equals(key)
                         || TailFileState.StateKeys.TIMESTAMP.equals(key)) {
-                    getLogger().info("Removed state {}={} stored by older version of NiFi.", new Object[]{key, oldState.get(key)});
+                    getLogger().info("Removed state {}={} stored by older version of NiFi.", key, oldState.get(key));
                     continue;
                 }
                 updatedState.put(key, oldState.get(key));
@@ -1250,7 +1250,7 @@ public class TailFile extends AbstractProcessor {
                 session.setState(updatedState, scope);
             }
         } catch (final IOException e) {
-            getLogger().warn("Failed to store state due to {}; some data may be duplicated on restart of NiFi", new Object[]{e});
+            getLogger().warn("Some data may be duplicated on restart of NiFi since failed to store state", e);
         }
     }
 
@@ -1260,20 +1260,20 @@ public class TailFile extends AbstractProcessor {
         try {
             reader = FileChannel.open(file.toPath(), StandardOpenOption.READ);
         } catch (final IOException ioe) {
-            getLogger().warn("Unable to open file {}; will attempt to access file again after the configured Yield Duration has elapsed: {}", new Object[]{file, ioe});
+            getLogger().warn("Unable to open file {}; will attempt to access file again after the configured Yield Duration has elapsed: ", file, ioe);
             return null;
         }
 
-        getLogger().debug("Created FileChannel {} for {}", new Object[]{reader, file});
+        getLogger().debug("Created FileChannel {} for {}", reader, file);
 
         try {
             reader.position(position);
         } catch (final IOException ioe) {
-            getLogger().error("Failed to read from {} due to {}", new Object[]{file, ioe});
+            getLogger().error("Failed to read from {}", file, ioe);
 
             try {
                 reader.close();
-                getLogger().debug("Closed FileChannel {}", new Object[]{reader});
+                getLogger().debug("Closed FileChannel {}", reader);
             } catch (final IOException ioe2) {
             }
 
@@ -1319,7 +1319,7 @@ public class TailFile extends AbstractProcessor {
             final List<File> rolledOffFiles = getRolledOffFiles(context, timestamp, tailFile);
             return recoverRolledFiles(context, session, tailFile, rolledOffFiles, expectedChecksum, position);
         } catch (final IOException e) {
-            getLogger().error("Failed to recover files that have rolled over due to {}", new Object[]{e});
+            getLogger().error("Failed to recover files that have rolled over", e);
             return false;
         }
     }
@@ -1346,7 +1346,7 @@ public class TailFile extends AbstractProcessor {
     private boolean recoverRolledFiles(final ProcessContext context, final ProcessSession session, final String tailFile, final List<File> rolledOffFiles, final Long expectedChecksum,
             final long position) {
         try {
-            getLogger().debug("Recovering Rolled Off Files; total number of files rolled off = {}", new Object[]{rolledOffFiles.size()});
+            getLogger().debug("Recovering Rolled Off Files; total number of files rolled off = {}", rolledOffFiles.size());
             TailFileObject tfo = states.get(tailFile);
 
             final long postRolloverTailMillis = context.getProperty(POST_ROLLOVER_TAIL_PERIOD).asTimePeriod(TimeUnit.MILLISECONDS);
@@ -1427,7 +1427,7 @@ public class TailFile extends AbstractProcessor {
 
             return rolloverOccurred;
         } catch (final IOException e) {
-            getLogger().error("Failed to recover files that have rolled over due to {}", new Object[]{e});
+            getLogger().error("Failed to recover files that have rolled over", e);
             return false;
         }
     }
@@ -1445,12 +1445,12 @@ public class TailFile extends AbstractProcessor {
             final long checksumResult = in.getChecksum().getValue();
             if (checksumResult != expectedChecksum) {
                 getLogger().debug("Checksum for {} did not match expected checksum. Checksum for file was {} but expected {}. Will consume entire file",
-                    new Object[]{fileToTail, checksumResult, expectedChecksum});
+                        fileToTail, checksumResult, expectedChecksum);
 
                 return false;
             }
 
-            getLogger().debug("Checksum for {} matched expected checksum. Will skip first {} bytes", new Object[]{fileToTail, position});
+            getLogger().debug("Checksum for {} matched expected checksum. Will skip first {} bytes", fileToTail, position);
 
             // This is the same file that we were reading when we shutdown. Start reading from this point on.
             FlowFile flowFile = session.create();
@@ -1489,7 +1489,7 @@ public class TailFile extends AbstractProcessor {
                 session.getProvenanceReporter().receive(flowFile, fileToTail.toURI().toString(), "FlowFile contains bytes 0 through " + position + " of source file",
                     TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos));
                 session.transfer(flowFile, REL_SUCCESS);
-                getLogger().debug("Created {} from rolled over file {} and routed to success", new Object[]{flowFile, fileToTail});
+                getLogger().debug("Created {} from rolled over file {} and routed to success", flowFile, fileToTail);
             }
 
             // We need to update the state to account for the fact that we just brought data in.
@@ -1559,7 +1559,7 @@ public class TailFile extends AbstractProcessor {
             flowFile = session.putAllAttributes(flowFile, attributes);
             session.getProvenanceReporter().receive(flowFile, file.toURI().toString());
             session.transfer(flowFile, REL_SUCCESS);
-            getLogger().debug("Created {} from {} and routed to success", new Object[]{flowFile, file});
+            getLogger().debug("Created {} from {} and routed to success", flowFile, file);
 
             // use a timestamp of lastModified() + 1 so that we do not ingest this file again.
             cleanup(context);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateCsv.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateCsv.java
@@ -567,7 +567,7 @@ public class ValidateCsv extends AbstractProcessor {
 
         if (isWholeFFValidation) {
             if (valid.get()) {
-                logger.debug("Successfully validated {} against schema; routing to 'valid'", new Object[]{flowFile});
+                logger.debug("Successfully validated {} against schema; routing to 'valid'", flowFile);
                 session.getProvenanceReporter().route(flowFile, REL_VALID);
                 session.transfer(flowFile, REL_VALID);
             } else {
@@ -577,7 +577,7 @@ public class ValidateCsv extends AbstractProcessor {
             }
         } else {
             if (valid.get()) {
-                logger.debug("Successfully validated {} against schema; routing to 'valid'", new Object[]{validFF.get()});
+                logger.debug("Successfully validated {} against schema; routing to 'valid'", validFF.get());
                 session.getProvenanceReporter().route(validFF.get(), REL_VALID, "All " + totalCount.get() + " line(s) are valid");
                 session.putAttribute(validFF.get(), "count.valid.lines", Integer.toString(totalCount.get()));
                 session.putAttribute(validFF.get(), "count.total.lines", Integer.toString(totalCount.get()));
@@ -588,8 +588,7 @@ public class ValidateCsv extends AbstractProcessor {
                 // because of the finally within the 'while' loop
                 totalCount.set(totalCount.get() - 1);
 
-                logger.debug("Successfully validated {}/{} line(s) in {} against schema; routing valid lines to 'valid' and invalid lines to 'invalid'",
-                        new Object[]{okCount.get(), totalCount.get(), flowFile});
+                logger.debug("Successfully validated {}/{} line(s) in {} against schema; routing valid lines to 'valid' and invalid lines to 'invalid'", okCount.get(), totalCount.get(), flowFile);
                 session.getProvenanceReporter().route(validFF.get(), REL_VALID, okCount.get() + " valid line(s)");
                 session.putAttribute(validFF.get(), "count.total.lines", Integer.toString(totalCount.get()));
                 session.putAttribute(validFF.get(), "count.valid.lines", Integer.toString(okCount.get()));
@@ -601,7 +600,7 @@ public class ValidateCsv extends AbstractProcessor {
                 session.transfer(invalidFF.get(), REL_INVALID);
                 session.remove(flowFile);
             } else {
-                logger.debug("All lines in {} are invalid; routing to 'invalid'", new Object[]{invalidFF.get()});
+                logger.debug("All lines in {} are invalid; routing to 'invalid'", invalidFF.get());
                 session.getProvenanceReporter().route(invalidFF.get(), REL_INVALID, "All " + totalCount.get() + " line(s) are invalid");
                 session.putAttribute(invalidFF.get(), "count.invalid.lines", Integer.toString(totalCount.get()));
                 session.putAttribute(invalidFF.get(), "count.total.lines", Integer.toString(totalCount.get()));

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateRecord.java
@@ -436,7 +436,7 @@ public class ValidateRecord extends AbstractProcessor {
             session.adjustCounter("Records Found Valid", validCount, false);
             session.adjustCounter("Records Found Invalid", invalidCount, false);
         } catch (final Exception e) {
-            getLogger().error("Failed to process {}; will route to failure", new Object[] {flowFile, e});
+            getLogger().error("Failed to process {}; will route to failure", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
             if (validFlowFile != null) {
                 session.remove(validFlowFile);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Wait.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Wait.java
@@ -330,7 +330,7 @@ public class Wait extends AbstractProcessor {
             // if the computed value is null, or empty, we transfer the FlowFile to failure relationship
             if (StringUtils.isBlank(fSignalId)) {
                 // We can't penalize f before getting it from session, so keep it in a temporal list.
-                logger.error("FlowFile {} has no attribute for given Release Signal Identifier", new Object[] {f});
+                logger.error("FlowFile {} has no attribute for given Release Signal Identifier", f);
                 failedFilteringFlowFiles.add(f);
                 return ACCEPT_AND_CONTINUE;
             }
@@ -442,7 +442,7 @@ public class Wait extends AbstractProcessor {
             try {
                 lWaitStartTimestamp = Long.parseLong(waitStartTimestamp);
             } catch (NumberFormatException nfe) {
-                logger.error("{} has an invalid value '{}' on FlowFile {}", new Object[] {WAIT_START_TIMESTAMP, waitStartTimestamp, flowFile});
+                logger.error("{} has an invalid value '{}' on FlowFile {}", WAIT_START_TIMESTAMP, waitStartTimestamp, flowFile);
                 transferToFailure.accept(flowFile);
                 continue;
             }
@@ -452,7 +452,7 @@ public class Wait extends AbstractProcessor {
                     .asTimePeriod(TimeUnit.MILLISECONDS);
             long now = System.currentTimeMillis();
             if (now > (lWaitStartTimestamp + expirationDuration)) {
-                logger.info("FlowFile {} expired after {}ms", new Object[] {flowFile, (now - lWaitStartTimestamp)});
+                logger.info("FlowFile {} expired after {}ms", flowFile, (now - lWaitStartTimestamp));
                 getFlowFilesFor.apply(REL_EXPIRED).add(flowFile);
                 continue;
             }
@@ -460,7 +460,7 @@ public class Wait extends AbstractProcessor {
             // If there's no signal yet, then we don't have to evaluate target counts. Return immediately.
             if (signal == null) {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("No release signal found for {} on FlowFile {} yet", new Object[] {signalId, flowFile});
+                    logger.debug("No release signal found for {} on FlowFile {} yet", signalId, flowFile);
                 }
                 getFlowFilesFor.apply(REL_WAIT).add(flowFile);
                 continue;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBin.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBin.java
@@ -98,7 +98,7 @@ public class RecordBin {
 
     public boolean offer(final FlowFile flowFile, final RecordReader recordReader, final ProcessSession flowFileSession, final boolean block) throws IOException {
         if (isComplete()) {
-            logger.debug("RecordBin.offer for id={} returning false because {} is complete", new Object[] {flowFile.getId(), this});
+            logger.debug("RecordBin.offer for id={} returning false because {} is complete", flowFile.getId(), this);
             return false;
         }
 
@@ -111,7 +111,7 @@ public class RecordBin {
         }
 
         if (!locked) {
-            logger.debug("RecordBin.offer for id={} returning false because failed to get lock for {}", new Object[] {flowFile.getId(), this});
+            logger.debug("RecordBin.offer for id={} returning false because failed to get lock for {}", flowFile.getId(), this);
             return false;
         }
 
@@ -119,15 +119,15 @@ public class RecordBin {
         this.fragmentCount++;
         try {
             if (isComplete()) {
-                logger.debug("RecordBin.offer for id={} returning false because {} is complete", new Object[] {flowFile.getId(), this});
+                logger.debug("RecordBin.offer for id={} returning false because {} is complete", flowFile.getId(), this);
                 return false;
             }
 
-            logger.debug("Migrating id={} to {}", new Object[] {flowFile.getId(), this});
+            logger.debug("Migrating id={} to {}", flowFile.getId(), this);
 
             if (recordWriter == null) {
                 final OutputStream rawOut = session.write(merged);
-                logger.debug("Created OutputStream using session {} for {}", new Object[] {session, this});
+                logger.debug("Created OutputStream using session {} for {}", session, this);
 
                 this.out = new ByteCountingOutputStream(rawOut);
 
@@ -262,7 +262,7 @@ public class RecordBin {
 
     public void rollback() {
         complete = true;
-        logger.debug("Marked {} as complete because rollback() was called", new Object[] {this});
+        logger.debug("Marked {} as complete because rollback() was called", this);
 
         writeLock.lock();
         try {
@@ -278,7 +278,7 @@ public class RecordBin {
 
             if (logger.isDebugEnabled()) {
                 final List<String> ids = flowFiles.stream().map(ff -> " id=" + ff.getId() + ",").collect(Collectors.toList());
-                logger.debug("Rolled back bin {} containing input FlowFiles {}", new Object[] {this, ids});
+                logger.debug("Rolled back bin {} containing input FlowFiles {}", this, ids);
             }
         } finally {
             writeLock.unlock();
@@ -291,7 +291,7 @@ public class RecordBin {
 
     private void fail() {
         complete = true;
-        logger.debug("Marked {} as complete because fail() was called", new Object[] {this});
+        logger.debug("Marked {} as complete because fail() was called", this);
 
         writeLock.lock();
         try {
@@ -327,14 +327,14 @@ public class RecordBin {
                 count = Integer.parseInt(countVal);
             } catch (final NumberFormatException nfe) {
                 logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute had a value of '{}' for {} but expected a number",
-                    new Object[] {flowFiles.size(), countAttributeName, countVal, flowFile});
+                        flowFiles.size(), countAttributeName, countVal, flowFile);
                 fail();
                 return;
             }
 
             if (expectedFragmentCount != null && count != expectedFragmentCount) {
                 logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute had a value of '{}' for {} but another FlowFile in the bin had a value of {}",
-                    new Object[] {flowFiles.size(), countAttributeName, countVal, flowFile, expectedFragmentCount});
+                        flowFiles.size(), countAttributeName, countVal, flowFile, expectedFragmentCount);
                 fail();
                 return;
             }
@@ -346,8 +346,7 @@ public class RecordBin {
         }
 
         if (expectedFragmentCount == null) {
-            logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute was not present on any of the FlowFiles",
-                new Object[] {flowFiles.size(), countAttributeName});
+            logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute was not present on any of the FlowFiles", flowFiles.size(), countAttributeName);
             fail();
             return;
         }
@@ -357,16 +356,16 @@ public class RecordBin {
         writeLock.lock();
         try {
             if (isComplete()) {
-                logger.debug("Cannot complete {} because it is already completed", new Object[] {this});
+                logger.debug("Cannot complete {} because it is already completed", this);
                 return;
             }
 
             complete = true;
-            logger.debug("Marked {} as complete because complete() was called", new Object[] {this});
+            logger.debug("Marked {} as complete because complete() was called", this);
 
             final WriteResult writeResult = recordWriter.finishRecordSet();
             recordWriter.close();
-            logger.debug("Closed Record Writer using session {} for {}", new Object[] {session, this});
+            logger.debug("Closed Record Writer using session {} for {}", session, this);
 
             if (flowFiles.isEmpty()) {
                 session.remove(merged);
@@ -382,7 +381,7 @@ public class RecordBin {
                 if (expectedFragmentCount != flowFiles.size()) {
                     logger.error("Could not merge bin with {} FlowFiles because the '{}' attribute had a value of '{}' but only {} of {} FlowFiles were encountered before this bin was evicted "
                                     + "(due to to Max Bin Age being reached or due to the Maximum Number of Bins being exceeded).",
-                            new Object[] {flowFiles.size(), countAttr.get(), expectedFragmentCount, flowFiles.size(), expectedFragmentCount});
+                            flowFiles.size(), countAttr.get(), expectedFragmentCount, flowFiles.size(), expectedFragmentCount);
                     fail();
                     return;
                 }
@@ -411,7 +410,7 @@ public class RecordBin {
 
             if (logger.isDebugEnabled()) {
                 final List<String> ids = flowFiles.stream().map(ff -> "id=" + ff.getId()).collect(Collectors.toList());
-                logger.debug("Completed bin {} with {} records with Merged FlowFile {} using input FlowFiles {}", new Object[] {this, writeResult.getRecordCount(), merged, ids});
+                logger.debug("Completed bin {} with {} records with Merged FlowFile {} using input FlowFiles {}", this, writeResult.getRecordCount(), merged, ids);
             }
         } catch (final Exception e) {
             session.rollback(true);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBinManager.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBinManager.java
@@ -131,7 +131,7 @@ public class RecordBinManager {
 
             if (accepted) {
                 acceptedBin = bin;
-                logger.debug("Transferred id={} to {}", new Object[] {flowFile.getId(), bin});
+                logger.debug("Transferred id={} to {}", flowFile.getId(), bin);
                 break;
             }
         }
@@ -154,7 +154,7 @@ public class RecordBinManager {
             throw new RuntimeException("Attempted to add " + flowFile + " to a new bin but failed. This is unexpected. Will roll back session and try again.");
         }
 
-        logger.debug("Transferred id={} to {}", new Object[] {flowFile.getId(), bin});
+        logger.debug("Transferred id={} to {}", flowFile.getId(), bin);
 
         if (!bin.isComplete()) {
             final int updatedBinCount = binCount.incrementAndGet();
@@ -275,7 +275,7 @@ public class RecordBinManager {
             final List<RecordBin> completeBins = entry.getValue();
 
             for (final RecordBin bin : completeBins) {
-                logger.debug("Completing Bin {} because {}", new Object[]{bin, completionReason});
+                logger.debug("Completing Bin {} because {}", bin, completionReason);
                 bin.complete(completionReason);
                 completed++;
             }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/relp/frame/RELPDecoder.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/relp/frame/RELPDecoder.java
@@ -133,7 +133,7 @@ public class RELPDecoder {
             if (currBytes.size() > 0) {
                 final long txnr = Long.parseLong(new String(currBytes.toByteArray(), charset));
                 frameBuilder.txnr(txnr);
-                logger.debug("Transaction number is {}", new Object[]{txnr});
+                logger.debug("Transaction number is {}", txnr);
 
                 currBytes.reset();
                 currState = RELPState.COMMAND;
@@ -178,12 +178,12 @@ public class RELPDecoder {
 
     private void processDATA(final byte b) {
         currBytes.write(b);
-        logger.trace("Data size is {}", new Object[] {currBytes.size()});
+        logger.trace("Data size is {}", currBytes.size());
 
         if (currBytes.size() >= frameBuilder.dataLength) {
             final byte[] data = currBytes.toByteArray();
             frameBuilder.data(data);
-            logger.debug("Reached expected data size of {}", new Object[] {frameBuilder.dataLength});
+            logger.debug("Reached expected data size of {}", frameBuilder.dataLength);
 
             currBytes.reset();
             currState = RELPState.TRAILER;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
@@ -305,7 +305,7 @@ public class TestExecuteProcess {
         final List<LogMessage> errorMessages = runner.getLogger().getErrorMessages();
         return (errorMessages.size() > 0
                 && errorMessages.stream()
-                    .anyMatch(m -> m.getMsg().contains("Failed to create process due to")));
+                    .anyMatch(m -> m.getMsg().contains("Failed to create process")));
     }
 
     /**

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
@@ -651,10 +651,10 @@ public class TestListenHTTP {
             try {
                 socket.connect(socketAddress, SOCKET_CONNECT_TIMEOUT);
                 connected = true;
-                runner.getLogger().debug("Server Socket Connected after {} ms", new Object[]{elapsed});
+                runner.getLogger().debug("Server Socket Connected after {} ms", elapsed);
                 socket.close();
             } catch (final Exception e) {
-                runner.getLogger().debug("Server Socket Connect Failed: [{}] {}", new Object[]{e.getClass(), e.getMessage()});
+                runner.getLogger().debug("Server Socket Connect Failed:", e);
             }
             final long connectElapsed = System.currentTimeMillis() - started;
             elapsed += connectElapsed;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
@@ -654,7 +654,7 @@ public class TestListenHTTP {
                 runner.getLogger().debug("Server Socket Connected after {} ms", elapsed);
                 socket.close();
             } catch (final Exception e) {
-                runner.getLogger().debug("Server Socket Connect Failed:", e);
+                runner.getLogger().debug("Server Socket Connect Failed", e);
             }
             final long connectElapsed = System.currentTimeMillis() - started;
             elapsed += connectElapsed;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/controller/MonitorMemory.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/controller/MonitorMemory.java
@@ -211,8 +211,7 @@ public class MonitorMemory extends AbstractReportingTask {
 
         final MemoryUsage usage = bean.getCollectionUsage();
         if (usage == null) {
-            getLogger().warn("{} could not determine memory usage for pool with name {}", new Object[] {this,
-                    context.getProperty(MEMORY_POOL_PROPERTY)});
+            getLogger().warn("{} could not determine memory usage for pool with name {}", this, context.getProperty(MEMORY_POOL_PROPERTY));
             return;
         }
 
@@ -230,7 +229,7 @@ public class MonitorMemory extends AbstractReportingTask {
                     bean.getName(), threshold, FormatUtils.formatDataSize(usage.getUsed()),
                     FormatUtils.formatDataSize(usage.getMax()), percentageUsed);
 
-            getLogger().warn("{}", new Object[] {message});
+            getLogger().warn("{}", message);
         } else if (lastValueWasExceeded) {
             lastValueWasExceeded = false;
             lastReportTime = System.currentTimeMillis();
@@ -238,7 +237,7 @@ public class MonitorMemory extends AbstractReportingTask {
                     bean.getName(), threshold, FormatUtils.formatDataSize(usage.getUsed()),
                     FormatUtils.formatDataSize(usage.getMax()), percentageUsed);
 
-            getLogger().info("{}", new Object[] {message});
+            getLogger().info("{}", message);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/reporting/ganglia/StandardGangliaReporter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/reporting/ganglia/StandardGangliaReporter.java
@@ -241,7 +241,7 @@ public class StandardGangliaReporter extends AbstractReportingTask {
         this.latestStatus.set(rootGroupStatus);
         gangliaReporter.run();
 
-        getLogger().info("{} Sent metrics to Ganglia", new Object[] {this});
+        getLogger().info("{} Sent metrics to Ganglia", this);
     }
 
     private long calculateProcessingNanos(final ProcessGroupStatus status) {

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/CSVRecordLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/CSVRecordLookupService.java
@@ -98,7 +98,7 @@ public class CSVRecordLookupService extends AbstractCSVLookupService implements 
                             } else if (!ignoreDuplicates && cache.containsKey(key)) {
                                 throw new IllegalStateException("Duplicate lookup key encountered: " + key + " in " + csvFile);
                             } else if (ignoreDuplicates && cache.containsKey(key)) {
-                                logger.warn("Duplicate lookup key encountered: {} in {}", new Object[]{key, csvFile});
+                                logger.warn("Duplicate lookup key encountered: {} in {}", key, csvFile);
                             }
 
                             // Put each key/value pair (except the lookup) into the properties

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/SimpleCsvFileLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/SimpleCsvFileLookupService.java
@@ -95,7 +95,7 @@ public class SimpleCsvFileLookupService extends AbstractCSVLookupService impleme
                             } else if (!ignoreDuplicates && properties.containsKey(key)) {
                                 throw new IllegalStateException("Duplicate lookup key encountered: " + key + " in " + csvFile);
                             } else if (ignoreDuplicates && properties.containsKey(key)) {
-                                logger.warn("Duplicate lookup key encountered: {} in {}", new Object[]{key, csvFile});
+                                logger.warn("Duplicate lookup key encountered: {} in {}", key, csvFile);
                             }
                             properties.put(key, value);
                         }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/maxmind/IPLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/maxmind/IPLookupService.java
@@ -385,7 +385,7 @@ public class IPLookupService extends AbstractControllerService implements Record
         final StopWatch stopWatch = new StopWatch(true);
         final DatabaseReader reader = new DatabaseReader.Builder(dbFile).build();
         stopWatch.stop();
-        getLogger().info("Completed loading of Maxmind Database.  Elapsed time was {} milliseconds.", new Object[]{stopWatch.getDuration(TimeUnit.MILLISECONDS)});
+        getLogger().info("Completed loading of Maxmind Database.  Elapsed time was {} milliseconds.", stopWatch.getDuration(TimeUnit.MILLISECONDS));
         databaseReader = reader;
         databaseChecksum = dbFileChecksum;
     }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/schema/inference/VolatileSchemaCache.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/schema/inference/VolatileSchemaCache.java
@@ -84,14 +84,14 @@ public class VolatileSchemaCache extends AbstractControllerService implements Re
 
         if (existingSchema == null) {
             // We successfully inserted into the cache.
-            getLogger().debug("Successfully cached schema with ID {} (no existing schema with this ID)", new Object[] {identifier});
+            getLogger().debug("Successfully cached schema with ID {} (no existing schema with this ID)", identifier);
             return identifier;
         }
 
         // There was already a Schema in the cache with that identifier.
         if (existingSchema.equals(schema)) {
             // Schemas match. Already cached successfully.
-            getLogger().debug("Successfully cached schema with ID {} (existing schema with this ID was equal)", new Object[] {identifier});
+            getLogger().debug("Successfully cached schema with ID {} (existing schema with this ID was equal)", identifier);
             return identifier;
         }
 
@@ -100,7 +100,7 @@ public class VolatileSchemaCache extends AbstractControllerService implements Re
         final String updatedIdentifier = identifier + "-" + UUID.randomUUID().toString();
         cache.put(updatedIdentifier, schema);
 
-        getLogger().debug("Schema with ID {} conflicted with new Schema. Resolved by using generated identifier {}", new Object[] {identifier, updatedIdentifier});
+        getLogger().debug("Schema with ID {} conflicted with new Schema. Resolved by using generated identifier {}", identifier, updatedIdentifier);
         return updatedIdentifier;
     }
 

--- a/nifi-extension-bundles/nifi-update-attribute-bundle/nifi-update-attribute-processor/src/main/java/org/apache/nifi/processors/attributes/UpdateAttribute.java
+++ b/nifi-extension-bundles/nifi-update-attribute-bundle/nifi-update-attribute-processor/src/main/java/org/apache/nifi/processors/attributes/UpdateAttribute.java
@@ -524,7 +524,7 @@ public class UpdateAttribute extends AbstractProcessor implements Searchable {
                 }
 
                 if (debugEnabled) {
-                    logger.debug("Updated attributes for {}; transferring to '{}'", new Object[]{match, REL_SUCCESS.getName()});
+                    logger.debug("Updated attributes for {}; transferring to '{}'", match, REL_SUCCESS.getName());
                 }
 
                 // add the match to the list to transfer
@@ -535,7 +535,7 @@ public class UpdateAttribute extends AbstractProcessor implements Searchable {
             incomingFlowFile = executeActions(session, context, null, defaultActions, incomingFlowFile, stateInitialAttributes, stateWorkingAttributes);
 
             if (debugEnabled) {
-                logger.debug("Updated attributes for {}; transferring to '{}'", new Object[]{incomingFlowFile, REL_SUCCESS.getName()});
+                logger.debug("Updated attributes for {}; transferring to '{}'", incomingFlowFile, REL_SUCCESS.getName());
             }
 
             // add the flowfile to the list to transfer
@@ -550,7 +550,7 @@ public class UpdateAttribute extends AbstractProcessor implements Searchable {
                     boolean setState = session.replaceState(stateMap, stateWorkingAttributes, Scope.LOCAL);
                     if (!setState) {
                         logger.warn("Failed to update the state after successfully processing {} due to having an old version of the StateMap. This is normally due to multiple threads running at " +
-                                "once; transferring to '{}'", new Object[]{incomingFlowFile, REL_FAILED_SET_STATE.getName()});
+                                "once; transferring to '{}'", incomingFlowFile, REL_FAILED_SET_STATE.getName());
 
                         flowFilesToTransfer.remove(incomingFlowFile);
                         if (flowFilesToTransfer.size() > 0) {

--- a/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/main/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLog.java
+++ b/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/main/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLog.java
@@ -213,7 +213,7 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
         try {
             provenanceUri = new URI("winlog", name, "/" + channel, query, null).toASCIIString();
         } catch (URISyntaxException e) {
-            getLogger().debug("Failed to construct detailed provenanceUri from channel={}, query={}, use simpler one.", new Object[]{channel, query});
+            getLogger().debug("Failed to construct detailed provenanceUri from channel={}, query={}, use simpler one.", channel, query);
             provenanceUri = String.format("winlog://%s/%s", name, channel);
         }
 
@@ -247,7 +247,7 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
         final boolean subscriptionFailed = evtSubscribeCallback != null
             && ((EventSubscribeXmlRenderingCallback) evtSubscribeCallback).isSubscriptionFailed();
         final boolean subscribing = subscribed && !subscriptionFailed;
-        getLogger().debug("subscribing? {}, subscribed={}, subscriptionFailed={}", new Object[]{subscribing, subscribed, subscriptionFailed});
+        getLogger().debug("subscribing? {}, subscribed={}, subscriptionFailed={}", subscribing, subscribed, subscriptionFailed);
         if (subscriptionFailed) {
             getLogger().info("Canceling a failed subscription.");
             unsubscribe();
@@ -318,7 +318,7 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
 
         } else if (inactiveDurationToReconnect > 0) {
             if ((now - lastActivityTimestamp) > inactiveDurationToReconnect) {
-                getLogger().info("Exceeds configured 'inactive duration to reconnect' {} ms. Unsubscribe to reconnect..", new Object[]{inactiveDurationToReconnect});
+                getLogger().info("Exceeds configured 'inactive duration to reconnect' {} ms. Unsubscribe to reconnect..", inactiveDurationToReconnect);
                 unsubscribe();
             }
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-flowfile-repo-serialization/src/main/java/org/apache/nifi/controller/repository/WriteAheadRepositoryRecordSerde.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-flowfile-repo-serialization/src/main/java/org/apache/nifi/controller/repository/WriteAheadRepositoryRecordSerde.java
@@ -121,8 +121,7 @@ public class WriteAheadRepositoryRecordSerde extends RepositoryRecordSerde imple
         out.writeLong(flowFile.getSize());
 
         if (associatedQueueId == null) {
-            logger.warn("{} Repository Record {} has no Connection associated with it; it will be destroyed on restart",
-                new Object[] {this, record});
+            logger.warn("{} Repository Record {} has no Connection associated with it; it will be destroyed on restart", this, record);
             writeString("", out);
         } else {
             writeString(associatedQueueId, out);
@@ -227,7 +226,7 @@ public class WriteAheadRepositoryRecordSerde extends RepositoryRecordSerde imple
         ffBuilder.size(in.readLong());
         final String connectionId = readString(in);
 
-        logger.debug("{} -> {}", new Object[] {recordId, connectionId});
+        logger.debug("{} -> {}", recordId, connectionId);
 
         deserializeClaim(in, version, ffBuilder);
 
@@ -331,7 +330,7 @@ public class WriteAheadRepositoryRecordSerde extends RepositoryRecordSerde imple
         final long size = in.readLong();
         final String connectionId = readString(in);
 
-        logger.debug("{} -> {}", new Object[] {recordId, connectionId});
+        logger.debug("{} -> {}", recordId, connectionId);
 
         ffBuilder.id(recordId);
         ffBuilder.entryDate(entryDate);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/parameter/StandardParameterProviderNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/parameter/StandardParameterProviderNode.java
@@ -319,7 +319,7 @@ public class StandardParameterProviderNode extends AbstractComponentNode impleme
                     }
 
                     if (parameter.getValue() == null) {
-                        getLogger().warn("Skipping parameter [{}], which is missing a value", new Object[] {parameterName});
+                        getLogger().warn("Skipping parameter [{}], which is missing a value", parameterName);
                         continue;
                     }
 
@@ -328,7 +328,7 @@ public class StandardParameterProviderNode extends AbstractComponentNode impleme
                         parameterNames.add(parameter.getDescriptor().getName());
                     } else {
                         getLogger().warn("Skipping parameter [{}], whose name has invalid characters.  Only alpha-numeric characters (a-z, A-Z, 0-9), hyphens (-), underscores (_), " +
-                                "periods (.), and spaces ( ) are accepted.", new Object[] {parameterName});
+                                "periods (.), and spaces ( ) are accepted.", parameterName);
                     }
                 }
                 this.fetchedParameterGroups.add(new ParameterGroup(groupName, toProvidedParameters(validParameters)));
@@ -501,8 +501,7 @@ public class StandardParameterProviderNode extends AbstractComponentNode impleme
                     if (isSensitivityChanged) {
                         final ParameterSensitivity currentSensitivity = currentParameter.getDescriptor().isSensitive() ? ParameterSensitivity.SENSITIVE : ParameterSensitivity.NON_SENSITIVE;
                         final ParameterSensitivity fetchedSensitivity = fetchedParameter.getDescriptor().isSensitive() ? ParameterSensitivity.SENSITIVE : ParameterSensitivity.NON_SENSITIVE;
-                        getLogger().info("Parameter [{}] sensitivity is being changed from {} to {}", new Object[] {descriptor.getName(),
-                                currentSensitivity.getName(), fetchedSensitivity.getName()});
+                        getLogger().info("Parameter [{}] sensitivity is being changed from {} to {}", descriptor.getName(), currentSensitivity.getName(), fetchedSensitivity.getName());
                     }
                 }
             }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -2527,7 +2527,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             return;
         }
 
-        LOG.info("{} {} FlowFiles have expired and will be removed", new Object[] {this, flowFiles.size()});
+        LOG.info("{} {} FlowFiles have expired and will be removed", this, flowFiles.size());
         final List<RepositoryRecord> expiredRecords = new ArrayList<>(flowFiles.size());
 
         final Connectable connectable = context.getConnectable();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/state/StandardStateManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/state/StandardStateManager.java
@@ -62,7 +62,7 @@ public class StandardStateManager implements StateManager {
     @Override
     public StateMap getState(final Scope scope) throws IOException {
         final StateMap stateMap = getProvider(scope).getState(componentId);
-        getLogger(componentId).debug("Returning {} State: {}", new Object[] {scope, stateMap});
+        getLogger(componentId).debug("Returning {} State: {}", scope, stateMap);
         return stateMap;
     }
 
@@ -70,19 +70,19 @@ public class StandardStateManager implements StateManager {
     @Override
     public boolean replace(final StateMap oldValue, final Map<String, String> newValue, final Scope scope) throws IOException {
         final boolean replaced = getProvider(scope).replace(oldValue, newValue, componentId);
-        getLogger(componentId).debug("{} State from old value {} to new value {} was {}", new Object[] {scope, oldValue, newValue, replaced});
+        getLogger(componentId).debug("{} State from old value {} to new value {} was {}", scope, oldValue, newValue, replaced);
         return replaced;
     }
 
     @Override
     public void setState(final Map<String, String> state, final Scope scope) throws IOException {
-        getLogger(componentId).debug("Setting {} State to {}", new Object[] {scope, state});
+        getLogger(componentId).debug("Setting {} State to {}", scope, state);
         getProvider(scope).setState(state, componentId);
     }
 
     @Override
     public void clear(final Scope scope) throws IOException {
-        getLogger(componentId).debug("Clearing {} State", new Object[] {scope});
+        getLogger(componentId).debug("Clearing {} State", scope);
         getProvider(scope).clear(componentId);
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -553,7 +553,7 @@ public final class StandardProcessGroup implements ProcessGroup {
                 try {
                     node.getProcessGroup().startProcessor(node, true);
                 } catch (final Throwable t) {
-                    LOG.error("Unable to start processor {} due to {}", new Object[]{node.getIdentifier(), t});
+                    LOG.error("Unable to start processor {}", node.getIdentifier(), t);
                 }
             });
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -1234,7 +1234,7 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
                             startConnectable(connectable);
                         }
                     } catch (final Throwable t) {
-                        LOG.error("Unable to start {} due to {}", new Object[]{connectable, t.toString()});
+                        LOG.error("Unable to start {}", connectable, t);
                         if (LOG.isDebugEnabled()) {
                             LOG.error("", t);
                         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardReloadComponent.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardReloadComponent.java
@@ -67,7 +67,7 @@ public class StandardReloadComponent implements ReloadComponent {
 
         // ghost components will have a null logger
         if (existingNode.getLogger() != null) {
-            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", new Object[]{id, newType, bundleCoordinate});
+            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", id, newType, bundleCoordinate);
         }
 
         final ExtensionManager extensionManager = flowController.getExtensionManager();
@@ -132,7 +132,7 @@ public class StandardReloadComponent implements ReloadComponent {
 
         // ghost components will have a null logger
         if (existingNode.getLogger() != null) {
-            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", new Object[]{id, newType, bundleCoordinate});
+            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", id, newType, bundleCoordinate);
         }
 
         final ExtensionManager extensionManager = flowController.getExtensionManager();
@@ -188,7 +188,7 @@ public class StandardReloadComponent implements ReloadComponent {
 
         // ghost components will have a null logger
         if (existingNode.getLogger() != null) {
-            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", new Object[]{id, newType, bundleCoordinate});
+            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", id, newType, bundleCoordinate);
         }
 
         final ExtensionManager extensionManager = flowController.getExtensionManager();
@@ -237,7 +237,7 @@ public class StandardReloadComponent implements ReloadComponent {
 
         // ghost components will have a null logger
         if (existingNode.getLogger() != null) {
-            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", new Object[]{id, newType, bundleCoordinate});
+            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", id, newType, bundleCoordinate);
         }
 
         final ExtensionManager extensionManager = flowController.getExtensionManager();
@@ -286,7 +286,7 @@ public class StandardReloadComponent implements ReloadComponent {
 
         // ghost components will have a null logger
         if (existingNode.getLogger() != null) {
-            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", new Object[]{id, newType, bundleCoordinate});
+            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", id, newType, bundleCoordinate);
         }
 
         final ExtensionManager extensionManager = flowController.getExtensionManager();
@@ -335,7 +335,7 @@ public class StandardReloadComponent implements ReloadComponent {
 
         // ghost components will have a null logger
         if (existingNode.getLogger() != null) {
-            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", new Object[]{id, newType, bundleCoordinate});
+            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", id, newType, bundleCoordinate);
         }
 
         final ExtensionManager extensionManager = flowController.getExtensionManager();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/SocketLoadBalancedFlowFileQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/SocketLoadBalancedFlowFileQueue.java
@@ -1018,7 +1018,7 @@ public class SocketLoadBalancedFlowFileQueue extends AbstractFlowFileQueue imple
             return;
         }
 
-        logger.info("{} {} FlowFiles have expired and will be removed", new Object[] {this, expired.size()});
+        logger.info("{} {} FlowFiles have expired and will be removed", this, expired.size());
         final List<RepositoryRecord> expiredRecords = new ArrayList<>(expired.size());
         final List<ProvenanceEventRecord> provenanceEvents = new ArrayList<>(expired.size());
 
@@ -1049,7 +1049,7 @@ public class SocketLoadBalancedFlowFileQueue extends AbstractFlowFileQueue imple
             provenanceEvents.add(provenanceEvent);
 
             final long flowFileLife = System.currentTimeMillis() - flowFile.getEntryDate();
-            logger.debug("{} terminated due to FlowFile expiration; life of FlowFile = {} ms", new Object[] {flowFile, flowFileLife});
+            logger.debug("{} terminated due to FlowFile expiration; life of FlowFile = {} ms", flowFile, flowFileLife);
         }
 
         try {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
@@ -758,7 +758,7 @@ public class FileSystemRepository implements ContentRepository {
         if (path != null) {
             final File file = path.toFile();
             if (!file.delete() && file.exists()) {
-                LOG.warn("Unable to delete {} at path {}", new Object[]{claim, path});
+                LOG.warn("Unable to delete {} at path {}", claim, path);
                 return false;
             }
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/WriteAheadFlowFileRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/WriteAheadFlowFileRepository.java
@@ -685,7 +685,7 @@ public class WriteAheadFlowFileRepository implements FlowFileRepository, SyncLis
             this.swapLocationSuffixes.remove(normalizeSwapLocation(swapLocation));
         }
 
-        logger.info("Repository updated to reflect that {} FlowFiles were swapped in to {}", new Object[]{swapRecords.size(), queue});
+        logger.info("Repository updated to reflect that {} FlowFiles were swapped in to {}", swapRecords.size(), queue);
     }
 
     void deleteRecursively(final File dir) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ReportingTaskWrapper.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ReportingTaskWrapper.java
@@ -47,7 +47,7 @@ public class ReportingTaskWrapper implements Runnable {
             taskNode.getReportingTask().onTrigger(taskNode.getReportingContext());
         } catch (final Throwable t) {
             final ComponentLog componentLog = new SimpleProcessLogger(taskNode.getIdentifier(), taskNode.getReportingTask(), new StandardLoggingContext(null));
-            componentLog.error("Error running task {} due to {}", new Object[]{taskNode.getReportingTask(), t.toString()});
+            componentLog.error("Error running task {}", taskNode.getReportingTask(), t);
             if (componentLog.isDebugEnabled()) {
                 componentLog.error("", t);
             }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/processors/DataGeneratorTestProcessor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/processors/DataGeneratorTestProcessor.java
@@ -73,7 +73,7 @@ public class DataGeneratorTestProcessor extends AbstractProcessor {
             }
         });
 
-        LOG.info("{} transferring {} to success", new Object[]{this, flowFile});
+        LOG.info("{} transferring {} to success", this, flowFile);
         session.transfer(flowFile, REL_SUCCESS);
         session.commit();
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/main/java/org/apache/nifi/nar/NarAutoLoader.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/main/java/org/apache/nifi/nar/NarAutoLoader.java
@@ -78,7 +78,7 @@ public class NarAutoLoader {
                 .narLoader(narLoader)
                 .build();
 
-        LOGGER.info("Starting NAR Auto-Loader Thread for directory {} ...", new Object[]{autoLoadPath});
+        LOGGER.info("Starting NAR Auto-Loader Thread for directory {} ...", autoLoadPath);
 
         final Thread autoLoaderThread = new Thread(narAutoLoaderTask);
         autoLoaderThread.setName("NAR Auto-Loader");

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/main/java/org/apache/nifi/nar/NarAutoLoaderTask.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/main/java/org/apache/nifi/nar/NarAutoLoaderTask.java
@@ -64,7 +64,7 @@ public class NarAutoLoaderTask implements Runnable {
             try {
                 WatchKey key;
                 try {
-                    LOGGER.debug("Polling for new NARs at {}", new Object[]{autoLoadPath});
+                    LOGGER.debug("Polling for new NARs at {}", autoLoadPath);
                     key = watchService.poll(pollIntervalMillis, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException x) {
                     LOGGER.info("WatchService interrupted, returning...");
@@ -88,16 +88,16 @@ public class NarAutoLoaderTask implements Runnable {
                         final String autoLoadFilename = autoLoadFile.toFile().getName().toLowerCase();
 
                         if (!autoLoadFilename.endsWith(".nar")) {
-                            LOGGER.info("Skipping non-nar file {}", new Object[]{autoLoadFilename});
+                            LOGGER.info("Skipping non-nar file {}", autoLoadFilename);
                             continue;
                         }
 
                         if (autoLoadFilename.startsWith(".")) {
-                            LOGGER.debug("Skipping partially written file {}", new Object[]{autoLoadFilename});
+                            LOGGER.debug("Skipping partially written file {}", autoLoadFilename);
                             continue;
                         }
 
-                        LOGGER.info("Found {} in auto-load directory", new Object[]{autoLoadFile});
+                        LOGGER.info("Found {} in auto-load directory", autoLoadFile);
                         candidateNars.add(autoLoadFile.toFile());
                     }
 
@@ -120,7 +120,7 @@ public class NarAutoLoaderTask implements Runnable {
                         readyNars.add(candidateNar);
                         candidateNarIter.remove();
                     } else {
-                        LOGGER.debug("Candidate NAR {} not ready yet, will check again next time", new Object[]{candidateNar.getName()});
+                        LOGGER.debug("Candidate NAR {} not ready yet, will check again next time", candidateNar.getName());
                     }
                 }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/main/java/org/apache/nifi/nar/StandardNarLoader.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-nar-loading-utils/src/main/java/org/apache/nifi/nar/StandardNarLoader.java
@@ -73,21 +73,21 @@ public class StandardNarLoader implements NarLoader {
 
     @Override
     public synchronized NarLoadResult load(final Collection<File> narFiles) {
-        LOGGER.info("Starting load process for {} NARs...", new Object[]{narFiles.size()});
+        LOGGER.info("Starting load process for {} NARs...", narFiles.size());
 
         final List<File> unpackedNars = new ArrayList<>();
 
         for (final File narFile : narFiles) {
-            LOGGER.debug("Unpacking {}...", new Object[]{narFile.getName()});
+            LOGGER.debug("Unpacking {}...", narFile.getName());
             final File unpackedNar = unpack(narFile);
             if (unpackedNar != null) {
-                LOGGER.debug("Completed unpacking {}", new Object[]{narFile.getName()});
+                LOGGER.debug("Completed unpacking {}", narFile.getName());
                 unpackedNars.add(unpackedNar);
             }
         }
 
         if (previouslySkippedBundles != null && !previouslySkippedBundles.isEmpty()) {
-            LOGGER.info("Including {} previously skipped bundle(s)", new Object[]{previouslySkippedBundles.size()});
+            LOGGER.info("Including {} previously skipped bundle(s)", previouslySkippedBundles.size());
             previouslySkippedBundles.forEach(b -> unpackedNars.add(b.getWorkingDirectory()));
         }
 
@@ -96,14 +96,13 @@ public class StandardNarLoader implements NarLoader {
             return new NarLoadResult(Collections.emptySet(), Collections.emptySet());
         }
 
-        LOGGER.info("Creating class loaders for {} NARs...", new Object[]{unpackedNars.size()});
+        LOGGER.info("Creating class loaders for {} NARs...", unpackedNars.size());
 
         final NarLoadResult narLoadResult = narClassLoaders.loadAdditionalNars(unpackedNars);
         final Set<Bundle> loadedBundles = narLoadResult.getLoadedBundles();
         final Set<BundleDetails> skippedBundles = narLoadResult.getSkippedBundles();
 
-        LOGGER.info("Successfully created class loaders for {} NARs, {} were skipped",
-                new Object[]{loadedBundles.size(), skippedBundles.size()});
+        LOGGER.info("Successfully created class loaders for {} NARs, {} were skipped", loadedBundles.size(), skippedBundles.size());
 
         // Store skipped bundles for next iteration
         previouslySkippedBundles = new HashSet<>(skippedBundles);
@@ -117,11 +116,9 @@ public class StandardNarLoader implements NarLoader {
                 final BundleCoordinate bundleCoordinate = bundle.getBundleDetails().getCoordinate();
                 final Set<ExtensionDefinition> extensionDefinitions = extensionManager.getTypes(bundleCoordinate);
                 if (extensionDefinitions.isEmpty()) {
-                    LOGGER.debug("No documentation to generate for {} because no extensions were found",
-                            new Object[]{bundleCoordinate.getCoordinate()});
+                    LOGGER.debug("No documentation to generate for {} because no extensions were found", bundleCoordinate.getCoordinate());
                 } else {
-                    LOGGER.debug("Generating documentation for {} extensions in {}",
-                            new Object[]{extensionDefinitions.size(), bundleCoordinate.getCoordinate()});
+                    LOGGER.debug("Generating documentation for {} extensions in {}", extensionDefinitions.size(), bundleCoordinate.getCoordinate());
                     DocGenerator.documentConfigurableComponent(extensionDefinitions, docsWorkingDir, extensionManager);
                 }
             }
@@ -146,12 +143,12 @@ public class StandardNarLoader implements NarLoader {
             final String version = attributes.getValue(NarManifestEntry.NAR_VERSION.getManifestName());
 
             if (NarClassLoaders.FRAMEWORK_NAR_ID.equals(narId)) {
-                LOGGER.error("Found a framework NAR, will not auto-load {}", new Object[]{narFile.getAbsolutePath()});
+                LOGGER.error("Found a framework NAR, will not auto-load {}", narFile.getAbsolutePath());
                 return null;
             }
 
             if (NarClassLoaders.JETTY_NAR_ID.equals(narId)) {
-                LOGGER.error("Found a Jetty NAR, will not auto-load {}", new Object[]{narFile.getAbsolutePath()});
+                LOGGER.error("Found a Jetty NAR, will not auto-load {}", narFile.getAbsolutePath());
                 return null;
             }
 
@@ -159,8 +156,7 @@ public class StandardNarLoader implements NarLoader {
 
             final Bundle bundle = extensionManager.getBundle(coordinate);
             if (bundle != null) {
-                LOGGER.warn("Found existing bundle with coordinate {}, will not load {}",
-                        new Object[]{coordinate, narFile.getAbsolutePath()});
+                LOGGER.warn("Found existing bundle with coordinate {}, will not load {}", coordinate, narFile.getAbsolutePath());
                 return null;
             }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/init/ReflectionUtils.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/init/ReflectionUtils.java
@@ -61,11 +61,9 @@ public class ReflectionUtils {
                 final Class<?>[] argumentTypes = method.getParameterTypes();
                 if (argumentTypes.length > args.length) {
                     if (logger == null) {
-                        LOG.error("Unable to invoke method {} on {} because method expects {} parameters but only {} were given",
-                            new Object[]{method.getName(), instance, argumentTypes.length, args.length});
+                        LOG.error("Unable to invoke method {} on {} because method expects {} parameters but only {} were given", method.getName(), instance, argumentTypes.length, args.length);
                     } else {
-                        logger.error("Unable to invoke method {} on {} because method expects {} parameters but only {} were given",
-                            new Object[]{method.getName(), instance, argumentTypes.length, args.length});
+                        logger.error("Unable to invoke method {} on {} because method expects {} parameters but only {} were given", method.getName(), instance, argumentTypes.length, args.length);
                     }
 
                     return false;
@@ -76,10 +74,10 @@ public class ReflectionUtils {
                     if (!argType.isAssignableFrom(args[i].getClass())) {
                         if (logger == null) {
                             LOG.error("Unable to invoke method {} on {} because method parameter {} is expected to be of type {} but argument passed was of type {}",
-                                new Object[]{method.getName(), instance, i, argType, args[i].getClass()});
+                                    method.getName(), instance, i, argType, args[i].getClass());
                         } else {
                             logger.error("Unable to invoke method {} on {} because method parameter {} is expected to be of type {} but argument passed was of type {}",
-                                new Object[]{method.getName(), instance, i, argType, args[i].getClass()});
+                                    method.getName(), instance, i, argType, args[i].getClass());
                         }
 
                         return false;
@@ -97,17 +95,17 @@ public class ReflectionUtils {
                     }
                 } catch (final InvocationTargetException ite) {
                     if (logger == null) {
-                        LOG.error("Unable to invoke method {} on {} due to {}", new Object[]{method.getName(), instance, ite.getCause()});
+                        LOG.error("Unable to invoke method {} on {}", method.getName(), instance, ite.getCause());
                         LOG.error("", ite.getCause());
                     } else {
-                        logger.error("Unable to invoke method {} on {} due to {}", new Object[]{method.getName(), instance, ite.getCause()});
+                        logger.error("Unable to invoke method {} on {}", method.getName(), instance, ite.getCause());
                     }
                 } catch (final IllegalAccessException | IllegalArgumentException t) {
                     if (logger == null) {
-                        LOG.error("Unable to invoke method {} on {} due to {}", new Object[]{method.getName(), instance, t});
+                        LOG.error("Unable to invoke method {} on {}", method.getName(), instance, t);
                         LOG.error("", t);
                     } else {
-                        logger.error("Unable to invoke method {} on {} due to {}", new Object[]{method.getName(), instance, t});
+                        logger.error("Unable to invoke method {} on {}", method.getName(), instance, t);
                     }
 
                     return false;

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/nar/StandardExtensionDiscoveringManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/nar/StandardExtensionDiscoveringManager.java
@@ -514,7 +514,7 @@ public class StandardExtensionDiscoveringManager implements ExtensionDiscovering
             } else {
                 final BaseClassLoaderKey baseClassLoaderKey = classloaderIsolationKey == null ? null : new BaseClassLoaderKey(bundle, classloaderIsolationKey);
                 final NarClassLoader narBundleClassLoader = (NarClassLoader) bundleClassLoader;
-                logger.debug("Including ClassLoader resources from {} for component {}", new Object[]{bundle.getBundleDetails(), instanceIdentifier});
+                logger.debug("Including ClassLoader resources from {} for component {}", bundle.getBundleDetails(), instanceIdentifier);
 
                 final Set<URL> instanceUrls = new LinkedHashSet<>(Arrays.asList(narBundleClassLoader.getURLs()));
                 final Set<File> narNativeLibDirs = new LinkedHashSet<>();
@@ -571,7 +571,7 @@ public class StandardExtensionDiscoveringManager implements ExtensionDiscovering
                     logger.debug("Creating InstanceClassLoader for type {} using newly created shared Base ClassLoader {} for component {}", type, sharedClassLoader, instanceIdentifier);
                     if (logger.isTraceEnabled()) {
                         for (URL url : sharedClassLoader.getURLs()) {
-                            logger.trace("Shared Base ClassLoader URL resource: {}", new Object[] {url.toExternalForm()});
+                            logger.trace("Shared Base ClassLoader URL resource: {}", url.toExternalForm());
                         }
                     }
 
@@ -590,7 +590,7 @@ public class StandardExtensionDiscoveringManager implements ExtensionDiscovering
 
         if (logger.isTraceEnabled()) {
             for (URL url : instanceClassLoader.getURLs()) {
-                logger.trace("URL resource {} for {}...", new Object[] {url.toExternalForm(), instanceIdentifier});
+                logger.trace("URL resource {} for {}...", url.toExternalForm(), instanceIdentifier);
             }
         }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-shell-authorizer/src/main/java/org/apache/nifi/authorization/ShellUserGroupProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-shell-authorizer/src/main/java/org/apache/nifi/authorization/ShellUserGroupProvider.java
@@ -205,13 +205,13 @@ public class ShellUserGroupProvider implements UserGroupProvider {
     @Override
     public UserAndGroups getUserAndGroups(String identity) throws AuthorizationAccessException {
         User user = getUserByIdentity(identity);
-        logger.debug("Retrieved user {} for identity {}", new Object[]{user, identity});
+        logger.debug("Retrieved user {} for identity {}", user, identity);
 
         Set<Group> groups = new HashSet<>();
         if (user != null) {
             for (Group g : getGroups()) {
                 if (g.getUsers().contains(user.getIdentifier())) {
-                    logger.debug("User {} belongs to group {}", new Object[]{user.getIdentity(), g.getName()});
+                    logger.debug("User {} belongs to group {}", user.getIdentity(), g.getName());
                     groups.add(g);
                 }
             }
@@ -256,7 +256,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
         fixedDelay = getDelayProperty(configurationContext, REFRESH_DELAY_PROPERTY, "5 mins");
         timeoutSeconds = getTimeoutProperty(configurationContext, COMMAND_TIMEOUT_PROPERTY, DEFAULT_COMMAND_TIMEOUT);
         shellRunner = new ShellRunner(timeoutSeconds);
-        logger.debug("Configured ShellRunner with command timeout of '{}' seconds", new Object[]{timeoutSeconds});
+        logger.debug("Configured ShellRunner with command timeout of '{}' seconds", timeoutSeconds);
 
         // Our next init step is to select the command set based on the operating system name:
         ShellCommandsProvider commands = getCommandsProvider();
@@ -480,7 +480,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
      */
     private void rebuildUsers(List<String> userLines, Map<String, User> idToUser, Map<String, User> usernameToUser, Map<String, User> gidToUser) {
         userLines.forEach(line -> {
-            logger.trace("Processing user: {}", new Object[]{line});
+            logger.trace("Processing user: {}", line);
 
             String[] record = line.split(":");
             if (record.length > 2) {
@@ -493,7 +493,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
                             .build();
                     idToUser.put(user.getIdentifier(), user);
                     usernameToUser.put(userIdentity, user);
-                    logger.debug("Refreshed user {}", new Object[]{user});
+                    logger.debug("Refreshed user {}", user);
 
                     if (!StringUtils.isBlank(primaryGroupIdentifier)) {
                         // create a temporary group to deterministically generate the group id and associate this user
@@ -502,7 +502,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
                                 .identifierGenerateFromSeed(getGroupIdentifierSeed(primaryGroupIdentifier))
                                 .build();
                         gidToUser.put(group.getIdentifier(), user);
-                        logger.debug("Associated primary group {} with user {}", new Object[]{group.getIdentifier(), userIdentity});
+                        logger.debug("Associated primary group {} with user {}", group.getIdentifier(), userIdentity);
                     } else {
                         logger.warn("Null or empty primary group id for: " + userIdentity);
                     }
@@ -528,7 +528,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
      */
     private void rebuildGroups(List<String> groupLines, Map<String, Group> groupsById) {
         groupLines.forEach(line -> {
-            logger.trace("Processing group: {}", new Object[]{line});
+            logger.trace("Processing group: {}", line);
 
             String[] record = line.split(":");
             if (record.length > 1) {
@@ -550,7 +550,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
                                             .identifierGenerateFromSeed(getUserIdentifierSeed(userIdentity))
                                             .build();
                                     users.add(tempUser.getIdentifier());
-                                    logger.debug("Added temp user {} for group {}", new Object[]{tempUser, groupName});
+                                    logger.debug("Added temp user {} for group {}", tempUser, groupName);
                                 }
                             }
                         } else {
@@ -574,7 +574,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
                             .addUsers(users)
                             .build();
                     groupsById.put(group.getIdentifier(), group);
-                    logger.debug("Refreshed group {}", new Object[] {group});
+                    logger.debug("Refreshed group {}", group);
                 } else {
                     logger.warn("Null, empty, or skipped group name: " + groupName + " or id: " + groupIdentifier);
                 }
@@ -596,7 +596,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
             Group primaryGroup = gidToGroup.get(primaryGid);
 
             if (primaryGroup == null) {
-                logger.warn("Primary group {} not found for {}", new Object[]{primaryGid, primaryUser.getIdentity()});
+                logger.warn("Primary group {} not found for {}", primaryGid, primaryUser.getIdentity());
             } else if (!excludeGroups.matcher(primaryGroup.getName()).matches()) {
                 Set<String> groupUsers = primaryGroup.getUsers();
                 if (!groupUsers.contains(primaryUser.getIdentifier())) {
@@ -609,12 +609,12 @@ public class ShellUserGroupProvider implements UserGroupProvider {
                             .addUsers(updatedUserIdentifiers)
                             .build();
                     gidToGroup.put(updatedGroup.getIdentifier(), updatedGroup);
-                    logger.debug("Added user {} to primary group {}", new Object[]{primaryUser, updatedGroup});
+                    logger.debug("Added user {} to primary group {}", primaryUser, updatedGroup);
                 } else {
-                    logger.debug("Primary group {} already contains user {}", new Object[]{primaryGroup, primaryUser});
+                    logger.debug("Primary group {} already contains user {}", primaryGroup, primaryUser);
                 }
             } else {
-                logger.debug("Primary group {} excluded from matcher for {}", new Object[]{primaryGroup.getName(), primaryUser.getIdentity()});
+                logger.debug("Primary group {} excluded from matcher for {}", primaryGroup.getName(), primaryUser.getIdentity());
             }
         });
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-shell-authorizer/src/main/java/org/apache/nifi/authorization/util/ShellRunner.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-shell-authorizer/src/main/java/org/apache/nifi/authorization/util/ShellRunner.java
@@ -57,7 +57,7 @@ public class ShellRunner {
         builder.redirectErrorStream(true);
 
         final List<String> builderCommand = builder.command();
-        logger.debug("Run Command '{}': {}", new Object[]{description, builderCommand});
+        logger.debug("Run Command '{}': {}", description, builderCommand);
 
         final Process proc = builder.start();
 

--- a/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardPublicPort.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardPublicPort.java
@@ -178,7 +178,7 @@ public class StandardPublicPort extends AbstractPort implements PublicPort {
         } catch (final TransmissionDisabledException e) {
             session.rollback();
         } catch (final Exception e) {
-            logger.error("{} Failed to process data due to {}", new Object[]{this, e});
+            logger.error("{} Failed to process data", this, e);
             if (logger.isDebugEnabled()) {
                 logger.error("", e);
             }

--- a/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
@@ -443,8 +443,8 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
                 final String uploadDataRate = stopWatch.calculateDataRate(numBytesReceived);
                 final long uploadMillis = stopWatch.getDuration(TimeUnit.MILLISECONDS);
                 final String dataSize = FormatUtils.formatDataSize(numBytesReceived);
-                logger.info("{} Successfully received {} ({}) from {} in {} milliseconds at a rate of {}", new Object[]{
-                    this, flowFileDescription, dataSize, transaction.getCommunicant().getUrl(), uploadMillis, uploadDataRate});
+                logger.info("{} Successfully received {} ({}) from {} in {} milliseconds at a rate of {}",
+                        this, flowFileDescription, dataSize, transaction.getCommunicant().getUrl(), uploadMillis, uploadDataRate);
             }
         });
 

--- a/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/AbstractFlowFileServerProtocol.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/protocol/AbstractFlowFileServerProtocol.java
@@ -247,7 +247,7 @@ public abstract class AbstractFlowFileServerProtocol implements ServerProtocol {
         while (continueTransaction) {
             final boolean useGzip = handshakeProperties.isUseGzip();
             final OutputStream flowFileOutputStream = useGzip ? new CompressionOutputStream(os) : os;
-            logger.debug("{} Sending {} to {}", new Object[]{this, flowFile, peer});
+            logger.debug("{} Sending {} to {}", this, flowFile, peer);
 
             final CheckedOutputStream checkedOutputStream = new CheckedOutputStream(flowFileOutputStream, crc);
 
@@ -368,7 +368,7 @@ public abstract class AbstractFlowFileServerProtocol implements ServerProtocol {
             throw e;
         }
 
-        logger.debug("{} received {} from {}", new Object[]{this, transactionResponse, peer});
+        logger.debug("{} received {} from {}", this, transactionResponse, peer);
         if (transactionResponse.getCode() == ResponseCode.TRANSACTION_FINISHED_BUT_DESTINATION_FULL) {
             peer.penalize(port.getIdentifier(), port.getYieldPeriod(TimeUnit.MILLISECONDS));
         } else if (transactionResponse.getCode() != ResponseCode.TRANSACTION_FINISHED) {
@@ -383,8 +383,7 @@ public abstract class AbstractFlowFileServerProtocol implements ServerProtocol {
         final String uploadDataRate = stopWatch.calculateDataRate(bytesSent);
         final long uploadMillis = stopWatch.getDuration(TimeUnit.MILLISECONDS);
         final String dataSize = FormatUtils.formatDataSize(bytesSent);
-        logger.info("{} Successfully sent {} ({}) to {} in {} milliseconds at a rate of {}", new Object[]{
-            this, flowFileDescription, dataSize, peer, uploadMillis, uploadDataRate});
+        logger.info("{} Successfully sent {} ({}) to {} in {} milliseconds at a rate of {}", this, flowFileDescription, dataSize, peer, uploadMillis, uploadDataRate);
 
         return flowFilesSent.size();
     }
@@ -550,8 +549,7 @@ public abstract class AbstractFlowFileServerProtocol implements ServerProtocol {
         final String uploadDataRate = stopWatch.calculateDataRate(bytesReceived);
         final long uploadMillis = stopWatch.getDuration(TimeUnit.MILLISECONDS);
         final String dataSize = FormatUtils.formatDataSize(bytesReceived);
-        logger.info("{} Successfully received {} ({}) from {} in {} milliseconds at a rate of {}", new Object[]{
-            this, flowFileDescription, dataSize, peer, uploadMillis, uploadDataRate});
+        logger.info("{} Successfully received {} ({}) from {} in {} milliseconds at a rate of {}", this, flowFileDescription, dataSize, peer, uploadMillis, uploadDataRate);
 
         return flowFilesReceived.size();
     }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/ReflectionUtils.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/ReflectionUtils.java
@@ -121,7 +121,7 @@ public class ReflectionUtils {
                         method.invoke(instance, argsToPass);
                     }
                 } catch (final IllegalAccessException | IllegalArgumentException | InvocationTargetException t) {
-                    LOG.error("Unable to invoke method {} on {} due to {}", new Object[]{method.getName(), instance, t});
+                    LOG.error("Unable to invoke method {} on {}", method.getName(), instance, t);
                     LOG.error("", t);
                     return false;
                 }

--- a/nifi-mock/src/test/java/org/apache/nifi/util/TestStandardProcessorTestRunner.java
+++ b/nifi-mock/src/test/java/org/apache/nifi/util/TestStandardProcessorTestRunner.java
@@ -343,7 +343,7 @@ public class TestStandardProcessorTestRunner {
         }
 
         public void onPropertyModified(final PropertyDescriptor descriptor, final String oldValue, final String newValue) {
-            getLogger().info("onPropertyModified called for PD {} with old value {} and new value {}", new Object[]{descriptor.getName(), oldValue, newValue});
+            getLogger().info("onPropertyModified called for PD {} with old value {} and new value {}", descriptor.getName(), oldValue, newValue);
             opmCalled = true;
         }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/db/CustomFlywayMigrationStrategy.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/db/CustomFlywayMigrationStrategy.java
@@ -129,7 +129,7 @@ public class CustomFlywayMigrationStrategy implements FlywayMigrationStrategy {
 
         // Migrate buckets
         final List<BucketEntityV1> sourceBuckets = legacyDatabaseService.getAllBuckets();
-        LOGGER.info("Migrating {} buckets..", new Object[]{sourceBuckets.size()});
+        LOGGER.info("Migrating {} buckets..", sourceBuckets.size());
 
         sourceBuckets.stream()
                 .map(b -> LegacyEntityMapper.createBucketEntity(b))
@@ -137,7 +137,7 @@ public class CustomFlywayMigrationStrategy implements FlywayMigrationStrategy {
 
         // Migrate flows
         final List<FlowEntityV1> sourceFlows = legacyDatabaseService.getAllFlows();
-        LOGGER.info("Migrating {} flows..", new Object[]{sourceFlows.size()});
+        LOGGER.info("Migrating {} flows..", sourceFlows.size());
 
         sourceFlows.stream()
                 .map(f -> LegacyEntityMapper.createFlowEntity(f))
@@ -145,7 +145,7 @@ public class CustomFlywayMigrationStrategy implements FlywayMigrationStrategy {
 
         // Migrate flow snapshots
         final List<FlowSnapshotEntityV1> sourceSnapshots = legacyDatabaseService.getAllFlowSnapshots();
-        LOGGER.info("Migrating {} flow snapshots..", new Object[]{sourceSnapshots.size()});
+        LOGGER.info("Migrating {} flow snapshots..", sourceSnapshots.size());
 
         sourceSnapshots.stream()
                 .map(fs -> LegacyEntityMapper.createFlowSnapshotEntity(fs))

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/extension/ExtensionManager.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/extension/ExtensionManager.java
@@ -108,7 +108,7 @@ public class ExtensionManager {
             if (classLoaderMap.containsKey(extensionClassName)) {
                 final String currDir = extensionClassLoader.getRootDir();
                 final String existingDir = classLoaderMap.get(extensionClassName).getRootDir();
-                LOGGER.warn("Skipping {} from {} which was already found in {}", new Object[]{extensionClassName, currDir, existingDir});
+                LOGGER.warn("Skipping {} from {} which was already found in {}", extensionClassName, currDir, existingDir);
             } else {
                 classLoaderMap.put(o.getClass().getCanonicalName(), extensionClassLoader);
             }
@@ -172,8 +172,7 @@ public class ExtensionManager {
         try {
             resources.add(dirFile.toURI().toURL());
         } catch (final MalformedURLException mfe) {
-            LOGGER.warn("Unable to add {} to classpath due to {}",
-                    new Object[]{dirFile.getAbsolutePath(), mfe.getMessage()}, mfe);
+            LOGGER.warn("Unable to add {} to classpath", dirFile.getAbsolutePath(), mfe);
         }
 
         if (dirFile.isDirectory()) {
@@ -186,8 +185,7 @@ public class ExtensionManager {
                         try {
                             resources.add(resource.toURI().toURL());
                         } catch (final MalformedURLException mfe) {
-                            LOGGER.warn("Unable to add {} to classpath due to {}",
-                                    new Object[]{resource.getAbsolutePath(), mfe.getMessage()}, mfe);
+                            LOGGER.warn("Unable to add {} to classpath", resource.getAbsolutePath(), mfe);
                         }
                     }
                 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/FlowMetadataSynchronizer.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/FlowMetadataSynchronizer.java
@@ -73,7 +73,7 @@ public class FlowMetadataSynchronizer {
         LOGGER.info("*  Synchronizing metadata from FlowPersistenceProvider to metadata database...");
 
         final List<BucketMetadata> metadata = metadataAwareFlowPersistenceProvider.getMetadata();
-        LOGGER.info("*  Synchronizing {} bucket(s)", new Object[]{metadata.size()});
+        LOGGER.info("*  Synchronizing {} bucket(s)", metadata.size());
 
         for (final BucketMetadata bucketMetadata : metadata) {
             final BucketEntity bucketEntity = new BucketEntity();
@@ -91,7 +91,7 @@ public class FlowMetadataSynchronizer {
 
     private void createFlows(final BucketMetadata bucketMetadata) {
         LOGGER.info("*  Synchronizing {} flow(s) for bucket {}",
-                new Object[]{bucketMetadata.getFlowMetadata().size(), bucketMetadata.getIdentifier()});
+                bucketMetadata.getFlowMetadata().size(), bucketMetadata.getIdentifier());
 
         for (final FlowMetadata flowMetadata : bucketMetadata.getFlowMetadata()) {
             final FlowEntity flowEntity = new FlowEntity();
@@ -110,8 +110,8 @@ public class FlowMetadataSynchronizer {
 
     private void createFlowSnapshots(final FlowMetadata flowMetadata) {
         LOGGER.info("*  Synchronizing {} version(s) for flow {}",
-                new Object[]{flowMetadata.getFlowSnapshotMetadata().size(),
-                        flowMetadata.getIdentifier()});
+                flowMetadata.getFlowSnapshotMetadata().size(),
+                flowMetadata.getIdentifier());
 
         for (final FlowSnapshotMetadata snapshotMetadata : flowMetadata.getFlowSnapshotMetadata()) {
             final FlowSnapshotEntity snapshotEntity = new FlowSnapshotEntity();

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/StandardAuthorizableLookup.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/StandardAuthorizableLookup.java
@@ -271,10 +271,10 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
             return bucket.isAllowPublicRead();
         } catch (ResourceNotFoundException rnfe) {
             // if not found then we can't determine public access, so return false to delegate to regular authorizer
-            logger.debug("Cannot determine public access, bucket not found with id [{}]", new Object[]{bucketId});
+            logger.debug("Cannot determine public access, bucket not found with id [{}]", bucketId);
             return false;
         } catch (Exception e) {
-            logger.error("Error checking public access to bucket with id [{}]", new Object[]{bucketId}, e);
+            logger.error("Error checking public access to bucket with id [{}]", bucketId, e);
             return false;
         }
     }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseAccessPolicyProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseAccessPolicyProvider.java
@@ -357,11 +357,9 @@ public class DatabaseAccessPolicyProvider extends AbstractConfigurableAccessPoli
         } else {
             // a policy already exists for the given resource and action, so just associate the user with that policy
             if (existingPolicy.getUsers().contains(initialUser.getIdentifier())) {
-                LOGGER.debug("'{}' is already part of the policy for {} {}",
-                        new Object[]{initialUser.getIdentity(), action.toString(), resourceIdentifier});
+                LOGGER.debug("'{}' is already part of the policy for {} {}", initialUser.getIdentity(), action, resourceIdentifier);
             } else {
-                LOGGER.debug("Adding '{}' to the policy for {} {}",
-                        new Object[]{initialUser.getIdentity(), action.toString(), resourceIdentifier});
+                LOGGER.debug("Adding '{}' to the policy for {} {}", initialUser.getIdentity(), action, resourceIdentifier);
                 insertPolicyUser(existingPolicy.getIdentifier(), userIdentifier);
             }
         }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseUserGroupProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseUserGroupProvider.java
@@ -88,9 +88,9 @@ public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider 
                         .identity(initialUserIdentity)
                         .build();
                 addUser(initialUser);
-                LOGGER.info("Created initial user with identity {}", new Object[]{initialUserIdentity});
+                LOGGER.info("Created initial user with identity {}", initialUserIdentity);
             } else {
-                LOGGER.debug("User already exists with identity {}", new Object[]{initialUserIdentity});
+                LOGGER.debug("User already exists with identity {}", initialUserIdentity);
             }
         }
     }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileAccessPolicyProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileAccessPolicyProvider.java
@@ -141,7 +141,7 @@ public class FileAccessPolicyProvider extends AbstractConfigurableAccessPolicyPr
             // get the authorizations file and ensure it exists
             authorizationsFile = new File(authorizationsPath.getValue());
             if (!authorizationsFile.exists()) {
-                logger.info("Creating new authorizations file at {}", new Object[] {authorizationsFile.getAbsolutePath()});
+                logger.info("Creating new authorizations file at {}", authorizationsFile.getAbsolutePath());
                 saveAuthorizations(new Authorizations());
             }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileUserGroupProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileUserGroupProvider.java
@@ -131,7 +131,7 @@ public class FileUserGroupProvider implements ConfigurableUserGroupProvider {
             // get the tenants file and ensure it exists
             tenantsFile = new File(tenantsPath.getValue());
             if (!tenantsFile.exists()) {
-                logger.info("Creating new users file at {}", new Object[] {tenantsFile.getAbsolutePath()});
+                logger.info("Creating new users file at {}", tenantsFile.getAbsolutePath());
                 saveTenants(new Tenants());
             }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/resource/ProxyChainAuthorizable.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/resource/ProxyChainAuthorizable.java
@@ -70,15 +70,14 @@ public class ProxyChainAuthorizable implements Authorizable {
                                                   final Map<String, String> resourceContext) {
         final Resource requestResource = wrappedAuthorizable.getRequestedResource();
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Requested resource is {}", new Object[]{requestResource.getIdentifier()});
+            LOGGER.debug("Requested resource is {}", requestResource.getIdentifier());
         }
 
         // if public access is allowed then we want to skip proxy authorization so just return
         final Boolean isPublicAccessAllowed = publicResourceCheck.apply(requestResource, action);
         if (isPublicAccessAllowed) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Proxy chain will not be checked, public access is allowed for {} on {}",
-                        new Object[]{action.toString(), requestResource.getIdentifier()});
+                LOGGER.debug("Proxy chain will not be checked, public access is allowed for {} on {}", action, requestResource.getIdentifier());
             }
             return AuthorizationResult.approved();
         }
@@ -87,7 +86,7 @@ public class ProxyChainAuthorizable implements Authorizable {
         NiFiUser proxyUser = user.getChain();
         while (proxyUser  != null) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Checking proxy [{}] for {}", new Object[]{proxyUser, action});
+                LOGGER.debug("Checking proxy [{}] for {}", proxyUser, action);
             }
 
             // if the proxy is denied then break out of the loop and return a denied result
@@ -109,15 +108,14 @@ public class ProxyChainAuthorizable implements Authorizable {
                           final Map<String, String> resourceContext) throws AccessDeniedException {
         final Resource requestResource = wrappedAuthorizable.getRequestedResource();
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Requested resource is {}", new Object[]{requestResource.getIdentifier()});
+            LOGGER.debug("Requested resource is {}", requestResource.getIdentifier());
         }
 
         // if public access is allowed then we want to skip proxy authorization so just return
         final Boolean isPublicAccessAllowed = publicResourceCheck.apply(requestResource, action);
         if (isPublicAccessAllowed) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Proxy chain will not be authorized, public access is allowed for {} on {}",
-                        new Object[]{action.toString(), requestResource.getIdentifier()});
+                LOGGER.debug("Proxy chain will not be authorized, public access is allowed for {} on {}", action, requestResource.getIdentifier());
             }
             return;
         }
@@ -126,7 +124,7 @@ public class ProxyChainAuthorizable implements Authorizable {
         NiFiUser proxyUser = user.getChain();
         while (proxyUser  != null) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Authorizing proxy [{}] for {}", new Object[]{proxyUser, action});
+                LOGGER.debug("Authorizing proxy [{}] for {}", proxyUser, action);
             }
 
             try {

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/resource/PublicCheckingAuthorizable.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/resource/PublicCheckingAuthorizable.java
@@ -61,21 +61,21 @@ public class PublicCheckingAuthorizable implements Authorizable {
                                                   final Map<String, String> resourceContext) {
         final Resource resource = getResource();
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Requested resource is {}", new Object[]{resource.getIdentifier()});
+            LOGGER.debug("Requested resource is {}", resource.getIdentifier());
         }
 
         // if public access is allowed then return approved
         final Boolean isPublicAccessAllowed = publicResourceCheck.apply(resource, action);
         if (isPublicAccessAllowed) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Public access is allowed for {}", new Object[]{resource.getIdentifier()});
+                LOGGER.debug("Public access is allowed for {}", resource.getIdentifier());
             }
             return AuthorizationResult.approved();
         }
 
         // otherwise delegate to the original inheriting authorizable
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Delegating to inheriting authorizable for {}", new Object[]{resource.getIdentifier()});
+            LOGGER.debug("Delegating to inheriting authorizable for {}", resource.getIdentifier());
         }
         return wrappedAuthorizable.checkAuthorization(authorizer, action, user, resourceContext);
     }
@@ -85,21 +85,21 @@ public class PublicCheckingAuthorizable implements Authorizable {
                           final Map<String, String> resourceContext) throws AccessDeniedException {
         final Resource resource = getResource();
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Requested resource is {}", new Object[]{resource.getIdentifier()});
+            LOGGER.debug("Requested resource is {}", resource.getIdentifier());
         }
 
         // if public access is allowed then skip authorization and return
         final Boolean isPublicAccessAllowed = publicResourceCheck.apply(resource, action);
         if (isPublicAccessAllowed) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Public access is allowed for {}", new Object[]{resource.getIdentifier()});
+                LOGGER.debug("Public access is allowed for {}", resource.getIdentifier());
             }
             return;
         }
 
         // otherwise delegate to the original authorizable
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Delegating to inheriting authorizable for {}", new Object[]{resource.getIdentifier()});
+            LOGGER.debug("Delegating to inheriting authorizable for {}", resource.getIdentifier());
         }
 
         wrappedAuthorizable.authorize(authorizer, action, user, resourceContext);

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/shell/ShellRunner.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/shell/ShellRunner.java
@@ -57,7 +57,7 @@ public class ShellRunner {
         builder.redirectErrorStream(true);
 
         final List<String> builderCommand = builder.command();
-        logger.debug("Run Command '{}': {}", new Object[]{description, builderCommand});
+        logger.debug("Run Command '{}': {}", description, builderCommand);
 
         final Process proc = builder.start();
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/shell/ShellUserGroupProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/shell/ShellUserGroupProvider.java
@@ -190,13 +190,13 @@ public class ShellUserGroupProvider implements UserGroupProvider {
     @Override
     public UserAndGroups getUserAndGroups(String identity) throws AuthorizationAccessException {
         User user = getUserByIdentity(identity);
-        logger.debug("Retrieved user {} for identity {}", new Object[]{user, identity});
+        logger.debug("Retrieved user {} for identity {}", user, identity);
 
         Set<Group> groups = new HashSet<>();
         if (user != null) {
             for (Group g : getGroups()) {
                 if (g.getUsers().contains(user.getIdentifier())) {
-                    logger.debug("User {} belongs to group {}", new Object[]{user.getIdentity(), g.getName()});
+                    logger.debug("User {} belongs to group {}", user.getIdentity(), g.getName());
                     groups.add(g);
                 }
             }
@@ -241,7 +241,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
         fixedDelay = getDelayProperty(configurationContext, REFRESH_DELAY_PROPERTY, "5 mins");
         timeoutSeconds = getTimeoutProperty(configurationContext, COMMAND_TIMEOUT_PROPERTY, DEFAULT_COMMAND_TIMEOUT);
         shellRunner = new ShellRunner(timeoutSeconds);
-        logger.debug("Configured ShellRunner with command timeout of '{}' seconds", new Object[]{timeoutSeconds});
+        logger.debug("Configured ShellRunner with command timeout of '{}' seconds", timeoutSeconds);
 
 
         // Our next init step is to select the command set based on the operating system name:
@@ -457,7 +457,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
      */
     private void rebuildUsers(List<String> userLines, Map<String, User> idToUser, Map<String, User> usernameToUser, Map<String, User> gidToUser) {
         userLines.forEach(line -> {
-            logger.trace("Processing user: {}", new Object[]{line});
+            logger.trace("Processing user: {}", line);
 
             String[] record = line.split(":");
             if (record.length > 2) {
@@ -470,7 +470,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
                             .build();
                     idToUser.put(user.getIdentifier(), user);
                     usernameToUser.put(userIdentity, user);
-                    logger.debug("Refreshed user {}", new Object[]{user});
+                    logger.debug("Refreshed user {}", user);
 
                     if (!StringUtils.isBlank(primaryGroupIdentifier)) {
                         // create a temporary group to deterministically generate the group id and associate this user
@@ -479,7 +479,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
                                 .identifierGenerateFromSeed(getGroupIdentifierSeed(primaryGroupIdentifier))
                                 .build();
                         gidToUser.put(group.getIdentifier(), user);
-                        logger.debug("Associated primary group {} with user {}", new Object[]{group.getIdentifier(), userIdentity});
+                        logger.debug("Associated primary group {} with user {}", group.getIdentifier(), userIdentity);
                     } else {
                         logger.warn("Null or empty primary group id for: " + userIdentity);
                     }
@@ -505,7 +505,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
      */
     private void rebuildGroups(List<String> groupLines, Map<String, Group> groupsById) {
         groupLines.forEach(line -> {
-            logger.trace("Processing group: {}", new Object[]{line});
+            logger.trace("Processing group: {}", line);
 
             String[] record = line.split(":");
             if (record.length > 1) {
@@ -527,7 +527,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
                                             .identifierGenerateFromSeed(getUserIdentifierSeed(userIdentity))
                                             .build();
                                     users.add(tempUser.getIdentifier());
-                                    logger.debug("Added temp user {} for group {}", new Object[]{tempUser, groupName});
+                                    logger.debug("Added temp user {} for group {}", tempUser, groupName);
                                 }
                             }
                         } else {
@@ -551,7 +551,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
                             .addUsers(users)
                             .build();
                     groupsById.put(group.getIdentifier(), group);
-                    logger.debug("Refreshed group {}", new Object[] {group});
+                    logger.debug("Refreshed group {}", group);
                 } else {
                     logger.warn("Null, empty, or skipped group name: " + groupName + " or id: " + groupIdentifier);
                 }
@@ -573,7 +573,7 @@ public class ShellUserGroupProvider implements UserGroupProvider {
             Group primaryGroup = gidToGroup.get(primaryGid);
 
             if (primaryGroup == null) {
-                logger.warn("Primary group {} not found for {}", new Object[]{primaryGid, primaryUser.getIdentity()});
+                logger.warn("Primary group {} not found for {}", primaryGid, primaryUser.getIdentity());
             } else if (!excludeGroups.matcher(primaryGroup.getName()).matches()) {
                 Set<String> groupUsers = primaryGroup.getUsers();
                 if (!groupUsers.contains(primaryUser.getIdentifier())) {
@@ -586,12 +586,12 @@ public class ShellUserGroupProvider implements UserGroupProvider {
                             .addUsers(updatedUserIdentifiers)
                             .build();
                     gidToGroup.put(updatedGroup.getIdentifier(), updatedGroup);
-                    logger.debug("Added user {} to primary group {}", new Object[]{primaryUser, updatedGroup});
+                    logger.debug("Added user {} to primary group {}", primaryUser, updatedGroup);
                 } else {
-                    logger.debug("Primary group {} already contains user {}", new Object[]{primaryGroup, primaryUser});
+                    logger.debug("Primary group {} already contains user {}", primaryGroup, primaryUser);
                 }
             } else {
-                logger.debug("Primary group {} excluded from matcher for {}", new Object[]{primaryGroup.getName(), primaryUser.getIdentity()});
+                logger.debug("Primary group {} excluded from matcher for {}", primaryGroup.getName(), primaryUser.getIdentity());
             }
         });
     }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/extension/StandardExtensionService.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/extension/StandardExtensionService.java
@@ -161,7 +161,7 @@ public class StandardExtensionService implements ExtensionService {
 
         final String extensionWorkingFilename = UUID.randomUUID().toString();
         final File extensionWorkingFile = new File(extensionsWorkingDir, extensionWorkingFilename);
-        LOGGER.debug("Writing bundle contents to working directory at {}", new Object[]{extensionWorkingFile.getAbsolutePath()});
+        LOGGER.debug("Writing bundle contents to working directory at {}", extensionWorkingFile.getAbsolutePath());
 
         try {
             // write the contents of the input stream to a temporary file in the extensions working directory
@@ -175,7 +175,7 @@ public class StandardExtensionService implements ExtensionService {
             final String sha256Hex = Hex.encodeHexString(sha256Digest.digest());
             final boolean sha256Supplied = !StringUtils.isBlank(clientSha256);
             if (sha256Supplied && !sha256Hex.equalsIgnoreCase(clientSha256)) {
-                LOGGER.error("Client provided SHA-256 of '{}', but server calculated '{}'", new Object[]{clientSha256, sha256Hex});
+                LOGGER.error("Client provided SHA-256 of '{}', but server calculated '{}'", clientSha256, sha256Hex);
                 throw new IllegalStateException("The SHA-256 of the received extension bundle does not match the SHA-256 provided by the client");
             }
 
@@ -196,7 +196,7 @@ public class StandardExtensionService implements ExtensionService {
             final boolean isSnapshotVersion = version.endsWith(SNAPSHOT_VERSION_SUFFIX);
             final boolean overwriteBundleVersion = isSnapshotVersion || existingBucket.isAllowExtensionBundleRedeploy();
 
-            LOGGER.debug("Extracted bundle details - '{}:{}:{}'", new Object[]{groupId, artifactId, version});
+            LOGGER.debug("Extracted bundle details - '{}:{}:{}'", groupId, artifactId, version);
 
             // a bundle with the same group, artifact, and version can exist in multiple buckets, but only if it contains the same binary content, or if its a snapshot version
             // we can determine that by comparing the SHA-256 digest of the incoming bundle against existing bundles with the same group, artifact, version
@@ -220,7 +220,7 @@ public class StandardExtensionService implements ExtensionService {
                     LOGGER.debug("Bundle overwriting allowed, deleting existing version...");
                     metadataService.deleteBundleVersion(existingVersion);
                 } else {
-                    LOGGER.warn("The specified version [{}] already exists for extension bundle [{}].", new Object[]{version, bundleEntity.getId()});
+                    LOGGER.warn("The specified version [{}] already exists for extension bundle [{}].", version, bundleEntity.getId());
                     throw new IllegalStateException("The specified version already exists for the given extension bundle");
                 }
             }
@@ -270,7 +270,7 @@ public class StandardExtensionService implements ExtensionService {
             dependencyEntities.forEach(d -> dependencies.add(ExtensionMappings.map(d)));
             bundleVersion.setDependencies(dependencies);
 
-            LOGGER.debug("Created bundle - '{}:{}:{}'", new Object[]{groupId, artifactId, version});
+            LOGGER.debug("Created bundle - '{}:{}:{}'", groupId, artifactId, version);
             return bundleVersion;
 
         } finally {
@@ -278,8 +278,7 @@ public class StandardExtensionService implements ExtensionService {
                 try {
                     extensionWorkingFile.delete();
                 } catch (Exception e) {
-                    LOGGER.warn("Error removing temporary extension bundle file at {}",
-                            new Object[]{extensionWorkingFile.getAbsolutePath()});
+                    LOGGER.warn("Error removing temporary extension bundle file at {}", extensionWorkingFile.getAbsolutePath());
                 }
             }
         }
@@ -342,7 +341,7 @@ public class StandardExtensionService implements ExtensionService {
             // Check the additionalDetails map to see if there is an entry, and if so populate it
             final String additionalDetailsContent = additionalDetails.get(extensionEntity.getName());
             if (!StringUtils.isBlank(additionalDetailsContent)) {
-                LOGGER.debug("Found additional details documentation for extension '{}'", new Object[]{extensionEntity.getName()});
+                LOGGER.debug("Found additional details documentation for extension '{}'", extensionEntity.getName());
                 extensionEntity.setAdditionalDetails(additionalDetailsContent);
             }
 
@@ -401,10 +400,10 @@ public class StandardExtensionService implements ExtensionService {
              final InputStream bufIn = new BufferedInputStream(in)) {
             if (overwriteBundleVersion) {
                 bundlePersistenceProvider.updateBundleVersion(context, bufIn);
-                LOGGER.debug("Bundle version updated in persistence provider - {}", new Object[]{versionCoordinate.toString()});
+                LOGGER.debug("Bundle version updated in persistence provider - {}", versionCoordinate);
             } else {
                 bundlePersistenceProvider.createBundleVersion(context, bufIn);
-                LOGGER.debug("Bundle version created in persistence provider - {}", new Object[]{versionCoordinate.toString()});
+                LOGGER.debug("Bundle version created in persistence provider - {}", versionCoordinate);
             }
         }
     }
@@ -545,7 +544,7 @@ public class StandardExtensionService implements ExtensionService {
         // retrieve the version of the bundle...
         final BundleVersionEntity existingVersion = metadataService.getBundleVersion(bundleId, version);
         if (existingVersion == null) {
-            LOGGER.warn("The specified version [{}] does not exist for extension bundle [{}].", new Object[]{version, bundleId});
+            LOGGER.warn("The specified version [{}] does not exist for extension bundle [{}].", version, bundleId);
             throw new ResourceNotFoundException("The specified extension bundle version does not exist.");
         }
         return getBundleVersion(existingBucket, existingBundle, existingVersion);
@@ -576,14 +575,14 @@ public class StandardExtensionService implements ExtensionService {
         // ensure the bundle exists
         final BundleEntity existingBundle = metadataService.getBundle(bucketId, groupId, artifactId);
         if (existingBundle == null) {
-            LOGGER.warn("The specified extension bundle [{}-{}-{}] does not exist.", new Object[]{bucketId, groupId, artifactId});
+            LOGGER.warn("The specified extension bundle [{}-{}-{}] does not exist.", bucketId, groupId, artifactId);
             throw new ResourceNotFoundException("The specified extension bundle does not exist in this bucket.");
         }
 
         //ensure the version of the bundle exists
         final BundleVersionEntity existingVersion = metadataService.getBundleVersion(bucketId, groupId, artifactId, version);
         if (existingVersion == null) {
-            LOGGER.warn("The specified extension bundle version [{}-{}-{}-{}] does not exist.", new Object[]{bucketId, groupId, artifactId, version});
+            LOGGER.warn("The specified extension bundle version [{}-{}-{}-{}] does not exist.", bucketId, groupId, artifactId, version);
             throw new ResourceNotFoundException("The specified extension bundle version does not exist in this bucket.");
         }
 
@@ -691,11 +690,8 @@ public class StandardExtensionService implements ExtensionService {
 
         if (existingBundleVersion == null) {
             LOGGER.warn("The specified extension bundle version does not exist for [{}] - [{}] - [{}] - [{}]",
-                    new Object[]{
-                            bundleVersion.getVersionMetadata().getBucketId(),
-                            bundleVersion.getBundle().getGroupId(),
-                            bundleVersion.getBundle().getArtifactId(),
-                            bundleVersion.getVersionMetadata().getVersion()});
+                    bundleVersion.getVersionMetadata().getBucketId(), bundleVersion.getBundle().getGroupId(),
+                    bundleVersion.getBundle().getArtifactId(), bundleVersion.getVersionMetadata().getVersion());
             throw new ResourceNotFoundException("The specified extension bundle version does not exist.");
         }
 
@@ -724,8 +720,7 @@ public class StandardExtensionService implements ExtensionService {
 
         final ExtensionEntity entity = metadataService.getExtensionByName(bundleVersion.getVersionMetadata().getId(), name);
         if (entity == null) {
-            LOGGER.warn("The specified extension [{}] does not exist in the specified bundle version [{}].",
-                    new Object[]{name, bundleVersion.getVersionMetadata().getId()});
+            LOGGER.warn("The specified extension [{}] does not exist in the specified bundle version [{}].", name, bundleVersion.getVersionMetadata().getId());
             throw new ResourceNotFoundException("The specified extension does not exist in this registry.");
         }
 
@@ -753,8 +748,7 @@ public class StandardExtensionService implements ExtensionService {
 
         final ExtensionEntity entity = metadataService.getExtensionByName(bundleVersion.getVersionMetadata().getId(), name);
         if (entity == null) {
-            LOGGER.warn("The specified extension [{}] does not exist in the specified bundle version [{}].",
-                    new Object[]{name, bundleVersion.getVersionMetadata().getId()});
+            LOGGER.warn("The specified extension [{}] does not exist in the specified bundle version [{}].", name, bundleVersion.getVersionMetadata().getId());
             throw new ResourceNotFoundException("The specified extension does not exist in this registry.");
         }
 
@@ -785,14 +779,12 @@ public class StandardExtensionService implements ExtensionService {
                 bundleVersion.getVersionMetadata().getId(), name);
 
         if (additionalDetailsEntity == null) {
-            LOGGER.warn("The specified extension [{}] does not exist in the specified bundle version [{}].",
-                    new Object[]{name, bundleVersion.getVersionMetadata().getId()});
+            LOGGER.warn("The specified extension [{}] does not exist in the specified bundle version [{}].", name, bundleVersion.getVersionMetadata().getId());
             throw new ResourceNotFoundException("The specified extension does not exist in this registry.");
         }
 
         if (!additionalDetailsEntity.getAdditionalDetails().isPresent()) {
-            LOGGER.warn("The specified extension [{}] does not have additional details in the specified bundle version [{}].",
-                    new Object[]{name, bundleVersion.getVersionMetadata().getId()});
+            LOGGER.warn("The specified extension [{}] does not have additional details in the specified bundle version [{}].", name, bundleVersion.getVersionMetadata().getId());
             throw new IllegalStateException("The specified extension does not have additional details.");
         }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketBundleResource.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketBundleResource.java
@@ -104,7 +104,7 @@ public class BucketBundleResource extends ApplicationResource {
             @FormDataParam("file") final FormDataContentDisposition fileMetaData,
             @FormDataParam("sha256") final String clientSha256) throws IOException {
 
-        LOGGER.debug("Creating extension bundle version for bundle type {}", new Object[]{bundleType});
+        LOGGER.debug("Creating extension bundle version for bundle type {}", bundleType);
 
         final BundleVersion createdBundleVersion = serviceFacade.createBundleVersion(
                 bucketId, bundleType, fileInputStream, clientSha256);

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-aws/nifi-registry-aws-extensions/src/main/java/org/apache/nifi/registry/aws/S3BundlePersistenceProvider.java
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-aws/nifi-registry-aws-extensions/src/main/java/org/apache/nifi/registry/aws/S3BundlePersistenceProvider.java
@@ -126,7 +126,7 @@ public class S3BundlePersistenceProvider implements BundlePersistenceProvider {
             region = Region.of(regionValue);
         }
 
-        LOGGER.debug("Using region {}", new Object[] {region.id()});
+        LOGGER.debug("Using region {}", region.id());
         return region;
     }
 
@@ -192,7 +192,7 @@ public class S3BundlePersistenceProvider implements BundlePersistenceProvider {
     private synchronized void createOrUpdateBundleVersion(final BundlePersistenceContext context, final InputStream contentStream)
             throws BundlePersistenceException {
         final String key = getKey(context.getCoordinate());
-        LOGGER.debug("Saving bundle version to S3 in bucket '{}' with key '{}'", new Object[]{s3BucketName, key});
+        LOGGER.debug("Saving bundle version to S3 in bucket '{}' with key '{}'", s3BucketName, key);
 
         final PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(s3BucketName)
@@ -202,7 +202,7 @@ public class S3BundlePersistenceProvider implements BundlePersistenceProvider {
         final RequestBody requestBody = RequestBody.fromInputStream(contentStream, context.getSize());
         try {
             s3Client.putObject(request, requestBody);
-            LOGGER.debug("Successfully saved bundle version to S3 bucket '{}' with key '{}'", new Object[]{s3BucketName, key});
+            LOGGER.debug("Successfully saved bundle version to S3 bucket '{}' with key '{}'", s3BucketName, key);
         } catch (Exception e) {
             throw new BundlePersistenceException("Error saving bundle version to S3 due to: " + e.getMessage(), e);
         }
@@ -212,7 +212,7 @@ public class S3BundlePersistenceProvider implements BundlePersistenceProvider {
     public synchronized void getBundleVersionContent(final BundleVersionCoordinate versionCoordinate, final OutputStream outputStream)
             throws BundlePersistenceException {
         final String key = getKey(versionCoordinate);
-        LOGGER.debug("Retrieving bundle version from S3 bucket '{}' with key '{}'", new Object[]{s3BucketName, key});
+        LOGGER.debug("Retrieving bundle version from S3 bucket '{}' with key '{}'", s3BucketName, key);
 
         final GetObjectRequest request = GetObjectRequest.builder()
                 .bucket(s3BucketName)
@@ -221,7 +221,7 @@ public class S3BundlePersistenceProvider implements BundlePersistenceProvider {
 
         try (final ResponseInputStream<GetObjectResponse> response = s3Client.getObject(request)) {
             IoUtils.copy(response, outputStream);
-            LOGGER.debug("Successfully retrieved bundle version from S3 bucket '{}' with key '{}'", new Object[]{s3BucketName, key});
+            LOGGER.debug("Successfully retrieved bundle version from S3 bucket '{}' with key '{}'", s3BucketName, key);
         } catch (Exception e) {
             throw new BundlePersistenceException("Error retrieving bundle version from S3 due to: " + e.getMessage(), e);
         }
@@ -230,7 +230,7 @@ public class S3BundlePersistenceProvider implements BundlePersistenceProvider {
     @Override
     public synchronized void deleteBundleVersion(final BundleVersionCoordinate versionCoordinate) throws BundlePersistenceException {
         final String key = getKey(versionCoordinate);
-        LOGGER.debug("Deleting bundle version from S3 bucket '{}' with key '{}'", new Object[]{s3BucketName, key});
+        LOGGER.debug("Deleting bundle version from S3 bucket '{}' with key '{}'", s3BucketName, key);
 
         final DeleteObjectRequest request = DeleteObjectRequest.builder()
                 .bucket(s3BucketName)
@@ -239,7 +239,7 @@ public class S3BundlePersistenceProvider implements BundlePersistenceProvider {
 
         try {
             s3Client.deleteObject(request);
-            LOGGER.debug("Successfully deleted bundle version from S3 bucket '{}' with key '{}'", new Object[]{s3BucketName, key});
+            LOGGER.debug("Successfully deleted bundle version from S3 bucket '{}' with key '{}'", s3BucketName, key);
         } catch (Exception e) {
             throw new BundlePersistenceException("Error deleting bundle version from S3 due to: " + e.getMessage(), e);
         }
@@ -251,7 +251,7 @@ public class S3BundlePersistenceProvider implements BundlePersistenceProvider {
         final String bundlePrefix = getBundlePrefix(bundleCoordinate.getBucketId(), bundleCoordinate.getGroupId(), bundleCoordinate.getArtifactId());
 
         final String prefix = basePrefix + bundlePrefix;
-        LOGGER.debug("Deleting all bundle versions from S3 bucket '{}' with prefix '{}'", new Object[]{s3BucketName, prefix});
+        LOGGER.debug("Deleting all bundle versions from S3 bucket '{}' with prefix '{}'", s3BucketName, prefix);
 
         try {
             // List all the objects in the bucket with the given prefix of group/artifact...
@@ -270,10 +270,10 @@ public class S3BundlePersistenceProvider implements BundlePersistenceProvider {
                         .key(s3ObjectKey)
                         .build()
                 );
-                LOGGER.debug("Successfully object from S3 bucket '{}' with key '{}'", new Object[]{s3BucketName, s3ObjectKey});
+                LOGGER.debug("Successfully object from S3 bucket '{}' with key '{}'", s3BucketName, s3ObjectKey);
             }
 
-            LOGGER.debug("Successfully deleted all bundle versions from S3 bucket '{}' with prefix '{}'", new Object[]{s3BucketName, prefix});
+            LOGGER.debug("Successfully deleted all bundle versions from S3 bucket '{}' with prefix '{}'", s3BucketName, prefix);
         } catch (Exception e) {
             throw new BundlePersistenceException("Error deleting bundle versions from S3 due to: " + e.getMessage(), e);
         }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/engine/StatelessReloadComponent.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/engine/StatelessReloadComponent.java
@@ -128,7 +128,7 @@ public class StatelessReloadComponent implements ReloadComponent {
 
         // ghost components will have a null logger
         if (existingNode.getLogger() != null) {
-            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", new Object[]{id, newType, bundleCoordinate});
+            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", id, newType, bundleCoordinate);
         }
 
         final ExtensionManager extensionManager = statelessEngine.getExtensionManager();
@@ -182,7 +182,7 @@ public class StatelessReloadComponent implements ReloadComponent {
 
         // ghost components will have a null logger
         if (existingNode.getLogger() != null) {
-            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", new Object[]{id, newType, bundleCoordinate});
+            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", id, newType, bundleCoordinate);
         }
 
         final ExtensionManager extensionManager = statelessEngine.getExtensionManager();
@@ -227,7 +227,7 @@ public class StatelessReloadComponent implements ReloadComponent {
 
         // ghost components will have a null logger
         if (existingNode.getLogger() != null) {
-            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", new Object[]{id, newType, bundleCoordinate});
+            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", id, newType, bundleCoordinate);
         }
 
         final ExtensionManager extensionManager = statelessEngine.getExtensionManager();
@@ -272,7 +272,7 @@ public class StatelessReloadComponent implements ReloadComponent {
 
         // ghost components will have a null logger
         if (existingNode.getLogger() != null) {
-            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", new Object[]{id, newType, bundleCoordinate});
+            existingNode.getLogger().debug("Reloading component {} to type {} from bundle {}", id, newType, bundleCoordinate);
         }
 
         final ExtensionManager extensionManager = statelessEngine.getExtensionManager();

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/engine/StatelessSchedulingAgent.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/engine/StatelessSchedulingAgent.java
@@ -94,7 +94,7 @@ public class StatelessSchedulingAgent implements SchedulingAgent {
 
         } catch (final Throwable t) {
             final ComponentLog componentLog = new SimpleProcessLogger(taskNode.getIdentifier(), taskNode.getReportingTask(), new StandardLoggingContext(null));
-            componentLog.error("Error running task {} due to {}", new Object[]{taskNode.getReportingTask(), t.toString()});
+            componentLog.error("Error running task {}", taskNode.getReportingTask(), t);
             if (componentLog.isDebugEnabled()) {
                 componentLog.error("", t);
             }

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/processors/tests/system/Duplicate.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/processors/tests/system/Duplicate.java
@@ -70,6 +70,6 @@ public class Duplicate extends AbstractProcessor {
         }
 
         session.transfer(output, REL_SUCCESS);
-        getLogger().info("Duplicated {} to create {} FlowFiles total", new Object[] {input, output.size()});
+        getLogger().info("Duplicated {} to create {} FlowFiles total", input, output.size());
     }
 }

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/processors/tests/system/GenerateFlowFile.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/processors/tests/system/GenerateFlowFile.java
@@ -150,7 +150,7 @@ public class GenerateFlowFile extends AbstractProcessor {
             session.transfer(flowFile, REL_SUCCESS);
         }
 
-        getLogger().info("Generated {} FlowFiles", new Object[] {numFlowFiles});
+        getLogger().info("Generated {} FlowFiles", numFlowFiles);
         generatedCount.addAndGet(numFlowFiles);
 
         session.commitAsync(() -> { },

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/reporting/WriteToFileReportingTask.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/reporting/WriteToFileReportingTask.java
@@ -110,6 +110,6 @@ public class WriteToFileReportingTask extends AbstractReportingTask {
             throw new ProcessException(e);
         }
 
-        getLogger().info("Wrote text to file {}", new Object[] {outFile.getAbsolutePath()});
+        getLogger().info("Wrote text to file {}", outFile.getAbsolutePath());
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13265](https://issues.apache.org/jira/browse/NIFI-13265)
In addition to removing the unnecessary instantiation of Object arrays in logging statements this PR also aimed to remove parameters meant for exceptions which had for example `due to...` syntax as this was an artifact of legacy behavior that did not properly handle Throwable arguments. In addition this PR fixed some of the logging arguments as well e.g. not calling toString on an argument.
If possible, please port these changes to both the 1.x and 2.x branches. 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
