### PR TITLE
NIFI-13403 Removed the use of toString in logging statements

### DIFF
--- a/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/command/FlowStatusRunner.java
+++ b/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/command/FlowStatusRunner.java
@@ -39,7 +39,7 @@ public class FlowStatusRunner implements CommandRunner {
     @Override
     public int runCommand(String[] args) {
         if (args.length == 2) {
-            CMD_LOGGER.info(periodicStatusReporterManager.statusReport(args[1]).toString());
+            CMD_LOGGER.info("{}", periodicStatusReporterManager.statusReport(args[1]));
             return OK.getStatusCode();
         } else {
             CMD_LOGGER.error("The 'flowStatus' command requires an input query. See the System Admin Guide 'FlowStatus Script Query' section for complete details.");

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-runtime/src/main/java/org/apache/nifi/minifi/MiNiFi.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-runtime/src/main/java/org/apache/nifi/minifi/MiNiFi.java
@@ -75,8 +75,7 @@ public class MiNiFi {
         }
 
         Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
-            logger.error("An Unknown Error Occurred in Thread {}: {}", t, e.toString());
-            logger.error("", e);
+            logger.error("An Unknown Error Occurred in Thread {}", t, e);
         });
 
         // register the shutdown hook

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-runtime/src/main/java/org/apache/nifi/minifi/bootstrap/BootstrapListener.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-runtime/src/main/java/org/apache/nifi/minifi/bootstrap/BootstrapListener.java
@@ -257,7 +257,7 @@ public class BootstrapListener implements BootstrapCommunicator {
                 try {
                     socket.close();
                 } catch (IOException ioe) {
-                    logger.warn("Failed to close socket to Bootstrap due to {}", ioe.toString());
+                    logger.warn("Failed to close socket to Bootstrap", ioe);
                 }
             }
         }

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerSelector.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerSelector.java
@@ -201,7 +201,7 @@ public class PeerSelector {
                         .append(" will").append(direction == TransferDirection.RECEIVE ? " send " : " receive ")
                         .append(df.format(percentage)).append("% of data");
             }
-            logger.debug(distributionDescription.toString());
+            logger.debug("{}", distributionDescription);
         }
     }
 

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
@@ -181,7 +181,7 @@ public class HttpClient extends AbstractSiteToSiteClient implements PeerStatusPr
                 commSession.setUserDn(apiClient.getTrustedPeerDn());
             } catch (final Exception e) {
                 apiClient.close();
-                logger.warn("Penalizing peer {}", peer, e);
+                logger.warn("Penalizing a peer {} due to {}", peer, e.toString());
                 peerSelector.penalize(peer, penaltyMillis);
 
                 // Following exceptions will be thrown even if we tried other peers, so throw it.

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/http/HttpClient.java
@@ -181,7 +181,7 @@ public class HttpClient extends AbstractSiteToSiteClient implements PeerStatusPr
                 commSession.setUserDn(apiClient.getTrustedPeerDn());
             } catch (final Exception e) {
                 apiClient.close();
-                logger.warn("Penalizing a peer {} due to {}", peer, e.toString());
+                logger.warn("Penalizing peer {}", peer, e);
                 peerSelector.penalize(peer, penaltyMillis);
 
                 // Following exceptions will be thrown even if we tried other peers, so throw it.

--- a/nifi-commons/nifi-write-ahead-log/src/main/java/org/apache/nifi/wali/LengthDelimitedJournal.java
+++ b/nifi-commons/nifi-write-ahead-log/src/main/java/org/apache/nifi/wali/LengthDelimitedJournal.java
@@ -175,7 +175,7 @@ public class LengthDelimitedJournal<T> implements WriteAheadJournal<T> {
             poison(t);
 
             final IOException ioe = (t instanceof IOException) ? (IOException) t : new IOException("Failed to create journal file " + journalFile, t);
-            logger.error("Failed to create new journal file {} due to {}", journalFile, ioe.toString(), ioe);
+            logger.error("Failed to create new journal file {}", journalFile, ioe);
             throw ioe;
         }
 

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -668,7 +668,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
             }
 
             if (getLogger().isDebugEnabled()) {
-                getLogger().debug(payload.toString());
+                getLogger().debug("{}", payload);
             }
             final HttpEntity entity = new NStringEntity(payload.toString(), ContentType.APPLICATION_JSON);
             final StopWatch watch = new StopWatch();
@@ -1035,7 +1035,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
                         .append("\n");
             }
 
-            getLogger().debug(builder.toString());
+            getLogger().debug("{}", builder);
         }
 
         return client.performRequest(request);

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/AbstractJsonRowRecordReader.java
@@ -199,7 +199,7 @@ public abstract class AbstractJsonRowRecordReader implements RecordReader {
         } catch (final MalformedRecordException mre) {
             throw mre;
         } catch (final Exception e) {
-            logger.debug("Failed to convert JSON Element {} into a Record object using schema {} due to {}", nextNode, schema, e.toString(), e);
+            logger.debug("Failed to convert JSON Element {} into a Record object using schema {}", nextNode, schema, e);
             throw new MalformedRecordException("Successfully parsed a JSON object from input but failed to convert into a Record object with the given schema", e);
         }
     }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/WriteJsonResult.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/WriteJsonResult.java
@@ -250,7 +250,7 @@ public class WriteJsonResult extends AbstractRecordSetWriter implements RecordSe
 
             endTask.apply(generator);
         } catch (final Exception e) {
-            logger.error("Failed to write {} with reader schema {} and writer schema {} as a JSON Object due to {}", record, record.getSchema(), writeSchema, e.toString(), e);
+            logger.error("Failed to write {} with reader schema {} and writer schema {} as a JSON Object", record, record.getSchema(), writeSchema, e);
             throw e;
         }
     }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractGetGcpVisionAnnotateOperationStatus.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractGetGcpVisionAnnotateOperationStatus.java
