### PR TITLE
NIFI-13415 Deprecate Property Protection and Encrypt Config

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/pom.xml
@@ -41,5 +41,10 @@
             <scope>provided</scope>
             <!-- Provided through isolated ClassLoader to avoid unnecessary runtime dependencies -->
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-deprecation-log</artifactId>
+            <version>1.27.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/main/java/org/apache/nifi/properties/NiFiPropertiesLoader.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-properties-loader/src/main/java/org/apache/nifi/properties/NiFiPropertiesLoader.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.properties;
 
+import org.apache.nifi.deprecation.log.DeprecationLogger;
+import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
 import org.apache.nifi.property.protection.loader.PropertyProtectionURLClassLoader;
 import org.apache.nifi.property.protection.loader.PropertyProviderFactoryLoader;
 import org.apache.nifi.util.NiFiBootstrapUtils;
@@ -44,6 +46,7 @@ import java.util.stream.Collectors;
 
 public class NiFiPropertiesLoader {
 
+    private static final DeprecationLogger deprecationLogger = DeprecationLoggerFactory.getLogger(NiFiPropertiesLoader.class);
     private static final Logger logger = LoggerFactory.getLogger(NiFiPropertiesLoader.class);
     private static final Base64.Encoder KEY_ENCODER = Base64.getEncoder().withoutPadding();
     private static final int SENSITIVE_PROPERTIES_KEY_LENGTH = 24;
@@ -162,6 +165,8 @@ public class NiFiPropertiesLoader {
         final NiFiProperties properties;
 
         if (protectedProperties.hasProtectedKeys()) {
+            deprecationLogger.warn("Support for encrypted application properties is deprecated for removal in NiFi 2.0.0");
+
             final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
 
             try {

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/pom.xml
@@ -36,5 +36,10 @@
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-property-protection-loader</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-deprecation-log</artifactId>
+            <version>1.27.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryPropertiesLoader.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties-loader/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryPropertiesLoader.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.registry.properties;
 
+import org.apache.nifi.deprecation.log.DeprecationLogger;
+import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
 import org.apache.nifi.properties.BootstrapProperties;
 import org.apache.nifi.properties.SensitivePropertyProvider;
 import org.apache.nifi.properties.SensitivePropertyProviderFactory;
@@ -33,6 +35,7 @@ import java.util.Properties;
 
 public class NiFiRegistryPropertiesLoader {
 
+    private static final DeprecationLogger deprecationLogger = DeprecationLoggerFactory.getLogger(NiFiRegistryPropertiesLoader.class);
     private static final Logger logger = LoggerFactory.getLogger(NiFiRegistryPropertiesLoader.class);
 
     private String keyHex;
@@ -125,6 +128,8 @@ public class NiFiRegistryPropertiesLoader {
     public NiFiRegistryProperties load(final File file) {
         final ProtectedNiFiRegistryProperties protectedNiFiProperties = readProtectedPropertiesFromDisk(file);
         if (protectedNiFiProperties.hasProtectedKeys()) {
+            deprecationLogger.warn("Support for encrypted application properties is deprecated for removal in NiFi 2.0.0");
+
             Security.addProvider(new BouncyCastleProvider());
             getSensitivePropertyProviderFactory()
                     .getSupportedProviders()

--- a/nifi-toolkit/nifi-toolkit-encrypt-config/src/main/groovy/org/apache/nifi/toolkit/encryptconfig/EncryptConfigMain.groovy
+++ b/nifi-toolkit/nifi-toolkit-encrypt-config/src/main/groovy/org/apache/nifi/toolkit/encryptconfig/EncryptConfigMain.groovy
@@ -90,6 +90,8 @@ class EncryptConfigMain {
     }
 
     static void main(String[] args) {
+        System.out.println("The encrypt-config command is deprecated for removal in NiFi 2.0.0")
+
         Security.addProvider(new BouncyCastleProvider())
 
         if (args.length < 1) {


### PR DESCRIPTION
# Summary

[NIFI-13415](https://issues.apache.org/jira/browse/NIFI-13415) Deprecates application property encryption support implemented through `nifi-property-protection-api` and related modules, and also deprecates the `encrypt-config` command for subsequent removal from the main branch in NiFi 2.0.0.

[NIFI-13414](https://issues.apache.org/jira/browse/NIFI-13414) Provides the background and associated removal pull request for the main branch.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
