### PR TITLE
NIFI-13352 Adjust Shutdown handling in ListenOTLP and Test Class

### DIFF
--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/nifi-opentelemetry-processors/src/main/java/org/apache/nifi/processors/opentelemetry/server/HttpServerFactory.java
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/nifi-opentelemetry-processors/src/main/java/org/apache/nifi/processors/opentelemetry/server/HttpServerFactory.java
@@ -20,6 +20,8 @@ import com.google.protobuf.Message;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import org.apache.nifi.event.transport.configuration.ShutdownQuietPeriod;
+import org.apache.nifi.event.transport.configuration.ShutdownTimeout;
 import org.apache.nifi.event.transport.configuration.TransportProtocol;
 import org.apache.nifi.event.transport.netty.NettyEventServerFactory;
 import org.apache.nifi.event.transport.netty.channel.LogExceptionChannelHandler;
@@ -55,6 +57,9 @@ public class HttpServerFactory extends NettyEventServerFactory {
                 new HttpProtocolNegotiationHandler(log, messages),
                 logExceptionChannelHandler
         ));
+
+        setShutdownQuietPeriod(ShutdownQuietPeriod.QUICK.getDuration());
+        setShutdownTimeout(ShutdownTimeout.QUICK.getDuration());
     }
 
     private SSLParameters getApplicationSslParameters(final SSLContext sslContext) {

--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/nifi-opentelemetry-processors/src/test/java/org/apache/nifi/processors/opentelemetry/ListenOTLPTest.java
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/nifi-opentelemetry-processors/src/test/java/org/apache/nifi/processors/opentelemetry/ListenOTLPTest.java
@@ -45,6 +45,7 @@ import org.apache.nifi.web.client.api.HttpResponseEntity;
 import org.apache.nifi.web.client.api.HttpResponseStatus;
 import org.apache.nifi.web.client.api.WebClientService;
 import org.apache.nifi.web.client.ssl.TlsContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,7 +126,7 @@ class ListenOTLPTest {
 
     private static final byte[] EMPTY_BYTES = new byte[]{};
 
-    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
 
     private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
 
@@ -203,6 +204,11 @@ class ListenOTLPTest {
         });
 
         webClientService = standardWebClientService;
+    }
+
+    @AfterEach
+    void stopRunner() {
+        runner.stop();
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-13352](https://issues.apache.org/jira/browse/NIFI-13352) Adjusts shutdown handling in the `ListenOTLP` Processor and associated test class to mitigate intermittent test failures related to socket connections.

Changes include shortening the shutdown quiet period for the `ListenOTLP` `HttpServerFactory` to avoiding waiting 2 seconds before closing the listening socket, instead waiting 100 ms. Changes to the test class include calling `TestRunner.stop()` in an `AfterEach` method to proactively close listening sockets.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
