### PR TITLE
NIFI-13410 Upgrade Apache Curator from 5.6.0 to 5.7.0

### DIFF
--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -24,7 +24,7 @@
     <packaging>pom</packaging>
     <description>NiFi: Framework Bundle</description>
     <properties>
-        <curator.version>5.6.0</curator.version>
+        <curator.version>5.7.0</curator.version>
         <guava.version>33.2.0-jre</guava.version>
         <tika.version>2.9.2</tika.version>
         <org.opensaml.version>4.3.2</org.opensaml.version>


### PR DESCRIPTION
# Summary

[NIFI-13410](https://issues.apache.org/jira/browse/NIFI-13410) Upgrades Apache Curator libraries from 5.6.0 to [5.7.0](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12314425&version=12354115) incorporating several bug fixes as well as feature detection based on ZooKeeper server version.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
