### PR TITLE
NIFI-13538 Do not include exception details in FlowFile attributes in DeleteFile (1.x backport)

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteFile.java
@@ -21,8 +21,6 @@ import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.Restricted;
 import org.apache.nifi.annotation.behavior.Restriction;
 import org.apache.nifi.annotation.behavior.SupportsBatching;
-import org.apache.nifi.annotation.behavior.WritesAttribute;
-import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -53,17 +51,6 @@ import java.util.concurrent.TimeUnit;
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
 @Tags({"file", "remove", "delete", "local", "files", "filesystem"})
 @CapabilityDescription("Deletes a file from the filesystem.")
-@WritesAttributes({
-        @WritesAttribute(
-                attribute = DeleteFile.ATTRIBUTE_FAILURE_REASON,
-                description = "Human-readable reason of failure. Only available if FlowFile is routed to relationship 'failure'."),
-        @WritesAttribute(
-                attribute = DeleteFile.ATTRIBUTE_EXCEPTION_CLASS,
-                description = "The class name of the exception thrown during processor execution. Only available if an exception caused the FlowFile to be routed to relationship 'failure'."),
-        @WritesAttribute(
-                attribute = DeleteFile.ATTRIBUTE_EXCEPTION_MESSAGE,
-                description = "The message of the exception thrown during processor execution. Only available if an exception caused the FlowFile to be routed to relationship 'failure'.")
-})
 @Restricted(
         restrictions = {
                 @Restriction(
@@ -75,10 +62,6 @@ import java.util.concurrent.TimeUnit;
         }
 )
 public class DeleteFile extends AbstractProcessor {
-
-    public static final String ATTRIBUTE_FAILURE_REASON = "DeleteFile.failure.reason";
-    public static final String ATTRIBUTE_EXCEPTION_CLASS = "DeleteFile.failure.exception.class";
-    public static final String ATTRIBUTE_EXCEPTION_MESSAGE = "DeleteFile.failure.exception.message";
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
@@ -172,11 +155,6 @@ public class DeleteFile extends AbstractProcessor {
     private void handleFailure(ProcessSession session, FlowFile flowFile, String errorMessage, Throwable throwable) {
         getLogger().error(errorMessage, throwable);
 
-        session.putAttribute(flowFile, ATTRIBUTE_FAILURE_REASON, errorMessage);
-        if (throwable != null) {
-            session.putAttribute(flowFile, ATTRIBUTE_EXCEPTION_CLASS, throwable.getClass().toString());
-            session.putAttribute(flowFile, ATTRIBUTE_EXCEPTION_MESSAGE, throwable.getMessage());
-        }
         session.penalize(flowFile);
         session.transfer(flowFile, REL_FAILURE);
     }

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDeleteFile.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDeleteFile.java
@@ -116,10 +116,6 @@ class TestDeleteFile {
         assertExists(fileToDelete);
         runner.assertAllFlowFilesTransferred(DeleteFile.REL_FAILURE);
         runner.assertPenalizeCount(1);
-        final MockFlowFile resultFlowFile = runner.getFlowFilesForRelationship(DeleteFile.REL_FAILURE).get(0);
-        resultFlowFile.assertAttributeExists(DeleteFile.ATTRIBUTE_FAILURE_REASON);
-        resultFlowFile.assertAttributeExists(DeleteFile.ATTRIBUTE_EXCEPTION_CLASS);
-        resultFlowFile.assertAttributeExists(DeleteFile.ATTRIBUTE_EXCEPTION_MESSAGE);
     }
 
     @Test
@@ -135,10 +131,6 @@ class TestDeleteFile {
         assertExists(fileToDelete);
         runner.assertAllFlowFilesTransferred(DeleteFile.REL_FAILURE, 1);
         runner.assertPenalizeCount(1);
-        final MockFlowFile resultFlowFile = runner.getFlowFilesForRelationship(DeleteFile.REL_FAILURE).get(0);
-        resultFlowFile.assertAttributeExists(DeleteFile.ATTRIBUTE_FAILURE_REASON);
-        resultFlowFile.assertAttributeNotExists(DeleteFile.ATTRIBUTE_EXCEPTION_CLASS);
-        resultFlowFile.assertAttributeNotExists(DeleteFile.ATTRIBUTE_EXCEPTION_MESSAGE);
     }
 
     private MockFlowFile enqueue(String directoryPath, String filename) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13538](https://issues.apache.org/jira/browse/NIFI-13538)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