@@ -89,7 +89,7 @@ abstract public class AbstractGetGcpVisionAnnotateOperationStatus extends Abstra
         try {
             String operationKey = context.getProperty(OPERATION_KEY).evaluateAttributeExpressions(flowFile).getValue();;
             Operation operation = getVisionClient().getOperationsClient().getOperation(operationKey);
-            getLogger().info(operation.toString());
+            getLogger().info("{}", operation);
             if (operation.getDone() && !operation.hasError()) {
                 GeneratedMessageV3 response = deserializeResponse(operation.getResponse().getValue());
                 FlowFile childFlowFile = session.create(flowFile);

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-processors/src/test/java/org/apache/nifi/processors/graph/util/InMemoryGraphClient.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-processors/src/test/java/org/apache/nifi/processors/graph/util/InMemoryGraphClient.java
@@ -98,7 +98,7 @@ public class InMemoryGraphClient extends AbstractControllerService implements Gr
                             Map<String, Object> resultReturnMap = new HashMap<>();
                             resultReturnMap.put(innerResultSet.getKey(), returnObject);
                             if (getLogger().isDebugEnabled()) {
-                                getLogger().debug(resultReturnMap.toString());
+                                getLogger().debug("{}", resultReturnMap);
                             }
                             // return the object to the graphQueryResultCallback object
                             graphQueryResultCallback.process(resultReturnMap, resultSet.hasNext());

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/src/main/java/org/apache/nifi/graph/TinkerpopClientService.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/src/main/java/org/apache/nifi/graph/TinkerpopClientService.java
@@ -466,7 +466,7 @@ public class TinkerpopClientService extends AbstractControllerService implements
         }
 
         if (getLogger().isDebugEnabled()) {
-            getLogger().debug(map.toString());
+            getLogger().debug("{}", map);
         }
 
         Binding bindings = new Binding();
@@ -492,7 +492,7 @@ public class TinkerpopClientService extends AbstractControllerService implements
                                 Map<String, Object> resultReturnMap = new HashMap<>();
                                 resultReturnMap.put(innerResultSet.getKey(), returnObject);
                                 if (getLogger().isDebugEnabled()) {
-                                    getLogger().debug(resultReturnMap.toString());
+                                    getLogger().debug("{}", resultReturnMap);
                                 }
                                 graphQueryResultCallback.process(resultReturnMap, resultSet.hasNext());
                             }

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
@@ -483,7 +483,7 @@ public class ExecuteGroovyScript extends AbstractProcessor {
             onCommitSQL(SQL);
             session.commitAsync();
         } catch (Throwable t) {
-            getLogger().error(t.toString(), t);
+            getLogger().error("", t);
             onFailSQL(SQL);
             if (toFailureOnError) {
                 //transfer all received to failure with two new attributes: ERROR_MESSAGE and ERROR_STACKTRACE.

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
@@ -483,7 +483,7 @@ public class ExecuteGroovyScript extends AbstractProcessor {
             onCommitSQL(SQL);
             session.commitAsync();
         } catch (Throwable t) {
-            getLogger().error("", t);
+            getLogger().error(t.toString(), t);
             onFailSQL(SQL);
             if (toFailureOnError) {
                 //transfer all received to failure with two new attributes: ERROR_MESSAGE and ERROR_STACKTRACE.

--- a/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/DeleteHBaseCells.java
+++ b/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/DeleteHBaseCells.java
@@ -84,7 +84,7 @@ public class DeleteHBaseCells extends AbstractDeleteHBase {
             .append(String.format("Column Family: %s\t", family))
             .append(String.format("Column Qualifier: %s\t", column))
             .append(String.format("Visibility Label: %s", visibility));
-        getLogger().debug(sb.toString());
+        getLogger().debug("{}", sb);
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseJSON.java
+++ b/nifi-extension-bundles/nifi-hbase-bundle/nifi-hbase-processors/src/main/java/org/apache/nifi/hbase/PutHBaseJSON.java
@@ -189,7 +189,7 @@ public class PutHBaseJSON extends AbstractPutHBase {
                 }
             });
         } catch (final ProcessException pe) {
-            getLogger().error("Failed to parse {} as JSON due to {}; routing to failure", flowFile, pe.toString(), pe);
+            getLogger().error("Failed to parse {} as JSON; routing to failure", flowFile, pe);
             return null;
         }
 

--- a/nifi-extension-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/PutKudu.java
+++ b/nifi-extension-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/PutKudu.java
@@ -587,7 +587,7 @@ public class PutKudu extends AbstractKuduProcessor {
             final List<RowError> rowErrors = putKuduResult.getRowErrorsForFlowFile(flowFile);
 
             if (rowErrors != null && !rowErrors.isEmpty()) {
-                rowErrors.forEach(rowError -> getLogger().error("Failed to write due to {}", rowError));
+                rowErrors.forEach(rowError -> getLogger().error("Failed to write due to {}", rowError.toString()));
                 flowFile = session.putAttribute(flowFile, RECORD_COUNT_ATTR, Integer.toString(count - rowErrors.size()));
                 totalCount -= rowErrors.size(); // Don't include error rows in the counter.
                 session.transfer(flowFile, REL_FAILURE);

--- a/nifi-extension-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/PutKudu.java
+++ b/nifi-extension-bundles/nifi-kudu-bundle/nifi-kudu-processors/src/main/java/org/apache/nifi/processors/kudu/PutKudu.java
@@ -587,7 +587,7 @@ public class PutKudu extends AbstractKuduProcessor {
             final List<RowError> rowErrors = putKuduResult.getRowErrorsForFlowFile(flowFile);
 
             if (rowErrors != null && !rowErrors.isEmpty()) {
-                rowErrors.forEach(rowError -> getLogger().error("Failed to write due to {}", rowError.toString()));
+                rowErrors.forEach(rowError -> getLogger().error("Failed to write due to {}", rowError));
                 flowFile = session.putAttribute(flowFile, RECORD_COUNT_ATTR, Integer.toString(count - rowErrors.size()));
                 totalCount -= rowErrors.size(); // Don't include error rows in the counter.
                 session.transfer(flowFile, REL_FAILURE);

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/IndexConfiguration.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/IndexConfiguration.java
@@ -97,8 +97,7 @@ public class IndexConfiguration {
         } catch (final FileNotFoundException | EOFException fnf) {
             return null; // file no longer exists or there's no record in this file
         } catch (final IOException ioe) {
-            logger.warn("Failed to read first entry in file {} due to {}", provenanceLogFile, ioe.toString());
-            logger.warn("", ioe);
+            logger.warn("Failed to read first entry in file {}", provenanceLogFile, ioe);
             return null;
         }
     }

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/LuceneEventIndex.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/LuceneEventIndex.java
@@ -901,8 +901,7 @@ public class LuceneEventIndex implements EventIndex {
                 }
             }
         } catch (final Exception e) {
-            logger.error("Failed to expire Provenance Query Results due to {}", e.toString());
-            logger.error("", e);
+            logger.error("Failed to expire Provenance Query Results", e);
         }
     }
 }

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/lucene/StandardIndexManager.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/lucene/StandardIndexManager.java
@@ -185,7 +185,7 @@ public class StandardIndexManager implements IndexManager {
             try {
                 close(count);
             } catch (final Exception e) {
-                logger.warn("Failed to close Index Writer {} due to {}", count.getWriter(), e.toString(), e);
+                logger.warn("Failed to close Index Writer {}", count.getWriter(), e);
             }
         }
     }
@@ -362,7 +362,7 @@ public class StandardIndexManager implements IndexManager {
                 }
             }
         } catch (final Exception e) {
-            logger.warn("Failed to close Index Writer {} due to {}", writer, e.toString(), e);
+            logger.warn("Failed to close Index Writer {}", writer, e);
         }
     }
 

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/WriteAheadStorePartition.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/WriteAheadStorePartition.java
@@ -659,7 +659,7 @@ public class WriteAheadStorePartition implements EventStorePartition {
                         }
                     } catch (final EOFException | FileNotFoundException eof) {
                         // Ran out of data. Continue on.
-                        logger.warn("Failed to find event with ID {} in Event File {} due to {}", minEventIdToReindex, eventFile, eof.toString());
+                        logger.warn("Failed to find event with ID {} in Event File {}", minEventIdToReindex, eventFile, eof);
                     } catch (final Exception e) {
                         logger.error("Failed to index Provenance Events found in {}", eventFile, e);
                     }

