### PR TITLE
NIFI-13478: Protobuf Reader fails to coerce type of repeated fields (nifi-1.x)

### DIFF
--- a/nifi-nar-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/main/java/org/apache/nifi/services/protobuf/converter/ProtobufDataConverter.java
+++ b/nifi-nar-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/main/java/org/apache/nifi/services/protobuf/converter/ProtobufDataConverter.java
@@ -225,8 +225,8 @@ public class ProtobufDataConverter {
                     break;
                 default:
                     throw new IllegalStateException(String.format("Unexpected type [%s] was received for field [%s]",
-                        protoType.getSimpleName(), protoField.getFieldName()));
-            };
+                            protoType.getSimpleName(), protoField.getFieldName()));
+            }
             return resolveFieldValue(protoField, processRepeatedValues(inputStream, valueReader), value -> value);
         } else {
             List<Integer> values = processRepeatedValues(inputStream, CodedInputStream::readEnum);
@@ -388,7 +388,14 @@ public class ProtobufDataConverter {
         if (coerceTypes) {
             final Optional<RecordField> recordField = rootRecordSchema.getField(protoField.getFieldName());
             if (recordField.isPresent()) {
-                resultValues = resultValues.stream().map(value -> DataTypeUtils.convertType(value, recordField.get().getDataType(), recordField.get().getFieldName())).collect(Collectors.toList());
+                final DataType dataType;
+                if (protoField.isRepeatable()) {
+                    final ArrayDataType arrayDataType = (ArrayDataType) recordField.get().getDataType();
+                    dataType = arrayDataType.getElementType();
+                } else {
+                    dataType = recordField.get().getDataType();
+                }
+                resultValues = resultValues.stream().map(value -> DataTypeUtils.convertType(value, dataType, recordField.get().getFieldName())).collect(Collectors.toList());
             }
         }
 

--- a/nifi-nar-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/test/java/org/apache/nifi/services/protobuf/TestProtobufRecordReader.java
+++ b/nifi-nar-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/test/java/org/apache/nifi/services/protobuf/TestProtobufRecordReader.java
@@ -19,6 +19,7 @@ package org.apache.nifi.services.protobuf;
 import com.google.protobuf.Descriptors;
 import com.squareup.wire.schema.Schema;
 import org.apache.nifi.serialization.SimpleRecordSchema;
+import org.apache.nifi.serialization.record.MapRecord;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
@@ -28,11 +29,13 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 
 import static org.apache.nifi.services.protobuf.ProtoTestUtil.generateInputDataForProto3;
+import static org.apache.nifi.services.protobuf.ProtoTestUtil.generateInputDataForRepeatedProto3;
 import static org.apache.nifi.services.protobuf.ProtoTestUtil.loadProto3TestSchema;
+import static org.apache.nifi.services.protobuf.ProtoTestUtil.loadRepeatedProto3TestSchema;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -43,7 +46,7 @@ public class TestProtobufRecordReader {
     private static Schema protoSchema;
 
     @BeforeAll
-    public static void setup(){
+    public static void setup() {
         protoSchema = loadProto3TestSchema();
     }
 
@@ -131,12 +134,41 @@ public class TestProtobufRecordReader {
         assertNull(field4);
     }
 
+    @Test
+    public void testReadRecordWithRepeatedFieldsAndCoerceTypeAndDropUnknownFields() throws Descriptors.DescriptorValidationException, IOException {
+        final ProtobufRecordReader reader = createReader(generateInputDataForRepeatedProto3(), "RootMessage", loadRepeatedProto3TestSchema(), generateRecordSchemaForRepeatedTest());
+        final Record record = reader.nextRecord(true, true);
+
+        final Object[] recordList = (Object[]) record.getValue("repeatedMessage");
+        assertInstanceOf(Object[].class, recordList);
+
+        final MapRecord firstRecord = (MapRecord) recordList[0];
+
+        final Object[] field1 = (Object[]) firstRecord.getValue("booleanField");
+        assertArrayEquals(new Boolean[]{true, false}, field1);
+
+        final Object[] field2 = (Object[]) firstRecord.getValue("stringField");
+        assertArrayEquals(new String[]{"Test text1", "Test text2"}, field2);
+
+        final Object field4 = firstRecord.getValue("int32Field");
+        assertNull(field4);
+    }
+
     private RecordSchema generateRecordSchema() {
-        final List<RecordField> fields = new ArrayList<>();
-        for (final String fieldName : new String[] {"booleanField", "stringField", "int32Field"}) {
-            fields.add(new RecordField(fieldName, RecordFieldType.STRING.getDataType()));
-        }
-        return new SimpleRecordSchema(fields);
+        return new SimpleRecordSchema(Arrays.asList(
+                new RecordField("booleanField", RecordFieldType.STRING.getDataType()),
+                new RecordField("stringField", RecordFieldType.STRING.getDataType()),
+                new RecordField("int32Field", RecordFieldType.STRING.getDataType()))
+        );
+    }
+
+    private RecordSchema generateRecordSchemaForRepeatedTest() {
+        return new SimpleRecordSchema(Arrays.asList(
+                new RecordField("repeatedMessage", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.RECORD.getRecordDataType(new SimpleRecordSchema(Arrays.asList(
+                        new RecordField("booleanField", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BOOLEAN.getDataType())),
+                        new RecordField("stringField", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.STRING.getDataType()))
+                )))))
+        ));
     }
 
     private ProtobufRecordReader createReader(InputStream in, String message, Schema schema, RecordSchema recordSchema) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13478](https://issues.apache.org/jira/browse/NIFI-13478)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
