### PR TITLE
NIFI-13393 Support passing in FF attributes to create Flow File

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/processor/ProcessSession.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/ProcessSession.java
@@ -309,6 +309,21 @@ public interface ProcessSession {
     FlowFile create();
 
     /**
+     * Creates a new {@link FlowFile} in the repository with no content and without any linkage to a parent FlowFile.
+     * The passed attributes are added to the new {@link FlowFile} in addition to some core attributes that are always added.
+     * <p>
+     * This method is appropriate only when data is received or created from an external system.
+     * Otherwise, this method should be avoided and instead {@link #create(FlowFile)} or {@link #create(Collection)} be used.
+     * <p>
+     * When this method is used, a {@link ProvenanceEventType#CREATE} or {@link ProvenanceEventType#RECEIVE} event should be generated.
+     * See the {@link #getProvenanceReporter()} method and {@link ProvenanceReporter} class for more information.
+     *
+     * @param attributes to add to the new {@link FlowFile}
+     * @return newly created FlowFile
+     */
+    FlowFile create(final Map<String, String> attributes);
+
+    /**
      * Creates a new {@link FlowFile} in the repository with no content but with a parent linkage to the {@code parent}.
      * The newly created FlowFile will inherit all the parent's attributes, except for the UUID.
      * <p>
@@ -319,6 +334,21 @@ public interface ProcessSession {
      * @return newly created {@link FlowFile}
      */
     FlowFile create(FlowFile parent);
+
+    /**
+     * Creates a new {@link FlowFile} in the repository with no content but with a parent linkage to the {@code parent}.
+     * The newly created FlowFile will inherit all the parent's attributes, except for the UUID.
+     * In addition, the newly created FlowFile will also have the attributes parameter added.
+     * The attributes in the parameter are added last, so they will overwrite any parent attributes with the same key.
+     * <p>
+     * This method will automatically generate a {@link ProvenanceEventType#FORK} or a {@link ProvenanceEventType#JOIN} event,
+     * depending on whether other FlowFiles are generated from the same parent before the session is committed.
+     *
+     * @param parent to base the new {@link FlowFile} on, inheriting attributes from
+     * @param attributes to add to the new {@link FlowFile}
+     * @return newly created {@link FlowFile}
+     */
+    FlowFile create(FlowFile parent, final Map<String, String> attributes);
 
     /**
      * Creates a new {@link FlowFile} in the repository with no content but with a parent linkage to all {@code parents}.

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/flow/ProcessSessionWrap.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/flow/ProcessSessionWrap.java
@@ -22,6 +22,7 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -374,7 +375,28 @@ public abstract class ProcessSessionWrap implements ProcessSession {
      */
     @Override
     public SessionFile create() {
-        return wrap(onMod(session.create()));
+        return create(Collections.emptyMap());
+    }
+
+
+    /**
+     * Creates a new FlowFile in the repository with no content and without any
+     * linkage to a parent FlowFile. The passed attributes are added
+     * to the new {@link FlowFile}. This method is appropriate only when
+     * data is received or created from an external system. Otherwise, this method
+     * should be avoided and should instead use {@link #create(FlowFile)} or
+     * {@see #create(Collection)}.
+     * <p>
+     * When this method is used, a Provenance CREATE or RECEIVE Event should be
+     * generated. See the {@link #getProvenanceReporter()} method and
+     * {@link ProvenanceReporter} class for more information
+     *
+     * @param attributes to add to the new {@link FlowFile}
+     * @return newly created FlowFile
+     */
+    @Override
+    public SessionFile create(final Map<String, String> attributes) {
+        return wrap(onMod(session.create(attributes)));
     }
 
     /**
@@ -390,7 +412,26 @@ public abstract class ProcessSessionWrap implements ProcessSession {
      */
     @Override
     public SessionFile create(FlowFile parent) {
-        return wrap(onMod(session.create(unwrap(parent))));
+        return create(parent, Collections.emptyMap());
+    }
+
+    /**
+     * Creates a new FlowFile in the repository with no content but with a
+     * parent linkage to <code>parent</code>. The newly created FlowFile will
+     * inherit all of the parent's attributes except for the UUID. The passed
+     * attributes will be added to the new {@link FlowFile} and they will
+     * overwrite any parent attributes with the same key. This method
+     * will automatically generate a Provenance FORK event or a Provenance JOIN
+     * event, depending on whether or not other FlowFiles are generated from the
+     * same parent before the ProcessSession is committed.
+     *
+     * @param parent to base the new flowfile on
+     * @param attributes to add to the new {@link FlowFile}
+     * @return newly created flowfile
+     */
+    @Override
+    public SessionFile create(FlowFile parent, final Map<String, String> attributes) {
+        return wrap(onMod(session.create(unwrap(parent), attributes)));
     }
 
     /**

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/BatchingSessionFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/BatchingSessionFactory.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -137,12 +138,22 @@ public class BatchingSessionFactory implements ProcessSessionFactory {
 
         @Override
         public FlowFile create() {
-            return session.create();
+            return create(Collections.emptyMap());
+        }
+
+        @Override
+        public FlowFile create(final Map<String, String> attributes) {
+            return session.create(attributes);
         }
 
         @Override
         public FlowFile create(FlowFile parent) {
-            return session.create(parent);
+            return create(parent, Collections.emptyMap());
+        }
+
+        @Override
+        public FlowFile create(FlowFile parent, final Map<String, String> attributes) {
+            return session.create(parent, attributes);
         }
 
         @Override

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockProcessSession.java
@@ -342,16 +342,28 @@ public class MockProcessSession implements ProcessSession {
 
     @Override
     public MockFlowFile create() {
+        return create(Collections.emptyMap());
+    }
+
+    @Override
+    public MockFlowFile create(final Map<String, String> attributes) {
         final MockFlowFile flowFile = new MockFlowFile(sharedState.nextFlowFileId());
         updateStateWithNewFlowFile(flowFile);
+        flowFile.putAttributes(attributes);
         return flowFile;
     }
 
     @Override
     public MockFlowFile create(final FlowFile flowFile) {
+        return create(flowFile, Collections.emptyMap());
+    }
+
+    @Override
+    public MockFlowFile create(FlowFile flowFile, final Map<String, String> attributes) {
         MockFlowFile newFlowFile = create();
         newFlowFile = (MockFlowFile) inheritAttributes(flowFile, newFlowFile);
         updateStateWithNewFlowFile(newFlowFile);
+        newFlowFile.putAttributes(attributes);
         return newFlowFile;
     }
 


### PR DESCRIPTION
method to avoid an extra flow file from being created

This PR is a proposal to see if the PMC agrees with this API change.
I have not written any new unit tests for this PR yet until I get buy-in on it.

I added two new create methods to the API of ProcessSession to allow the option of
passing in ff attributes to be added to the flow file being created. This is not
a breaking change because the original create methods are still there.

ProcessSession
FlowFile create(FlowFile parent, final Map<String, String> attributes);
FlowFile create(final Map<String, String> attributes);

Changing a core API is a very significant change but I hope people will see it
as worthwhile to allow us to to avoid creating an extra FlowFile object in many
places that FlowFiles are created. Not all places set attributes right after \
FF creation, but very many of them do and could benefit.

There are 150+ places where these new methods can be used and I only changed the
GenerateTableFetch processor to call them so you how the new methods are used.
I expect using these new create methods has the potential to
avoid noticeable transient memory allocation like the earlier API addition of
SessionContext.isAutoTerminated did.

Also if this PR is approved, myself and others can change processors to call these
new methods in a future PRs (not as part of this PR).

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13393](https://issues.apache.org/jira/browse/NIFI-13393)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-13393) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-13393`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-13393`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

No new files or dependencies

### Documentation

No documentation changes.