### PR TITLE
NIFI-13411 - Dependencies housekeeping 1.x pre 1.26.1 release

### DIFF
--- a/nifi-nar-bundles/nifi-provenance-repository-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-provenance-repository-bundle/pom.xml
@@ -27,7 +27,7 @@
         <module>nifi-provenance-repository-nar</module>
     </modules>
     <properties>
-        <lucene.version>8.11.2</lucene.version>
+        <lucene.version>8.11.3</lucene.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-toolkit/pom.xml
+++ b/nifi-toolkit/pom.xml
@@ -36,7 +36,7 @@
         <module>nifi-toolkit-kafka-migrator</module>
     </modules>
     <properties>
-        <toolkit.groovy.version>3.0.19</toolkit.groovy.version>
+        <toolkit.groovy.version>3.0.21</toolkit.groovy.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -104,15 +104,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
-        <com.amazonaws.version>1.12.710</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.25.40</software.amazon.awssdk.version>
+        <com.amazonaws.version>1.12.744</com.amazonaws.version>
+        <software.amazon.awssdk.version>2.25.70</software.amazon.awssdk.version>
         <gson.version>2.10.1</gson.version>
-        <kotlin.version>1.9.23</kotlin.version>
+        <kotlin.version>1.9.24</kotlin.version>
         <okhttp.version>4.12.0</okhttp.version>
         <okio.version>3.9.0</okio.version>
         <org.apache.commons.cli.version>1.7.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.17.0</org.apache.commons.codec.version>
-        <org.apache.commons.compress.version>1.26.1</org.apache.commons.compress.version>
+        <org.apache.commons.compress.version>1.26.2</org.apache.commons.compress.version>
         <com.github.luben.zstd-jni.version>1.5.6-3</com.github.luben.zstd-jni.version>
         <org.apache.commons.lang3.version>3.14.0</org.apache.commons.lang3.version>
         <org.apache.commons.net.version>3.10.0</org.apache.commons.net.version>
@@ -121,34 +121,34 @@
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
         <org.bouncycastle.version>1.78.1</org.bouncycastle.version>
-        <testcontainers.version>1.19.7</testcontainers.version>
-        <org.slf4j.version>2.0.12</org.slf4j.version>
+        <testcontainers.version>1.19.8</testcontainers.version>
+        <org.slf4j.version>2.0.13</org.slf4j.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <ranger.version>2.4.0</ranger.version>
         <jetty.version>9.4.54.v20240208</jetty.version>
-        <jackson.bom.version>2.17.0</jackson.bom.version>
+        <jackson.bom.version>2.17.1</jackson.bom.version>
         <avro.version>1.11.3</avro.version>
         <jaxb.runtime.version>2.3.9</jaxb.runtime.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
-        <json.smart.version>2.5.0</json.smart.version>
-        <nifi.groovy.version>3.0.19</nifi.groovy.version>
+        <json.smart.version>2.5.1</json.smart.version>
+        <nifi.groovy.version>3.0.21</nifi.groovy.version>
         <groovy.eclipse.batch.version>3.0.8-01</groovy.eclipse.batch.version>
         <surefire.version>3.2.5</surefire.version>
         <hadoop.version>3.4.0</hadoop.version>
         <ozone.version>1.2.1</ozone.version>
         <gcs.version>2.1.5</gcs.version>
         <aspectj.version>1.9.6</aspectj.version>
-        <jersey.bom.version>2.41</jersey.bom.version>
+        <jersey.bom.version>2.43</jersey.bom.version>
         <log4j2.version>2.23.1</log4j2.version>
         <mockito.version>4.11.0</mockito.version>
         <logback.version>1.3.14</logback.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <netty.4.version>4.1.109.Final</netty.4.version>
-        <spring.version>5.3.34</spring.version>
-        <spring.security.version>5.8.11</spring.security.version>
-        <swagger.annotations.version>1.6.12</swagger.annotations.version>
+        <netty.4.version>4.1.111.Final</netty.4.version>
+        <spring.version>5.3.37</spring.version>
+        <spring.security.version>5.8.13</spring.security.version>
+        <swagger.annotations.version>1.6.14</swagger.annotations.version>
         <h2.version>2.2.224</h2.version>
         <zookeeper.version>3.9.2</zookeeper.version>
         <caffeine.version>2.9.3</caffeine.version>
@@ -327,7 +327,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.0</version>
+                <version>5.10.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
# Summary

[NIFI-13411](https://issues.apache.org/jira/browse/NIFI-13411) - Dependencies housekeeping 1.x pre 1.26.1 release

* Lucene from 8.11.2 to 8.11.3
* Groovy from 3.0.19 to 3.0.21
* AWS SDK from 1.12.710 to 1.12.744
* AWS SDK from 2.25.40 to 2.25.70
* Kotlin from 1.9.23 to 1.9.24
* Test containers from 1.19.7 to 1.19.8
* SLF4J from 2.0.12 to 2.0.13
* Jackson from 2.17.0 to 2.17.1
* JSON Smart from 2.5.0 to 2.5.1
* Jersey from 2.41 to 2.43
* Netty 4 from 4.1.109.Final to 4.1.111.Final
* Spring from 5.3.34 to 5.3.37
* Spring Security from 5.8.11 to 5.8.13
* Swagger Annotations from 1.6.12 to 1.6.14
* JUnit from 5.10.0 to 5.10.2

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
