### PR TITLE
NIFI-13196 Backport: Add a new isAutoTerminated(Relationship) method

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/processor/ProcessContext.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/ProcessContext.java
@@ -130,6 +130,13 @@ public interface ProcessContext extends PropertyContext, ClusterContext {
     Set<Relationship> getAvailableRelationships();
 
     /**
+     * Indicates whether or not the given relationship is configured to be auto-terminated
+     * @param relationship the relationship
+     * @return <code>true</code> if the given relationship is auto-terminated, <code>false</code> otherwise
+     */
+    boolean isAutoTerminated(Relationship relationship);
+
+    /**
      * @return true if the processor has one or more incoming connections,
      * false otherwise
      */

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessContext.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessContext.java
@@ -465,6 +465,11 @@ public class MockProcessContext extends MockControllerServiceLookup implements P
         return relationships;
     }
 
+    @Override
+    public boolean isAutoTerminated(final Relationship relationship) {
+        return false;
+    }
+
     public void setUnavailableRelationships(final Set<Relationship> relationships) {
         this.unavailableRelationships = Collections.unmodifiableSet(new HashSet<>(relationships));
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/scheduling/ConnectableProcessContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/scheduling/ConnectableProcessContext.java
@@ -260,6 +260,11 @@ public class ConnectableProcessContext implements ProcessContext {
     }
 
     @Override
+    public boolean isAutoTerminated(final Relationship relationship) {
+        return connectable.isAutoTerminated(relationship);
+    }
+
+    @Override
     public boolean hasIncomingConnection() {
         return connectable.hasIncomingConnection();
     }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/StandardProcessContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/processor/StandardProcessContext.java
@@ -303,6 +303,11 @@ public class StandardProcessContext implements ProcessContext, ControllerService
     }
 
     @Override
+    public boolean isAutoTerminated(final Relationship relationship) {
+        return procNode.isAutoTerminated(relationship);
+    }
+
+    @Override
     public String getControllerServiceName(final String serviceIdentifier) {
         verifyTaskActive();
         return controllerServiceProvider.getControllerServiceName(serviceIdentifier);

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/mock/MockProcessContext.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/mock/MockProcessContext.java
@@ -96,6 +96,11 @@ public class MockProcessContext implements ProcessContext {
     }
 
     @Override
+    public boolean isAutoTerminated(final Relationship relationship) {
+        return false;
+    }
+
+    @Override
     public boolean hasIncomingConnection() {
         return true;
     }


### PR DESCRIPTION
 to ProcessContext

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13196](https://issues.apache.org/jira/browse/NIFI-13196)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-13196) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-13196`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-13196`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

I compiled with contrib-check and I ran some flows in the UI.  

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### UI Contributions

No UI changes

### Licensing

No new files or dependencies

### Documentation

No documentation changes
