### PR TITLE
NIFI-13358 - NiFi Registry - rework action menus for flows and bundles

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/explorer/grid-list/dialogs/delete-bundle-version/nf-registry-delete-bundle-version.html
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/explorer/grid-list/dialogs/delete-bundle-version/nf-registry-delete-bundle-version.html
@@ -1,0 +1,53 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div id="nifi-registry-delete-bundle-version-dialog">
+    <div class="pad-bottom-md" fxLayout="row" fxLayoutAlign="space-between center">
+        <mat-card-title>
+            Delete Bundle Version
+        </mat-card-title>
+        <button mat-icon-button (click)="cancel()">
+            <mat-icon color="primary">close</mat-icon>
+        </button>
+    </div>
+    <div fxLayout="column" fxLayoutAlign="space-between start" class="pad-bottom-sm">
+        <div class="pad-bottom-sm label-name">
+            <label>Choose Version</label>
+        </div>
+        <div class="fill-available-width bundle-version-dropdown-field">
+            <mat-form-field appearance="fill" fxFlex>
+                <mat-select panelClass="bundle-version-dropdown-select" [(value)]="selectedVersion">
+                    <mat-option *ngFor="let snapshotMeta of droplet.snapshotMetadata" [value]="snapshotMeta.version">
+                        <span *ngIf="snapshotMeta === droplet.snapshotMetadata[0]">Latest (Version {{snapshotMeta.version}})</span>
+                        <span *ngIf="snapshotMeta != droplet.snapshotMetadata[0]">Version {{snapshotMeta.version}}</span>
+                    </mat-option>
+                </mat-select>
+            </mat-form-field>
+        </div>
+    </div>
+    <div fxLayout="row">
+        <span fxFlex></span>
+        <button (click)="cancel()" color="fds-regular" mat-raised-button
+                i18n="Cancel deletion of bundle version selection|A button to cancel the deletion of the bundle version from the registry.">
+            Cancel
+        </button>
+        <button class="push-left-sm" data-automation-id="delete-bundle-version-button" (click)="deleteVersion()"
+                color="fds-primary" mat-raised-button i18n="Delete the selected bundle version|A button to delete the bundle version from the registry.">
+            Delete
+        </button>
+    </div>
+</div>

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/explorer/grid-list/dialogs/delete-bundle-version/nf-registry-delete-bundle-version.js
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/explorer/grid-list/dialogs/delete-bundle-version/nf-registry-delete-bundle-version.js
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from '@angular/core';
+import NfRegistryApi from 'services/nf-registry.api';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FdsSnackBarService } from '@nifi-fds/core';
+
+/**
+ * NfRegistryDeleteBundleVersion constructor.
+ *
+ * @param nfRegistryApi         The api service.
+ * @param fdsSnackBarService    The FDS snack bar service module.
+ * @param matDialogRef          The angular material dialog ref.
+ * @param data                  The data passed into this component.
+ * @constructor
+ */
+function NfRegistryDeleteBundleVersion(nfRegistryApi, fdsSnackBarService, matDialogRef, data) {
+    // Services
+    this.snackBarService = fdsSnackBarService;
+    this.nfRegistryApi = nfRegistryApi;
+    this.dialogRef = matDialogRef;
+    // local state
+    this.keepDialogOpen = false;
+    this.protocol = location.protocol;
+    this.droplet = data.droplet;
+    this.selectedVersion = this.droplet.snapshotMetadata[0].version;
+}
+
+NfRegistryDeleteBundleVersion.prototype = {
+    constructor: NfRegistryDeleteBundleVersion,
+
+    /**
+     * Delete specified bundle version.
+     */
+    deleteVersion: function () {
+        var self = this;
+        var version = this.selectedVersion;
+
+        this.nfRegistryApi.deleteBundleVersion(this.droplet.link.href, version).subscribe(function (response) {
+            if (!response.status || response.status === 200) {
+                self.snackBarService.openCoaster({
+                    title: 'Success',
+                    message: 'Bundle version successfully deleted.',
+                    verticalPosition: 'bottom',
+                    horizontalPosition: 'right',
+                    icon: 'fa fa-check-circle-o',
+                    color: '#1EB475',
+                    duration: 3000
+                });
+
+                if (self.keepDialogOpen !== true) {
+                    self.dialogRef.close();
+                }
+            } else {
+                self.dialogRef.close();
+            }
+        });
+    },
+
+    /**
+     * Cancel the deletion of the bundle version and close dialog.
+     */
+    cancel: function () {
+        this.dialogRef.close();
+    }
+};
+
+NfRegistryDeleteBundleVersion.annotations = [
+    new Component({
+        templateUrl: './nf-registry-delete-bundle-version.html'
+    })
+];
+
+NfRegistryDeleteBundleVersion.parameters = [
+    NfRegistryApi,
+    FdsSnackBarService,
+    MatDialogRef,
+    MAT_DIALOG_DATA
+];
+
+export default NfRegistryDeleteBundleVersion;

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/explorer/grid-list/dialogs/download-bundle-version/nf-registry-download-bundle-version.html
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/explorer/grid-list/dialogs/download-bundle-version/nf-registry-download-bundle-version.html
@@ -1,0 +1,53 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div id="nifi-registry-download-bundle-version-dialog">
+    <div class="pad-bottom-md" fxLayout="row" fxLayoutAlign="space-between center">
+        <mat-card-title>
+            Download Bundle Version
+        </mat-card-title>
+        <button mat-icon-button (click)="cancel()">
+            <mat-icon color="primary">close</mat-icon>
+        </button>
+    </div>
+    <div fxLayout="column" fxLayoutAlign="space-between start" class="pad-bottom-sm">
+        <div class="pad-bottom-sm label-name">
+            <label>Choose Version</label>
+        </div>
+        <div class="fill-available-width bundle-version-dropdown-field">
+            <mat-form-field appearance="fill" fxFlex>
+                <mat-select panelClass="bundle-version-dropdown-select" [(value)]="selectedVersion">
+                    <mat-option *ngFor="let snapshotMeta of droplet.snapshotMetadata" [value]="snapshotMeta.version">
+                        <span *ngIf="snapshotMeta === droplet.snapshotMetadata[0]">Latest (Version {{snapshotMeta.version}})</span>
+                        <span *ngIf="snapshotMeta != droplet.snapshotMetadata[0]">Version {{snapshotMeta.version}}</span>
+                    </mat-option>
+                </mat-select>
+            </mat-form-field>
+        </div>
+    </div>
+    <div fxLayout="row">
+        <span fxFlex></span>
+        <button (click)="cancel()" color="fds-regular" mat-raised-button
+                i18n="Cancel the download of the bundle version|A button to cancel the download of the bundle version from the registry.">
+            Cancel
+        </button>
+        <button class="push-left-sm" data-automation-id="download-bundle-version-button" (click)="downloadVersion()"
+                color="fds-primary" mat-raised-button i18n="Download the selected bundle version|A button to download the selected bundle version from the registry.">
+            Download
+        </button>
+    </div>
+</div>

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/explorer/grid-list/dialogs/download-bundle-version/nf-registry-download-bundle-version.js
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/explorer/grid-list/dialogs/download-bundle-version/nf-registry-download-bundle-version.js
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from '@angular/core';
+import NfRegistryApi from 'services/nf-registry.api';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FdsSnackBarService } from '@nifi-fds/core';
+
+/**
+ * NfRegistryDownloadBundleVersion constructor.
+ *
+ * @param nfRegistryApi         The api service.
+ * @param fdsSnackBarService    The FDS snack bar service module.
+ * @param matDialogRef          The angular material dialog ref.
+ * @param data                  The data passed into this component.
+ * @constructor
+ */
+function NfRegistryDownloadBundleVersion(nfRegistryApi, fdsSnackBarService, matDialogRef, data) {
+    // Services
+    this.snackBarService = fdsSnackBarService;
+    this.nfRegistryApi = nfRegistryApi;
+    this.dialogRef = matDialogRef;
+    // local state
+    this.keepDialogOpen = false;
+    this.protocol = location.protocol;
+    this.droplet = data.droplet;
+    this.selectedVersion = this.droplet.snapshotMetadata[0].version;
+}
+
+NfRegistryDownloadBundleVersion.prototype = {
+    constructor: NfRegistryDownloadBundleVersion,
+
+    /**
+     * Download the selected bundle version
+     */
+    downloadVersion: function () {
+        var self = this;
+        var version = this.selectedVersion;
+
+        this.nfRegistryApi.downloadBundleVersion(this.droplet.link.href, version, this.droplet.artifactId).subscribe(function (response) {
+            if (!response.status || response.status === 200) {
+                self.snackBarService.openCoaster({
+                    title: 'Success',
+                    message: 'Successfully downloaded the bundle version.',
+                    verticalPosition: 'bottom',
+                    horizontalPosition: 'right',
+                    icon: 'fa fa-check-circle-o',
+                    color: '#1EB475',
+                    duration: 3000
+                });
+
+                if (self.keepDialogOpen !== true) {
+                    self.dialogRef.close();
+                }
+            } else {
+                self.dialogRef.close();
+            }
+        });
+    },
+
+    /**
+     * Cancel an export of a version and close dialog.
+     */
+    cancel: function () {
+        this.dialogRef.close();
+    }
+};
+
+NfRegistryDownloadBundleVersion.annotations = [
+    new Component({
+        templateUrl: './nf-registry-download-bundle-version.html'
+    })
+];
+
+NfRegistryDownloadBundleVersion.parameters = [
+    NfRegistryApi,
+    FdsSnackBarService,
+    MatDialogRef,
+    MAT_DIALOG_DATA
+];
+
+export default NfRegistryDownloadBundleVersion;

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/explorer/grid-list/registry/nf-registry-grid-list-viewer.html
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/components/explorer/grid-list/registry/nf-registry-grid-list-viewer.html
@@ -74,7 +74,7 @@ limitations under the License.
                         </button>
                         <mat-menu class="fds-primary-dropdown-button-menu" #primaryButtonDropdownMenu="matMenu"
                                   [overlapTrigger]="false">