--- a/nifi-extension-bundles/nifi-questdb-bundle/nifi-questdb/src/main/java/org/apache/nifi/questdb/embedded/LockedClient.java
+++ b/nifi-extension-bundles/nifi-questdb-bundle/nifi-questdb/src/main/java/org/apache/nifi/questdb/embedded/LockedClient.java
@@ -69,7 +69,7 @@ final class LockedClient implements Client {
     }
 
     private <R> R lockedOperation(final Callable<R> operation) throws DatabaseException {
-        LOGGER.debug("Start locking client {}", client.toString());
+        LOGGER.debug("Start locking client {}", client);
         try {
             if (!lock.tryLock(lockAttemptDuration.toMillis(), TimeUnit.MILLISECONDS)) {
                 throw new LockUnsuccessfulException("Could not lock read lock on the database");

--- a/nifi-extension-bundles/nifi-questdb-bundle/nifi-questdb/src/main/java/org/apache/nifi/questdb/embedded/TableWriterBasedInsertRowContext.java
+++ b/nifi-extension-bundles/nifi-questdb-bundle/nifi-questdb/src/main/java/org/apache/nifi/questdb/embedded/TableWriterBasedInsertRowContext.java
@@ -42,7 +42,7 @@ final class TableWriterBasedInsertRowContext implements InsertRowContext {
         actualRow = null;
 
         if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("Appending new row to the table writer: {}", actualRow.toString());
+            LOGGER.trace("Appending new row to the table writer: {}", actualRow);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ConvertJSONToSQL.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ConvertJSONToSQL.java
@@ -328,7 +328,7 @@ public class ConvertJSONToSQL extends AbstractProcessor {
                 }
             });
         } catch (ProcessException e) {
-            getLogger().error("Failed to convert {} into a SQL statement due to {}; routing to failure", flowFile, e.toString(), e);
+            getLogger().error("Failed to convert {} into a SQL statement", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }
@@ -346,7 +346,7 @@ public class ConvertJSONToSQL extends AbstractProcessor {
                 }
             });
         } catch (final ProcessException pe) {
-            getLogger().error("Failed to parse {} as JSON due to {}; routing to failure", flowFile, pe.toString(), pe);
+            getLogger().error("Failed to parse {} as JSON", flowFile, pe);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
@@ -314,7 +314,7 @@ public class FetchFile extends AbstractProcessor {
         try (final FileInputStream fis = new FileInputStream(file)) {
             flowFile = session.importFrom(fis, flowFile);
         } catch (final IOException | FlowFileAccessException ioe) {
-            getLogger().error("Could not fetch file {} from file system for {} due to {}; routing to failure", file, flowFile, ioe.toString(), ioe);
+            getLogger().error("Could not fetch file {} from file system for {}", file, flowFile, ioe);
             session.transfer(session.penalize(flowFile), REL_FAILURE);
             return;
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -406,7 +406,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
                 }
             }
 
-            logger.debug(sb.toString());
+            logger.debug("{}", sb);
         }
 
         performanceLoggingTimestamp = System.currentTimeMillis();
@@ -626,7 +626,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
                 @Override
                 public FileVisitResult postVisitDirectory(final Path dir, final IOException e) {
                     if (e != null) {
-                        getLogger().error("Error during visiting directory {}: {}", dir.toString(), e.getMessage(), e);
+                        getLogger().error("Error during visiting directory {}", dir, e);
                     }
 
                     return FileVisitResult.CONTINUE;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceText.java
@@ -426,12 +426,8 @@ public class ReplaceText extends AbstractProcessor {
             logger.info("Transferred {} to 'failure'", flowFile, e);
             session.transfer(flowFile, REL_FAILURE);
             return;
-        } catch (BufferOverflowException e) {
+        } catch (BufferOverflowException | IllegalAttributeException | AttributeExpressionLanguageException e) {
             logger.warn("Transferred {} to 'failure'", flowFile, e);
-            session.transfer(flowFile, REL_FAILURE);
-            return;
-        } catch (IllegalAttributeException | AttributeExpressionLanguageException e) {
-            logger.warn("Transferred {} to 'failure' due to {}", flowFile, e.toString(), e);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
@@ -799,7 +799,7 @@ public class TailFile extends AbstractProcessor {
                     cleanup(context);
                     tfo.setState(new TailFileState(filename, file, fileChannel, position, timestamp, file.length(), checksum, tfo.getState().getBuffer()));
                 } catch (final IOException ioe) {
-                    getLogger().error("Attempted to position Reader at current position in file {} but failed to do so due to {}", file, ioe.toString(), ioe);
+                    getLogger().error("Attempted to position Reader at current position in file {} but failed to do so", file, ioe);
                     context.yield();
                     return;
                 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateRecord.java
@@ -522,7 +522,7 @@ public class ValidateRecord extends AbstractProcessor {
                 sb.append(error).append("\n");
             }
 
-            getLogger().debug(sb.toString());
+            getLogger().debug("{}", sb);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/FTPTransfer.java
@@ -185,7 +185,7 @@ public class FTPTransfer implements FileTransfer {
                 client.disconnect();
             }
         } catch (final Exception ex) {
-            logger.warn("Failed to close FTPClient due to {}", ex.toString(), ex);
+            logger.warn("Failed to close FTPClient", ex);
         }
         client = null;
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/util/SFTPTransfer.java
@@ -673,7 +673,7 @@ public class SFTPTransfer implements FileTransfer {
                 sftpClient.close();
             }
         } catch (final Exception ex) {
-            logger.warn("Failed to close SFTPClient due to {}", ex.toString(), ex);
+            logger.warn("Failed to close SFTPClient", ex);
         }
         sftpClient = null;
 
@@ -682,7 +682,7 @@ public class SFTPTransfer implements FileTransfer {
                 sshClient.disconnect();
             }
         } catch (final Exception ex) {
-            logger.warn("Failed to close SSHClient due to {}", ex.toString(), ex);
+            logger.warn("Failed to close SSHClient", ex);
         }
         sshClient = null;
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/controller/ControllerStatusReportingTask.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/main/java/org/apache/nifi/controller/ControllerStatusReportingTask.java
@@ -164,7 +164,7 @@ public class ControllerStatusReportingTask extends AbstractReportingTask {
         printProcessorStatus(controllerStatus, builder, showDeltas, divisor);
 
         builder.append(processorBorderLine);
-        processorLogger.info(builder.toString());
+        processorLogger.info("{}", builder);
     }
 
     private void printConnectionStatuses(final ProcessGroupStatus controllerStatus, final boolean showDeltas, final long divisor) {
@@ -180,7 +180,7 @@ public class ControllerStatusReportingTask extends AbstractReportingTask {
         printConnectionStatus(controllerStatus, builder, showDeltas, divisor);
 
         builder.append(connectionBorderLine);
-        connectionLogger.info(builder.toString());
+        connectionLogger.info("{}", builder);
     }
 
     private void printCounters(final ProcessGroupStatus controllerStatus, final boolean showDeltas, final long divisor) {
@@ -196,7 +196,7 @@ public class ControllerStatusReportingTask extends AbstractReportingTask {
         printCounterStatus(controllerStatus, builder, showDeltas, divisor);
 
         builder.append(counterBorderLine);
-        counterLogger.info(builder.toString());
+        counterLogger.info("{}", builder);
     }
 
     private void printCounterStatus(final ProcessGroupStatus status, final StringBuilder builder, final boolean showDeltas, final long divisor) {

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/LoggingRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/LoggingRecordSink.java
@@ -89,7 +89,7 @@ public class LoggingRecordSink extends AbstractControllerService implements Reco
                     baos.reset();
                     writer.write(r);
                     writer.flush();
-                    log.log(logLevel, baos.toString());
+                    log.log(logLevel, "{}", baos);
                 }
                 writeResult = writer.finishRecordSet();
                 writer.flush();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
@@ -154,8 +154,7 @@ public abstract class AbstractHeartbeatMonitor implements HeartbeatMonitor {
             } catch (final Exception e) {
                 clusterCoordinator.reportEvent(null, Severity.ERROR,
                         "Received heartbeat from " + heartbeat.getNodeIdentifier() + " but failed to process heartbeat due to " + e);
-                logger.error("Failed to process heartbeat from {} due to {}", heartbeat.getNodeIdentifier(), e.toString());
-                logger.error("", e);
+                logger.error("Failed to process heartbeat from {}", heartbeat.getNodeIdentifier(), e);
             }
         }
 
@@ -193,8 +192,7 @@ public abstract class AbstractHeartbeatMonitor implements HeartbeatMonitor {
                     try {
                         removeHeartbeat(nodeIdentifier);
                     } catch (final Exception e) {
-                        logger.warn("Failed to remove heartbeat for {} due to {}", nodeIdentifier, e.toString());
-                        logger.warn("", e);
+                        logger.warn("Failed to remove heartbeat for {}", nodeIdentifier, e);
                     }
                 }
             }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/StandardAsyncClusterResponse.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/StandardAsyncClusterResponse.java
