### PR TITLE
NIFI-13416: Inherited Parameter Table Improvements

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.html
@@ -39,7 +39,9 @@
                         <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
                         <td mat-cell *matCellDef="let item">
                             <div class="flex justify-between items-center">
-                                <div>
+                                <div
+                                    class="whitespace-nowrap overflow-hidden text-ellipsis leading-normal"
+                                    [title]="item.entity.parameter.name">
                                     {{ item.entity.parameter.name }}
                                 </div>
                                 @if (hasDescription(item)) {
@@ -47,7 +49,16 @@
                                         class="fa fa-info-circle primary-color"
                                         nifiTooltip
                                         [tooltipComponentType]="TextTip"
-                                        [tooltipInputData]="item.entity.parameter.description"></i>
+                                        [tooltipInputData]="item.entity.parameter.description"
+                                        [delayClose]="false"></i>
+                                }
+                                @if (canOverride(item)) {
+                                    <i
+                                        class="fa fa-level-down primary-color"
+                                        nifiTooltip
+                                        [tooltipComponentType]="TextTip"
+                                        tooltipInputData="This parameter is inherited form another Parameter Context."
+                                        [delayClose]="false"></i>
                                 }
                             </div>
                         </td>
@@ -119,6 +130,12 @@
                                         <button mat-menu-item [routerLink]="getParameterLink(item)">
                                             <i class="fa fa-long-arrow-right primary-color mr-2"></i>
                                             Go to
+                                        </button>
+                                    }
+                                    @if (canOverride(item)) {
+                                        <button mat-menu-item (click)="overrideParameter(item)">
+                                            <i class="fa mr-2"></i>
+                                            Override
                                         </button>
                                     }
                                     @if (canEdit(item) && !isDisabled) {


### PR DESCRIPTION
NIFI-13416:
- Allowing new parameters to override inherited parameters.
- Adding a new Override action to prepopulate the parameter name and sensitivity.
- Showing an indicator when a parameter in the listing is inherited.