### PR TITLE
NIFI-13454: Renaming FileParameterProvider to KubernetesSecretParamet…

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/main/java/org/apache/nifi/parameter/KubernetesSecretParameterProvider.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/main/java/org/apache/nifi/parameter/KubernetesSecretParameterProvider.java
@@ -34,6 +34,7 @@ import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.stream.io.LimitingInputStream;
 
+import java.beans.ParameterDescriptor;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -53,8 +54,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @Tags({"file"})
-@CapabilityDescription("Fetches parameters from files.  Parameter groups are indicated by a set of directories, and files within the directories map to parameter names. " +
-        "The content of the file becomes the parameter value.")
+@CapabilityDescription("Fetches parameters from files, in the format provided by Kubernetes mounted secrets.  " +
+        "Parameter groups are indicated by a set of directories, and files within the directories map to parameter names. " +
+        "The content of the file becomes the parameter value.  Since Kubernetes mounted Secrets are base64-encoded, the " +
+        "parameter provider defaults to Base64-decoding the value of the parameter from the file.")
 
 @Restricted(
         restrictions = {
@@ -63,7 +66,7 @@ import java.util.stream.Collectors;
                         explanation = "Provides operator the ability to read from any file that NiFi has access to.")
         }
 )
-public class FileParameterProvider extends AbstractParameterProvider implements VerifiableParameterProvider  {
+public class KubernetesSecretParameterProvider extends AbstractParameterProvider implements VerifiableParameterProvider  {
     private static final int MAX_SIZE_LIMIT = 8096;
     private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/main/java/org/apache/nifi/parameter/KubernetesSecretParameterProvider.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/main/java/org/apache/nifi/parameter/KubernetesSecretParameterProvider.java
@@ -34,7 +34,6 @@ import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.stream.io.LimitingInputStream;
 
-import java.beans.ParameterDescriptor;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/main/resources/META-INF/services/org.apache.nifi.parameter.ParameterProvider
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/main/resources/META-INF/services/org.apache.nifi.parameter.ParameterProvider
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 org.apache.nifi.parameter.EnvironmentVariableParameterProvider
-org.apache.nifi.parameter.FileParameterProvider
+org.apache.nifi.parameter.KubernetesSecretParameterProvider
 org.apache.nifi.parameter.DatabaseParameterProvider
 org.apache.nifi.parameter.OnePasswordParameterProvider

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/main/resources/docs/org.apache.nifi.parameter.KubernetesSecretParameterProvider/additionalDetails.html
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-parameter-providers/src/main/resources/docs/org.apache.nifi.parameter.KubernetesSecretParameterProvider/additionalDetails.html
@@ -16,23 +16,24 @@
 -->
 <head>
     <meta charset="utf-8" />
-    <title>FileParameterProvider</title>
+    <title>KubernetesSecretParameterProvider</title>
 
     <link rel="stylesheet" href="../../../../../css/component-usage.css" type="text/css" />
 </head>
 <body>
-    <h3>Deriving Parameters from Files</h3>
+    <h3>Deriving Parameters from mounted Kubernetes Secret files</h3>
 
     <p>
-        The FileParameterProvider maps a directory to a parameter group named after the directory, and the files
+        The KubernetesSecretParameterProvider maps a directory to a parameter group named after the directory, and the files
         within the directory to parameters.  Each file's name is mapped to a parameter, and the content of the file
         becomes the value.  Hidden files and nested directories are ignored.
     </p>
 
     <p>
-        While this provider can be useful in a range of cases, it particularly matches the mounted volume secret
-        structure in Kubernetes.  A full discussion of Kubernetes secrets is beyond the scope of this document,
-        but a brief overview can illustrate how these secrets can be mapped to parameter groups.
+        While this provider can be useful in a range of cases since it simply reads parameter values from local files, it
+        particularly matches the mounted volume secret structure in Kubernetes.  A full discussion of Kubernetes secrets
+        is beyond the scope of this document, but a brief overview can illustrate how these secrets can be mapped to
+        parameter groups.
     </p>
 
     <h3>Kubernetes Mounted Secrets Example</h3>
@@ -82,7 +83,7 @@ sys.access.key  sys.admin.password sys.admin.username
 
     <p>
         Therefore, to map this secret to a parameter group that will populate a Parameter Context named 'system-credentials',
-        you should simply provide the following configuration to the FileParameterProvider:
+        you should simply provide the following configuration to the KubernetesSecretParameterProvider:
 
         <ul>
             <li><b>Parameter Group Directories</b> - /etc/secrets/system-credentials</li>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/edit-parameter-provider/edit-parameter-provider.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/edit-parameter-provider/edit-parameter-provider.component.spec.ts
@@ -43,8 +43,8 @@ describe('EditParameterProvider', () => {
             bulletins: [],
             component: {
                 id: '369487d7-018d-1000-817a-1d8d9a8f4a91',
-                name: 'Group 1 - FileParameterProvider',
-                type: 'org.apache.nifi.parameter.FileParameterProvider',
+                name: 'Group 1 - KubernetesSecretParameterProvider',
+                type: 'org.apache.nifi.parameter.KubernetesSecretParameterProvider',
                 bundle: {
                     group: 'org.apache.nifi',
                     artifact: 'nifi-standard-nar',

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/fetch-parameter-provider-parameters/fetch-parameter-provider-parameters.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/parameter-providers/fetch-parameter-provider-parameters/fetch-parameter-provider-parameters.component.spec.ts
@@ -45,8 +45,8 @@ describe('FetchParameterProviderParameters', () => {
             bulletins: [],
             component: {
                 id: '369487d7-018d-1000-817a-1d8d9a8f4a91',
-                name: 'Group 1 - FileParameterProvider',
-                type: 'org.apache.nifi.parameter.FileParameterProvider',
+                name: 'Group 1 - KubernetesSecretParameterProvider',
+                type: 'org.apache.nifi.parameter.KubernetesSecretParameterProvider',
                 bundle: {
                     group: 'org.apache.nifi',
                     artifact: 'nifi-standard-nar',


### PR DESCRIPTION
…erProvider

# Summary

[NIFI-13454](https://issues.apache.org/jira/browse/NIFI-13454)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
