### PR TITLE
NIFI-13321: Fixing the mocking of child components in unit tests

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/access-policies/feature/access-policies.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/access-policies/feature/access-policies.component.spec.ts
@@ -19,30 +19,17 @@ import { AccessPolicies } from './access-policies.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../state/access-policy/access-policy.reducer';
-import { Component } from '@angular/core';
+import { Navigation } from '../../../ui/common/navigation/navigation.component';
+import { MockComponent } from 'ng-mocks';
 
 describe('AccessPolicies', () => {
     let component: AccessPolicies;
     let fixture: ComponentFixture<AccessPolicies>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [AccessPolicies],
-            imports: [RouterModule, RouterTestingModule, MockNavigation],
-            providers: [
-                provideMockStore({
-                    initialState
-                })
-            ]
+            imports: [RouterModule, RouterTestingModule, MockComponent(Navigation)]
         });
         fixture = TestBed.createComponent(AccessPolicies);
         component = fixture.componentInstance;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/bulletins/feature/bulletins.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/bulletins/feature/bulletins.component.spec.ts
@@ -19,30 +19,18 @@ import { Bulletins } from './bulletins.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Component } from '@angular/core';
 import { BulletinBoard } from '../ui/bulletin-board/bulletin-board.component';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialBulletinBoardState } from '../state/bulletin-board/bulletin-board.reducer';
+import { Navigation } from '../../../ui/common/navigation/navigation.component';
+import { MockComponent } from 'ng-mocks';
 
 describe('Bulletins', () => {
     let component: Bulletins;
     let fixture: ComponentFixture<Bulletins>;
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
 
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [Bulletins],
-            imports: [RouterModule, RouterTestingModule, MockNavigation, BulletinBoard],
-            providers: [
-                provideMockStore({
-                    initialState: initialBulletinBoardState
-                })
-            ]
+            imports: [RouterModule, RouterTestingModule, MockComponent(Navigation), MockComponent(BulletinBoard)]
         });
         fixture = TestBed.createComponent(Bulletins);
         component = fixture.componentInstance;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/cluster/feature/cluster.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/cluster/feature/cluster.component.spec.ts
