### PR TITLE
NIFI-13561 Enable Jira Automatic Linking in GitHub

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -28,6 +28,8 @@ github:
     squash:  true
     merge:   true
     rebase:  true
+  autolink_jira:
+    - NIFI
 notifications:
     commits:      commits@nifi.apache.org
     issues:       issues@nifi.apache.org


### PR DESCRIPTION
# Summary

[NIFI-13561](https://issues.apache.org/jira/browse/NIFI-13561) Enables [automatic linking](https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#autolink) for commit messages in GitHub to the Apache Jira system.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
