### PR TITLE
[NIFI-13370] - dark-mode support for browser inputs

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/assets/styles/_app.scss
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-frontend/src/main/nifi/apps/nifi/src/assets/styles/_app.scss
@@ -233,6 +233,15 @@
     $material-theme-warn-palette-lighter: mat.get-color-from-palette($material-theme-warn-palette, lighter);
     $material-theme-warn-palette-darker: mat.get-color-from-palette($material-theme-warn-palette, darker);
 
+    // support dark-mode browser default inputs (time, color, ...)
+    input {
+        color-scheme: if(
+                $is-dark,
+                dark,
+                light
+        );
+    }
+
     // semantic classes for the material theme
 
     .primary-contrast {


### PR DESCRIPTION
[NIFI-13370](https://issues.apache.org/jira/browse/NIFI-13370)
<img width="349" alt="Screenshot 2024-06-06 at 10 44 08 AM" src="https://github.com/apache/nifi/assets/713866/b57a8268-9232-4562-a1d4-e3b8f41f4df7">
<img width="264" alt="Screenshot 2024-06-06 at 10 44 49 AM" src="https://github.com/apache/nifi/assets/713866/b3deac0b-4094-4a27-939c-4ee4f8ea8e1b">