@@ -16,7 +16,6 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { Cluster } from './cluster.component';
@@ -27,17 +26,12 @@ import { selectClusterListing } from '../state/cluster-listing/cluster-listing.s
 import { clusterListingFeatureKey } from '../state/cluster-listing';
 import { ClusterState } from '../state';
 import { ErrorBanner } from '../../../ui/common/error-banner/error-banner.component';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../../../ui/common/navigation/navigation.component';
 
 describe('Cluster', () => {
     let component: Cluster;
     let fixture: ComponentFixture<Cluster>;
-
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
 
     beforeEach(() => {
         const initialState: ClusterState = {
@@ -45,7 +39,13 @@ describe('Cluster', () => {
         };
         TestBed.configureTestingModule({
             declarations: [Cluster],
-            imports: [ClusterNodeListing, MatTabsModule, RouterTestingModule, MockNavigation, ErrorBanner],
+            imports: [
+                ClusterNodeListing,
+                MatTabsModule,
+                RouterTestingModule,
+                MockComponent(Navigation),
+                MockComponent(ErrorBanner)
+            ],
             providers: [
                 provideMockStore({
                     initialState,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/counters/feature/counters.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/counters/feature/counters.component.spec.ts
@@ -22,24 +22,25 @@ import { initialState } from '../state/counter-listing/counter-listing.reducer';
 import { CounterListing } from '../ui/counter-listing/counter-listing.component';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Component } from '@angular/core';
+import { countersFeatureKey } from '../state';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../../../ui/common/navigation/navigation.component';
 
 describe('Counters', () => {
     let component: Counters;
     let fixture: ComponentFixture<Counters>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [Counters, CounterListing],
-            imports: [RouterModule, RouterTestingModule, MockNavigation],
-            providers: [provideMockStore({ initialState })]
+            imports: [RouterModule, RouterTestingModule, MockComponent(Navigation)],
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [countersFeatureKey]: initialState
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(Counters);
         component = fixture.componentInstance;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/error/feature/error.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/error/feature/error.component.spec.ts
@@ -20,24 +20,25 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Error } from './error.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../state/current-user/current-user.reducer';
-import { Component } from '@angular/core';
+import { errorFeatureKey } from '../../../state/error';
+import { MockComponent } from 'ng-mocks';
+import { PageContent } from '../../../ui/common/page-content/page-content.component';
 
 describe('Error', () => {
     let component: Error;
     let fixture: ComponentFixture<Error>;
 
-    @Component({
-        selector: 'page-content',
-        standalone: true,
-        template: ''
-    })
-    class MockPageContent {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [Error],
-            imports: [MockPageContent],
-            providers: [provideMockStore({ initialState })]
+            imports: [MockComponent(PageContent)],
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [errorFeatureKey]: initialState
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(Error);
         component = fixture.componentInstance;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-configuration-history/feature/flow-configuration-history.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-configuration-history/feature/flow-configuration-history.component.spec.ts
@@ -20,27 +20,23 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FlowConfigurationHistory } from './flow-configuration-history.component';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Component } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialHistoryState } from '../state/flow-configuration-history-listing/flow-configuration-history-listing.reducer';
 import { FlowConfigurationHistoryListing } from '../ui/flow-configuration-history-listing/flow-configuration-history-listing.component';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../../../ui/common/navigation/navigation.component';
 
 describe('FlowConfigurationHistory', () => {
     let component: FlowConfigurationHistory;
     let fixture: ComponentFixture<FlowConfigurationHistory>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [FlowConfigurationHistory],
-            imports: [RouterModule, RouterTestingModule, MockNavigation, FlowConfigurationHistoryListing],
-            providers: [provideMockStore({ initialState: initialHistoryState })]
+            imports: [
+                RouterModule,
+                RouterTestingModule,
+                MockComponent(Navigation),
+                MockComponent(FlowConfigurationHistoryListing)
+            ]
         });
         fixture = TestBed.createComponent(FlowConfigurationHistory);
         component = fixture.componentInstance;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.spec.ts
@@ -21,35 +21,19 @@ import { Canvas } from './canvas.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/flow/flow.reducer';
 import { ContextMenu } from '../../../../ui/common/context-menu/context-menu.component';
-import { Component } from '@angular/core';
 import { CdkContextMenuTrigger } from '@angular/cdk/menu';
 import { selectBreadcrumbs } from '../../state/flow/flow.selectors';
 import { BreadcrumbEntity } from '../../state/shared';
+import { MockComponent } from 'ng-mocks';
+import { GraphControls } from './graph-controls/graph-controls.component';
+import { HeaderComponent } from './header/header.component';
+import { FooterComponent } from './footer/footer.component';
+import { canvasFeatureKey } from '../../state';
+import { flowFeatureKey } from '../../state/flow';
 
 describe('Canvas', () => {
     let component: Canvas;
     let fixture: ComponentFixture<Canvas>;
-
-    @Component({
-        selector: 'fd-header',
-        standalone: true,
-        template: ''
-    })
-    class MockHeader {}
-
-    @Component({
-        selector: 'fd-footer',
-        standalone: true,
-        template: ''
-    })
-    class MockFooter {}
-
-    @Component({
-        selector: 'graph-controls',
-        standalone: true,
-        template: ''
-    })
-    class MockGraphControls {}
 
     beforeEach(() => {
         const breadcrumbEntity: BreadcrumbEntity = {
@@ -67,10 +51,20 @@ describe('Canvas', () => {
 
         TestBed.configureTestingModule({
             declarations: [Canvas],
-            imports: [CdkContextMenuTrigger, ContextMenu, MockGraphControls, MockHeader, MockFooter],
+            imports: [
+                CdkContextMenuTrigger,
+                ContextMenu,
+                MockComponent(GraphControls),
+                MockComponent(HeaderComponent),
+                MockComponent(FooterComponent)
+            ],
             providers: [
                 provideMockStore({
-                    initialState,
+                    initialState: {
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    },
                     selectors: [
                         {
                             selector: selectBreadcrumbs,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/graph-controls.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/graph-controls.component.spec.ts
@@ -22,21 +22,16 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../state/flow/flow.reducer';
 import { NavigationControl } from './navigation-control/navigation-control.component';
 import { OperationControl } from './operation-control/operation-control.component';
-import { Component } from '@angular/core';
 import { selectBreadcrumbs } from '../../../state/flow/flow.selectors';
 import { Birdseye } from './navigation-control/birdseye/birdseye.component';
 import { BreadcrumbEntity } from '../../../state/shared';
+import { MockComponent } from 'ng-mocks';
+import { canvasFeatureKey } from '../../../state';
+import { flowFeatureKey } from '../../../state/flow';
 
 describe('GraphControls', () => {
     let component: GraphControls;
     let fixture: ComponentFixture<GraphControls>;
-
-    @Component({
-        selector: 'birdseye',
-        standalone: true,
-        template: ''
-    })
-    class MockBirdseye {}
 
     beforeEach(() => {
         const breadcrumbEntity: BreadcrumbEntity = {
@@ -53,10 +48,19 @@ describe('GraphControls', () => {
         };
 
         TestBed.configureTestingModule({
-            imports: [GraphControls, NavigationControl, OperationControl, MockBirdseye],
+            imports: [
+                GraphControls,
+                MockComponent(NavigationControl),
+                MockComponent(OperationControl),
+                MockComponent(Birdseye)
+            ],
             providers: [
                 provideMockStore({
-                    initialState,
+                    initialState: {
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    },
                     selectors: [
                         {
                             selector: selectBreadcrumbs,
@@ -65,13 +69,6 @@ describe('GraphControls', () => {
                     ]
                 })
             ]
-        }).overrideComponent(NavigationControl, {
-            remove: {
-                imports: [Birdseye]
-            },
-            add: {
-                imports: [MockBirdseye]
-            }
         });
 
         fixture = TestBed.createComponent(GraphControls);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/graph-controls.component.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/graph-controls.component.ts
@@ -26,7 +26,6 @@ import { NavigationControl } from './navigation-control/navigation-control.compo
 import { OperationControl } from './operation-control/operation-control.component';
 import { AsyncPipe } from '@angular/common';
 import { NiFiState } from '../../../../../state';
-import { selectSupportsManagedAuthorizer } from '../../../../../state/flow-configuration/flow-configuration.selectors';
 
 @Component({
     selector: 'graph-controls',
@@ -39,7 +38,6 @@ export class GraphControls {
     navigationCollapsed$ = this.store.select(selectNavigationCollapsed);
     operationCollapsed$ = this.store.select(selectOperationCollapsed);
     breadcrumbEntity$ = this.store.select(selectBreadcrumbs);
-    supportsManagedAuthorizer$ = this.store.select(selectSupportsManagedAuthorizer);
 
     constructor(private store: Store<NiFiState>) {}
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/navigation-control.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/navigation-control/navigation-control.component.spec.ts
@@ -20,35 +20,27 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NavigationControl } from './navigation-control.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../state/flow/flow.reducer';
-import { Component } from '@angular/core';
 import { Birdseye } from './birdseye/birdseye.component';
+import { canvasFeatureKey } from '../../../../state';
+import { flowFeatureKey } from '../../../../state/flow';
+import { MockComponent } from 'ng-mocks';
 
 describe('NavigationControl', () => {
     let component: NavigationControl;
     let fixture: ComponentFixture<NavigationControl>;
 
-    @Component({
-        selector: 'birdseye',
-        standalone: true,
-        template: ''
-    })
-    class MockBirdseye {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [NavigationControl, MockBirdseye],
+            imports: [NavigationControl, MockComponent(Birdseye)],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
-        }).overrideComponent(NavigationControl, {
-            remove: {
-                imports: [Birdseye]
-            },
-            add: {
-                imports: [MockBirdseye]
-            }
         });
 
         fixture = TestBed.createComponent(NavigationControl);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/flow-status/flow-status.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/flow-status/flow-status.component.spec.ts
@@ -22,26 +22,22 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { Component } from '@angular/core';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../../../state/flow/flow.reducer';
+import { Search } from '../search/search.component';
+import { MockComponent } from 'ng-mocks';
+import { canvasFeatureKey } from '../../../../state';
+import { flowFeatureKey } from '../../../../state/flow';
 
 describe('FlowStatus', () => {
     let component: FlowStatus;
     let fixture: ComponentFixture<FlowStatus>;
 
-    @Component({
-        selector: 'search',
-        standalone: true,
-        template: ''
-    })
-    class MockSearch {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
                 FlowStatus,
-                MockSearch,
+                MockComponent(Search),
                 HttpClientTestingModule,
                 CdkOverlayOrigin,
                 CdkConnectedOverlay,
@@ -51,7 +47,11 @@ describe('FlowStatus', () => {
             ],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/header.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/header.component.spec.ts
@@ -27,7 +27,6 @@ import { selectControllerBulletins, selectControllerStatus } from '../../../stat
 import { ControllerStatus, flowFeatureKey } from '../../../state/flow';
 import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { Component } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ClusterSummary } from '../../../../../state/cluster-summary';
 import { selectClusterSummary } from '../../../../../state/cluster-summary/cluster-summary.selectors';
@@ -40,24 +39,14 @@ import * as fromFlowConfiguration from '../../../../../state/flow-configuration/
 import { selectLoginConfiguration } from '../../../../../state/login-configuration/login-configuration.selectors';
 import * as fromLoginConfiguration from '../../../../../state/login-configuration/login-configuration.reducer';
 import { navigationFeatureKey } from '../../../../../state/navigation';
+import { canvasFeatureKey } from '../../../state';
+import { MockComponent } from 'ng-mocks';
+import { FlowStatus } from './flow-status/flow-status.component';
+import { Navigation } from '../../../../../ui/common/navigation/navigation.component';
 
 describe('HeaderComponent', () => {
     let component: HeaderComponent;
     let fixture: ComponentFixture<HeaderComponent>;
-
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
-    @Component({
-        selector: 'flow-status',
-        standalone: true,
-        template: ''
-    })
-    class MockFlowStatus {}
 
     const clusterSummary: ClusterSummary = {
         clustered: false,
@@ -89,9 +78,9 @@ describe('HeaderComponent', () => {
         TestBed.configureTestingModule({
             imports: [
                 HeaderComponent,
-                NewCanvasItem,
+                MockComponent(NewCanvasItem),
                 HttpClientTestingModule,
-                MockFlowStatus,
+                MockComponent(FlowStatus),
                 MatMenuModule,
                 MatDividerModule,
                 RouterTestingModule,
@@ -99,13 +88,15 @@ describe('HeaderComponent', () => {
                 CdkConnectedOverlay,
                 FormsModule,
                 ReactiveFormsModule,
-                MockNavigation
+                MockComponent(Navigation)
             ],
             providers: [
                 provideMockStore({
                     initialState: {
-                        [flowFeatureKey]: fromFlow.initialState,
-                        [navigationFeatureKey]: fromNavigation.initialState
+                        [canvasFeatureKey]: {
+                            [flowFeatureKey]: fromFlow.initialState,
+                            [navigationFeatureKey]: fromNavigation.initialState
+                        }
                     },
                     selectors: [
                         {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/processor/edit-processor/edit-processor.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/processor/edit-processor/edit-processor.component.spec.ts
@@ -22,12 +22,12 @@ import { EditComponentDialogRequest } from '../../../../../state/flow';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { ComponentType } from '../../../../../../../state/shared';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Component } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../../../../state/error/error.reducer';
 import { ClusterConnectionService } from '../../../../../../../service/cluster-connection.service';
 
 import 'codemirror/addon/hint/show-hint';
+import { MockComponent } from 'ng-mocks';
+import { ErrorBanner } from '../../../../../../../ui/common/error-banner/error-banner.component';
+import { CanvasUtils } from '../../../../../service/canvas-utils.service';
 
 describe('EditProcessor', () => {
     let component: EditProcessor;
@@ -725,25 +725,21 @@ describe('EditProcessor', () => {
         }
     };
 
-    @Component({
-        selector: 'error-banner',
-        standalone: true,
-        template: ''
-    })
-    class MockErrorBanner {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [EditProcessor, MockErrorBanner, NoopAnimationsModule],
+            imports: [EditProcessor, MockComponent(ErrorBanner), NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({
-                    initialState
-                }),
                 {
                     provide: ClusterConnectionService,
                     useValue: {
                         isDisconnectionAcknowledged: jest.fn()
+                    }
+                },
+                {
+                    provide: CanvasUtils,
+                    useValue: {
+                        runnableSupportsModification: jest.fn()
                     }
                 },
                 { provide: MatDialogRef, useValue: null }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.spec.ts
@@ -21,27 +21,27 @@ import { ControllerServices } from './controller-services.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { initialState } from '../../state/controller-services/controller-services.reducer';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Component } from '@angular/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../../../../ui/common/navigation/navigation.component';
+import { canvasFeatureKey } from '../../state';
+import { controllerServicesFeatureKey } from '../../state/controller-services';
 
 describe('ControllerServices', () => {
     let component: ControllerServices;
     let fixture: ComponentFixture<ControllerServices>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [ControllerServices],
-            imports: [RouterTestingModule, MockNavigation, HttpClientTestingModule],
+            imports: [RouterTestingModule, MockComponent(Navigation), HttpClientTestingModule],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [canvasFeatureKey]: {
+                            [controllerServicesFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/manage-remote-ports/manage-remote-ports.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/flow-designer/ui/manage-remote-ports/manage-remote-ports.component.spec.ts
@@ -20,28 +20,25 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ManageRemotePorts } from './manage-remote-ports.component';
 import { provideMockStore } from '@ngrx/store/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Component } from '@angular/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { initialState } from '../../state/manage-remote-ports/manage-remote-ports.reducer';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../../../../ui/common/navigation/navigation.component';
+import { remotePortsFeatureKey } from '../../state/manage-remote-ports';
 
 describe('ManageRemotePorts', () => {
     let component: ManageRemotePorts;
     let fixture: ComponentFixture<ManageRemotePorts>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [ManageRemotePorts],
-            imports: [RouterTestingModule, MockNavigation, HttpClientTestingModule],
+            imports: [RouterTestingModule, MockComponent(Navigation), HttpClientTestingModule],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [remotePortsFeatureKey]: initialState
+                    }
                 })
             ]
         });

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/parameter-contexts/feature/parameter-contexts.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/parameter-contexts/feature/parameter-contexts.component.spec.ts
@@ -18,32 +18,24 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ParameterContexts } from './parameter-contexts.component';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../state/parameter-context-listing/parameter-context-listing.reducer';
 import { ParameterContextListing } from '../ui/parameter-context-listing/parameter-context-listing.component';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Component } from '@angular/core';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../../../ui/common/navigation/navigation.component';
 
 describe('ParameterContexts', () => {
     let component: ParameterContexts;
     let fixture: ComponentFixture<ParameterContexts>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
-            declarations: [ParameterContexts, ParameterContextListing],
-            imports: [RouterModule, RouterTestingModule, MockNavigation],
-            providers: [
-                provideMockStore({
-                    initialState
-                })
+            declarations: [ParameterContexts],
+            imports: [
+                RouterModule,
+                RouterTestingModule,
+                MockComponent(Navigation),
+                MockComponent(ParameterContextListing)
             ]
         });
         fixture = TestBed.createComponent(ParameterContexts);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/provenance/feature/provenance.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/provenance/feature/provenance.component.spec.ts
@@ -22,26 +22,26 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { initialState } from '../state/provenance-event-listing/provenance-event-listing.reducer';
-import { Component } from '@angular/core';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../../../ui/common/navigation/navigation.component';
+import { provenanceFeatureKey } from '../state';
+import { provenanceEventListingFeatureKey } from '../state/provenance-event-listing';
 
 describe('Provenance', () => {
     let component: Provenance;
     let fixture: ComponentFixture<Provenance>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [Provenance],
-            imports: [RouterModule, RouterTestingModule, MockNavigation],
+            imports: [RouterModule, RouterTestingModule, MockComponent(Navigation)],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [provenanceFeatureKey]: {
+                            [provenanceEventListingFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/provenance/ui/provenance-event-listing/provenance-event-table/provenance-event-table.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/provenance/ui/provenance-event-listing/provenance-event-table/provenance-event-table.component.spec.ts
@@ -20,29 +20,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProvenanceEventTable } from './provenance-event-table.component';
 import { MatTableModule } from '@angular/material/table';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../../state/error/error.reducer';
-import { Component } from '@angular/core';
+import { MockComponent } from 'ng-mocks';
+import { ErrorBanner } from '../../../../../ui/common/error-banner/error-banner.component';
 
 describe('ProvenanceEventTable', () => {
     let component: ProvenanceEventTable;
     let fixture: ComponentFixture<ProvenanceEventTable>;
 
-    @Component({
-        selector: 'error-banner',
-        standalone: true,
-        template: ''
-    })
-    class MockErrorBanner {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ProvenanceEventTable, MockErrorBanner, MatTableModule, NoopAnimationsModule],
-            providers: [
-                provideMockStore({
-                    initialState
-                })
-            ]
+            imports: [ProvenanceEventTable, MockComponent(ErrorBanner), MatTableModule, NoopAnimationsModule]
         });
         fixture = TestBed.createComponent(ProvenanceEventTable);
         component = fixture.componentInstance;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/queue/feature/queue.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/queue/feature/queue.component.spec.ts
@@ -18,32 +18,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { Queue } from './queue.component';
-import { provideMockStore } from '@ngrx/store/testing';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { initialState } from '../state/queue-listing/queue-listing.reducer';
-import { Component } from '@angular/core';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../../../ui/common/navigation/navigation.component';
 
 describe('Queue', () => {
     let component: Queue;
     let fixture: ComponentFixture<Queue>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [Queue],
-            imports: [RouterModule, RouterTestingModule, MockNavigation],
-            providers: [
-                provideMockStore({
-                    initialState
-                })
-            ]
+            imports: [RouterModule, RouterTestingModule, MockComponent(Navigation)]
         });
         fixture = TestBed.createComponent(Queue);
         component = fixture.componentInstance;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/queue/ui/queue-listing/flowfile-table/flowfile-table.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/queue/ui/queue-listing/flowfile-table/flowfile-table.component.spec.ts
@@ -20,29 +20,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FlowFileTable } from './flowfile-table.component';
 import { MatTableModule } from '@angular/material/table';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Component } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../../state/error/error.reducer';
+import { MockComponent } from 'ng-mocks';
+import { ErrorBanner } from '../../../../../ui/common/error-banner/error-banner.component';
 
 describe('FlowFileTable', () => {
     let component: FlowFileTable;
     let fixture: ComponentFixture<FlowFileTable>;
 
-    @Component({
-        selector: 'error-banner',
-        standalone: true,
-        template: ''
-    })
-    class MockErrorBanner {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [FlowFileTable, MockErrorBanner, MatTableModule, NoopAnimationsModule],
-            providers: [
-                provideMockStore({
-                    initialState
-                })
-            ]
+            imports: [FlowFileTable, MockComponent(ErrorBanner), MatTableModule, NoopAnimationsModule]
         });
         fixture = TestBed.createComponent(FlowFileTable);
         component = fixture.componentInstance;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/settings/feature/settings.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/settings/feature/settings.component.spec.ts
@@ -23,26 +23,26 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { initialState } from '../state/general/general.reducer';
-import { Component } from '@angular/core';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../../../ui/common/navigation/navigation.component';
+import { settingsFeatureKey } from '../state';
+import { generalFeatureKey } from '../state/general';
 
 describe('Settings', () => {
     let component: Settings;
     let fixture: ComponentFixture<Settings>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [Settings],
-            imports: [MatTabsModule, RouterModule, RouterTestingModule, MockNavigation],
+            imports: [MatTabsModule, RouterModule, RouterTestingModule, MockComponent(Navigation)],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [settingsFeatureKey]: {
+                            [generalFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/settings/ui/flow-analysis-rules/edit-flow-analysis-rule/edit-flow-analysis-rule.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/settings/ui/flow-analysis-rules/edit-flow-analysis-rule/edit-flow-analysis-rule.component.spec.ts
@@ -21,12 +21,11 @@ import { EditFlowAnalysisRule } from './edit-flow-analysis-rule.component';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { EditFlowAnalysisRuleDialogRequest } from '../../../state/flow-analysis-rules';
-import { Component } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../../state/error/error.reducer';
 import { ClusterConnectionService } from '../../../../../service/cluster-connection.service';
 
 import 'codemirror/addon/hint/show-hint';
+import { MockComponent } from 'ng-mocks';
+import { ErrorBanner } from '../../../../../ui/common/error-banner/error-banner.component';
 
 describe('EditFlowAnalysisRule', () => {
     let component: EditFlowAnalysisRule;
@@ -95,21 +94,11 @@ describe('EditFlowAnalysisRule', () => {
         }
     };
 
-    @Component({
-        selector: 'error-banner',
-        standalone: true,
-        template: ''
-    })
-    class MockErrorBanner {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [EditFlowAnalysisRule, MockErrorBanner, NoopAnimationsModule],
+            imports: [EditFlowAnalysisRule, MockComponent(ErrorBanner), NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({
-                    initialState
-                }),
                 {
                     provide: ClusterConnectionService,
                     useValue: {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/settings/ui/registry-clients/edit-registry-client/edit-registry-client.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/settings/ui/registry-clients/edit-registry-client/edit-registry-client.component.spec.ts
@@ -21,12 +21,11 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { EditRegistryClient } from './edit-registry-client.component';
 import { EditRegistryClientDialogRequest } from '../../../state/registry-clients';
-import { Component } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../../state/error/error.reducer';
 import { ClusterConnectionService } from '../../../../../service/cluster-connection.service';
 
 import 'codemirror/addon/hint/show-hint';
+import { MockComponent } from 'ng-mocks';
+import { ErrorBanner } from '../../../../../ui/common/error-banner/error-banner.component';
 
 describe('EditRegistryClient', () => {
     let component: EditRegistryClient;
@@ -108,21 +107,11 @@ describe('EditRegistryClient', () => {
         }
     };
 
-    @Component({
-        selector: 'error-banner',
-        standalone: true,
-        template: ''
-    })
-    class MockErrorBanner {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [EditRegistryClient, MockErrorBanner, NoopAnimationsModule],
+            imports: [EditRegistryClient, MockComponent(ErrorBanner), NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({
-                    initialState
-                }),
                 {
                     provide: ClusterConnectionService,
                     useValue: {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/settings/ui/reporting-tasks/edit-reporting-task/edit-reporting-task.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/settings/ui/reporting-tasks/edit-reporting-task/edit-reporting-task.component.spec.ts
@@ -21,12 +21,11 @@ import { EditReportingTask } from './edit-reporting-task.component';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { EditReportingTaskDialogRequest } from '../../../state/reporting-tasks';
-import { Component } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../../state/error/error.reducer';
 import { ClusterConnectionService } from '../../../../../service/cluster-connection.service';
 
 import 'codemirror/addon/hint/show-hint';
+import { ErrorBanner } from '../../../../../ui/common/error-banner/error-banner.component';
+import { MockComponent } from 'ng-mocks';
 
 describe('EditReportingTask', () => {
     let component: EditReportingTask;
@@ -388,21 +387,11 @@ describe('EditReportingTask', () => {
         }
     };
 
-    @Component({
-        selector: 'error-banner',
-        standalone: true,
-        template: ''
-    })
-    class MockErrorBanner {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [EditReportingTask, MockErrorBanner, NoopAnimationsModule],
+            imports: [EditReportingTask, MockComponent(ErrorBanner), NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({
-                    initialState
-                }),
                 {
                     provide: ClusterConnectionService,
                     useValue: {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/summary/feature/summary.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/summary/feature/summary.component.spec.ts
@@ -22,26 +22,26 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { Summary } from './summary.component';
 import { initialState } from '../state/summary-listing/summary-listing.reducer';
-import { Component } from '@angular/core';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../../../ui/common/navigation/navigation.component';
+import { summaryFeatureKey } from '../state';
+import { summaryListingFeatureKey } from '../state/summary-listing';
 
 describe('Summary', () => {
     let component: Summary;
     let fixture: ComponentFixture<Summary>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [Summary],
-            imports: [MatTabsModule, RouterModule, RouterTestingModule, MockNavigation],
+            imports: [MatTabsModule, RouterModule, RouterTestingModule, MockComponent(Navigation)],
             providers: [
                 provideMockStore({
-                    initialState
+                    initialState: {
+                        [summaryFeatureKey]: {
+                            [summaryListingFeatureKey]: initialState
+                        }
+                    }
                 })
             ]
         });

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/users/feature/users.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/pages/users/feature/users.component.spec.ts
@@ -22,24 +22,27 @@ import { RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { UserListing } from '../ui/user-listing/user-listing.component';
 import { initialState } from '../state/user-listing/user-listing.reducer';
-import { Component } from '@angular/core';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../../../ui/common/navigation/navigation.component';
+import { usersFeatureKey } from '../state';
 
 describe('Users', () => {
     let component: Users;
     let fixture: ComponentFixture<Users>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [Users, UserListing],
-            imports: [RouterModule, RouterTestingModule, MockNavigation],
-            providers: [provideMockStore({ initialState })]
+            imports: [RouterModule, RouterTestingModule, MockComponent(Navigation)],
+            providers: [
+                provideMockStore({
+                    initialState: {
+                        [usersFeatureKey]: {
+                            [usersFeatureKey]: initialState
+                        }
+                    }
+                })
+            ]
         });
         fixture = TestBed.createComponent(Users);
         component = fixture.componentInstance;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/ui/common/advanced-ui/advanced-ui.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/ui/common/advanced-ui/advanced-ui.component.spec.ts
@@ -19,7 +19,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AdvancedUi } from './advanced-ui.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Component } from '@angular/core';
 import { provideMockStore } from '@ngrx/store/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { selectCurrentUser } from '../../../state/current-user/current-user.selectors';
@@ -33,21 +32,16 @@ import { selectLoginConfiguration } from '../../../state/login-configuration/log
 import * as fromLoginConfiguration from '../../../state/login-configuration/login-configuration.reducer';
 import { currentUserFeatureKey } from '../../../state/current-user';
 import { navigationFeatureKey } from '../../../state/navigation';
+import { MockComponent } from 'ng-mocks';
+import { Navigation } from '../navigation/navigation.component';
 
 describe('AdvancedUi', () => {
     let component: AdvancedUi;
     let fixture: ComponentFixture<AdvancedUi>;
 
-    @Component({
-        selector: 'navigation',
-        standalone: true,
-        template: ''
-    })
-    class MockNavigation {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [AdvancedUi, HttpClientTestingModule, RouterTestingModule, MockNavigation],
+            imports: [AdvancedUi, HttpClientTestingModule, RouterTestingModule, MockComponent(Navigation)],
             providers: [
                 provideMockStore({
                     initialState: {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/ui/common/controller-service/edit-controller-service/edit-controller-service.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/ui/common/controller-service/edit-controller-service/edit-controller-service.component.spec.ts
@@ -21,12 +21,11 @@ import { EditControllerService } from './edit-controller-service.component';
 import { EditControllerServiceDialogRequest } from '../../../../state/shared';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Component } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../../state/error/error.reducer';
 import { ClusterConnectionService } from '../../../../service/cluster-connection.service';
 
 import 'codemirror/addon/hint/show-hint';
+import { ErrorBanner } from '../../error-banner/error-banner.component';
+import { MockComponent } from 'ng-mocks';
 
 describe('EditControllerService', () => {
     let component: EditControllerService;
@@ -547,21 +546,11 @@ describe('EditControllerService', () => {
         }
     };
 
-    @Component({
-        selector: 'error-banner',
-        standalone: true,
-        template: ''
-    })
-    class MockErrorBanner {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [EditControllerService, MockErrorBanner, NoopAnimationsModule],
+            imports: [EditControllerService, MockComponent(ErrorBanner), NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({
-                    initialState
-                }),
                 {
                     provide: ClusterConnectionService,
                     useValue: {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/ui/common/edit-tenant/edit-tenant-dialog.component.spec.ts
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/app/ui/common/edit-tenant/edit-tenant-dialog.component.spec.ts
@@ -21,9 +21,8 @@ import { EditTenantDialog } from './edit-tenant-dialog.component';
 import { EditTenantRequest } from '../../../state/shared';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Component } from '@angular/core';
-import { provideMockStore } from '@ngrx/store/testing';
-import { initialState } from '../../../state/error/error.reducer';
+import { ErrorBanner } from '../error-banner/error-banner.component';
+import { MockComponent } from 'ng-mocks';
 
 describe('EditTenantDialog', () => {
     let component: EditTenantDialog;
@@ -785,21 +784,11 @@ describe('EditTenantDialog', () => {
         ]
     };
 
-    @Component({
-        selector: 'error-banner',
-        standalone: true,
-        template: ''
-    })
-    class MockErrorBanner {}
-
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [EditTenantDialog, MockErrorBanner, NoopAnimationsModule],
+            imports: [EditTenantDialog, MockComponent(ErrorBanner), NoopAnimationsModule],
             providers: [
                 { provide: MAT_DIALOG_DATA, useValue: data },
-                provideMockStore({
-                    initialState
-                }),
                 { provide: MatDialogRef, useValue: null }
             ]
         });

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package-lock.json
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package-lock.json
@@ -66,6 +66,7 @@
                 "happy-dom": "^14.10.1",
                 "jest": "^29.7.0",
                 "jest-preset-angular": "^14.0.3",
+                "ng-mocks": "^14.12.2",
                 "nx": "18.1.3",
                 "postcss": "^8.4.32",
                 "prettier": "^3.2.5",
@@ -20280,6 +20281,21 @@
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
+        },
+        "node_modules/ng-mocks": {
+            "version": "14.12.2",
+            "resolved": "https://registry.npmjs.org/ng-mocks/-/ng-mocks-14.12.2.tgz",
+            "integrity": "sha512-7HFb1G4I9885ipqdm0o+kPhFvy5EfEooIfl1DqxA84rvig6FhugZ8UDgV6YPYlwnGQyfwmAOexoPTuSVs36bhw==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/help-me-mom"
+            },
+            "peerDependencies": {
+                "@angular/common": "5.0.0-alpha - 5 || 6.0.0-alpha - 6 || 7.0.0-alpha - 7 || 8.0.0-alpha - 8 || 9.0.0-alpha - 9 || 10.0.0-alpha - 10 || 11.0.0-alpha - 11 || 12.0.0-alpha - 12 || 13.0.0-alpha - 13 || 14.0.0-alpha - 14 || 15.0.0-alpha - 15 || 16.0.0-alpha - 16 || 17.0.0-alpha - 17",
+                "@angular/core": "5.0.0-alpha - 5 || 6.0.0-alpha - 6 || 7.0.0-alpha - 7 || 8.0.0-alpha - 8 || 9.0.0-alpha - 9 || 10.0.0-alpha - 10 || 11.0.0-alpha - 11 || 12.0.0-alpha - 12 || 13.0.0-alpha - 13 || 14.0.0-alpha - 14 || 15.0.0-alpha - 15 || 16.0.0-alpha - 16 || 17.0.0-alpha - 17",
+                "@angular/forms": "5.0.0-alpha - 5 || 6.0.0-alpha - 6 || 7.0.0-alpha - 7 || 8.0.0-alpha - 8 || 9.0.0-alpha - 9 || 10.0.0-alpha - 10 || 11.0.0-alpha - 11 || 12.0.0-alpha - 12 || 13.0.0-alpha - 13 || 14.0.0-alpha - 14 || 15.0.0-alpha - 15 || 16.0.0-alpha - 16 || 17.0.0-alpha - 17",
+                "@angular/platform-browser": "5.0.0-alpha - 5 || 6.0.0-alpha - 6 || 7.0.0-alpha - 7 || 8.0.0-alpha - 8 || 9.0.0-alpha - 9 || 10.0.0-alpha - 10 || 11.0.0-alpha - 11 || 12.0.0-alpha - 12 || 13.0.0-alpha - 13 || 14.0.0-alpha - 14 || 15.0.0-alpha - 15 || 16.0.0-alpha - 16 || 17.0.0-alpha - 17"
+            }
         },
         "node_modules/ngx-skeleton-loader": {
             "version": "8.1.0",

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package.json
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/package.json
@@ -72,6 +72,7 @@
         "happy-dom": "^14.10.1",
         "jest": "^29.7.0",
         "jest-preset-angular": "^14.0.3",
+        "ng-mocks": "^14.12.2",
         "nx": "18.1.3",
         "postcss": "^8.4.32",
         "prettier": "^3.2.5",


### PR DESCRIPTION
NIFI-13321:
- Fixing the mocking of child components in unit tests.
- Removing any provided dependency that is no longer needed.