### PR TITLE
NIFI-13452 GetSlackReaction processor

### DIFF
--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ConsumeSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ConsumeSlack.java
@@ -90,7 +90,7 @@ import static java.lang.String.format;
     @WritesAttribute(attribute = "slack.message.count", description = "The number of slack messages that are included in the FlowFile"),
     @WritesAttribute(attribute = "mime.type", description = "Set to application/json, as the output will always be in JSON format")
 })
-@SeeAlso({ListenSlack.class})
+@SeeAlso({ListenSlack.class, PublishSlack.class, GetSlackReaction.class})
 @Tags({"slack", "conversation", "conversation.history", "social media", "team", "text", "unstructured"})
 @CapabilityDescription("Retrieves messages from one or more configured Slack channels. The messages are written out in JSON format. " +
     "See Usage / Additional Details for more information about how to configure this Processor and enable it to retrieve messages from Slack.")

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/GetSlackReaction.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/GetSlackReaction.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.slack;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.reactions.ReactionsGetRequest;
+import com.slack.api.methods.response.reactions.ReactionsGetResponse;
+import com.slack.api.model.Reaction;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.configuration.DefaultSettings;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.slack.util.RateLimit;
+import org.apache.nifi.processors.slack.util.SlackResponseUtil;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+@WritesAttributes({
+        @WritesAttribute(attribute = "slack.channel.id", description = "The ID of the Slack Channel from which the messages were retrieved"),
+        @WritesAttribute(attribute = "slack.message.timestamp", description = "The timestamp of the Slack message the reactions are fetched for."),
+        @WritesAttribute(attribute = "slack.reaction.<emoji name>", description = "The name of the emoji and the reaction count that was provided for the message."),
+        @WritesAttribute(attribute = "minutes.waited", description = "The total number of minutes waited while the reactions were captured."),
+        @WritesAttribute(attribute = "error.message", description = "The error message on fetching reactions.")
+})
+@SeeAlso({ListenSlack.class, ConsumeSlack.class, PublishSlack.class})
+@Tags({"slack", "conversation", "reactions.get", "social media", "emoji"})
+@CapabilityDescription("Retrieves reactions for a given message. The reactions are written as attributes.")
+@DefaultSettings(penaltyDuration = "5 min")
+public class GetSlackReaction extends AbstractProcessor {
+
+    static final PropertyDescriptor ACCESS_TOKEN = new PropertyDescriptor.Builder()
+            .name("Access Token")
+            .description("OAuth Access Token used for authenticating/authorizing the Slack request sent by NiFi. This may be either a User Token or a Bot Token. " +
+                    "It must be granted the reactions:read scope and channels:history, groups:history, im:history or mpim:history, depending on the type of conversation being used.")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .required(true)
+            .sensitive(true)
+            .build();
+
+    static final PropertyDescriptor CHANNEL_ID = new PropertyDescriptor.Builder()
+            .name("Channel ID")
+            .description("The ID of the channel.")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    static final PropertyDescriptor THREAD_TIMESTAMP = new PropertyDescriptor.Builder()
+            .name("Message Timestamp")
+            .description("Slack message's timestamp the reactions are fetched for.")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    static final PropertyDescriptor RELEASE_IF_ONE_REACTION = new PropertyDescriptor.Builder()
+            .name("Release If One Reaction Arrived")
+            .description("It is possible to wait for the first reaction or wait for the specified amount of time to fetch all possible reactions.")
+            .required(true)
+            .allowableValues("true", "false")
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .defaultValue("true")
+            .build();
+
+    static final PropertyDescriptor WAIT_MONITOR_WINDOW = new PropertyDescriptor.Builder()
+            .name("Wait Monitor Window")
+            .description("Processor will periodically poll reactions for the given time duration if no reaction arrived yet or " +
+                    RELEASE_IF_ONE_REACTION.getDisplayName() + " is set to false.")
+            .required(true)
+            .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
+            .defaultValue("1 hour")
+            .build();
+
+    static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("FlowFiles are routed to this relationship if fetching reactions were successful")
+            .build();
+
+    static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("FlowFiles are routed to this relationship if an error occurred when fetching reactions")
+            .build();
+
+    static final Relationship REL_WAIT = new Relationship.Builder()
+            .name("wait")
+            .description("Self loop relationship which is used when waiting for further reactions")
+            .build();
+
+    static final Relationship REL_NO_REACTION = new Relationship.Builder()
+            .name("no_reaction")
+            .description("FlowFiles are routed to this relationship if no reaction arrived for the message in the given timeframe")
+            .build();
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return Arrays.asList(CHANNEL_ID,
+                             ACCESS_TOKEN,
+                             THREAD_TIMESTAMP,
+                             WAIT_MONITOR_WINDOW,
+                             RELEASE_IF_ONE_REACTION);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return Set.of(REL_SUCCESS,
+                REL_WAIT,
+                REL_NO_REACTION,
+                REL_FAILURE);
+    }
+
+    public static final String ATTR_WAIT_TIME = "minutes.waited";
+    public static final String ATTR_ERROR_MESSAGE = "error.message";
+    public static final String ATTR_MESSAGE_TIMESTAMP = "slack.message.timestamp";
+    public static final String ATTR_CHANNEL_ID = "slack.channel.id";
+    public static final int PENALTY_MINUTES = 5;
+
+    @Override
+    public boolean isStateful(final ProcessContext context) {
+        return true;
+    }
+
+    private RateLimit rateLimit;
+    private volatile App slackApp;
+    private MethodsClient client;
+
+    @OnScheduled
+    public void setup(final ProcessContext context) {
+        rateLimit = new RateLimit(getLogger());
+        slackApp = createSlackApp(context);
+        client = initializeClient(slackApp);
+    }
+
+    @OnStopped
+    public void shutdown() {
+        if (slackApp != null) {
+            slackApp.stop();
+            slackApp = null;
+        }
+        rateLimit = null;
+    }
+
+    public RateLimit getRateLimit() {
+        return rateLimit;
+    }
+
+    private App createSlackApp(final ProcessContext context) {
+        final String botToken = context.getProperty(ACCESS_TOKEN).getValue();
+        final AppConfig appConfig = AppConfig.builder()
+                .singleTeamBotToken(botToken)
+                .build();
+
+        return new App(appConfig);
+    }
+
+    protected MethodsClient initializeClient(final App slackApp) {
+        slackApp.start();
+        return slackApp.client();
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        if (rateLimit.isLimitReached()) {
+            getLogger().debug("Will not fetch reactions from Slack because rate limit has been reached");
+            context.yield();
+            return;
+        }
+
+        FlowFile flowFile = session.get();
+
+        final String botToken = context.getProperty(ACCESS_TOKEN).getValue();
+        final String channelId = context.getProperty(CHANNEL_ID).evaluateAttributeExpressions(flowFile).getValue();
+        final String threadTimestamp = context.getProperty(THREAD_TIMESTAMP).evaluateAttributeExpressions(flowFile).getValue();
+        final boolean releaseIfOneReaction = context.getProperty(RELEASE_IF_ONE_REACTION).asBoolean();
+        final long waitMonitorWindow = context.getProperty(WAIT_MONITOR_WINDOW).asTimePeriod(TimeUnit.MINUTES);
+        int timeWaited = Integer.parseInt(Optional.ofNullable(flowFile.getAttribute(ATTR_WAIT_TIME)).orElse("0"));
+
+        try {
+            final ReactionsGetResponse results = fetchReactions(channelId, botToken, threadTimestamp);
+            final ReactionsGetResponse.Message message = results.getMessage();
+
+            if (message == null) {
+                throw new ProcessException(String.format("Failed to fetch message [%s] in channel [%s]", threadTimestamp, channelId));
+            }
+
+            final List<Reaction> reactions = results.getMessage().getReactions();
+
+            if ((timeWaited >= waitMonitorWindow) || (waitMonitorWindow < PENALTY_MINUTES)) {
+                if (!reactionFound(reactions)) {
+                    flowFile = session.putAllAttributes(flowFile, createAttributeMap(channelId, threadTimestamp));
+                    session.transfer(flowFile, REL_NO_REACTION);
+                } else {
+                    createSuccessOutput(session, flowFile, channelId, threadTimestamp, reactions);
+                }
+            } else {
+                if (reactionFound(reactions) && releaseIfOneReaction) {
+                    createSuccessOutput(session, flowFile, channelId, threadTimestamp, reactions);
+                } else {
+                    flowFile = session.putAttribute(flowFile, ATTR_WAIT_TIME, String.valueOf(timeWaited + PENALTY_MINUTES));
+                    session.transfer(session.penalize(flowFile), REL_WAIT);
+                }
+            }
+        } catch (Exception e) {
+           if (SlackResponseUtil.isRateLimited(e)) {
+                    session.rollback();
+                    getLogger().warn("Slack indicated that the Rate Limit has been exceeded when attempting to fetch reactions for message [{}] in channel [{}]", threadTimestamp, channelId);
+                    yieldOnException(e, context);
+                } else {
+                    Map<String, String> attributeMap = createAttributeMap(channelId, threadTimestamp);
+                    attributeMap.put(ATTR_ERROR_MESSAGE, e.getMessage());
+                    final FlowFile outFlowFile = session.putAllAttributes(flowFile, attributeMap);
+                    session.transfer(session.penalize(outFlowFile), REL_FAILURE);
+                }
+        }
+    }
+
+    private ReactionsGetResponse fetchReactions(final String channelId, final String accessToken, final String threadTimestamp) throws SlackApiException, IOException {
+        ReactionsGetRequest request = ReactionsGetRequest.builder()
+                .channel(channelId)
+                .full(true)
+                .token(accessToken)
+                .timestamp(threadTimestamp)
+                .build();
+
+        return client.reactionsGet(request);
+    }
+
+    private void createSuccessOutput(final ProcessSession session, FlowFile flowFile, String channelId, String threadTimestamp, final List<Reaction> reactions)  {
+        for (Reaction reaction : reactions) {
+            flowFile = session.putAttribute(flowFile, "slack.reaction." + reaction.getName(), String.valueOf(reaction.getCount()));
+        }
+
+        flowFile = session.putAllAttributes(flowFile, createAttributeMap(channelId, threadTimestamp));
+        session.transfer(flowFile, REL_SUCCESS);
+    }
+
+    private Map<String, String> createAttributeMap(String channelId, String threadTimestamp) {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(ATTR_CHANNEL_ID, channelId);
+        attributes.put(ATTR_MESSAGE_TIMESTAMP, threadTimestamp);
+        return attributes;
+    }
+
+    private void yieldOnException(final Throwable t, final ProcessContext context) {
+        final int retryAfterSeconds = SlackResponseUtil.getRetryAfterSeconds(t);
+        rateLimit.retryAfter(Duration.ofSeconds(retryAfterSeconds));
+        context.yield();
+    }
+
+    private static boolean reactionFound(final List<Reaction> reactions) {
+        return reactions != null && !reactions.isEmpty();
+    }
+}

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ListenSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ListenSlack.java
@@ -76,7 +76,7 @@ import java.util.regex.Pattern;
 @WritesAttributes({
     @WritesAttribute(attribute = "mime.type", description = "Set to application/json, as the output will always be in JSON format")
 })
