### PR TITLE
NIFI-13031 Allow rest call - /flow/process-groups/{id}/status to be more accurate when using nodewise option

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ConnectionStatusSnapshotDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ConnectionStatusSnapshotDTO.java
@@ -321,6 +321,7 @@ public class ConnectionStatusSnapshotDTO implements Cloneable {
         other.setQueuedSize(getQueuedSize());
         other.setPercentUseBytes(getPercentUseBytes());
         other.setPercentUseCount(getPercentUseCount());
+        other.setFlowFileAvailability(getFlowFileAvailability());
 
         return other;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessGroupStatusSnapshotDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessGroupStatusSnapshotDTO.java
@@ -566,9 +566,7 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
         if (connectionStatusSnapshots != null) {
             final List<ConnectionStatusSnapshotEntity> collectionStatusSnapshotEntities = new ArrayList<>();
             for (final ConnectionStatusSnapshotEntity connectionStatusSnapshotEntity : connectionStatusSnapshots) {
-                ConnectionStatusSnapshotEntity clone = connectionStatusSnapshotEntity.clone();
-                clone.setId(connectionStatusSnapshotEntity.getId());
-                collectionStatusSnapshotEntities.add(clone);
+                collectionStatusSnapshotEntities.add(connectionStatusSnapshotEntity.clone());
             }
             other.setConnectionStatusSnapshots(collectionStatusSnapshotEntities);
         }
@@ -576,9 +574,7 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
         if (processorStatusSnapshots != null) {
             final List<ProcessorStatusSnapshotEntity> processorStatusSnapshotEntities = new ArrayList<>();
             for (final ProcessorStatusSnapshotEntity processorStatusSnapshotEntity : processorStatusSnapshots) {
-                ProcessorStatusSnapshotEntity clone = processorStatusSnapshotEntity.clone();
-                clone.setId(processorStatusSnapshotEntity.getId());
-                processorStatusSnapshotEntities.add(clone);
+                processorStatusSnapshotEntities.add(processorStatusSnapshotEntity.clone());
             }
             other.setProcessorStatusSnapshots(processorStatusSnapshotEntities);
         }
@@ -586,9 +582,7 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
         if (remoteProcessGroupStatusSnapshots != null) {
             final List<RemoteProcessGroupStatusSnapshotEntity> remoteProcessGroupStatusSnapshotEntities = new ArrayList<>();
             for (final RemoteProcessGroupStatusSnapshotEntity remoteProcessGroupStatusSnapshotEntity : remoteProcessGroupStatusSnapshots) {
-                RemoteProcessGroupStatusSnapshotEntity clone = remoteProcessGroupStatusSnapshotEntity.clone();
-                clone.setId(remoteProcessGroupStatusSnapshotEntity.getId());
-                remoteProcessGroupStatusSnapshotEntities.add(clone);
+                remoteProcessGroupStatusSnapshotEntities.add(remoteProcessGroupStatusSnapshotEntity.clone());
             }
             other.setRemoteProcessGroupStatusSnapshots(remoteProcessGroupStatusSnapshotEntities);
         }
@@ -599,9 +593,7 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
         if (processGroupStatusSnapshots != null) {
             final List<ProcessGroupStatusSnapshotEntity> childGroups = new ArrayList<>();
             for (final ProcessGroupStatusSnapshotEntity procGroupStatus : processGroupStatusSnapshots) {
-                ProcessGroupStatusSnapshotEntity clone = procGroupStatus.clone();
-                clone.setId(procGroupStatus.getId());
-                childGroups.add(clone);
+                childGroups.add(procGroupStatus.clone());
             }
             other.setProcessGroupStatusSnapshots(childGroups);
         }
@@ -613,9 +605,7 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
         if (portStatusSnapshots != null) {
             final List<PortStatusSnapshotEntity> portStatusSnapshotEntities = new ArrayList<>();
             for (final PortStatusSnapshotEntity portStatusSnapshotEntity : portStatusSnapshots) {
-               PortStatusSnapshotEntity clone = portStatusSnapshotEntity.clone();
-               clone.setId(portStatusSnapshotEntity.getId());
-               portStatusSnapshotEntities.add(clone);
+               portStatusSnapshotEntities.add(portStatusSnapshotEntity.clone());
             }
             return portStatusSnapshotEntities;
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessGroupStatusSnapshotDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessGroupStatusSnapshotDTO.java
@@ -563,9 +563,9 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
 
         other.setProcessingNanos(getProcessingNanos());
 
-        if (getConnectionStatusSnapshots() != null) {
+        if (connectionStatusSnapshots != null) {
             final List<ConnectionStatusSnapshotEntity> collectionStatusSnapshotEntities = new ArrayList<>();
-            for (final ConnectionStatusSnapshotEntity connectionStatusSnapshotEntity :  getConnectionStatusSnapshots()) {
+            for (final ConnectionStatusSnapshotEntity connectionStatusSnapshotEntity : connectionStatusSnapshots) {
                 ConnectionStatusSnapshotEntity clone = connectionStatusSnapshotEntity.clone();
                 clone.setId(connectionStatusSnapshotEntity.getId());
                 collectionStatusSnapshotEntities.add(clone);
@@ -573,9 +573,9 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
             other.setConnectionStatusSnapshots(collectionStatusSnapshotEntities);
         }
 
-        if (getProcessorStatusSnapshots() != null) {
+        if (processorStatusSnapshots != null) {
             final List<ProcessorStatusSnapshotEntity> processorStatusSnapshotEntities = new ArrayList<>();
-            for (final ProcessorStatusSnapshotEntity processorStatusSnapshotEntity :  getProcessorStatusSnapshots() ) {
+            for (final ProcessorStatusSnapshotEntity processorStatusSnapshotEntity : processorStatusSnapshots) {
                 ProcessorStatusSnapshotEntity clone = processorStatusSnapshotEntity.clone();
                 clone.setId(processorStatusSnapshotEntity.getId());
                 processorStatusSnapshotEntities.add(clone);
@@ -583,9 +583,9 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
             other.setProcessorStatusSnapshots(processorStatusSnapshotEntities);
         }
 
-        if (getRemoteProcessGroupStatusSnapshots() != null) {
+        if (remoteProcessGroupStatusSnapshots != null) {
             final List<RemoteProcessGroupStatusSnapshotEntity> remoteProcessGroupStatusSnapshotEntities = new ArrayList<>();
-            for (final RemoteProcessGroupStatusSnapshotEntity remoteProcessGroupStatusSnapshotEntity :  getRemoteProcessGroupStatusSnapshots() ) {
+            for (final RemoteProcessGroupStatusSnapshotEntity remoteProcessGroupStatusSnapshotEntity : remoteProcessGroupStatusSnapshots) {
                 RemoteProcessGroupStatusSnapshotEntity clone = remoteProcessGroupStatusSnapshotEntity.clone();
                 clone.setId(remoteProcessGroupStatusSnapshotEntity.getId());
                 remoteProcessGroupStatusSnapshotEntities.add(clone);
@@ -593,25 +593,8 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
             other.setRemoteProcessGroupStatusSnapshots(remoteProcessGroupStatusSnapshotEntities);
         }
 
-        if (getInputPortStatusSnapshots() != null) {
-            final List<PortStatusSnapshotEntity> portStatusSnapshotEntities = new ArrayList<>();
-            for (final PortStatusSnapshotEntity portStatusSnapshotEntity :  getInputPortStatusSnapshots()) {
-               PortStatusSnapshotEntity clone = portStatusSnapshotEntity.clone();
-               clone.setId(portStatusSnapshotEntity.getId());
-               portStatusSnapshotEntities.add(clone);
-            }
-            other.setInputPortStatusSnapshots(portStatusSnapshotEntities);
-        }
-
-        if (getOutputPortStatusSnapshots() != null) {
-            final List<PortStatusSnapshotEntity> portStatusSnapshotEntities = new ArrayList<>();
-            for (final PortStatusSnapshotEntity portStatusSnapshotEntity :  getOutputPortStatusSnapshots()) {
-                PortStatusSnapshotEntity clone = portStatusSnapshotEntity.clone();
-                clone.setId(portStatusSnapshotEntity.getId());
-                portStatusSnapshotEntities.add(clone);
-            }
-            other.setOutputPortStatusSnapshots(portStatusSnapshotEntities);
-        }
+        other.setInputPortStatusSnapshots(copyPortStatusSnapshots(inputPortStatusSnapshots));
+        other.setOutputPortStatusSnapshots(copyPortStatusSnapshots(outputPortStatusSnapshots));
 
         if (processGroupStatusSnapshots != null) {
             final List<ProcessGroupStatusSnapshotEntity> childGroups = new ArrayList<>();
@@ -624,5 +607,19 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
         }
 
         return other;
+    }
+
+    private Collection<PortStatusSnapshotEntity> copyPortStatusSnapshots(Collection<PortStatusSnapshotEntity> portStatusSnapshots) {
+        if (portStatusSnapshots != null) {
+            final List<PortStatusSnapshotEntity> portStatusSnapshotEntities = new ArrayList<>();
+            for (final PortStatusSnapshotEntity portStatusSnapshotEntity : portStatusSnapshots) {
+               PortStatusSnapshotEntity clone = portStatusSnapshotEntity.clone();
+               clone.setId(portStatusSnapshotEntity.getId());
+               portStatusSnapshotEntities.add(clone);
+            }
+            return portStatusSnapshotEntities;
+        }
+
+        return null;
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessGroupStatusSnapshotDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessGroupStatusSnapshotDTO.java
@@ -563,28 +563,66 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
 
         other.setProcessingNanos(getProcessingNanos());
 
-        other.setConnectionStatusSnapshots(copy(getConnectionStatusSnapshots()));
-        other.setProcessorStatusSnapshots(copy(getProcessorStatusSnapshots()));
-        other.setRemoteProcessGroupStatusSnapshots(copy(getRemoteProcessGroupStatusSnapshots()));
-        other.setInputPortStatusSnapshots(copy(getInputPortStatusSnapshots()));
-        other.setOutputPortStatusSnapshots(copy(getOutputPortStatusSnapshots()));
+        if (getConnectionStatusSnapshots() != null) {
+            final List<ConnectionStatusSnapshotEntity> collectionStatusSnapshotEntities = new ArrayList<>();
+            for (final ConnectionStatusSnapshotEntity connectionStatusSnapshotEntity :  getConnectionStatusSnapshots()) {
+                ConnectionStatusSnapshotEntity clone = connectionStatusSnapshotEntity.clone();
+                clone.setId(connectionStatusSnapshotEntity.getId());
+                collectionStatusSnapshotEntities.add(clone);
+            }
+            other.setConnectionStatusSnapshots(collectionStatusSnapshotEntities);
+        }
+
+        if (getProcessorStatusSnapshots() != null) {
+            final List<ProcessorStatusSnapshotEntity> processorStatusSnapshotEntities = new ArrayList<>();
+            for (final ProcessorStatusSnapshotEntity processorStatusSnapshotEntity :  getProcessorStatusSnapshots() ) {
+                ProcessorStatusSnapshotEntity clone = processorStatusSnapshotEntity.clone();
+                clone.setId(processorStatusSnapshotEntity.getId());
+                processorStatusSnapshotEntities.add(clone);
+            }
+            other.setProcessorStatusSnapshots(processorStatusSnapshotEntities);
+        }
+
+        if (getRemoteProcessGroupStatusSnapshots() != null) {
+            final List<RemoteProcessGroupStatusSnapshotEntity> remoteProcessGroupStatusSnapshotEntities = new ArrayList<>();
+            for (final RemoteProcessGroupStatusSnapshotEntity remoteProcessGroupStatusSnapshotEntity :  getRemoteProcessGroupStatusSnapshots() ) {
+                RemoteProcessGroupStatusSnapshotEntity clone = remoteProcessGroupStatusSnapshotEntity.clone();
+                clone.setId(remoteProcessGroupStatusSnapshotEntity.getId());
+                remoteProcessGroupStatusSnapshotEntities.add(clone);
+            }
+            other.setRemoteProcessGroupStatusSnapshots(remoteProcessGroupStatusSnapshotEntities);
+        }
+
+        if (getInputPortStatusSnapshots() != null) {
+            final List<PortStatusSnapshotEntity> portStatusSnapshotEntities = new ArrayList<>();
+            for (final PortStatusSnapshotEntity portStatusSnapshotEntity :  getInputPortStatusSnapshots()) {
+               PortStatusSnapshotEntity clone = portStatusSnapshotEntity.clone();
+               clone.setId(portStatusSnapshotEntity.getId());
+               portStatusSnapshotEntities.add(clone);
+            }
+            other.setInputPortStatusSnapshots(portStatusSnapshotEntities);
+        }
+
+        if (getOutputPortStatusSnapshots() != null) {
+            final List<PortStatusSnapshotEntity> portStatusSnapshotEntities = new ArrayList<>();
+            for (final PortStatusSnapshotEntity portStatusSnapshotEntity :  getOutputPortStatusSnapshots()) {
+                PortStatusSnapshotEntity clone = portStatusSnapshotEntity.clone();
+                clone.setId(portStatusSnapshotEntity.getId());
+                portStatusSnapshotEntities.add(clone);
+            }
+            other.setOutputPortStatusSnapshots(portStatusSnapshotEntities);
+        }
 
         if (processGroupStatusSnapshots != null) {
             final List<ProcessGroupStatusSnapshotEntity> childGroups = new ArrayList<>();
             for (final ProcessGroupStatusSnapshotEntity procGroupStatus : processGroupStatusSnapshots) {
-                childGroups.add(procGroupStatus.clone());
+                ProcessGroupStatusSnapshotEntity clone = procGroupStatus.clone();
+                clone.setId(procGroupStatus.getId());
+                childGroups.add(clone);
             }
             other.setProcessGroupStatusSnapshots(childGroups);
         }
 
         return other;
-    }
-
-    private <T> Collection<T> copy(final Collection<T> original) {
-        if (original == null) {
-            return null;
-        }
-
-        return new ArrayList<T>(original);
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ConnectionStatisticsSnapshotEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ConnectionStatisticsSnapshotEntity.java
@@ -67,6 +67,7 @@ public class ConnectionStatisticsSnapshotEntity extends Entity implements Readab
     @Override
     public ConnectionStatisticsSnapshotEntity clone() {
         final ConnectionStatisticsSnapshotEntity other = new ConnectionStatisticsSnapshotEntity();
+        other.setId(this.getId());
         other.setCanRead(this.getCanRead());
         other.setConnectionStatisticsSnapshot(this.getConnectionStatisticsSnapshot().clone());
 

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ConnectionStatusSnapshotEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ConnectionStatusSnapshotEntity.java
@@ -66,6 +66,7 @@ public class ConnectionStatusSnapshotEntity extends Entity implements ReadablePe
     @Override
     public ConnectionStatusSnapshotEntity clone() {
         final ConnectionStatusSnapshotEntity other = new ConnectionStatusSnapshotEntity();
+        other.setId(this.getId());
         other.setCanRead(this.getCanRead());
         other.setConnectionStatusSnapshot(this.getConnectionStatusSnapshot().clone());
 

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/PortStatusSnapshotEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/PortStatusSnapshotEntity.java
@@ -67,6 +67,7 @@ public class PortStatusSnapshotEntity extends Entity implements ReadablePermissi
     @Override
     public PortStatusSnapshotEntity clone() {
         final PortStatusSnapshotEntity other = new PortStatusSnapshotEntity();
+        other.setId(this.getId());
         other.setCanRead(this.getCanRead());
         other.setPortStatusSnapshot(this.getPortStatusSnapshot().clone());
 

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessGroupStatusSnapshotEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessGroupStatusSnapshotEntity.java
@@ -66,6 +66,7 @@ public class ProcessGroupStatusSnapshotEntity extends Entity implements Readable
     @Override
     public ProcessGroupStatusSnapshotEntity clone() {
         final ProcessGroupStatusSnapshotEntity other = new ProcessGroupStatusSnapshotEntity();
+        other.setId(this.getId());
         other.setCanRead(this.getCanRead());
         other.setProcessGroupStatusSnapshot(this.getProcessGroupStatusSnapshot().clone());
 

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessorStatusSnapshotEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessorStatusSnapshotEntity.java
@@ -66,6 +66,7 @@ public class ProcessorStatusSnapshotEntity extends Entity implements ReadablePer
     @Override
     public ProcessorStatusSnapshotEntity clone() {
         final ProcessorStatusSnapshotEntity other = new ProcessorStatusSnapshotEntity();
+        other.setId(this.getId());
         other.setCanRead(this.getCanRead());
         other.setProcessorStatusSnapshot(this.getProcessorStatusSnapshot().clone());
 

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/RemoteProcessGroupStatusSnapshotEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/RemoteProcessGroupStatusSnapshotEntity.java
@@ -67,6 +67,7 @@ public class RemoteProcessGroupStatusSnapshotEntity extends Entity implements Re
     @Override
     public RemoteProcessGroupStatusSnapshotEntity clone() {
         final RemoteProcessGroupStatusSnapshotEntity other = new RemoteProcessGroupStatusSnapshotEntity();
+        other.setId(this.getId());
         other.setCanRead(this.getCanRead());
         other.setRemoteProcessGroupStatusSnapshot(this.getRemoteProcessGroupStatusSnapshot().clone());
 


### PR DESCRIPTION

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13031](https://issues.apache.org/jira/browse/NIFI-13031)
Issue affects connections, processors, input/output ports, remote PGs.

Possible acceptance test:
On cluster, set up PG with GenerateFlowFile to UpdateAttribute connection.
Run a few flowfiles through.
Run rest api call against this PG 
(InvokeHTTP using: /flow/process-groups/{id}/status?nodewise=true)

Before PR, the results show the aggregateSnapshot and one of the nodes (probably the first following the aggregateSnapshot in the results) have the same values for connections and processors.  Now each node will reflect its own values.



# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
