### PR TITLE
NIFI-13422: Use unique instances for ScanRule implementatations for QueryNiFiReportingTask

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-hive-bundle/pom.xml
@@ -137,7 +137,7 @@
         <hive3.version>3.1.3</hive3.version>
         <hive.version>${hive3.version}</hive.version>
         <avatica.version>1.24.0</avatica.version>
-        <calcite.version>1.36.0</calcite.version>
+        <calcite.version>1.37.0</calcite.version>
         <calcite.avatica.version>1.6.0</calcite.avatica.version>
     </properties>
 

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/pom.xml
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.36.0</version>
+            <version>1.37.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/bulletins/BulletinProjectTableScanRule.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/bulletins/BulletinProjectTableScanRule.java
@@ -30,13 +30,11 @@ import java.util.List;
  * the projection is removed.
  */
 public class BulletinProjectTableScanRule extends RelOptRule {
-    public static final BulletinProjectTableScanRule INSTANCE = new BulletinProjectTableScanRule();
 
-    private BulletinProjectTableScanRule() {
+    public BulletinProjectTableScanRule() {
         super(
             operand(LogicalProject.class,
-                operand(BulletinTableScan.class, none())),
-            "BulletinProjectTableScanRule");
+                operand(BulletinTableScan.class, none())));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/bulletins/BulletinTableScan.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/bulletins/BulletinTableScan.java
@@ -77,7 +77,7 @@ public class BulletinTableScan extends TableScan implements EnumerableRel {
 
     @Override
     public void register(RelOptPlanner planner) {
-        planner.addRule(BulletinProjectTableScanRule.INSTANCE);
+        planner.addRule(new BulletinProjectTableScanRule());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatus/ConnectionStatusProjectTableScanRule.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatus/ConnectionStatusProjectTableScanRule.java
@@ -30,13 +30,11 @@ import java.util.List;
  * the projection is removed.
  */
 public class ConnectionStatusProjectTableScanRule extends RelOptRule {
-    public static final ConnectionStatusProjectTableScanRule INSTANCE = new ConnectionStatusProjectTableScanRule();
 
-    private ConnectionStatusProjectTableScanRule() {
+    public ConnectionStatusProjectTableScanRule() {
         super(
             operand(LogicalProject.class,
-                operand(ConnectionStatusTableScan.class, none())),
-            "ConnectionStatusProjectTableScanRule");
+                operand(ConnectionStatusTableScan.class, none())));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatus/ConnectionStatusTableScan.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatus/ConnectionStatusTableScan.java
@@ -77,7 +77,7 @@ public class ConnectionStatusTableScan extends TableScan implements EnumerableRe
 
     @Override
     public void register(RelOptPlanner planner) {
-        planner.addRule(ConnectionStatusProjectTableScanRule.INSTANCE);
+        planner.addRule(new ConnectionStatusProjectTableScanRule());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatuspredictions/ConnectionStatusPredictionsEnumerator.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatuspredictions/ConnectionStatusPredictionsEnumerator.java
@@ -48,7 +48,7 @@ public class ConnectionStatusPredictionsEnumerator implements Enumerator<Object>
 
     @Override
     public boolean moveNext() {
-        //currentRow = null;
+        currentRow = null;
         final ConnectionStatus connectionStatus = connectionStatusIterator.next();
         if (connectionStatus == null) {
             // If we are out of data, close the InputStream. We do this because

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatuspredictions/ConnectionStatusPredictionsEnumerator.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatuspredictions/ConnectionStatusPredictionsEnumerator.java
@@ -48,7 +48,7 @@ public class ConnectionStatusPredictionsEnumerator implements Enumerator<Object>
 
     @Override
     public boolean moveNext() {
-        currentRow = null;
+        //currentRow = null;
         final ConnectionStatus connectionStatus = connectionStatusIterator.next();
         if (connectionStatus == null) {
             // If we are out of data, close the InputStream. We do this because

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatuspredictions/ConnectionStatusPredictionsProjectTableScanRule.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatuspredictions/ConnectionStatusPredictionsProjectTableScanRule.java
@@ -30,13 +30,11 @@ import java.util.List;
  * the projection is removed.
  */
 public class ConnectionStatusPredictionsProjectTableScanRule extends RelOptRule {
-    public static final ConnectionStatusPredictionsProjectTableScanRule INSTANCE = new ConnectionStatusPredictionsProjectTableScanRule();
 
-    private ConnectionStatusPredictionsProjectTableScanRule() {
+    public ConnectionStatusPredictionsProjectTableScanRule() {
         super(
             operand(LogicalProject.class,
-                operand(ConnectionStatusPredictionsTableScan.class, none())),
-            "ConnectionStatusProjectTableScanRule");
+                operand(ConnectionStatusPredictionsTableScan.class, none())));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatuspredictions/ConnectionStatusPredictionsTableScan.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/connectionstatuspredictions/ConnectionStatusPredictionsTableScan.java
@@ -77,7 +77,7 @@ public class ConnectionStatusPredictionsTableScan extends TableScan implements E
 
     @Override
     public void register(RelOptPlanner planner) {
-        planner.addRule(ConnectionStatusPredictionsProjectTableScanRule.INSTANCE);
+        planner.addRule(new ConnectionStatusPredictionsProjectTableScanRule());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/flowconfighistory/FlowConfigHistoryProjectTableScanRule.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/flowconfighistory/FlowConfigHistoryProjectTableScanRule.java
@@ -30,13 +30,11 @@ import java.util.List;
  * the projection is removed.
  */
 public class FlowConfigHistoryProjectTableScanRule extends RelOptRule {
-    public static final FlowConfigHistoryProjectTableScanRule INSTANCE = new FlowConfigHistoryProjectTableScanRule();
 
-    private FlowConfigHistoryProjectTableScanRule() {
+    public FlowConfigHistoryProjectTableScanRule() {
         super(
             operand(LogicalProject.class,
-                operand(FlowConfigHistoryTableScan.class, none())),
-            "BulletinProjectTableScanRule");
+                operand(FlowConfigHistoryTableScan.class, none())));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/flowconfighistory/FlowConfigHistoryTableScan.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/flowconfighistory/FlowConfigHistoryTableScan.java
@@ -77,7 +77,7 @@ public class FlowConfigHistoryTableScan extends TableScan implements EnumerableR
 
     @Override
     public void register(RelOptPlanner planner) {
-        planner.addRule(FlowConfigHistoryProjectTableScanRule.INSTANCE);
+        planner.addRule(new FlowConfigHistoryProjectTableScanRule());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/metrics/JvmMetricsProjectTableScanRule.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/metrics/JvmMetricsProjectTableScanRule.java
@@ -30,9 +30,8 @@ import java.util.List;
  * the projection is removed.
  */
 public class JvmMetricsProjectTableScanRule extends RelOptRule {
-    public static final JvmMetricsProjectTableScanRule INSTANCE = new JvmMetricsProjectTableScanRule();
 
-    private JvmMetricsProjectTableScanRule() {
+    public JvmMetricsProjectTableScanRule() {
         super(
             operand(LogicalProject.class,
                 operand(JvmMetricsTableScan.class, none())),

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/metrics/JvmMetricsTableScan.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/metrics/JvmMetricsTableScan.java
@@ -77,7 +77,7 @@ public class JvmMetricsTableScan extends TableScan implements EnumerableRel {
 
     @Override
     public void register(RelOptPlanner planner) {
-        planner.addRule(JvmMetricsProjectTableScanRule.INSTANCE);
+        planner.addRule(new JvmMetricsProjectTableScanRule());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/processgroupstatus/ProcessGroupStatusProjectTableScanRule.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/processgroupstatus/ProcessGroupStatusProjectTableScanRule.java
@@ -30,13 +30,11 @@ import java.util.List;
  * the projection is removed.
  */
 public class ProcessGroupStatusProjectTableScanRule extends RelOptRule {
-    public static final ProcessGroupStatusProjectTableScanRule INSTANCE = new ProcessGroupStatusProjectTableScanRule();
 
-    private ProcessGroupStatusProjectTableScanRule() {
+    public ProcessGroupStatusProjectTableScanRule() {
         super(
             operand(LogicalProject.class,
-                operand(ProcessGroupStatusTableScan.class, none())),
-            "ProcessGroupStatusProjectTableScanRule");
+                operand(ProcessGroupStatusTableScan.class, none())));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/processgroupstatus/ProcessGroupStatusTableScan.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/processgroupstatus/ProcessGroupStatusTableScan.java
@@ -77,7 +77,7 @@ public class ProcessGroupStatusTableScan extends TableScan implements Enumerable
 
     @Override
     public void register(RelOptPlanner planner) {
-        planner.addRule(ProcessGroupStatusProjectTableScanRule.INSTANCE);
+        planner.addRule(new ProcessGroupStatusProjectTableScanRule());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/processorstatus/ProcessorStatusProjectTableScanRule.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/processorstatus/ProcessorStatusProjectTableScanRule.java
@@ -30,13 +30,11 @@ import java.util.List;
  * the projection is removed.
  */
 public class ProcessorStatusProjectTableScanRule extends RelOptRule {
-    public static final ProcessorStatusProjectTableScanRule INSTANCE = new ProcessorStatusProjectTableScanRule();
 
-    private ProcessorStatusProjectTableScanRule() {
+    public ProcessorStatusProjectTableScanRule() {
         super(
             operand(LogicalProject.class,
-                operand(ProcessorStatusTableScan.class, none())),
-            "ProcessorStatusProjectTableScanRule");
+                operand(ProcessorStatusTableScan.class, none())));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/processorstatus/ProcessorStatusTableScan.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/processorstatus/ProcessorStatusTableScan.java
@@ -77,7 +77,7 @@ public class ProcessorStatusTableScan extends TableScan implements EnumerableRel
 
     @Override
     public void register(RelOptPlanner planner) {
-        planner.addRule(ProcessorStatusProjectTableScanRule.INSTANCE);
+        planner.addRule(new ProcessorStatusProjectTableScanRule());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/provenance/ProvenanceProjectTableScanRule.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/provenance/ProvenanceProjectTableScanRule.java
@@ -30,13 +30,11 @@ import java.util.List;
  * the projection is removed.
  */
 public class ProvenanceProjectTableScanRule extends RelOptRule {
-    public static final ProvenanceProjectTableScanRule INSTANCE = new ProvenanceProjectTableScanRule();
 
-    private ProvenanceProjectTableScanRule() {
+    public ProvenanceProjectTableScanRule() {
         super(
             operand(LogicalProject.class,
-                operand(ProvenanceTableScan.class, none())),
-            "ProvenanceProjectTableScanRule");
+                operand(ProvenanceTableScan.class, none())));
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/provenance/ProvenanceTableScan.java
+++ b/nifi-nar-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/provenance/ProvenanceTableScan.java
@@ -77,7 +77,7 @@ public class ProvenanceTableScan extends TableScan implements EnumerableRel {
 
     @Override
     public void register(RelOptPlanner planner) {
-        planner.addRule(ProvenanceProjectTableScanRule.INSTANCE);
+        planner.addRule(new ProvenanceProjectTableScanRule());
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/pom.xml
@@ -252,7 +252,7 @@
             <dependency>
                 <groupId>org.apache.calcite</groupId>
                 <artifactId>calcite-core</artifactId>
-                <version>1.36.0</version>
+                <version>1.37.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>log4j</groupId>


### PR DESCRIPTION
# Summary

[NIFI-13422](https://issues.apache.org/jira/browse/NIFI-13422) This PR proposes to replace the singleton ScanRule implementations to use unique instances with no description for 1.x (main has been refactored but not backported)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `support/nifi-1.x` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