@@ -132,7 +132,7 @@ public class StandardAsyncClusterResponse implements AsyncClusterResponse {
         for (final Map.Entry<String, Long> entry : timingInfo.entrySet()) {
             sb.append(entry.getKey()).append(" took ").append(TimeUnit.NANOSECONDS.toMillis(entry.getValue())).append(" millis\n");
         }
-        logger.debug(sb.toString());
+        logger.debug("{}", sb);
     }
 
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ThreadPoolRequestReplicator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/replication/ThreadPoolRequestReplicator.java
@@ -795,7 +795,7 @@ public class ThreadPoolRequestReplicator implements RequestReplicator {
 
         logger.debug("For {} {} (Request ID {}), minimum response time = {}, max = {}, average = {} ms",
                 response.getMethod(), response.getURIPath(), response.getRequestIdentifier(), stats.getMin(), stats.getMax(), stats.getAverage());
-        logger.debug(sb.toString());
+        logger.debug("{}", sb);
     }
 
 
@@ -865,8 +865,7 @@ public class ThreadPoolRequestReplicator implements RequestReplicator {
                 nodeResponse = replicateRequest(request, nodeId, uri, requestId, clusterResponse);
             } catch (final Throwable t) {
                 nodeResponse = new NodeResponse(nodeId, method, uri, t);
-                logger.warn("Failed to replicate request {} {} to {} due to {}", method, uri.getPath(), nodeId, t.toString());
-                logger.warn("", t);
+                logger.warn("Failed to replicate request {} {} to {}", method, uri.getPath(), nodeId, t);
             }
 
             if (callback != null) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/flowanalysis/AbstractFlowAnalysisRuleNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/flowanalysis/AbstractFlowAnalysisRuleNode.java
@@ -287,7 +287,7 @@ public abstract class AbstractFlowAnalysisRuleNode extends AbstractComponentNode
 
             componentLog.error("Failed to invoke {} method", cause);
 
-            log.error("Failed to invoke {} method of {} due to {}", annotation.getSimpleName(), getFlowAnalysisRule(), cause.toString());
+            log.error("Failed to invoke {} method of {}", annotation.getSimpleName(), getFlowAnalysisRule(), cause);
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProcessSession.java
@@ -685,7 +685,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
                 timingInfo.append("; Updating Provenance Event Repository took ");
                 formatNanos(updateProvenanceNanos, timingInfo);
 
-                LOG.debug(timingInfo.toString());
+                LOG.debug("{}", timingInfo);
             }
 
             // Update local state
@@ -2582,7 +2582,7 @@ public class StandardProcessSession implements ProcessSession, ProvenanceEventEn
             context.getProvenanceRepository().registerEvents(iterable);
             context.getFlowFileRepository().updateRepository(expiredRecords);
         } catch (final IOException e) {
-            LOG.error("Failed to update FlowFile Repository to record expired records due to {}", e.toString(), e);
+            LOG.error("Failed to update FlowFile Repository to record expired records", e);
         }
 
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
@@ -759,7 +759,7 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
             final Throwable cause = e instanceof InvocationTargetException ? e.getCause() : e;
             final ComponentLog componentLog = new SimpleProcessLogger(getIdentifier(), StandardControllerServiceNode.this, new StandardLoggingContext(StandardControllerServiceNode.this));
             componentLog.error("Failed to invoke @OnDisabled method due to {}", cause);
-            LOG.error("Failed to invoke @OnDisabled method of {}", getControllerServiceImplementation(), cause);
+            LOG.error("Failed to invoke @OnDisabled method of {} due to {}", getControllerServiceImplementation(), cause.toString());
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
@@ -759,7 +759,7 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
             final Throwable cause = e instanceof InvocationTargetException ? e.getCause() : e;
             final ComponentLog componentLog = new SimpleProcessLogger(getIdentifier(), StandardControllerServiceNode.this, new StandardLoggingContext(StandardControllerServiceNode.this));
             componentLog.error("Failed to invoke @OnDisabled method due to {}", cause);
-            LOG.error("Failed to invoke @OnDisabled method of {} due to {}", getControllerServiceImplementation(), cause.toString());
+            LOG.error("Failed to invoke @OnDisabled method of {}", getControllerServiceImplementation(), cause);
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/logging/repository/StandardLogRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/logging/repository/StandardLogRepository.java
@@ -58,7 +58,7 @@ public class StandardLogRepository implements LogRepository {
                 try {
                     observer.onLogMessage(logMessage);
                 } catch (final Exception observerThrowable) {
-                    logger.error("Failed to pass log message to Observer {} due to {}", observer, observerThrowable.toString());
+                    logger.error("Failed to pass log message to Observer {}", observer, observerThrowable);
                 }
             }
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/remote/StandardRemoteProcessGroup.java
@@ -1288,10 +1288,7 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
                                         requestAccountResponse.getStatus(), requestAccountResponse.getStatusInfo().getReasonPhrase());
                             }
                         } catch (final Exception re) {
-                            logger.error("{} Failed to request account due to {}", this, re.toString());
-                            if (logger.isDebugEnabled()) {
-                                logger.error("", re);
-                            }
+                            logger.error("{} Failed to request account", this, re);
                         }
 
                         authorizationIssue = e.getDescription();
@@ -1299,8 +1296,7 @@ public class StandardRemoteProcessGroup implements RemoteProcessGroup {
                         authorizationIssue = e.getDescription();
                     } else {
                         final String message = e.getDescription();
-                        logger.warn("{} When communicating with remote instance, got unexpected result. {}",
-                                new Object[]{this, message});
+                        logger.warn("{} When communicating with remote instance, got unexpected result. {}", this, message);
                         authorizationIssue = "Unable to determine Site-to-Site availability.";
                     }
                 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
