### PR TITLE
NIFI-13380: When determining if Record Type A is 'wider' than Record …

### DIFF
--- a/nifi-commons/nifi-record-path/pom.xml
+++ b/nifi-commons/nifi-record-path/pom.xml
@@ -125,5 +125,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-json-record-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -1884,7 +1884,41 @@ public class DataTypeUtils {
             return Optional.of(otherRecordDataType);
         }
 
+        // Check if all fields in 'thisSchema' are equal to or wider than all fields in 'otherSchema'
+        if (isRecordWider(thisSchema, otherSchema)) {
+            return Optional.of(thisRecordDataType);
+        }
+        if (isRecordWider(otherSchema, thisSchema)) {
+            return Optional.of(otherRecordDataType);
+        }
+
         return Optional.empty();
+    }
+
+    public static boolean isRecordWider(final RecordSchema potentiallyWider, final RecordSchema potentiallyNarrower) {
+        final List<RecordField> narrowerFields = potentiallyNarrower.getFields();
+
+        for (final RecordField narrowerField : narrowerFields) {
+            final Optional<RecordField> widerField = potentiallyWider.getField(narrowerField.getFieldName());
+            if (widerField.isEmpty()) {
+                return false;
+            }
+
+            if (widerField.get().getDataType().equals(narrowerField.getDataType())) {
+                continue;
+            }
+
+            final Optional<DataType> widerType = getWiderType(widerField.get().getDataType(), narrowerField.getDataType());
+            if (widerType.isEmpty()) {
+                return false;
+            }
+
+            if (!widerType.get().equals(widerField.get().getDataType())) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static boolean isDecimalType(final RecordFieldType fieldType) {

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
@@ -112,6 +112,67 @@ public class TestDataTypeUtils {
     }
 
     @Test
+    public void testWiderRecordWhenChildRecordHasAllFieldsContainedWithin() {
+        final Record jane = DataTypeUtils.toRecord(Map.of(
+                "name", "Jane"
+        ), "");
+
+        final Record smallRecord = DataTypeUtils.toRecord(Map.of(
+            "firstName", "John",
+            "lastName", "Doe",
+            "child", jane,
+            "age", 30), "");
+
+        final Record janeWithAge = DataTypeUtils.toRecord(Map.of(
+            "name", "Jane",
+            "age", 2
+        ), "");
+
+        final Record widerRecord = DataTypeUtils.toRecord(Map.of(
+            "firstName", "John",
+            "lastName", "Doe",
+            "fullName", "John Doe",
+            "child", janeWithAge,
+            "age", 30), "");
+
+        final Optional<DataType> widerType = DataTypeUtils.getWiderType(RecordFieldType.RECORD.getRecordDataType(smallRecord.getSchema()),
+            RecordFieldType.RECORD.getRecordDataType(widerRecord.getSchema()));
+        assertTrue(widerType.isPresent());
+        assertEquals(((RecordDataType) widerType.get()).getChildSchema(), widerRecord.getSchema());
+    }
+
+    @Test
+    public void testIsRecordWiderWithExtraField() {
+        final Record jane = DataTypeUtils.toRecord(Map.of(
+        ), "");
+
+        final Record smallRecord = DataTypeUtils.toRecord(Map.of(
+            "firstName", "John",
+            "lastName", "Doe",
+            "child", jane,
+            "age", 30), "");
+
+        final Record janeWithAge = DataTypeUtils.toRecord(Map.of(
+            "name", "Jane",
+            "age", 2
+        ), "");
+
+        final Record widerRecord = DataTypeUtils.toRecord(Map.of(
+            "firstName", "John",
+            "lastName", "Doe",
+            "fullName", "John Doe",
+            "child", janeWithAge,
+            "age", 30), "");
+
+        assertFalse(DataTypeUtils.isRecordWider(smallRecord.getSchema(), widerRecord.getSchema()));
+        assertTrue(DataTypeUtils.isRecordWider(widerRecord.getSchema(), smallRecord.getSchema()));
+
+        assertFalse(DataTypeUtils.isRecordWider(jane.getSchema(), janeWithAge.getSchema()));
+        assertTrue(DataTypeUtils.isRecordWider(janeWithAge.getSchema(), jane.getSchema()));
+    }
+
+
+    @Test
     public void testWiderRecordDifferingFields() {
         final Record firstRecord = DataTypeUtils.toRecord(Map.of(
                 "firstName", "John",


### PR DESCRIPTION
…Type B, and both have a RECORD with the same name but different schemas, instead of determining that A is not wider than B, perform a recursive comparison to check if the RECORD within A's schema is wider than the RECORD within B's schema.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13380](https://issues.apache.org/jira/browse/NIFI-13380)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