-@SeeAlso({ConsumeSlack.class})
+@SeeAlso({ConsumeSlack.class, PublishSlack.class, ListenSlack.class, GetSlackReaction.class})
 @Tags({"slack", "real-time", "event", "message", "command", "listen", "receive", "social media", "team", "text", "unstructured"})
 @CapabilityDescription("Retrieves real-time messages or Slack commands from one or more Slack conversations. The messages are written out in JSON format. " +
     "Note that this Processor should be used to obtain real-time messages and commands from Slack and does not provide a mechanism for obtaining historical messages. " +

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PublishSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PublishSlack.java
@@ -73,7 +73,7 @@ import java.util.Set;
     the contents of the FlowFile can be sent as the message. If sending a user-defined message, the contents of the FlowFile may also be optionally uploaded as
     a file attachment.
     """)
-@SeeAlso({ListenSlack.class, ConsumeSlack.class})
+@SeeAlso({ListenSlack.class, ConsumeSlack.class, GetSlackReaction.class})
 @Tags({"slack", "conversation", "chat.postMessage", "social media", "team", "text", "unstructured", "write", "upload", "send", "publish"})
 @WritesAttributes({
     @WritesAttribute(attribute = "slack.channel.id", description = "The ID of the Slack Channel from which the messages were retrieved"),

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -16,3 +16,4 @@
 org.apache.nifi.processors.slack.ConsumeSlack
 org.apache.nifi.processors.slack.ListenSlack
 org.apache.nifi.processors.slack.PublishSlack
+org.apache.nifi.processors.slack.GetSlackReaction

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/TestGetSlackReaction.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/TestGetSlackReaction.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.slack;
+
+import com.slack.api.bolt.App;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.request.reactions.ReactionsGetRequest;
+import com.slack.api.methods.response.reactions.ReactionsGetResponse;
+import com.slack.api.model.Reaction;
+
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.apache.nifi.processors.slack.GetSlackReaction.ATTR_ERROR_MESSAGE;
+import static org.apache.nifi.processors.slack.GetSlackReaction.ATTR_WAIT_TIME;
+import static org.apache.nifi.processors.slack.GetSlackReaction.REL_FAILURE;
+import static org.apache.nifi.processors.slack.GetSlackReaction.REL_NO_REACTION;
+import static org.apache.nifi.processors.slack.GetSlackReaction.REL_SUCCESS;
+import static org.apache.nifi.processors.slack.GetSlackReaction.REL_WAIT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+@ExtendWith(MockitoExtension.class)
+public class TestGetSlackReaction {
+    public static final String TEST_MESSAGE_TS = "123456.789";
+    public static final String TEST_CHANNEL_ID = "cid1";
+    private TestRunner testRunner;
+    GetSlackReaction processor;
+    @Mock
+    private MethodsClient clientMock;
+
+    @BeforeEach
+    public void setup() {
+        processor = new GetSlackReaction() {
+            @Override
+            protected MethodsClient initializeClient(final App slackApp) {
+                return clientMock;
+            }
+        };
+
+        testRunner = TestRunners.newTestRunner(processor);
+        testRunner.setProperty(GetSlackReaction.ACCESS_TOKEN, "token");
+        testRunner.setProperty(GetSlackReaction.CHANNEL_ID, TEST_CHANNEL_ID);
+        testRunner.setProperty(GetSlackReaction.THREAD_TIMESTAMP, TEST_MESSAGE_TS);
+    }
+
+    @Test
+    public void testImmediateReaction() throws Exception {
+        when(clientMock.reactionsGet(any(ReactionsGetRequest.class))).thenReturn(fetchReactions("thumbs_up", 1));
+        final MockFlowFile inputFlowFile = new MockFlowFile(0);
+        testRunner.enqueue(inputFlowFile);
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
+        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        assertEquals("1", ff0.getAttribute("slack.reaction.thumbs_up"));
+        testRunner.clearTransferState();
+    }
+
+    @Test
+    public void testWaitForFurtherReactions() throws Exception {
+        testRunner.setProperty(GetSlackReaction.RELEASE_IF_ONE_REACTION, "false");
+        testRunner.setProperty(GetSlackReaction.WAIT_MONITOR_WINDOW, "10 min");
+
+        when(clientMock.reactionsGet(any(ReactionsGetRequest.class))).thenReturn(fetchReactions("thumbs_up", 1));
+        final MockFlowFile inputFlowFile = new MockFlowFile(0);
+        testRunner.enqueue(inputFlowFile);
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(REL_WAIT, 1);
+        MockFlowFile waitingFF = testRunner.getFlowFilesForRelationship(REL_WAIT).get(0);
+        assertEquals("5", waitingFF.getAttribute(ATTR_WAIT_TIME));
+        assertEquals(1, testRunner.getPenalizedFlowFiles().size());
+
+        testRunner.clearTransferState();
+        testRunner.enqueue(waitingFF);
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(REL_WAIT, 1);
+        waitingFF = testRunner.getFlowFilesForRelationship(REL_WAIT).get(0);
+        testRunner.clearTransferState();
+
+        final Reaction thumbsUp = getReaction("thumbs_up", 3);
+        final Reaction coolDoge = getReaction("cool_doge", 1);
+        when(clientMock.reactionsGet(any(ReactionsGetRequest.class))).thenReturn(fetchReactions(Arrays.asList(thumbsUp, coolDoge)));
+        testRunner.enqueue(waitingFF);
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
+        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        assertEquals("3", ff0.getAttribute("slack.reaction.thumbs_up"));
+        assertEquals("1", ff0.getAttribute("slack.reaction.cool_doge"));
+        assertEquals("10", waitingFF.getAttribute(ATTR_WAIT_TIME));
+        testRunner.clearTransferState();
+    }
+
+    @Test
+    public void testNoReaction() throws Exception {
+        when(clientMock.reactionsGet(any(ReactionsGetRequest.class))).thenReturn(fetchReactions(emptyList()));
+        final MockFlowFile inputFlowFile = new MockFlowFile(0);
+        testRunner.enqueue(inputFlowFile);
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(REL_WAIT, 1);
+        testRunner.clearTransferState();
+    }
+
+    @Test
+    public void testWaitMonitorWindowLessThanPenaltyPeriod() throws Exception {
+        when(clientMock.reactionsGet(any(ReactionsGetRequest.class))).thenReturn(fetchReactions(emptyList()));
+        testRunner.setProperty(GetSlackReaction.WAIT_MONITOR_WINDOW, "2 min");
+        final MockFlowFile inputFlowFile = new MockFlowFile(0);
+        testRunner.enqueue(inputFlowFile);
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(REL_NO_REACTION, 1);
+        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(REL_NO_REACTION).get(0);
+        ff0.assertAttributeEquals(GetSlackReaction.ATTR_CHANNEL_ID, TEST_CHANNEL_ID);
+        ff0.assertAttributeEquals(GetSlackReaction.ATTR_MESSAGE_TIMESTAMP, TEST_MESSAGE_TS);
+        testRunner.clearTransferState();
+    }
+
+    @Test
+    public void testRequestRateLimited() throws Exception {
+        when(clientMock.reactionsGet(any(ReactionsGetRequest.class))).thenReturn(fetchReactions("thumbs_up", 1));
+        final MockFlowFile inputFlowFile = new MockFlowFile(0);
+        testRunner.enqueue(inputFlowFile);
+        testRunner.run(1, false, true);
+        testRunner.assertAllFlowFilesTransferred(GetSlackReaction.REL_SUCCESS, 1);
+        testRunner.clearTransferState();
+
+        // Set processor to be in rate limited state, therefore it will process 0 flowfiles
+        processor.getRateLimit().retryAfter(Duration.ofSeconds(30));
+        testRunner.enqueue(inputFlowFile);
+        testRunner.run(1, true, false);
+        testRunner.assertAllFlowFilesTransferred(GetSlackReaction.REL_SUCCESS, 0);
+    }
+
+    @Test
+    public void testErrorResponse() throws Exception {
+        //response without message
+        when(clientMock.reactionsGet(any(ReactionsGetRequest.class))).thenReturn(new ReactionsGetResponse());
+        final MockFlowFile inputFlowFile = new MockFlowFile(0);
+        testRunner.enqueue(inputFlowFile);
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(REL_FAILURE, 1);
+        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(REL_FAILURE).get(0);
+        ff0.assertAttributeExists(ATTR_ERROR_MESSAGE);
+        ff0.assertAttributeEquals(GetSlackReaction.ATTR_CHANNEL_ID, TEST_CHANNEL_ID);
+        ff0.assertAttributeEquals(GetSlackReaction.ATTR_MESSAGE_TIMESTAMP, TEST_MESSAGE_TS);
+        testRunner.clearTransferState();
+    }
+
+    public ReactionsGetResponse fetchReactions(final List<Reaction> reactions) {
+        final ReactionsGetResponse response = createReactionsGetResponse();
+        response.getMessage().setReactions(reactions);
+        return response;
+    }
+
+    public ReactionsGetResponse fetchReactions(final String name, final Integer count) {
+        final ReactionsGetResponse response = createReactionsGetResponse();
+        response.getMessage().setReactions(List.of(getReaction(name, count)));
+        return response;
+    }
+
+    public Reaction getReaction(final String name, final Integer count) {
+        final Reaction reaction = new Reaction();
+        reaction.setName(name);
+        reaction.setCount(count);
+        return reaction;
+    }
+
+    public ReactionsGetResponse createReactionsGetResponse() {
+        final ReactionsGetResponse.Message message = new ReactionsGetResponse.Message();
+        message.setText("Dummy text");
+        final ReactionsGetResponse response = new ReactionsGetResponse();
+        response.setOk(true);
+        response.setMessage(message);
+        return response;
+    }
+
+}

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/TestGetSlackReaction.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/TestGetSlackReaction.java
@@ -37,12 +37,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
-import static org.apache.nifi.processors.slack.GetSlackReaction.ATTR_ERROR_MESSAGE;
-import static org.apache.nifi.processors.slack.GetSlackReaction.ATTR_WAIT_TIME;
-import static org.apache.nifi.processors.slack.GetSlackReaction.REL_FAILURE;
-import static org.apache.nifi.processors.slack.GetSlackReaction.REL_NO_REACTION;
-import static org.apache.nifi.processors.slack.GetSlackReaction.REL_SUCCESS;
-import static org.apache.nifi.processors.slack.GetSlackReaction.REL_WAIT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -76,8 +70,8 @@ public class TestGetSlackReaction {
         final MockFlowFile inputFlowFile = new MockFlowFile(0);
         testRunner.enqueue(inputFlowFile);
         testRunner.run();
-        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
-        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        testRunner.assertAllFlowFilesTransferred(GetSlackReaction.REL_SUCCESS, 1);
+        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(GetSlackReaction.REL_SUCCESS).get(0);
         assertEquals("1", ff0.getAttribute("slack.reaction.thumbs_up"));
         testRunner.clearTransferState();
     }
@@ -91,16 +85,16 @@ public class TestGetSlackReaction {
         final MockFlowFile inputFlowFile = new MockFlowFile(0);
         testRunner.enqueue(inputFlowFile);
         testRunner.run();
-        testRunner.assertAllFlowFilesTransferred(REL_WAIT, 1);
-        MockFlowFile waitingFF = testRunner.getFlowFilesForRelationship(REL_WAIT).get(0);
-        assertEquals("5", waitingFF.getAttribute(ATTR_WAIT_TIME));
+        testRunner.assertAllFlowFilesTransferred(GetSlackReaction.REL_WAIT, 1);
+        MockFlowFile waitingFF = testRunner.getFlowFilesForRelationship(GetSlackReaction.REL_WAIT).get(0);
+        assertEquals("5", waitingFF.getAttribute(GetSlackReaction.ATTR_WAIT_TIME));
         assertEquals(1, testRunner.getPenalizedFlowFiles().size());
 
         testRunner.clearTransferState();
         testRunner.enqueue(waitingFF);
         testRunner.run();
-        testRunner.assertAllFlowFilesTransferred(REL_WAIT, 1);
-        waitingFF = testRunner.getFlowFilesForRelationship(REL_WAIT).get(0);
+        testRunner.assertAllFlowFilesTransferred(GetSlackReaction.REL_WAIT, 1);
+        waitingFF = testRunner.getFlowFilesForRelationship(GetSlackReaction.REL_WAIT).get(0);
         testRunner.clearTransferState();
 
         final Reaction thumbsUp = getReaction("thumbs_up", 3);
@@ -108,11 +102,11 @@ public class TestGetSlackReaction {
         when(clientMock.reactionsGet(any(ReactionsGetRequest.class))).thenReturn(fetchReactions(Arrays.asList(thumbsUp, coolDoge)));
         testRunner.enqueue(waitingFF);
         testRunner.run();
-        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
-        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        testRunner.assertAllFlowFilesTransferred(GetSlackReaction.REL_SUCCESS, 1);
+        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(GetSlackReaction.REL_SUCCESS).get(0);
         assertEquals("3", ff0.getAttribute("slack.reaction.thumbs_up"));
         assertEquals("1", ff0.getAttribute("slack.reaction.cool_doge"));
-        assertEquals("10", waitingFF.getAttribute(ATTR_WAIT_TIME));
+        assertEquals("10", waitingFF.getAttribute(GetSlackReaction.ATTR_WAIT_TIME));
         testRunner.clearTransferState();
     }
 
@@ -122,7 +116,7 @@ public class TestGetSlackReaction {
         final MockFlowFile inputFlowFile = new MockFlowFile(0);
         testRunner.enqueue(inputFlowFile);
         testRunner.run();
-        testRunner.assertAllFlowFilesTransferred(REL_WAIT, 1);
+        testRunner.assertAllFlowFilesTransferred(GetSlackReaction.REL_WAIT, 1);
         testRunner.clearTransferState();
     }
 
@@ -133,8 +127,8 @@ public class TestGetSlackReaction {
         final MockFlowFile inputFlowFile = new MockFlowFile(0);
         testRunner.enqueue(inputFlowFile);
         testRunner.run();
-        testRunner.assertAllFlowFilesTransferred(REL_NO_REACTION, 1);
-        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(REL_NO_REACTION).get(0);
+        testRunner.assertAllFlowFilesTransferred(GetSlackReaction.REL_NO_REACTION, 1);
+        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(GetSlackReaction.REL_NO_REACTION).get(0);
         ff0.assertAttributeEquals(GetSlackReaction.ATTR_CHANNEL_ID, TEST_CHANNEL_ID);
         ff0.assertAttributeEquals(GetSlackReaction.ATTR_MESSAGE_TIMESTAMP, TEST_MESSAGE_TS);
         testRunner.clearTransferState();
@@ -163,9 +157,9 @@ public class TestGetSlackReaction {
         final MockFlowFile inputFlowFile = new MockFlowFile(0);
         testRunner.enqueue(inputFlowFile);
         testRunner.run();
-        testRunner.assertAllFlowFilesTransferred(REL_FAILURE, 1);
-        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(REL_FAILURE).get(0);
-        ff0.assertAttributeExists(ATTR_ERROR_MESSAGE);
+        testRunner.assertAllFlowFilesTransferred(GetSlackReaction.REL_FAILURE, 1);
+        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(GetSlackReaction.REL_FAILURE).get(0);
+        ff0.assertAttributeExists(GetSlackReaction.ATTR_ERROR_MESSAGE);
         ff0.assertAttributeEquals(GetSlackReaction.ATTR_CHANNEL_ID, TEST_CHANNEL_ID);
         ff0.assertAttributeEquals(GetSlackReaction.ATTR_MESSAGE_TIMESTAMP, TEST_MESSAGE_TS);
         testRunner.clearTransferState();


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13452](https://issues.apache.org/jira/browse/NIFI-13452)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
