### PR TITLE
NIFI-13488 Upgrade Apache POI from 5.2.5 to 5.3.0

### DIFF
--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
     <properties>
         <spring.integration.version>6.3.1</spring.integration.version>
-        <poi.version>5.2.5</poi.version>
+        <poi.version>5.3.0</poi.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-media-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-media-bundle/pom.xml
@@ -24,7 +24,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <poi.version>5.2.5</poi.version>
+        <poi.version>5.3.0</poi.version>
         <mime4j.version>0.8.11</mime4j.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-poi-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-poi-bundle/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>nifi-poi-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <poi.version>5.2.5</poi.version>
+        <poi.version>5.3.0</poi.version>
     </properties>
     <modules>
         <module>nifi-poi-nar</module>


### PR DESCRIPTION
# Summary

[NIFI-13488](https://issues.apache.org/jira/browse/NIFI-13488) Upgrades Apache POI dependencies across several extension bundles from 5.2.5 to [5.3.0](https://poi.apache.org/changes.html#5.3.0) incorporating transitive dependency upgrades and bug fixes.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
