### PR TITLE
NIFI-13357 Remove APP_INSTALLATION_TOKEN from GitHubFlowRegistryClient

### DIFF
--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubAuthenticationType.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubAuthenticationType.java
@@ -17,13 +17,40 @@
 
 package org.apache.nifi.github;
 
+import org.apache.nifi.components.DescribedValue;
+
 /**
  * Enumeration of authentication types for the GitHub client.
  */
-public enum GitHubAuthenticationType {
+public enum GitHubAuthenticationType implements DescribedValue {
 
-    NONE,
-    PERSONAL_ACCESS_TOKEN,
-    APP_INSTALLATION_TOKEN,
-    APP_INSTALLATION
+    NONE("None", "Authentication disabled"),
+
+    PERSONAL_ACCESS_TOKEN("Personal Access Token", "User-based Personal Access Token"),
+
+    APP_INSTALLATION("App Installation", "App-based Installation Token provisioning from a Private Key");
+
+    private final String displayName;
+
+    private final String description;
+
+    GitHubAuthenticationType(final String displayName, final String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
 }

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubFlowRegistryClient.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubFlowRegistryClient.java
@@ -106,7 +106,7 @@ public class GitHubFlowRegistryClient extends AbstractFlowRegistryClient {
     static final PropertyDescriptor AUTHENTICATION_TYPE = new PropertyDescriptor.Builder()
             .name("Authentication Type")
             .description("The type of authentication to use for accessing GitHub")
-            .allowableValues(GitHubAuthenticationType.values())
+            .allowableValues(GitHubAuthenticationType.class)
             .defaultValue(GitHubAuthenticationType.NONE.name())
             .required(true)
             .build();
@@ -118,15 +118,6 @@ public class GitHubFlowRegistryClient extends AbstractFlowRegistryClient {
             .required(true)
             .sensitive(true)
             .dependsOn(AUTHENTICATION_TYPE, GitHubAuthenticationType.PERSONAL_ACCESS_TOKEN.name())
-            .build();
-
-    static final PropertyDescriptor APP_INSTALLATION_TOKEN = new PropertyDescriptor.Builder()
-            .name("App Installation Token")
-            .description("The app installation token to use for authentication")
-            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-            .required(true)
-            .sensitive(true)
-            .dependsOn(AUTHENTICATION_TYPE, GitHubAuthenticationType.APP_INSTALLATION_TOKEN.name())
             .build();
 
     static final PropertyDescriptor APP_ID = new PropertyDescriptor.Builder()
@@ -155,7 +146,6 @@ public class GitHubFlowRegistryClient extends AbstractFlowRegistryClient {
             REPOSITORY_PATH,
             AUTHENTICATION_TYPE,
             PERSONAL_ACCESS_TOKEN,
-            APP_INSTALLATION_TOKEN,
             APP_ID,
             APP_PRIVATE_KEY
     );
@@ -660,7 +650,6 @@ public class GitHubFlowRegistryClient extends AbstractFlowRegistryClient {
                 .apiUrl(context.getProperty(GITHUB_API_URL).getValue())
                 .authenticationType(GitHubAuthenticationType.valueOf(context.getProperty(AUTHENTICATION_TYPE).getValue()))
                 .personalAccessToken(context.getProperty(PERSONAL_ACCESS_TOKEN).getValue())
-                .appInstallationToken(context.getProperty(APP_INSTALLATION_TOKEN).getValue())
                 .appId(context.getProperty(APP_ID).getValue())
                 .appPrivateKey(context.getProperty(APP_PRIVATE_KEY).getValue())
                 .repoOwner(context.getProperty(REPOSITORY_OWNER).getValue())

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubRepositoryClient.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubRepositoryClient.java
@@ -86,7 +86,6 @@ public class GitHubRepositoryClient {
 
         switch (authenticationType) {
             case PERSONAL_ACCESS_TOKEN -> gitHubBuilder.withOAuthToken(builder.personalAccessToken);
-            case APP_INSTALLATION_TOKEN -> gitHubBuilder.withAppInstallationToken(builder.appInstallationToken);
             case APP_INSTALLATION -> gitHubBuilder.withAuthorizationProvider(getAppInstallationAuthorizationProvider(builder, appPermissions));
         }
 
@@ -462,7 +461,6 @@ public class GitHubRepositoryClient {
         private String apiUrl;
         private GitHubAuthenticationType authenticationType;
         private String personalAccessToken;
-        private String appInstallationToken;
         private String repoOwner;
         private String repoName;
         private String repoPath;
@@ -481,11 +479,6 @@ public class GitHubRepositoryClient {
 
         public Builder personalAccessToken(final String personalAccessToken) {
             this.personalAccessToken = personalAccessToken;
-            return this;
-        }
-
-        public Builder appInstallationToken(final String appInstallationToken) {
-            this.appInstallationToken = appInstallationToken;
             return this;
         }
 


### PR DESCRIPTION
# Summary

[NIFI-13357](https://issues.apache.org/jira/browse/NIFI-13357) Removes the `APP_INSTALLATION_TOKEN` Authentication option from the `GitHubFlowRegistryClient` in favor of the `APP_INSTALLATION` option implemented in 
[NIFI-13231](https://issues.apache.org/jira/browse/NIFI-13231).

The `APP_INSTALLATION_TOKEN` option required external token provision to produce and sign a JWT with a short expiration, which was not optimal for long-lived access to GitHub repositories. The new `APP_INSTALLATION` option integrates App Installation Token provision using a configured App ID and Private Key, supporting long-lived service-based access. As the initial version was released in NiFi 2.0.0-M3, this is a breaking change, but the impact should be minimal based on the expiration issues with external token provisioning.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