-                            <button mat-menu-item *ngFor="let action of nfRegistryService.dropletActions"
+                            <button mat-menu-item *ngFor="let action of nfRegistryService.getDropletActions(droplet)"
                                     [disabled]="action.disabled(droplet)"
                                     (click)="nfRegistryService.executeDropletAction(action, droplet)">
                                 {{action.name}}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/nf-registry.module.js
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/nf-registry.module.js
@@ -55,6 +55,8 @@ import {
 import NfRegistryImportVersionedFlow from './components/explorer/grid-list/dialogs/import-versioned-flow/nf-registry-import-versioned-flow';
 import NfRegistryImportNewFlow from './components/explorer/grid-list/dialogs/import-new-flow/nf-registry-import-new-flow';
 import NfRegistryExportVersionedFlow from './components/explorer/grid-list/dialogs/export-versioned-flow/nf-registry-export-versioned-flow';
+import NfRegistryDeleteBundleVersion from './components/explorer/grid-list/dialogs/delete-bundle-version/nf-registry-delete-bundle-version';
+import NfRegistryDownloadBundleVersion from './components/explorer/grid-list/dialogs/download-bundle-version/nf-registry-download-bundle-version';
 import { NfRegistryExplorerAbout } from './components/explorer/dialogs/about/nf-registry-explorer-about';
 
 function NfRegistryModule() {
@@ -97,7 +99,9 @@ NfRegistryModule.annotations = [
             NfUserLoginComponent,
             NfRegistryExportVersionedFlow,
             NfRegistryImportVersionedFlow,
-            NfRegistryImportNewFlow
+            NfRegistryImportNewFlow,
+            NfRegistryDeleteBundleVersion,
+            NfRegistryDownloadBundleVersion
         ],
         entryComponents: [
             NfRegistryAddUser,
@@ -111,6 +115,8 @@ NfRegistryModule.annotations = [
             NfRegistryExportVersionedFlow,
             NfRegistryImportVersionedFlow,
             NfRegistryImportNewFlow,
+            NfRegistryDeleteBundleVersion,
+            NfRegistryDownloadBundleVersion,
             NfRegistryExplorerAbout
         ],
         providers: [


### PR DESCRIPTION
# Summary

[NIFI-13358](https://issues.apache.org/jira/browse/NIFI-13358) - NiFi Registry - rework action menus for flows and bundles

![Screenshot 2024-06-04 at 17 14 23](https://github.com/apache/nifi/assets/11541012/9f2de09f-3a51-432f-8161-e64a801d0904)
![Screenshot 2024-06-04 at 17 14 10](https://github.com/apache/nifi/assets/11541012/3ae73dab-c153-4d75-a100-27e1a655c16a)
![Screenshot 2024-06-04 at 17 13 52](https://github.com/apache/nifi/assets/11541012/af4de72a-ffea-47b6-8647-453879f41cf3)
![Screenshot 2024-06-04 at 17 13 34](https://github.com/apache/nifi/assets/11541012/c7eb33a9-421c-45b3-9b7c-156b7381c88c)
![Screenshot 2024-06-04 at 17 12 32](https://github.com/apache/nifi/assets/11541012/7533c682-896f-45cb-b7b3-d3753e93b935)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### UI Contributions

- [ ] NiFi is modernizing its UI. Any contributions that update the [current UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui) also need to be implemented in the [new UI](https://github.com/apache/nifi/tree/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi).  

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