@@ -603,7 +603,7 @@ public class ExtensionBuilder {
                processorNode.setBulletinLevel(ds.bulletinLevel());
            }
        } catch (final Exception ex) {
-           logger.error("Error while setting default settings from DefaultSettings annotation: {}", ex.toString(), ex);
+           logger.error("Error while setting default settings from DefaultSettings annotation", ex);
        }
    }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -3267,10 +3267,7 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
             try {
                 remoteGroup.refreshFlowContents();
             } catch (final CommunicationsException e) {
-                LOG.warn("Unable to communicate with remote instance {} due to {}", remoteGroup, e.toString());
-                if (LOG.isDebugEnabled()) {
-                    LOG.warn("", e);
-                }
+                LOG.warn("Unable to communicate with remote instance {}", remoteGroup, e);
             }
         }
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
@@ -794,8 +794,7 @@ public class SwappablePriorityQueue {
                     droppedSize = dropAction.drop(activeQueueRecords, requestor);
                     logger.debug("For DropFlowFileRequest {}, Dropped {} from active queue", requestIdentifier, droppedSize);
                 } catch (final IOException ioe) {
-                    logger.error("Failed to drop the FlowFiles from queue {} due to {}", getQueueIdentifier(), ioe.toString());
-                    logger.error("", ioe);
+                    logger.error("Failed to drop the FlowFiles from queue {}", getQueueIdentifier(), ioe);
 
                     dropRequest.setState(DropFlowFileState.FAILURE, "Failed to drop FlowFiles due to " + ioe.toString());
                     return;
@@ -817,8 +816,7 @@ public class SwappablePriorityQueue {
                 try {
                     droppedSize = dropAction.drop(swapQueue, requestor);
                 } catch (final IOException ioe) {
-                    logger.error("Failed to drop the FlowFiles from queue {} due to {}", getQueueIdentifier(), ioe.toString());
-                    logger.error("", ioe);
+                    logger.error("Failed to drop the FlowFiles from queue {}", getQueueIdentifier(), ioe);
 
                     dropRequest.setState(DropFlowFileState.FAILURE, "Failed to drop FlowFiles due to " + ioe.toString());
                     return;
@@ -886,8 +884,7 @@ public class SwappablePriorityQueue {
                     dropRequest.getDroppedSize().getObjectCount(), dropRequest.getDroppedSize().getByteCount(), getQueueIdentifier(), requestor);
                 dropRequest.setState(DropFlowFileState.COMPLETE);
             } catch (final Exception e) {
-                logger.error("Failed to drop FlowFiles from Connection with ID {} due to {}", getQueueIdentifier(), e.toString());
-                logger.error("", e);
+                logger.error("Failed to drop FlowFiles from Connection with ID {}", getQueueIdentifier(), e);
                 dropRequest.setState(DropFlowFileState.FAILURE, "Failed to drop FlowFiles due to " + e.toString());
             }
         } finally {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/client/async/nio/NioAsyncLoadBalanceClient.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/clustered/client/async/nio/NioAsyncLoadBalanceClient.java
@@ -264,7 +264,7 @@ public class NioAsyncLoadBalanceClient implements AsyncLoadBalanceClient {
                 try {
                     success = loadBalanceSession.communicate();
                 } catch (final Exception e) {
-                    logger.error("Failed to communicate with Peer {}", nodeIdentifier.toString(), e);
+                    logger.error("Failed to communicate with Peer {}", nodeIdentifier, e);
                     eventReporter.reportEvent(Severity.ERROR, "Load Balanced Connection", "Failed to communicate with Peer " + nodeIdentifier + " when load balancing data for Connection with ID " +
                         loadBalanceSession.getPartition().getConnectionId() + " due to " + e);
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/repository/FileSystemRepository.java
@@ -487,8 +487,7 @@ public class FileSystemRepository implements ContentRepository {
             }
         } catch (final IOException e) {
             final String action = archiveData ? "archive" : "remove";
-            LOG.warn("Unable to {} unknown file {} from File System Repository due to {}", action, fileDescription, e.toString());
-            LOG.warn("", e);
+            LOG.warn("Unable to {} unknown file {} from File System Repository", action, fileDescription, e);
         }
     }
 
@@ -519,7 +518,7 @@ public class FileSystemRepository implements ContentRepository {
         LOG.debug("Obtaining active resource claims, will return a list of {} resource claims for container {}", activeResourceClaims.size(), containerName);
         if (LOG.isTraceEnabled()) {
             LOG.trace("Listing of resource claims:");
-            activeResourceClaims.forEach(claim -> LOG.trace(claim.toString()));
+            activeResourceClaims.forEach(claim -> LOG.trace("{}", claim));
         }
 
         return activeResourceClaims;
@@ -1321,10 +1320,7 @@ public class FileSystemRepository implements ContentRepository {
                     return;
                 }
             } catch (final IOException ioe) {
-                LOG.warn("Failed to delete {} from archive due to {}", toDelete, ioe.toString());
-                if (LOG.isDebugEnabled()) {
-                    LOG.warn("", ioe);
-                }
+                LOG.warn("Failed to delete {} from archive", toDelete, ioe);
             }
         }
 
@@ -1361,10 +1357,7 @@ public class FileSystemRepository implements ContentRepository {
                                 LOG.debug("Deleted archived ContentClaim with ID {} from Container {} because it was older than the configured max archival duration",
                                         file.toFile().getName(), containerName);
                             } catch (final IOException ioe) {
-                                LOG.warn("Failed to remove archived ContentClaim with ID {} from Container {} due to {}", file.toFile().getName(), containerName, ioe.toString());
-                                if (LOG.isDebugEnabled()) {
-                                    LOG.warn("", ioe);
-                                }
+                                LOG.warn("Failed to remove archived ContentClaim with ID {} from Container {}", file.toFile().getName(), containerName, ioe);
                             }
                         } else if (usableSpace < minRequiredSpace) {
                             notYetExceedingThreshold.add(new ArchiveInfo(container, file, attrs.size(), lastModTime));
@@ -1374,10 +1367,7 @@ public class FileSystemRepository implements ContentRepository {
                     }
                 });
             } catch (final IOException ioe) {
-                LOG.warn("Failed to cleanup archived files in {} due to {}", archive, ioe.toString());
-                if (LOG.isDebugEnabled()) {
-                    LOG.warn("", ioe);
-                }
+                LOG.warn("Failed to cleanup archived files in {}", archive, ioe);
             }
         }
         final long deleteExpiredMillis = stopWatch.getElapsed(TimeUnit.MILLISECONDS);
@@ -1417,10 +1407,7 @@ public class FileSystemRepository implements ContentRepository {
                             archiveFilesDeleted, FormatUtils.formatDataSize(archiveBytesDeleted), notYetExceedingThreshold.size());
                 }
             } catch (final IOException ioe) {
-                LOG.warn("Failed to delete {} from archive due to {}", archiveInfo, ioe.toString());
-                if (LOG.isDebugEnabled()) {
-                    LOG.warn("", ioe);
-                }
+                LOG.warn("Failed to delete {} from archive", archiveInfo, ioe);
             }
         }
 
@@ -1479,10 +1466,7 @@ public class FileSystemRepository implements ContentRepository {
                                         successCount++;
                                     }
                                 } catch (final Exception e) {
-                                    LOG.warn("Failed to archive {} due to {}", claim, e.toString());
-                                    if (LOG.isDebugEnabled()) {
-                                        LOG.warn("", e);
-                                    }
+                                    LOG.warn("Failed to archive {}", claim, e);
                                 }
                             } else if (remove(claim)) {
                                 successCount++;
@@ -1505,10 +1489,7 @@ public class FileSystemRepository implements ContentRepository {
                     }
                 }
             } catch (final Throwable t) {
-                LOG.error("Failed to handle destructable claims due to {}", t.toString());
-                if (LOG.isDebugEnabled()) {
-                    LOG.error("", t);
-                }
+                LOG.error("Failed to handle destructable claims", t);
             }
         }
     }
