### PR TITLE
NIFI-13381 use AllowableValues for PutSFTP/PutFTP Conflict Resolution property

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/FileTransfer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/FileTransfer.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
+import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
@@ -207,17 +208,49 @@ public interface FileTransfer extends Closeable {
     public static final String FILE_MODIFY_DATE_ATTR_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
 
     public static final String CONFLICT_RESOLUTION_REPLACE = "REPLACE";
+    AllowableValue CONFLICT_RESOLUTION_REPLACE_ALLOWABLE =
+            new AllowableValue(CONFLICT_RESOLUTION_REPLACE, CONFLICT_RESOLUTION_REPLACE,
+                    "Remote file is replaced with new file, FlowFile goes to success");
+
     public static final String CONFLICT_RESOLUTION_RENAME = "RENAME";
+    AllowableValue CONFLICT_RESOLUTION_RENAME_ALLOWABLE =
+            new AllowableValue(CONFLICT_RESOLUTION_RENAME, CONFLICT_RESOLUTION_RENAME,
+                    "New file is renamed with a one-up number at the beginning, FlowFile goes to success");
+
     public static final String CONFLICT_RESOLUTION_IGNORE = "IGNORE";
+    AllowableValue CONFLICT_RESOLUTION_IGNORE_ALLOWABLE =
+            new AllowableValue(CONFLICT_RESOLUTION_IGNORE, CONFLICT_RESOLUTION_IGNORE,
+                    "File is not transferred, FlowFile goes to success");
+
     public static final String CONFLICT_RESOLUTION_REJECT = "REJECT";
+    AllowableValue CONFLICT_RESOLUTION_REJECT_ALLOWABLE =
+            new AllowableValue(CONFLICT_RESOLUTION_REJECT, CONFLICT_RESOLUTION_REJECT,
+                    "File is not transferred, FlowFile goes to reject");
+
     public static final String CONFLICT_RESOLUTION_FAIL = "FAIL";
+    AllowableValue CONFLICT_RESOLUTION_FAIL_ALLOWABLE =
+            new AllowableValue(CONFLICT_RESOLUTION_FAIL, CONFLICT_RESOLUTION_FAIL,
+                    "File is not transferred, FlowFile goes to failure");
+
     public static final String CONFLICT_RESOLUTION_NONE = "NONE";
+    AllowableValue CONFLICT_RESOLUTION_NONE_ALLOWABLE =
+            new AllowableValue(CONFLICT_RESOLUTION_NONE, CONFLICT_RESOLUTION_NONE,
+                    "Do not check for conflict before transfer, FlowFile goes to success or failure");
+
+    AllowableValue[] CONFLICT_RESOLUTION_ALLOWABLE_VALUES = new AllowableValue[] {
+            CONFLICT_RESOLUTION_REPLACE_ALLOWABLE,
+            CONFLICT_RESOLUTION_IGNORE_ALLOWABLE,
+            CONFLICT_RESOLUTION_RENAME_ALLOWABLE,
+            CONFLICT_RESOLUTION_REJECT_ALLOWABLE,
+            CONFLICT_RESOLUTION_FAIL_ALLOWABLE,
+            CONFLICT_RESOLUTION_NONE_ALLOWABLE};
+
     public static final PropertyDescriptor CONFLICT_RESOLUTION = new PropertyDescriptor.Builder()
         .name("Conflict Resolution")
         .description("Determines how to handle the problem of filename collisions")
         .required(true)
-        .allowableValues(CONFLICT_RESOLUTION_REPLACE, CONFLICT_RESOLUTION_IGNORE, CONFLICT_RESOLUTION_RENAME, CONFLICT_RESOLUTION_REJECT, CONFLICT_RESOLUTION_FAIL, CONFLICT_RESOLUTION_NONE)
-        .defaultValue(CONFLICT_RESOLUTION_NONE)
+        .allowableValues(CONFLICT_RESOLUTION_ALLOWABLE_VALUES)
+        .defaultValue(CONFLICT_RESOLUTION_NONE_ALLOWABLE)
         .build();
     public static final PropertyDescriptor REJECT_ZERO_BYTE = new PropertyDescriptor.Builder()
         .name("Reject Zero-Byte Files")


### PR DESCRIPTION
# Summary

[NIFI-13381](https://issues.apache.org/jira/browse/NIFI-13381)

Use AllowableValues for PutSFTP/PutFTP Conflict Resolution property. This allows us to better document what the choices do.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
