### PR TITLE
NIFI-13541 [MiNiFi] Validate flow during startup

### DIFF
--- a/minifi/minifi-commons/minifi-commons-utils/src/main/java/org/apache/nifi/minifi/commons/utils/RetryUtil.java
+++ b/minifi/minifi-commons/minifi-commons-utils/src/main/java/org/apache/nifi/minifi/commons/utils/RetryUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.minifi.commons.utils;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public final class RetryUtil {
+
+    private RetryUtil() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static  <T> Optional<T> retry(Supplier<T> input, Predicate<T> predicate, int maxRetries, int pauseDurationMillis) {
+        int retries = 0;
+        while (true) {
+            T t = input.get();
+            if (predicate.test(t)) {
+                return Optional.empty();
+            }
+            if (retries == maxRetries) {
+                return Optional.ofNullable(t);
+            }
+            retries++;
+            try {
+                Thread.sleep(pauseDurationMillis);
+            } catch (InterruptedException e) {
+            }
+        }
+    }
+}

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/pom.xml
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/pom.xml
@@ -146,6 +146,11 @@ limitations under the License.
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi.minifi</groupId>
+            <artifactId>minifi-commons-utils</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-python-framework-api</artifactId>
             <version>2.0.0-SNAPSHOT</version>

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/validator/FlowValidator.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/validator/FlowValidator.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.minifi.validator;
+
+import static org.apache.nifi.components.AsyncLoadedProcessor.LoadState.DOWNLOADING_DEPENDENCIES;
+import static org.apache.nifi.components.AsyncLoadedProcessor.LoadState.INITIALIZING_ENVIRONMENT;
+import static org.apache.nifi.components.AsyncLoadedProcessor.LoadState.LOADING_PROCESSOR_CODE;
+import static org.apache.nifi.components.validation.ValidationStatus.INVALID;
+import static org.apache.nifi.components.validation.ValidationStatus.VALIDATING;
+import static org.apache.nifi.minifi.commons.utils.RetryUtil.retry;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.apache.nifi.components.AsyncLoadedProcessor;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.controller.ComponentNode;
+import org.apache.nifi.controller.flow.FlowManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class FlowValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowValidator.class);
+
+    private static final Set<AsyncLoadedProcessor.LoadState> INITIALIZING_ASYNC_PROCESSOR_STATES =
+        Set.of(INITIALIZING_ENVIRONMENT, DOWNLOADING_DEPENDENCIES, LOADING_PROCESSOR_CODE);
+
+    private static final int ASYNC_LOADING_COMPONENT_INIT_RETRY_PAUSE_DURATION_MS = 5000;
+    private static final int ASYNC_LOADING_COMPONENT_INIT_MAX_RETRIES = 60;
+    private static final int VALIDATION_RETRY_PAUSE_DURATION_MS = 1000;
+    private static final int VALIDATION_MAX_RETRIES = 5;
+
+    private FlowValidator() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static List<ValidationResult> validate(FlowManager flowManager) {
+        List<? extends ComponentNode> componentNodes = extractComponentNodes(flowManager);
+
+        retry(() -> initializingAsyncLoadingComponents(componentNodes), List::isEmpty,
+            ASYNC_LOADING_COMPONENT_INIT_MAX_RETRIES, ASYNC_LOADING_COMPONENT_INIT_RETRY_PAUSE_DURATION_MS)
+            .ifPresent(components -> {
+                LOGGER.error("The following components are async loading components and are still initializing: {}", components);
+                throw new IllegalStateException("Maximum retry number exceeded while waiting for async loading components to be initialized");
+            });
+
+        retry(() -> componentsInValidatingState(componentNodes), List::isEmpty, VALIDATION_MAX_RETRIES, VALIDATION_RETRY_PAUSE_DURATION_MS)
+            .ifPresent(components -> {
+                LOGGER.error("The following components are still in VALIDATING state: {}", components);
+                throw new IllegalStateException("Maximum retry number exceeded while waiting for components to be validated");
+            });
+
+        return componentNodes.stream()
+            .map(ComponentNode::getValidationErrors)
+            .flatMap(Collection::stream)
+            .toList();
+    }
+
+    private static List<? extends ComponentNode> extractComponentNodes(FlowManager flowManager) {
+        return Stream.of(
+                flowManager.getAllControllerServices(),
+                flowManager.getAllReportingTasks(),
+                Set.copyOf(flowManager.getRootGroup().findAllProcessors()))
+            .flatMap(Set::stream)
+            .toList();
+    }
+
+    private static List<? extends ComponentNode> componentsInValidatingState(List<? extends ComponentNode> componentNodes) {
+        return componentNodes.stream()
+            .filter(componentNode -> componentNode.performValidation() == VALIDATING)
+            .toList();
+    }
+
+    private static List<? extends ComponentNode> initializingAsyncLoadingComponents(List<? extends ComponentNode> componentNodes) {
+        return componentNodes.stream()
+            .filter(componentNode -> componentNode.performValidation() == INVALID)
+            .filter(componentNode -> componentNode.getComponent() instanceof AsyncLoadedProcessor asyncLoadedProcessor
+                && INITIALIZING_ASYNC_PROCESSOR_STATES.contains(asyncLoadedProcessor.getState()))
+            .toList();
+    }
+}

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-server/src/main/java/org/apache/nifi/minifi/StandardMiNiFiServer.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-server/src/main/java/org/apache/nifi/minifi/StandardMiNiFiServer.java
@@ -19,11 +19,14 @@ package org.apache.nifi.minifi;
 
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.nifi.minifi.validator.FlowValidator.validate;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.headless.HeadlessNiFiServer;
 import org.apache.nifi.minifi.bootstrap.BootstrapListener;
 import org.apache.nifi.minifi.c2.C2NifiClientService;
