### PR TITLE
NIFI-13351 Enhance QueryDatabaseTable/Record to not call session.putAttribute multiple times

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractQueryDatabaseTable.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractQueryDatabaseTable.java
@@ -478,19 +478,22 @@ public abstract class AbstractQueryDatabaseTable extends AbstractDatabaseFetchPr
                 // Even though the maximum value and total count are known at this point, to maintain consistent behavior if Output Batch Size is set, do not store the attributes
                 if (outputBatchSize == 0) {
                     for (int i = 0; i < resultSetFlowFiles.size(); i++) {
+                        final Map<String, String> newAttributesMap = new HashMap<>();
+
                         // Add maximum values as attributes
                         for (Map.Entry<String, String> entry : statePropertyMap.entrySet()) {
                             // Get just the column name from the key
                             String key = entry.getKey();
                             String colName = key.substring(key.lastIndexOf(NAMESPACE_DELIMITER) + NAMESPACE_DELIMITER.length());
-                            resultSetFlowFiles.set(i, session.putAttribute(resultSetFlowFiles.get(i), "maxvalue." + colName, entry.getValue()));
+                            newAttributesMap.put("maxvalue." + colName, entry.getValue());
                         }
 
-                        //set count on all FlowFiles
+                        // Set count for all FlowFiles
                         if (maxRowsPerFlowFile > 0) {
-                            resultSetFlowFiles.set(i,
-                                    session.putAttribute(resultSetFlowFiles.get(i), FRAGMENT_COUNT, Integer.toString(fragmentIndex)));
+                            newAttributesMap.put(FRAGMENT_COUNT, Integer.toString(fragmentIndex));
                         }
+
+                        resultSetFlowFiles.set(i, session.putAllAttributes(resultSetFlowFiles.get(i), newAttributesMap));
                     }
                 }
             } catch (final SQLException e) {


### PR DESCRIPTION
NIFI-13351 Enhance QueryDatabaseTable and QueryDatabaseTableRecord processors not to call session.putAttribute multiple times

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13351](https://issues.apache.org/jira/browse/NIFI-13351)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-13351) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-13351`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-13351`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

I checked that existing unit tests exercised the new code and existing tests provided good coverage.
I also run the new code in the NiFi and tested the processor and looked at flow files and confirmed that the attributes written by the new code really appeared in the output flow files.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

No UI changes

### Licensing

No new files or dependencies

### Documentation

No documentation changes needed.