@@ -1566,15 +1547,10 @@ public class FileSystemRepository implements ContentRepository {
                     final ContainerState containerState = containerStateMap.get(containerName);
                     containerState.signalCreationReady(); // indicate that we've finished cleaning up the archive.
                 } catch (final IOException ioe) {
-                    LOG.error("Failed to cleanup archive for container {} due to {}", containerName, ioe.toString());
-                    if (LOG.isDebugEnabled()) {
-                        LOG.error("", ioe);
-                    }
-                    return;
+                    LOG.error("Failed to cleanup archive for container {}", containerName, ioe);
                 }
             } catch (final Throwable t) {
-                LOG.error("Failed to cleanup archive for container {} due to {}", containerName, t.toString());
-                LOG.error("", t);
+                LOG.error("Failed to cleanup archive for container {}", containerName, t);
             }
         }
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/scheduling/StandardProcessScheduler.java
@@ -216,8 +216,7 @@ public final class StandardProcessScheduler implements ProcessScheduler {
             try {
                 schedulingAgent.shutdown();
             } catch (final Throwable t) {
-                LOG.error("Failed to shutdown Scheduling Agent {} due to {}", schedulingAgent, t.toString());
-                LOG.error("", t);
+                LOG.error("Failed to shutdown Scheduling Agent {}", schedulingAgent, t);
             }
         }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
