### PR TITLE
NIFI-13159 PutFTP/PutSFTP change when delete happens on REPLACE

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/PutFileTransfer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/PutFileTransfer.java
@@ -225,7 +225,6 @@ public abstract class PutFileTransfer<T extends FileTransfer> extends AbstractPr
                 logger.warn("Resolving conflict by rejecting {} due to conflicting filename with a directory or file already on remote server", flowFile);
                 break;
             case FileTransfer.CONFLICT_RESOLUTION_REPLACE:
-                transfer.deleteFile(flowFile, path, fileName);
                 destinationRelationship = REL_SUCCESS;
                 transferFile = true;
                 penalizeFile = false;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
@@ -475,6 +475,18 @@ public class FTPTransfer implements FileTransfer {
         }
 
         if (!filename.equals(tempFilename)) {
+            // if destination fullPath already exists, delete it before rename
+            try {
+                int reply = client.mlst(fullPath);
+                if (FTPReply.isPositiveCompletion(reply)) {
+                    if (!client.deleteFile(fullPath)) {
+                        throw new IOException("Failed to remove file " + fullPath + " due to " + client.getReplyString());
+                    }
+                }
+            } catch (final IOException e) {
+                throw new IOException("Failed to replace remote file " + fullPath, e);
+            }
+
             try {
                 logger.debug("Renaming remote path from {} to {} for {}", tempFilename, filename, flowFile);
                 final boolean renameSuccessful = client.rename(tempFilename, filename);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
@@ -478,7 +478,8 @@ public class FTPTransfer implements FileTransfer {
             try {
                 // file was transferred to a temporary filename, attempt to delete destination filename before rename
                 client.deleteFile(fullPath);
-            } catch (final IOException ignore) {
+            } catch (final IOException e) {
+                logger.debug("Failed to remove {} before renaming temporary file", fullPath, e);
             }
 
             try {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
@@ -475,16 +475,10 @@ public class FTPTransfer implements FileTransfer {
         }
 
         if (!filename.equals(tempFilename)) {
-            // if destination fullPath already exists, delete it before rename
             try {
-                int reply = client.mlst(fullPath);
-                if (FTPReply.isPositiveCompletion(reply)) {
-                    if (!client.deleteFile(fullPath)) {
-                        throw new IOException("Failed to remove file " + fullPath + " due to " + client.getReplyString());
-                    }
-                }
-            } catch (final IOException e) {
-                throw new IOException("Failed to replace remote file " + fullPath, e);
+                // file was transferred to a temporary filename, attempt to delete destination filename before rename
+                client.deleteFile(fullPath);
+            } catch (final IOException ignore) {
             }
 
             try {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
@@ -788,7 +788,8 @@ public class SFTPTransfer implements FileTransfer {
             try {
                 // file was transferred to a temporary filename, attempt to delete destination filename before rename
                 sftpClient.rm(fullPath);
-            } catch (final SFTPException ignore) {
+            } catch (final SFTPException e) {
+                logger.debug("Failed to remove {} before renaming temporary file", fullPath, e);
             }
 
             try {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestServerSFTPTransfer.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/util/TestServerSFTPTransfer.java
@@ -643,27 +643,6 @@ public class TestServerSFTPTransfer {
     }
 
     @Test
-    public void testPutWhenFileAlreadyExists() throws IOException {
-        final String permissions = "rw-rw-rw-";
-
-        final Map<PropertyDescriptor, String> properties = createBaseProperties();
-        properties.put(SFTPTransfer.PERMISSIONS, permissions);
-
-        final String fileContent = "this is a test";
-
-        try (final SFTPTransfer transfer = createSFTPTransfer(properties);
-             final InputStream in = new ByteArrayInputStream(fileContent.getBytes(StandardCharsets.UTF_8))) {
-
-            // Verify file already exists
-            final FileInfo fileInfoBefore = transfer.getRemoteFileInfo(null, DIR_2, FILE_1);
-            assertNotNull(fileInfoBefore);
-
-            // Should fail because file already exists
-            assertThrows(IOException.class, () -> transfer.put(null, DIR_2, FILE_1, in));
-        }
-    }
-
-    @Test
     public void testPutWhenDirectoryDoesNotExist() throws IOException {
         final String permissions = "rw-rw-rw-";
 


### PR DESCRIPTION
# Summary

[NIFI-13159](https://issues.apache.org/jira/browse/NIFI-13159)

For PutFTP/PutSFTP conflict resolution strategy REPLACE, when DOT_RENAME or temp filename is used, delay the deletion of remote file until after temp file transfer completes.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ x Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### UI Contributions

- [x] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
