### PR TITLE
NIFI-13523: Refreshing the controller service listing after creation or deletion

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/state/management-controller-services/management-controller-services.effects.ts
@@ -158,18 +158,18 @@ export class ManagementControllerServicesEffects {
         this.actions$.pipe(
             ofType(ManagementControllerServicesActions.createControllerServiceSuccess),
             map((action) => action.response),
-            tap(() => {
+            tap((response) => {
                 this.dialog.closeAll();
-            }),
-            switchMap((response) =>
-                of(
+
+                this.store.dispatch(
                     ManagementControllerServicesActions.selectControllerService({
                         request: {
                             id: response.controllerService.id
                         }
                     })
-                )
-            )
+                );
+            }),
+            switchMap(() => of(ManagementControllerServicesActions.loadManagementControllerServices()))
         )
     );
 
@@ -595,6 +595,13 @@ export class ManagementControllerServicesEffects {
                     )
                 )
             )
+        )
+    );
+
+    deleteControllerServiceSuccess$ = createEffect(() =>
+        this.actions$.pipe(
+            ofType(ManagementControllerServicesActions.deleteControllerServiceSuccess),
+            switchMap(() => of(ManagementControllerServicesActions.loadManagementControllerServices()))
         )
     );
 


### PR DESCRIPTION
NIFI-13523:
- Refreshing the controller service listing after creation or deletion to ensure allowable values of other services is accurate.