### PR TITLE
NIFI-13484 Fix HBase_2_ClientService.getResults methods, so they properly return a single row when startRow and endRow/stopRow are the same.

### DIFF
--- a/nifi-extension-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/nifi-hbase_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_2_ClientService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/nifi-hbase_2-client-service/src/main/java/org/apache/nifi/hbase/HBase_2_ClientService.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -745,7 +746,13 @@ public class HBase_2_ClientService extends AbstractControllerService implements 
             scan = scan.withStartRow(startRow.getBytes(StandardCharsets.UTF_8));
         }
         if (!StringUtils.isBlank(endRow)) {
-            scan = scan.withStopRow(endRow.getBytes(StandardCharsets.UTF_8));
+            byte[] endRowBytes = endRow.getBytes(StandardCharsets.UTF_8);
+
+            if (endRow.equals(startRow)) {
+                scan = scan.withStopRow(endRowBytes, true);
+            } else {
+                scan = scan.withStopRow(endRowBytes, false);
+            }
         }
 
         if (authorizations != null && authorizations.size() > 0) {
@@ -792,7 +799,12 @@ public class HBase_2_ClientService extends AbstractControllerService implements 
     protected ResultScanner getResults(final Table table, final byte[] startRow, final byte[] endRow, final Collection<Column> columns, List<String> authorizations) throws IOException {
         Scan scan = new Scan();
         scan = scan.withStartRow(startRow);
-        scan = scan.withStopRow(endRow);
+        if (Arrays.equals(startRow, endRow)) {
+            scan = scan.withStopRow(endRow, true);
+        } else {
+            scan = scan.withStopRow(endRow, false);
+        }
+
 
         if (authorizations != null && authorizations.size() > 0) {
             scan.setAuthorizations(new Authorizations(authorizations));


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13484](https://issues.apache.org/jira/browse/NIFI-13484)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
