### PR TITLE
NIFI-13557 Corrected regular expression for short months in order to allow for single digit months.

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/text/RegexDateTimeMatcher.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/text/RegexDateTimeMatcher.java
@@ -384,7 +384,7 @@ public class RegexDateTimeMatcher implements DateTimeMatcher {
         }
 
         private void addShortMonth() {
-            patterns.add("(?:0[1-9]|1[0-2])");
+            patterns.add("(?:0?[1-9]|1[0-2])");
             range = range.plus(1, 2);
         }
 

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/text/TestRegexDateTimeMatcher.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/text/TestRegexDateTimeMatcher.java
@@ -34,6 +34,8 @@ public class TestRegexDateTimeMatcher {
         exampleToPattern.put("2018/12/12", "yyyy/MM/dd");
         exampleToPattern.put("12/12/2018", "MM/dd/yyyy");
         exampleToPattern.put("12/12/18", "MM/dd/yy");
+        exampleToPattern.put("1/1/18", "M/d/yy");
+        exampleToPattern.put("1/10/18", "M/d/yy");
         exampleToPattern.put("1:40:55", "HH:mm:ss");
         exampleToPattern.put("01:0:5", "HH:mm:ss");
         exampleToPattern.put("12/12/2018 13:04:08 GMT-05:00", "MM/dd/yyyy HH:mm:ss z");


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13557](https://issues.apache.org/jira/browse/NIFI-13557)
This fix corrects any 'Date Format' , 'Time Format' and 'Timestamp Format' (used in various record readers) to allow for reading single digit months. Before this fix whether a user specified  `MM` or `M` only double digit months could be read. That logic was incorrect as the underlying code uses  `java.time.format.DateTimeFormatter` and per the [DateTimeFormatter javadoc](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html) specifying single digit month `M` should support both single and double digits.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
