### PR TITLE
NIFI-13326 : FIX unable to login JWT decode error

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/services/nf-storage.service.js
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/services/nf-storage.service.js
@@ -183,9 +183,7 @@ NfRegistryStorage.prototype = {
      */
     getJwtPayload: function (jwt) {
         if (isDefinedAndNotNull(jwt)) {
-            jwt=jwt.replace(/[\-]/g,"+");
-            jwt=jwt.replace(/[\_]/g,"/");
-            var segments = jwt.split(/\./);
+            var segments = jwt.replace(/[\-]/g, '+').replace(/[\_]/g, '/').split(/\./);
             if (segments.length !== 3) {
                 return '';
             }

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/services/nf-storage.service.js
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/services/nf-storage.service.js
@@ -182,9 +182,9 @@ NfRegistryStorage.prototype = {
      * @returns {string}
      */
     getJwtPayload: function (jwt) {
-        jwt=jwt.replace(/[\-]/g,"+");
-        jwt=jwt.replace(/[\_]/g,"/");
         if (isDefinedAndNotNull(jwt)) {
+            jwt=jwt.replace(/[\-]/g,"+");
+            jwt=jwt.replace(/[\_]/g,"/");
             var segments = jwt.split(/\./);
             if (segments.length !== 3) {
                 return '';

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/services/nf-storage.service.js
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/services/nf-storage.service.js
@@ -182,6 +182,8 @@ NfRegistryStorage.prototype = {
      * @returns {string}
      */
     getJwtPayload: function (jwt) {
+        jwt=jwt.replace(/[\-]/g,"+");
+        jwt=jwt.replace(/[\_]/g,"/");
         if (isDefinedAndNotNull(jwt)) {
             var segments = jwt.split(/\./);
             if (segments.length !== 3) {


### PR DESCRIPTION
This commit fix the NiFi registry part of an issue https://issues.apache.org/jira/projects/NIFI/issues/NIFI-13326

This error make users unable to login for some combinations of Registry domain name + username

No additional dependencies/libraries/licenses are used.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13326](https://issues.apache.org/jira/browse/NIFI-13326)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [X] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [X] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