@@ -35,27 +38,13 @@ import org.apache.nifi.util.NiFiProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- *
- */
 public class StandardMiNiFiServer extends HeadlessNiFiServer implements MiNiFiServer {
 
     private static final Logger logger = LoggerFactory.getLogger(StandardMiNiFiServer.class);
-    public static final String BOOTSTRAP_PORT_PROPERTY = "nifi.bootstrap.listen.port";
+    private static final String BOOTSTRAP_PORT_PROPERTY = "nifi.bootstrap.listen.port";
 
     private BootstrapListener bootstrapListener;
-
-    /* A reference to the client service for handling*/
     private C2NifiClientService c2NifiClientService;
-
-
-    public StandardMiNiFiServer() {
-        super();
-    }
-
-    public FlowStatusReport getStatusReport(String requestString) throws StatusRequestException {
-        return StatusConfigReporter.getStatus(getFlowController(), requestString, logger);
-    }
 
     @Override
     public void start() {
@@ -65,6 +54,16 @@ public class StandardMiNiFiServer extends HeadlessNiFiServer implements MiNiFiSe
         initC2();
         sendStartedStatus();
         startHeartbeat();
+    }
+
+    @Override
+    protected void validateFlow() {
+        List<ValidationResult> validationErrors = validate(getFlowController().getFlowManager());
+        if (!validationErrors.isEmpty()) {
+            logger.error("Validation errors found when loading the flow: {}", validationErrors);
+            throw new IllegalStateException("Unable to start flow due to validation errors");
+        }
+        logger.info("Flow validated successfully");
     }
 
     @Override
@@ -84,6 +83,10 @@ public class StandardMiNiFiServer extends HeadlessNiFiServer implements MiNiFiSe
         if (c2NifiClientService != null) {
             c2NifiClientService.stop();
         }
+    }
+
+    public FlowStatusReport getStatusReport(String requestString) throws StatusRequestException {
+        return StatusConfigReporter.getStatus(getFlowController(), requestString, logger);
     }
 
     private void initC2() {

--- a/nifi-framework-bundle/nifi-framework/nifi-headless-server/src/main/java/org/apache/nifi/headless/HeadlessNiFiServer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-headless-server/src/main/java/org/apache/nifi/headless/HeadlessNiFiServer.java
@@ -169,6 +169,7 @@ public class HeadlessNiFiServer implements NiFiServer {
             flowService.start();
             flowService.load(null);
             flowController.onFlowInitialized(true);
+            validateFlow();
             FlowManager flowManager = flowController.getFlowManager();
             flowManager.getGroup(flowManager.getRootGroupId()).startProcessing();
 
@@ -193,6 +194,10 @@ public class HeadlessNiFiServer implements NiFiServer {
             }
             startUpFailure(new Exception("Unable to load flow due to: " + e, e));
         }
+    }
+
+    protected void validateFlow() {
+        logger.info("Flow validation not implemented. Proceeding without validating the flow");
     }
 
     private void startUpFailure(Throwable t) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13541](https://issues.apache.org/jira/browse/NIFI-13541)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
