### PR TITLE
NIFI-13465: Fix NPE in QueryNiFiReportingTask when analytics tables are queried without analytics enabled

### DIFF
--- a/nifi-extension-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/MetricsSqlQueryService.java
+++ b/nifi-extension-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/MetricsSqlQueryService.java
@@ -148,12 +148,11 @@ public class MetricsSqlQueryService implements MetricsQueryService {
         final NiFiTable connectionStatusTable = new NiFiTable("CONNECTION_STATUS", connectionStatusDataSource, getLogger());
         database.addTable(connectionStatusTable);
 
-        if (context.isAnalyticsEnabled()) {
-            final ResettableDataSource predictionDataSource = new ConnectionStatusPredictionDataSource(context, groupStatusCache);
-            final NiFiTable connectionStatusPredictionsTable = new NiFiTable("CONNECTION_STATUS_PREDICTIONS", predictionDataSource, getLogger());
-            database.addTable(connectionStatusPredictionsTable);
-        } else {
-            getLogger().debug("Analytics is not enabled, CONNECTION_STATUS_PREDICTIONS table is not available for querying");
+        final ResettableDataSource predictionDataSource = new ConnectionStatusPredictionDataSource(context, groupStatusCache);
+        final NiFiTable connectionStatusPredictionsTable = new NiFiTable("CONNECTION_STATUS_PREDICTIONS", predictionDataSource, getLogger());
+        database.addTable(connectionStatusPredictionsTable);
+        if (!context.isAnalyticsEnabled()) {
+            getLogger().info("Analytics is not enabled, CONNECTION_STATUS_PREDICTIONS table will not contain any rows");
         }
 
         final ResettableDataSource processorStatusDataSource = new ProcessorStatusDataSource(context, groupStatusCache);

--- a/nifi-extension-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/datasources/ConnectionStatusPredictionDataSource.java
+++ b/nifi-extension-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/datasources/ConnectionStatusPredictionDataSource.java
@@ -88,6 +88,10 @@ public class ConnectionStatusPredictionDataSource implements ResettableDataSourc
     private Object[] toArray(final ConnectionStatus status) {
         final ConnectionStatusPredictions predictions = status.getPredictions();
 
+        if (predictions == null) {
+            return new Object[8];
+        }
+
         return new Object[] {
             status.getId(),
             predictions.getNextPredictedQueuedBytes(),


### PR DESCRIPTION
# Summary

[NIFI-13465](https://issues.apache.org/jira/browse/NIFI-13465)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
