### PR TITLE
NIFI-13372 Add processor DeleteSFTP

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteSFTP.java
@@ -19,8 +19,6 @@ package org.apache.nifi.processors.standard;
 import org.apache.nifi.annotation.behavior.DefaultRunDuration;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
-import org.apache.nifi.annotation.behavior.WritesAttribute;
-import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.documentation.UseCase;
@@ -65,22 +63,7 @@ import java.util.concurrent.TimeUnit;
                 Using 'DeleteSFTP', delete the file residing on an SFTP server only after the result has been stored.
                 """
 )
-@WritesAttributes({
-        @WritesAttribute(
-                attribute = DeleteSFTP.ATTRIBUTE_FAILURE_REASON,
-                description = "Human-readable reason of failure. Only available if FlowFile is routed to relationship 'failure'."),
-        @WritesAttribute(
-                attribute = DeleteSFTP.ATTRIBUTE_EXCEPTION_CLASS,
-                description = "The class name of the exception thrown during processor execution. Only available if an exception caused the FlowFile to be routed to relationship 'failure'."),
-        @WritesAttribute(
-                attribute = DeleteSFTP.ATTRIBUTE_EXCEPTION_MESSAGE,
-                description = "The message of the exception thrown during processor execution. Only available if an exception caused the FlowFile to be routed to relationship 'failure'.")
-})
 public class DeleteSFTP extends AbstractProcessor {
-
-    public static final String ATTRIBUTE_FAILURE_REASON = "DeleteSFTP.failure.reason";
-    public static final String ATTRIBUTE_EXCEPTION_CLASS = "DeleteSFTP.failure.exception.class";
-    public static final String ATTRIBUTE_EXCEPTION_MESSAGE = "DeleteSFTP.failure.exception.message";
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
@@ -232,11 +215,6 @@ public class DeleteSFTP extends AbstractProcessor {
     private void handleFailure(ProcessSession session, FlowFile flowFile, String errorMessage, Throwable throwable) {
         getLogger().error(errorMessage, throwable);
 
-        session.putAttribute(flowFile, ATTRIBUTE_FAILURE_REASON, errorMessage);
-        if (throwable != null) {
-            session.putAttribute(flowFile, ATTRIBUTE_EXCEPTION_CLASS, throwable.getClass().toString());
-            session.putAttribute(flowFile, ATTRIBUTE_EXCEPTION_MESSAGE, throwable.getMessage());
-        }
         session.penalize(flowFile);
         session.transfer(flowFile, REL_FAILURE);
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteSFTP.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.annotation.behavior.DefaultRunDuration;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.SupportsBatching;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.documentation.UseCase;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.FlowFileAccessException;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processor.util.file.transfer.FileTransfer;
+import org.apache.nifi.processors.standard.util.FTPTransfer;
+import org.apache.nifi.processors.standard.util.SFTPTransfer;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@SupportsBatching(defaultDuration = DefaultRunDuration.TWENTY_FIVE_MILLIS)
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+@Tags({"remote", "remove", "delete", "sftp"})
+@CapabilityDescription("Deletes a file residing on an SFTP server.")
+@UseCase(
+        description = "Delete source file only after its processing completed",
+        configuration = """
+                Retrieve a file residing on an SFTP server, e.g. using 'ListSFTP' and 'FetchSFTP'.
+                Process the file using any combination of processors.
+                Store the resulting file to a destination, e.g. using 'PutFile'.
+                Using 'DeleteSFTP', delete the file residing on an SFTP server only after the result has been stored.
+                """
+)
+@WritesAttributes({
+        @WritesAttribute(
+                attribute = DeleteSFTP.ATTRIBUTE_FAILURE_REASON,
+                description = "Human-readable reason of failure. Only available if FlowFile is routed to relationship 'failure'."),
+        @WritesAttribute(
+                attribute = DeleteSFTP.ATTRIBUTE_EXCEPTION_CLASS,
+                description = "The class name of the exception thrown during processor execution. Only available if an exception caused the FlowFile to be routed to relationship 'failure'."),
+        @WritesAttribute(
+                attribute = DeleteSFTP.ATTRIBUTE_EXCEPTION_MESSAGE,
+                description = "The message of the exception thrown during processor execution. Only available if an exception caused the FlowFile to be routed to relationship 'failure'.")
+})
+public class DeleteSFTP extends AbstractProcessor {
+
+    public static final String ATTRIBUTE_FAILURE_REASON = "DeleteSFTP.failure.reason";
+    public static final String ATTRIBUTE_EXCEPTION_CLASS = "DeleteSFTP.failure.exception.class";
+    public static final String ATTRIBUTE_EXCEPTION_MESSAGE = "DeleteSFTP.failure.exception.message";
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("All FlowFiles, for which an existing file has been deleted, are routed to this relationship")
+            .build();
+    public static final Relationship REL_NOT_FOUND = new Relationship.Builder()
+            .name("not found")
+            .description("All FlowFiles, for which the file to delete did not exist, are routed to this relationship")
+            .build();
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("All FlowFiles, for which an existing file could not be deleted, are routed to this relationship")
+            .build();
+
+    private final static Set<Relationship> relationships = Set.of(REL_SUCCESS, REL_NOT_FOUND, REL_FAILURE);
+
+    public static final PropertyDescriptor DIRECTORY_PATH = new PropertyDescriptor.Builder()
+            .name("Directory Path")
+            .displayName("Directory Path")
+            .description("The path to the directory the file to delete is located in.")
+            .required(true)
+            .defaultValue("${" + CoreAttributes.ABSOLUTE_PATH.key() + "}")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+    public static final PropertyDescriptor FILENAME = new PropertyDescriptor.Builder()
+            .name("Filename")
+            .displayName("Filename")
+            .description("The name of the file to delete.")
+            .required(true)
+            .defaultValue("${" + CoreAttributes.FILENAME.key() + "}")
+            .addValidator(StandardValidators.NON_EMPTY_EL_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    private final static List<PropertyDescriptor> properties = List.of(
+            DIRECTORY_PATH,
+            FILENAME,
+            SFTPTransfer.HOSTNAME,
+            SFTPTransfer.PORT,
+            SFTPTransfer.USERNAME,
+            SFTPTransfer.PASSWORD,
+            SFTPTransfer.PRIVATE_KEY_PATH,
+            SFTPTransfer.PRIVATE_KEY_PASSPHRASE,
+            SFTPTransfer.STRICT_HOST_KEY_CHECKING,
+            SFTPTransfer.HOST_KEY_FILE,
+            SFTPTransfer.BATCH_SIZE,
+            SFTPTransfer.CONNECTION_TIMEOUT,
+            SFTPTransfer.DATA_TIMEOUT,
+            SFTPTransfer.USE_KEEPALIVE_ON_TIMEOUT,
+            SFTPTransfer.USE_COMPRESSION,
+            SFTPTransfer.PROXY_CONFIGURATION_SERVICE,
+            FTPTransfer.PROXY_TYPE,
+            FTPTransfer.PROXY_HOST,
+            FTPTransfer.PROXY_PORT,
+            FTPTransfer.HTTP_PROXY_USERNAME,
+            FTPTransfer.HTTP_PROXY_PASSWORD,
+            SFTPTransfer.CIPHERS_ALLOWED,
+            SFTPTransfer.KEY_ALGORITHMS_ALLOWED,
+            SFTPTransfer.KEY_EXCHANGE_ALGORITHMS_ALLOWED,
+            SFTPTransfer.MESSAGE_AUTHENTICATION_CODES_ALLOWED
+    );
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        final ComponentLog logger = getLogger();
+        String hostname = context.getProperty(FileTransfer.HOSTNAME).evaluateAttributeExpressions(flowFile).getValue();
+
+        final int maxNumberOfFiles = context.getProperty(SFTPTransfer.BATCH_SIZE).asInteger();
+        int fileCount = 0;
+
+        try (final SFTPTransfer transfer = new SFTPTransfer(context, logger)) {
+            do {
+                //evaluate again inside the loop as each flowfile can have a different hostname
+                hostname = context.getProperty(FileTransfer.HOSTNAME).evaluateAttributeExpressions(flowFile).getValue();
+
+                final long startNanos = System.nanoTime();
+
+                final String directoryPathProperty = context.getProperty(DIRECTORY_PATH).evaluateAttributeExpressions(flowFile).getValue();
+                final String filename = context.getProperty(FILENAME).evaluateAttributeExpressions(flowFile).getValue();
+
+                try {
+                    final Path directoryPath = Paths.get(directoryPathProperty).normalize();
+                    final Path filePath = directoryPath.resolve(filename).normalize();
+
+                    if (!directoryPath.equals(filePath.getParent())) {
+                        final String errorMessage = "Attempting to delete file at path '%s' which is not a direct child of the directory '%s'"
+                                .formatted(filePath, directoryPath);
+
+                        handleFailure(session, flowFile, errorMessage, null);
+                        continue;
+                    }
+
+                    transfer.deleteFile(flowFile, directoryPath.toString(), filename);
+
+                    session.transfer(flowFile, REL_SUCCESS);
+                    final String transitUri = "sftp://%s".formatted(filePath);
+                    final long transferMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+                    logger.debug("Successfully deleted file at path {} in {} millis; routing to success", flowFile, transferMillis);
+                    session.getProvenanceReporter().invokeRemoteProcess(flowFile, transitUri, "Object deleted");
+                } catch (FileNotFoundException fileNotFoundException) {
+                    session.transfer(flowFile, REL_NOT_FOUND);
+                } catch (IOException ioException) {
+                    final String errorMessage = "Failed to delete file '%s' in directory '%s'"
+                            .formatted(filename, directoryPathProperty);
+
+                    handleFailure(session, flowFile, errorMessage, ioException);
+                }
+            } while (isScheduled()
+                    && (getRelationships().size() == context.getAvailableRelationships().size())
+                    && (++fileCount < maxNumberOfFiles)
+                    && ((flowFile = session.get()) != null));
+        } catch (final IOException | FlowFileAccessException | ProcessException e) {
+            context.yield();
+
+            Throwable cause = switch (e) {
+                case FlowFileAccessException ffaEx -> ffaEx.getCause();
+                case ProcessException pEx -> pEx.getCause();
+                default -> e;
+            };
+
+            String errorMessage = "Routing to failure since unable to delete %s from remote host %s".formatted(flowFile, hostname);
+            handleFailure(session, flowFile, errorMessage, cause);
+        }
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
+        final Collection<ValidationResult> results = new ArrayList<>();
+        SFTPTransfer.validateProxySpec(validationContext, results);
+        return results;
+    }
+
+    private void handleFailure(ProcessSession session, FlowFile flowFile, String errorMessage, Throwable throwable) {
+        getLogger().error(errorMessage, throwable);
+
+        session.putAttribute(flowFile, ATTRIBUTE_FAILURE_REASON, errorMessage);
+        if (throwable != null) {
+            session.putAttribute(flowFile, ATTRIBUTE_EXCEPTION_CLASS, throwable.getClass().toString());
+            session.putAttribute(flowFile, ATTRIBUTE_EXCEPTION_MESSAGE, throwable.getMessage());
+        }
+        session.penalize(flowFile);
+        session.transfer(flowFile, REL_FAILURE);
+    }
+}

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteSFTP.java
@@ -102,7 +102,7 @@ public class DeleteSFTP extends AbstractProcessor {
             .displayName("Directory Path")
             .description("The path to the directory the file to delete is located in.")
             .required(true)
-            .defaultValue("${" + CoreAttributes.ABSOLUTE_PATH.key() + "}")
+            .defaultValue("${" + CoreAttributes.PATH.key() + "}")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -23,6 +23,7 @@ org.apache.nifi.processors.standard.CountText
 org.apache.nifi.processors.standard.CryptographicHashContent
 org.apache.nifi.processors.standard.DebugFlow
 org.apache.nifi.processors.standard.DeleteFile
+org.apache.nifi.processors.standard.DeleteSFTP
 org.apache.nifi.processors.standard.DetectDuplicate
 org.apache.nifi.processors.standard.DeduplicateRecord
 org.apache.nifi.processors.standard.DistributeLoad

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDeleteSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDeleteSFTP.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processors.standard.util.SFTPTransfer;
+import org.apache.nifi.processors.standard.util.SSHTestServer;
+import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestDeleteSFTP {
+
+    private static final int BATCH_SIZE = 2;
+
+    private final TestRunner runner = TestRunners.newTestRunner(DeleteSFTP.class);
+    private final SSHTestServer sshTestServer = new SSHTestServer();
+    private Path sshServerRootPath;
+
+    @BeforeEach
+    void setRunner() throws IOException {
+        sshTestServer.startServer();
+        sshServerRootPath = Paths.get(sshTestServer.getVirtualFileSystemPath()).toAbsolutePath();
+
+        runner.setProperty(SFTPTransfer.HOSTNAME, sshTestServer.getHost());
+        runner.setProperty(SFTPTransfer.PORT, Integer.toString(sshTestServer.getSSHPort()));
+        runner.setProperty(SFTPTransfer.USERNAME, sshTestServer.getUsername());
+        runner.setProperty(SFTPTransfer.PASSWORD, sshTestServer.getPassword());
+        runner.setProperty(SFTPTransfer.BATCH_SIZE, Integer.toString(BATCH_SIZE));
+    }
+
+    @AfterEach
+    void clearDirectory() throws IOException {
+        sshTestServer.stopServer();
+        FileUtils.deleteQuietly(sshServerRootPath.toFile());
+    }
+
+    @Test
+    void deletesExistingFile() throws IOException {
+        final Path fileToDelete = createFile("rel/path", "test.txt");
+        final MockFlowFile enqueuedFlowFile = enqueue(fileToDelete);
+        assertExists(fileToDelete);
+
+        runner.run();
+
+        assertNotExists(fileToDelete);
+        runner.assertAllFlowFilesTransferred(DeleteSFTP.REL_SUCCESS, 1);
+        runner.assertAllFlowFiles(
+                DeleteSFTP.REL_SUCCESS,
+                flowFileInRelationship -> assertEquals(enqueuedFlowFile, flowFileInRelationship)
+        );
+        runner.assertProvenanceEvent(ProvenanceEventType.REMOTE_INVOCATION);
+    }
+
+    @Test
+    void sendsFlowFileToNotFoundWhenFileDoesNotExist() throws IOException {
+        final Path directoryPath = Files.createDirectories(sshServerRootPath.resolve("rel/path"));
+        final String filename = "not-exist.txt";
+        final Path fileToDelete = directoryPath.resolve(filename);
+        enqueue(fileToDelete);
+        assertNotExists(fileToDelete);
+
+        runner.run();
+
+        assertNotExists(fileToDelete);
+        runner.assertAllFlowFilesTransferred(DeleteSFTP.REL_NOT_FOUND);
+    }
+
+    @Test
+    void sendsFlowFileToNotFoundWhenDirectoryDoesNotExist() {
+        final Path directoryPath = sshServerRootPath.resolve("rel/path");
+        final String filename = "not-exist.txt";
+        final Path fileToDelete = directoryPath.resolve(filename);
+        enqueue(fileToDelete);
+        assertNotExists(fileToDelete);
+
+        runner.run();
+
+        assertNotExists(fileToDelete);
+        runner.assertAllFlowFilesTransferred(DeleteSFTP.REL_NOT_FOUND);
+    }
+
+    @Test
+    void sendsFlowFileToFailureWhenTargetIsADirectory() throws IOException {
+        Path fileToDelete = Files.createDirectories(sshServerRootPath.resolve("a/directory"));
+        enqueue(fileToDelete);
+        assertExists(fileToDelete);
+
+        runner.run();
+
+        assertExists(fileToDelete);
+        runner.assertAllFlowFilesTransferred(DeleteSFTP.REL_FAILURE);
+        runner.assertPenalizeCount(1);
+        final MockFlowFile resultFlowFile = runner.getFlowFilesForRelationship(DeleteSFTP.REL_FAILURE).getFirst();
+        resultFlowFile.assertAttributeExists(DeleteSFTP.ATTRIBUTE_FAILURE_REASON);
+        resultFlowFile.assertAttributeExists(DeleteSFTP.ATTRIBUTE_EXCEPTION_CLASS);
+        resultFlowFile.assertAttributeExists(DeleteSFTP.ATTRIBUTE_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    void sendsFlowFileToFailureWhenFileIsNotADirectChildOfTheDirectory() throws IOException {
+        final Path directoryPath = Files.createDirectories(sshServerRootPath.resolve("rel/path"));
+        final String filename = "../sibling.txt";
+        enqueue(directoryPath.toString(), filename);
+        final Path fileToDelete = Files.writeString(directoryPath.resolve(filename), "sibling content");
+        assertExists(fileToDelete);
+
+        runner.run();
+
+        assertExists(fileToDelete);
+        runner.assertAllFlowFilesTransferred(DeleteSFTP.REL_FAILURE, 1);
+        runner.assertPenalizeCount(1);
+        final MockFlowFile resultFlowFile = runner.getFlowFilesForRelationship(DeleteSFTP.REL_FAILURE).getFirst();
+        resultFlowFile.assertAttributeExists(DeleteSFTP.ATTRIBUTE_FAILURE_REASON);
+        resultFlowFile.assertAttributeNotExists(DeleteSFTP.ATTRIBUTE_EXCEPTION_CLASS);
+        resultFlowFile.assertAttributeNotExists(DeleteSFTP.ATTRIBUTE_EXCEPTION_MESSAGE);
+    }
+
+    @Test
+    void deletesUpToBatchSizeFilesWithASingleConnection() throws IOException {
+        for (int fileNumber = 1; fileNumber <= 2 * BATCH_SIZE; fileNumber++) {
+            final Path fileToDelete = createFile("a/directory", "file-%d".formatted(fileNumber));
+            enqueue(fileToDelete);
+            assertExists(fileToDelete);
+        }
+
+        runner.run();
+        runner.assertTransferCount(DeleteSFTP.REL_SUCCESS, BATCH_SIZE);
+        runner.clearTransferState();
+
+        runner.run();
+        runner.assertTransferCount(DeleteSFTP.REL_SUCCESS, BATCH_SIZE);
+        runner.assertQueueEmpty();
+    }
+
+    private Path createFile(String directoryPath, String filename) throws IOException {
+        Path directory = Files.createDirectories(sshServerRootPath.resolve(directoryPath));
+
+        return Files.writeString(directory.resolve(filename), "some text");
+    }
+
+    private MockFlowFile enqueue(Path path) {
+        final Path relativePath = sshServerRootPath.relativize(path);
+
+        return enqueue("/%s".formatted(relativePath.getParent()), relativePath.getFileName().toString());
+    }
+
+    private MockFlowFile enqueue(String directoryPath, String filename) {
+        final Map<String, String> attributes = Map.of(
+                CoreAttributes.ABSOLUTE_PATH.key(), directoryPath,
+                CoreAttributes.FILENAME.key(), filename
+        );
+
+        return runner.enqueue("data", attributes);
+    }
+
+    private static void assertNotExists(Path filePath) {
+        assertTrue(Files.notExists(filePath), () -> "File " + filePath + "still exists");
+    }
+
+    private static void assertExists(Path filePath) {
+        assertTrue(Files.exists(filePath), () -> "File " + filePath + "does not exist");
+    }
+}

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDeleteSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDeleteSFTP.java
@@ -175,7 +175,7 @@ class TestDeleteSFTP {
 
     private MockFlowFile enqueue(String directoryPath, String filename) {
         final Map<String, String> attributes = Map.of(
-                CoreAttributes.ABSOLUTE_PATH.key(), directoryPath,
+                CoreAttributes.PATH.key(), directoryPath,
                 CoreAttributes.FILENAME.key(), filename
         );
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDeleteSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDeleteSFTP.java
@@ -119,10 +119,6 @@ class TestDeleteSFTP {
         assertExists(fileToDelete);
         runner.assertAllFlowFilesTransferred(DeleteSFTP.REL_FAILURE);
         runner.assertPenalizeCount(1);
-        final MockFlowFile resultFlowFile = runner.getFlowFilesForRelationship(DeleteSFTP.REL_FAILURE).getFirst();
-        resultFlowFile.assertAttributeExists(DeleteSFTP.ATTRIBUTE_FAILURE_REASON);
-        resultFlowFile.assertAttributeExists(DeleteSFTP.ATTRIBUTE_EXCEPTION_CLASS);
-        resultFlowFile.assertAttributeExists(DeleteSFTP.ATTRIBUTE_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -138,10 +134,6 @@ class TestDeleteSFTP {
         assertExists(fileToDelete);
         runner.assertAllFlowFilesTransferred(DeleteSFTP.REL_FAILURE, 1);
         runner.assertPenalizeCount(1);
-        final MockFlowFile resultFlowFile = runner.getFlowFilesForRelationship(DeleteSFTP.REL_FAILURE).getFirst();
-        resultFlowFile.assertAttributeExists(DeleteSFTP.ATTRIBUTE_FAILURE_REASON);
-        resultFlowFile.assertAttributeNotExists(DeleteSFTP.ATTRIBUTE_EXCEPTION_CLASS);
-        resultFlowFile.assertAttributeNotExists(DeleteSFTP.ATTRIBUTE_EXCEPTION_MESSAGE);
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Adds new processor `DeleteSFTP` to the bundle standard-processors.

See issue [NIFI-13372](https://issues.apache.org/jira/browse/NIFI-13372) for the motivation behind the addition.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