@@ -204,7 +204,7 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
             logger.info("In order to inherit proposed dataflow, will stop any components that will be affected by the update");
             if (logger.isDebugEnabled()) {
                 logger.debug("Will stop the following components:");
-                logger.debug(activeSet.toString());
+                logger.debug("{}", activeSet);
                 final String differencesToString = flowDifferences.stream()
                         .map(FlowDifference::toString)
                         .collect(Collectors.joining("\n"));

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/local/WriteAheadLocalStateProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/state/providers/local/WriteAheadLocalStateProvider.java
@@ -178,8 +178,7 @@ public class WriteAheadLocalStateProvider extends AbstractStateProvider {
         try {
             writeAheadLog.shutdown();
         } catch (final IOException ioe) {
-            logger.warn("Failed to shut down {} successfully due to {}", this, ioe.toString());
-            logger.warn("", ioe);
+            logger.warn("Failed to shut down {} successfully", this, ioe);
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ConnectableTask.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ConnectableTask.java
@@ -291,7 +291,7 @@ public class ConnectableTask {
 
                     try {
                         rawSession.commitAsync(null, t -> {
-                            procLog.error("Failed to commit session {} due to {}; rolling back", rawSession, t.toString(), t);
+                            procLog.error("Failed to commit session {}; rolling back", rawSession, t);
                         });
                     } catch (final TerminatedTaskException tte) {
                         procLog.debug("Cannot commit Batch Process Session because the Task was forcefully terminated", tte);
@@ -301,8 +301,7 @@ public class ConnectableTask {
                 try {
                     updateEventRepo(startNanos, startCpuTime, startGcMillis, invocationCount, measureCpuTime, performanceTracker);
                 } catch (final IOException e) {
-                    logger.error("Unable to update FlowFileEvent Repository for {}; statistics may be inaccurate. Reason for failure: {}", connectable.getRunnableComponent(), e.toString());
-                    logger.error("", e);
+                    logger.error("Unable to update FlowFileEvent Repository for {}; statistics may be inaccurate.", connectable.getRunnableComponent(), e);
                 }
             } finally {
                 lifecycleState.decrementActiveThreadCount();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ExpireFlowFiles.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/tasks/ExpireFlowFiles.java
@@ -56,7 +56,7 @@ public class ExpireFlowFiles implements Runnable {
         try {
             expireFlowFiles(rootGroup);
         } catch (final Exception e) {
-            logger.error("Failed to expire FlowFiles due to {}", e.toString(), e);
+            logger.error("Failed to expire FlowFiles", e);
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/diagnostics/SystemDiagnosticsFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/diagnostics/SystemDiagnosticsFactory.java
@@ -93,10 +93,7 @@ public class SystemDiagnosticsFactory {
             flowFileRepoStorageUsage.setFreeSpace(0L);
             flowFileRepoStorageUsage.setTotalSpace(-1L);
 
-            logger.warn("Unable to determine FlowFile Repository usage due to {}", ioe.toString());
-            if (logger.isDebugEnabled()) {
-                logger.warn("", ioe);
-            }
+            logger.warn("Unable to determine FlowFile Repository usage", ioe);
         }
         systemDiagnostics.setFlowFileRepositoryStorageUsage(flowFileRepoStorageUsage);
 
@@ -111,10 +108,7 @@ public class SystemDiagnosticsFactory {
                 containerFree = contentRepo.getContainerUsableSpace(containerName);
                 containerCapacity = contentRepo.getContainerCapacity(containerName);
             } catch (final IOException ioe) {
-                logger.warn("Unable to determine Content Repository usage for container {} due to {}", containerName, ioe.toString());
-                if (logger.isDebugEnabled()) {
-                    logger.warn("", ioe);
-                }
+                logger.warn("Unable to determine Content Repository usage for container {}", containerName, ioe);
             }
 
             final StorageUsage storageUsage = new StorageUsage();
@@ -136,10 +130,7 @@ public class SystemDiagnosticsFactory {
                 containerFree = provenanceRepository.getContainerUsableSpace(containerName);
                 containerCapacity = provenanceRepository.getContainerCapacity(containerName);
             } catch (final IOException ioe) {
-                logger.warn("Unable to determine Provenance Repository usage for container {} due to {}", containerName, ioe.toString());
-                if (logger.isDebugEnabled()) {
-                    logger.warn("", ioe);
-                }
+                logger.warn("Unable to determine Provenance Repository usage for container {}", containerName, ioe);
             }
 
             final StorageUsage storageUsage = new StorageUsage();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/nar/StandardExtensionDiscoveringManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-nar-utils/src/main/java/org/apache/nifi/nar/StandardExtensionDiscoveringManager.java
@@ -793,7 +793,7 @@ public class StandardExtensionDiscoveringManager implements ExtensionDiscovering
             builder.append("\n\t=== End ").append(entry.getKey().getSimpleName()).append(" types ===");
         }
 
-        logger.info(builder.toString());
+        logger.info("{}", builder);
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-zookeeper-leader-election/src/main/java/org/apache/nifi/framework/cluster/leader/zookeeper/CuratorLeaderElectionManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-zookeeper-leader-election/src/main/java/org/apache/nifi/framework/cluster/leader/zookeeper/CuratorLeaderElectionManager.java
@@ -322,11 +322,7 @@ public class CuratorLeaderElectionManager extends TrackedLeaderElectionManager {
                 // If there is no ZNode, then there is no elected leader.
                 return Optional.empty();
             } catch (final Exception e) {
-                logger.warn("Unable to determine the Elected Leader for role '{}' due to {}; assuming no leader has been elected", roleName, e.toString());
-                if (logger.isDebugEnabled()) {
-                    logger.warn("", e);
-                }
-
+                logger.warn("Unable to determine the Elected Leader for role '{}'; assuming no leader has been elected", roleName, e);
                 return Optional.empty();
             }
         } finally {
@@ -563,10 +559,7 @@ public class CuratorLeaderElectionManager extends TrackedLeaderElectionManager {
                     try {
                         listener.onStopLeading();
                     } catch (final Exception e) {
-                        logger.error("This node is no longer leader for role '{}' but failed to shutdown leadership responsibilities properly due to: {}", roleName, e.toString());
-                        if (logger.isDebugEnabled()) {
-                            logger.error("", e);
-                        }
+                        logger.error("This node is no longer leader for role '{}' but failed to shutdown leadership responsibilities properly", roleName, e);
                     }
                 }
             }

--- a/nifi-framework-bundle/nifi-framework/nifi-runtime/src/main/java/org/apache/nifi/NiFi.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-runtime/src/main/java/org/apache/nifi/NiFi.java
@@ -188,7 +188,7 @@ public class NiFi implements NiFiEntryPoint {
 
     protected void setDefaultUncaughtExceptionHandler() {
         Thread.setDefaultUncaughtExceptionHandler((thread, exception) -> {
-            LOGGER.error("An Unknown Error Occurred in Thread {}: {}", thread, exception.toString(), exception);
+            LOGGER.error("An Unknown Error Occurred in Thread {}", thread, exception);
         });
     }
 
@@ -442,7 +442,7 @@ public class NiFi implements NiFiEntryPoint {
             passwordFile.delete();
 
         } catch (IOException e) {
-            LOGGER.error("Caught IOException while retrieving the {} -passed keyfile; aborting: {}", KEY_FILE_FLAG, e.toString());
+            LOGGER.error("Caught IOException while retrieving the {} -passed keyfile; aborting", KEY_FILE_FLAG, e);
             System.exit(1);
         }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/SocketRemoteSiteListener.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/SocketRemoteSiteListener.java
@@ -130,10 +130,7 @@ public class SocketRemoteSiteListener implements RemoteSiteListener {
                     }
 
                 } catch (final IOException e) {
-                    LOG.error("Unable to open server socket due to {}", e.toString());
-                    if (LOG.isDebugEnabled()) {
-                        LOG.error("", e);
-                    }
+                    LOG.error("Unable to open server socket", e);
                 }
 
 
@@ -285,21 +282,12 @@ public class SocketRemoteSiteListener implements RemoteSiteListener {
                                 }
                                 LOG.debug("Finished communicating with {} ({})", peer, protocol);
                             } catch (final Exception e) {
-                                LOG.error("Unable to communicate with remote instance {} ({}) due to {}; closing connection", peer, protocol, e.toString());
-                                if (LOG.isDebugEnabled()) {
-                                    LOG.error("", e);
-                                }
+                                LOG.error("Unable to communicate with remote instance {} ({}); closing connection", peer, protocol, e);
                             }
                         } catch (final IOException e) {
-                            LOG.error("Unable to communicate with remote instance {} due to {}; closing connection", peer, e.toString());
-                            if (LOG.isDebugEnabled()) {
-                                LOG.error("", e);
-                            }
+                            LOG.error("Unable to communicate with remote instance {}; closing connection", peer, e);
                         } catch (final Throwable t) {
-                            LOG.error("Handshake failed when communicating with {}; closing connection. Reason for failure: {}", peerUri, t.toString());
-                            if (LOG.isDebugEnabled()) {
-                                LOG.error("", t);
-                            }
+                            LOG.error("Handshake failed when communicating with {}; closing connection.", peerUri, t);
                         } finally {
                             LOG.trace("Cleaning up");
                             try {
@@ -307,7 +295,7 @@ public class SocketRemoteSiteListener implements RemoteSiteListener {
                                     protocol.shutdown(peer);
                                 }
                             } catch (final Exception protocolException) {
-                                LOG.warn("Failed to shutdown protocol due to {}", protocolException.toString());
+                                LOG.warn("Failed to shutdown protocol", protocolException);
                             }
 
                             try {
@@ -315,7 +303,7 @@ public class SocketRemoteSiteListener implements RemoteSiteListener {
                                     peer.close();
                                 }
                             } catch (final Exception peerException) {
-                                LOG.warn("Failed to close peer due to {}; some resources may not be appropriately cleaned up", peerException.toString());
+                                LOG.warn("Failed to close peer; some resources may not be appropriately cleaned up", peerException);
                             }
                             LOG.trace("Finished cleaning up");
                         }
@@ -399,10 +387,7 @@ public class SocketRemoteSiteListener implements RemoteSiteListener {
                 }
             }
         } catch (final IOException e) {
-            LOG.error("RemoteSiteListener Unable to accept connection due to {}", e.toString());
-            if (LOG.isDebugEnabled()) {
-                LOG.error("", e);
-            }
+            LOG.error("RemoteSiteListener Unable to accept connection", e);
             return acceptedSocket;
         }
         LOG.trace("Got connection");

--- a/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/StandardRemoteGroupPort.java
@@ -280,10 +280,7 @@ public class StandardRemoteGroupPort extends RemoteGroupPort {
             if (t instanceof TransmissionDisabledException) {
                 logger.debug(message, t);
             } else {
-                logger.error("{} failed to communicate with remote NiFi instance due to {}", this, t.toString());
-                if (logger.isDebugEnabled()) {
-                    logger.error("", t);
-                }
+                logger.error("{} failed to communicate with remote NiFi instance", this, t);
 
                 remoteGroup.getEventReporter().reportEvent(Severity.ERROR, CATEGORY, message);
             }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/dto/DtoFactoryTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/dto/DtoFactoryTest.java
@@ -83,7 +83,7 @@ public class DtoFactoryTest {
         final List<AllowableValueEntity> allowableValues = dto.getAllowableValues();
         final List<String> namesActual = allowableValues.stream()
                 .map(v -> v.getAllowableValue().getDisplayName()).collect(Collectors.toList());
-        logger.trace(namesActual.toString());
+        logger.trace("{}", namesActual);
         assertEquals(Arrays.asList("ReaderX", "ReaderY", "ReaderZ"), namesActual);
     }
 
@@ -106,7 +106,7 @@ public class DtoFactoryTest {
         final List<AllowableValueEntity> allowableValues = dto.getAllowableValues();
         final List<String> namesActual = allowableValues.stream()
                 .map(v -> v.getAllowableValue().getDisplayName()).collect(Collectors.toList());
-        logger.trace(namesActual.toString());
+        logger.trace("{}", namesActual);
         assertEquals(Arrays.asList("Default Signature", "Signature v4", "Signature v2"), namesActual);
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/X509AuthenticationProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/X509AuthenticationProvider.java
@@ -157,7 +157,7 @@ public class X509AuthenticationProvider extends NiFiAuthenticationProvider {
             user = user.getChain();
         }
         builder.append("\n============");
-        LOGGER.trace(builder.toString());
+        LOGGER.trace("{}", builder);
     }
 
     /**

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/ocsp/OcspCertificateValidator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/ocsp/OcspCertificateValidator.java
@@ -128,9 +128,9 @@ public class OcspCertificateValidator {
                 ocspCache = Caffeine.newBuilder().expireAfterWrite(cacheDurationMillis, TimeUnit.MILLISECONDS).build(ocspRequest -> {
                     final String subjectDn = ocspRequest.getSubjectCertificate().getSubjectX500Principal().getName();
 
-                    logger.info(String.format("Validating client certificate via OCSP: <%s>", subjectDn));
+                    logger.info("Validating client certificate via OCSP: <{}>", subjectDn);
                     final OcspStatus ocspStatus = getOcspStatus(ocspRequest);
-                    logger.info(String.format("Client certificate status for <%s>: %s", subjectDn, ocspStatus.toString()));
+                    logger.info("Client certificate status for <{}>: {}", subjectDn, ocspStatus);
 
                     return ocspStatus;
                 });
@@ -341,14 +341,14 @@ public class OcspCertificateValidator {
 
             // only proceed if the response was successful
             if (ocspResponse.getStatus() != OCSPRespBuilder.SUCCESSFUL) {
-                logger.warn(String.format("OCSP request was unsuccessful (%s).", ocspStatus.getResponseStatus().toString()));
+                logger.warn("OCSP request was unsuccessful ({}).", ocspStatus.getResponseStatus());
                 return ocspStatus;
             }
 
             // ensure the appropriate response object
             final Object ocspResponseObject = ocspResponse.getResponseObject();
             if (!(ocspResponseObject instanceof BasicOCSPResp)) {
-                logger.warn(String.format("Unexpected OCSP response object: %s", ocspResponseObject));
+                logger.warn("Unexpected OCSP response object: {}", ocspResponseObject);
                 return ocspStatus;
             }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
@@ -140,7 +140,7 @@ class GitFlowMetaData {
     }
 
     private static boolean hasAtLeastOneReference(Repository repo) throws IOException {
-        logger.info("Checking references for repository {}", repo.toString());
+        logger.info("Checking references for repository {}", repo);
         for (Ref ref : repo.getRefDatabase().getRefs()) {
             if (ref.getObjectId() == null) {
                 continue;

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/hook/LoggingEventHookProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/hook/LoggingEventHookProvider.java
@@ -53,7 +53,7 @@ public class LoggingEventHookProvider
 
         builder.append("] ");
 
-        LOGGER.info(builder.toString());
+        LOGGER.info("{}", builder);
     }
 
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileAccessPolicyProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileAccessPolicyProvider.java
@@ -157,7 +157,7 @@ public class FileAccessPolicyProvider extends AbstractConfigurableAccessPolicyPr
             // load the authorizations
             load();
 
-            logger.info(String.format("Authorizations file loaded at %s", new Date().toString()));
+            logger.info("Authorizations file loaded at {}", new Date());
         } catch (JAXBException | SAXException e) {
             throw new SecurityProviderCreationException(e);
         }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileUserGroupProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileUserGroupProvider.java
@@ -140,7 +140,7 @@ public class FileUserGroupProvider implements ConfigurableUserGroupProvider {
 
             load();
 
-            logger.info(String.format("Users/Groups file loaded at %s", new Date().toString()));
+            logger.info("Users/Groups file loaded at {}", new Date());
         } catch (SecurityProviderCreationException | JAXBException | IllegalStateException | SAXException e) {
             throw new SecurityProviderCreationException(e);
         }

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
@@ -166,8 +166,7 @@ public class NiFiRegistrySecurityConfig {
 
             // return a 401 response
             final int status = HttpServletResponse.SC_UNAUTHORIZED;
-            logger.info("Client could not be authenticated due to: {} Returning 401 response.", authenticationException.toString());
-            logger.debug("", authenticationException);
+            logger.info("Client could not be authenticated. Returning 401 response.", authenticationException);
 
             if (!response.isCommitted()) {
                 response.setStatus(status);
@@ -186,7 +185,7 @@ public class NiFiRegistrySecurityConfig {
             if (accessDeniedException instanceof CsrfException) {
                 status = HttpServletResponse.SC_FORBIDDEN;
                 message = "Access Denied: CSRF Header and Cookie not matched";
-                logger.info("Access Denied: CSRF Header [{}] not matched: {}", CsrfCookieName.REQUEST_TOKEN.getCookieName(), accessDeniedException.toString());
+                logger.info("Access Denied: CSRF Header [{}] not matched", CsrfCookieName.REQUEST_TOKEN.getCookieName(), accessDeniedException);
             } else {
                 status = HttpServletResponse.SC_UNAUTHORIZED;
                 message = "Access Denied";

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
@@ -185,7 +185,7 @@ public class NiFiRegistrySecurityConfig {
             if (accessDeniedException instanceof CsrfException) {
                 status = HttpServletResponse.SC_FORBIDDEN;
                 message = "Access Denied: CSRF Header and Cookie not matched";
-                logger.info("Access Denied: CSRF Header [{}] not matched", CsrfCookieName.REQUEST_TOKEN.getCookieName(), accessDeniedException);
+                logger.info("Access Denied: CSRF Header [{}] not matched: {}", CsrfCookieName.REQUEST_TOKEN.getCookieName(), accessDeniedException.toString());
             } else {
                 status = HttpServletResponse.SC_UNAUTHORIZED;
                 message = "Access Denied";

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
@@ -166,7 +166,8 @@ public class NiFiRegistrySecurityConfig {
 
             // return a 401 response
             final int status = HttpServletResponse.SC_UNAUTHORIZED;
-            logger.info("Client could not be authenticated. Returning 401 response.", authenticationException);
+            logger.info("Client could not be authenticated due to: {} Returning 401 response.", authenticationException.toString());
+            logger.debug("HTTP 401 Unauthorized", authenticationException);
 
             if (!response.isCommitted()) {
                 response.setStatus(status);

--- a/nifi-stateless/nifi-stateless-bootstrap/src/main/java/org/apache/nifi/stateless/bootstrap/RunStatelessFlow.java
+++ b/nifi-stateless/nifi-stateless-bootstrap/src/main/java/org/apache/nifi/stateless/bootstrap/RunStatelessFlow.java
@@ -96,7 +96,7 @@ public class RunStatelessFlow {
 
         final StatelessDataflowValidation validation = dataflow.performValidation();
         if (!validation.isValid()) {
-            logger.error(validation.toString());
+            logger.error("{}", validation);
             throw new IllegalStateException("Dataflow is not valid");
         }
 

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/controller/reporting/LogComponentStatuses.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/controller/reporting/LogComponentStatuses.java
@@ -121,7 +121,7 @@ public class LogComponentStatuses implements Runnable {
         }
 
         builder.append(processorBorderLine);
-        logger.info(builder.toString());
+        logger.info("{}", builder);
     }
 
     private void addStatus(final ProcessorAndEvent processorAndEvent, final StringBuilder builder, final int secondsInEvent, final long totalNanos) {
@@ -182,7 +182,7 @@ public class LogComponentStatuses implements Runnable {
         }
 
         builder.append(counterBorderLine);
-        logger.info(builder.toString());
+        logger.info("{}", builder);
     }
 
     private static class ProcessorAndEvent {

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/session/StatelessProcessSession.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/session/StatelessProcessSession.java
@@ -341,7 +341,7 @@ public class StatelessProcessSession extends StandardProcessSession {
             procEvent.setInvocations(1);
             getRepositoryContext().getFlowFileEventRepository().updateRepository(procEvent, connectable.getIdentifier());
         } catch (final IOException e) {
-            logger.error("Unable to update FlowFileEvent Repository for {}; statistics may be inaccurate. Reason for failure: {}", connectable.getRunnableComponent(), e.toString(), e);
+            logger.error("Unable to update FlowFileEvent Repository for {}; statistics may be inaccurate.", connectable.getRunnableComponent(), e);
         }
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13403](https://issues.apache.org/jira/browse/NIFI-13403)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
