### PR TITLE
NIFI-13450 Regenerate MiNiFi Agent Manifest between Heartbeats

### DIFF
--- a/c2/c2-client-bundle/c2-client-service/src/test/java/org/apache/nifi/c2/client/service/C2HeartbeatManagerTest.java
+++ b/c2/c2-client-bundle/c2-client-service/src/test/java/org/apache/nifi/c2/client/service/C2HeartbeatManagerTest.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
 import org.apache.nifi.c2.client.api.C2Client;
 import org.apache.nifi.c2.client.service.model.RuntimeInfoWrapper;
 import org.apache.nifi.c2.protocol.api.C2Heartbeat;
@@ -53,6 +55,9 @@ public class C2HeartbeatManagerTest {
     private ReentrantLock mockHeartbeatLock;
 
     @Mock
+    private Supplier<RuntimeInfoWrapper> mockRuntimeInfoWrapperSupplier;
+
+    @Mock
     private RuntimeInfoWrapper mockRuntimeInfoWrapper;
 
     @Mock
@@ -75,6 +80,7 @@ public class C2HeartbeatManagerTest {
 
     @Test
     void shouldSendHeartbeatAndProcessEmptyResponse() {
+        when(mockRuntimeInfoWrapperSupplier.get()).thenReturn(mockRuntimeInfoWrapper);
         when(mockHeartbeatLock.tryLock()).thenReturn(true);
         C2Heartbeat mockC2Heartbeat = mock(C2Heartbeat.class);
         when(mockC2HeartbeatFactory.create(mockRuntimeInfoWrapper)).thenReturn(mockC2Heartbeat);
@@ -91,6 +97,7 @@ public class C2HeartbeatManagerTest {
 
     @Test
     void shouldSendHeartbeatAndProcessResponseWithNoOperation() {
+        when(mockRuntimeInfoWrapperSupplier.get()).thenReturn(mockRuntimeInfoWrapper);
         when(mockHeartbeatLock.tryLock()).thenReturn(true);
         C2Heartbeat mockC2Heartbeat = mock(C2Heartbeat.class);
         when(mockC2HeartbeatFactory.create(mockRuntimeInfoWrapper)).thenReturn(mockC2Heartbeat);
@@ -108,6 +115,7 @@ public class C2HeartbeatManagerTest {
 
     @Test
     void shouldSendHeartbeatAndProcessResponseWithMultipleOperation() {
+        when(mockRuntimeInfoWrapperSupplier.get()).thenReturn(mockRuntimeInfoWrapper);
         when(mockHeartbeatLock.tryLock()).thenReturn(true);
         C2Heartbeat mockC2Heartbeat = mock(C2Heartbeat.class);
         when(mockC2HeartbeatFactory.create(mockRuntimeInfoWrapper)).thenReturn(mockC2Heartbeat);
@@ -128,6 +136,7 @@ public class C2HeartbeatManagerTest {
 
     @Test
     void shouldReleaseHeartbeatLockWhenExceptionOccurs() {
+        when(mockRuntimeInfoWrapperSupplier.get()).thenReturn(mockRuntimeInfoWrapper);
         when(mockHeartbeatLock.tryLock()).thenReturn(true);
         when(mockC2HeartbeatFactory.create(mockRuntimeInfoWrapper)).thenThrow(new RuntimeException());
 

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/C2NifiClientService.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/C2NifiClientService.java
@@ -174,7 +174,7 @@ public class C2NifiClientService {
         this.c2OperationManager = new C2OperationManager(
             client, c2OperationHandlerProvider, heartbeatLock, operationQueueDAO, c2OperationRestartHandler);
         this.c2HeartbeatManager = new C2HeartbeatManager(
-            client, heartbeatFactory, heartbeatLock, generateRuntimeInfo(), c2OperationManager);
+            client, heartbeatFactory, heartbeatLock, this::generateRuntimeInfo, c2OperationManager);
     }
 
     private C2ClientConfig generateClientConfig(NiFiProperties properties) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13450](https://issues.apache.org/jira/browse/NIFI-13450)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
