### PR TITLE
NIFI-13327: Allow migrating properties of Parameter Providers

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/parameter/ParameterProvider.java
+++ b/nifi-api/src/main/java/org/apache/nifi/parameter/ParameterProvider.java
@@ -16,13 +16,13 @@
  */
 package org.apache.nifi.parameter;
 
+import java.io.IOException;
+import java.util.List;
 import org.apache.nifi.annotation.lifecycle.OnConfigurationRestored;
 import org.apache.nifi.components.ConfigurableComponent;
 import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.reporting.InitializationException;
-
-import java.io.IOException;
-import java.util.List;
 
 /**
  * Defines a provider that is responsible for fetching from an external source Parameters with
@@ -85,4 +85,22 @@ public interface ParameterProvider extends ConfigurableComponent {
      * @throws IOException if there is an I/O problem while fetching the Parameters
      */
     List<ParameterGroup> fetchParameters(ConfigurationContext context) throws IOException;
+
+    /**
+     * <p>
+     * Allows for the migration of an old property configuration to a new configuration. This allows the Parameter Provider to evolve over time,
+     * as it allows properties to be renamed, removed, or reconfigured.
+     * </p>
+     *
+     * <p>
+     * This method is called only when a Parameter Provider is restored from a previous configuration. For example, when NiFi is restarted and the
+     * flow is restored from disk, when a previously configured flow is imported (e.g., from a JSON file that was exported or a NiFi Registry),
+     * or when a node joins a cluster and inherits a flow that has a new Parameter Provider. Once called, the method will not be invoked again for this
+     * Parameter Provider until NiFi is restarted.
+     * </p>
+     *
+     * @param config the current property configuration
+     */
+    default void migrateProperties(PropertyConfiguration config) {
+    }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -265,6 +265,8 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                     service.migrateConfiguration(originalPropertyValues, serviceFactory);
                 } else if (extension instanceof final ReportingTaskNode task) {
                     task.migrateConfiguration(originalPropertyValues, serviceFactory);
+                } else if (extension instanceof final ParameterProviderNode parameterProvider) {
+                    parameterProvider.migrateConfiguration(originalPropertyValues, serviceFactory);
                 }
             }
         } finally {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ParameterProviderNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ParameterProviderNode.java
@@ -16,8 +16,10 @@
  */
 package org.apache.nifi.controller;
 
+import java.util.Map;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.migration.ControllerServiceFactory;
 import org.apache.nifi.nar.ExtensionManager;
 import org.apache.nifi.parameter.ParameterContext;
 import org.apache.nifi.parameter.ParameterProvider;
@@ -79,4 +81,6 @@ public interface ParameterProviderNode extends ComponentNode {
      * @return a list of results indicating whether or not the given configuration is valid
      */
     List<ConfigVerificationResult> verifyConfiguration(ConfigurationContext context, ComponentLog logger, ExtensionManager extensionManager);
+
+    void migrateConfiguration(Map<String, String> originalPropertyValues, ControllerServiceFactory serviceFactory);
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13327](https://issues.apache.org/jira/browse/NIFI-13327)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
