### PR TITLE
NIFI-13464 - Adding nifi-deprecation-log to classpath

### DIFF
--- a/nifi-registry/nifi-registry-assembly/pom.xml
+++ b/nifi-registry/nifi-registry-assembly/pom.xml
@@ -164,6 +164,12 @@
             <groupId>org.apache.nifi.registry</groupId>
             <artifactId>nifi-registry-properties-loader</artifactId>
         </dependency>
+        <!-- Dependency for logging deprecated features -->
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-deprecation-log</artifactId>
+            <version>1.27.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <properties>


### PR DESCRIPTION
# Summary

[NIFI-13464](https://issues.apache.org/jira/browse/NIFI-13464) - NiFi Registry - DeprecationLoggerFactory NoClassDefFoundError

With https://github.com/apache/nifi/commit/e99344fadab4af67b86b03d130bc196c9b9715eb (#8979) nifi-deprecation-log has been added to ./lib/bootstrap but it also needs to be in ./lib.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
