### PR TITLE
NIFI-13563: Updated Provenance Repository so that instead of returnin…

### DIFF
--- a/minifi/minifi-nar-bundles/minifi-provenance-repository-bundle/minifi-provenance-repositories/src/main/java/org/apache/nifi/provenance/NoOpProvenanceRepository.java
+++ b/minifi/minifi-nar-bundles/minifi-provenance-repository-bundle/minifi-provenance-repositories/src/main/java/org/apache/nifi/provenance/NoOpProvenanceRepository.java
@@ -26,7 +26,6 @@ import org.apache.nifi.provenance.search.SearchableField;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Collections.EMPTY_SET;
@@ -104,8 +103,8 @@ public class NoOpProvenanceRepository implements ProvenanceRepository {
   }
 
   @Override
-  public Optional<ProvenanceEventRecord> getLatestCachedEvent(final String componentId) throws IOException {
-    return Optional.empty();
+  public List<ProvenanceEventRecord> getLatestCachedEvents(final String componentId) {
+    return List.of();
   }
 
   @Override

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/WriteAheadProvenanceRepository.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/WriteAheadProvenanceRepository.java
@@ -57,7 +57,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 
@@ -258,8 +257,8 @@ public class WriteAheadProvenanceRepository implements ProvenanceRepository {
     }
 
     @Override
-    public Optional<ProvenanceEventRecord> getLatestCachedEvent(final String componentId) throws IOException {
-        return eventIndex.getLatestCachedEvent(componentId);
+    public List<ProvenanceEventRecord> getLatestCachedEvents(final String componentId) throws IOException {
+        return eventIndex.getLatestCachedEvents(componentId);
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/EventIndex.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/EventIndex.java
@@ -28,8 +28,8 @@ import org.apache.nifi.provenance.store.EventStore;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * An Event Index is responsible for indexing Provenance Events in such a way that the index can be quickly
@@ -83,13 +83,13 @@ public interface EventIndex extends Closeable {
     QuerySubmission submitQuery(Query query, EventAuthorizer authorizer, String userId);
 
     /**
-     * Retrieves the most recent Provenance Event that is cached for the given component that is also accessible by the given user
+     * Retrieves the list of Provenance Events that are cached for the most recent invocation of the given component
      * @param componentId the ID of the component
      *
      * @return an Optional containing the event, or an empty optional if no events are available or none of the available events are accessible by the given user
      * @throws IOException if unable to read from the repository
      */
-    Optional<ProvenanceEventRecord> getLatestCachedEvent(String componentId) throws IOException;
+    List<ProvenanceEventRecord> getLatestCachedEvents(String componentId) throws IOException;
 
     /**
      * Asynchronously computes the lineage for the FlowFile that is identified by the Provenance Event with the given ID.

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/LatestEventsQuery.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/LatestEventsQuery.java
@@ -17,21 +17,24 @@
 
 package org.apache.nifi.provenance.index.lucene;
 
-import java.util.List;
-import java.util.Optional;
-
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.search.Query;
 import org.apache.nifi.provenance.serialization.StorageSummary;
 import org.apache.nifi.util.RingBuffer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class LatestEventsQuery implements CachedQuery {
 
     final RingBuffer<Long> latestRecords = new RingBuffer<>(1000);
 
     @Override
-    public void update(final ProvenanceEventRecord event, final StorageSummary storageSummary) {
-        latestRecords.add(storageSummary.getEventId());
+    public void update(final Map<ProvenanceEventRecord, StorageSummary> events) {
+        for (final StorageSummary storageSummary : events.values()) {
+            latestRecords.add(storageSummary.getEventId());
+        }
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/main/java/org/apache/nifi/provenance/VolatileProvenanceRepository.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/main/java/org/apache/nifi/provenance/VolatileProvenanceRepository.java
@@ -50,7 +50,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -492,14 +491,15 @@ public class VolatileProvenanceRepository implements ProvenanceRepository {
     }
 
     @Override
-    public Optional<ProvenanceEventRecord> getLatestCachedEvent(final String componentId) throws IOException {
-        final List<ProvenanceEventRecord> matches = ringBuffer.getSelectedElements(event -> componentId.equals(event.getComponentId()));
+    public List<ProvenanceEventRecord> getLatestCachedEvents(final String componentId) {
+        final List<ProvenanceEventRecord> matches = ringBuffer.getSelectedElements(
+            event -> componentId.equals(event.getComponentId()), 1);
 
         if (matches.isEmpty()) {
-            return Optional.empty();
+            return List.of();
         }
 
-        return Optional.of(matches.get(matches.size() - 1));
+        return List.of(matches.getLast());
     }
 
     @Override

--- a/nifi-framework-api/src/main/java/org/apache/nifi/provenance/ProvenanceRepository.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/provenance/ProvenanceRepository.java
@@ -26,7 +26,6 @@ import org.apache.nifi.provenance.search.SearchableField;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 public interface ProvenanceRepository extends ProvenanceEventRepository {
@@ -95,12 +94,12 @@ public interface ProvenanceRepository extends ProvenanceEventRepository {
     QuerySubmission submitQuery(Query query, NiFiUser user);
 
     /**
-     * Retrieves the most recent Provenance Event that is cached for the given component that is also accessible by the given user
+     * Retrieves the Provenance Events that are cached for the most recent invocation of the given component.
      * @param componentId the ID of the component
-     * @return an Optional containing the event, or an empty optional if no events are available or none of the available events are accessible by the given user
+     * @return the list of events that are cached for the given component
      * @throws IOException if unable to read from the repository
      */
-    Optional<ProvenanceEventRecord> getLatestCachedEvent(String componentId) throws IOException;
+    List<ProvenanceEventRecord> getLatestCachedEvents(String componentId) throws IOException;
 
     /**
      * @param queryIdentifier of the query

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/provenance/LatestProvenanceEventsDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/provenance/LatestProvenanceEventsDTO.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.web.api.dto.provenance;
+
+import jakarta.xml.bind.annotation.XmlType;
+
+import java.util.List;
+
+@XmlType(name = "latestProvenanceEvents")
+public class LatestProvenanceEventsDTO {
+    private String componentId;
+    private List<ProvenanceEventDTO> provenanceEvents;
+
+    /**
+     * @return the ID of the component whose latest events were fetched
+     */
+    public String getComponentId() {
+        return componentId;
+    }
+
+    public void setComponentId(final String componentId) {
+        this.componentId = componentId;
+    }
+
+    /**
+     * @return the latest provenance events that were recorded for the associated component
+     */
+    public List<ProvenanceEventDTO> getProvenanceEvents() {
+        return provenanceEvents;
+    }
+
+    public void setProvenanceEvents(final List<ProvenanceEventDTO> provenanceEvents) {
+        this.provenanceEvents = provenanceEvents;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/LatestProvenanceEventsEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/LatestProvenanceEventsEntity.java
@@ -15,20 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.provenance.index.lucene;
+package org.apache.nifi.web.api.entity;
 
-import org.apache.nifi.provenance.ProvenanceEventRecord;
-import org.apache.nifi.provenance.search.Query;
-import org.apache.nifi.provenance.serialization.StorageSummary;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.apache.nifi.web.api.dto.provenance.LatestProvenanceEventsDTO;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+@XmlRootElement(name = "latestProvenanceEventsEntity")
+public class LatestProvenanceEventsEntity extends Entity {
+    private LatestProvenanceEventsDTO latestProvenanceEvents;
 
-public interface CachedQuery {
+    /**
+     * @return latest provenance events
+     */
+    public LatestProvenanceEventsDTO getLatestProvenanceEvents() {
+        return latestProvenanceEvents;
+    }
 
-    void update(Map<ProvenanceEventRecord, StorageSummary> events);
-
-    Optional<List<Long>> evaluate(Query query);
-
+    public void setLatestProvenanceEvents(LatestProvenanceEventsDTO latestProvenanceEvents) {
+        this.latestProvenanceEvents = latestProvenanceEvents;
+    }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/StandardHttpResponseMapper.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/StandardHttpResponseMapper.java
@@ -51,6 +51,7 @@ import org.apache.nifi.cluster.coordination.http.endpoints.GroupStatusEndpointMe
 import org.apache.nifi.cluster.coordination.http.endpoints.InputPortsEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.LabelEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.LabelsEndpointMerger;
+import org.apache.nifi.cluster.coordination.http.endpoints.LatestProvenanceEventsMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.ListFlowFilesEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.NarDetailsEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.NarSummariesEndpointMerger;
@@ -111,7 +112,7 @@ import java.util.stream.Collectors;
 
 public class StandardHttpResponseMapper implements HttpResponseMapper {
 
-    private Logger logger = LoggerFactory.getLogger(StandardHttpResponseMapper.class);
+    private final Logger logger = LoggerFactory.getLogger(StandardHttpResponseMapper.class);
 
     private final List<EndpointResponseMerger> endpointMergers = new ArrayList<>();
 
@@ -145,6 +146,7 @@ public class StandardHttpResponseMapper implements HttpResponseMapper {
         endpointMergers.add(new FlowSnippetEndpointMerger());
         endpointMergers.add(new ProvenanceQueryEndpointMerger());
         endpointMergers.add(new ProvenanceEventEndpointMerger());
+        endpointMergers.add(new LatestProvenanceEventsMerger());
         endpointMergers.add(new ControllerServiceEndpointMerger());
         endpointMergers.add(new ControllerServicesEndpointMerger());
         endpointMergers.add(new ControllerServiceReferenceEndpointMerger());

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/LatestProvenanceEventsMerger.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/LatestProvenanceEventsMerger.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.cluster.coordination.http.endpoints;
+
+import org.apache.nifi.cluster.coordination.http.EndpointResponseMerger;
+import org.apache.nifi.cluster.manager.NodeResponse;
+import org.apache.nifi.cluster.protocol.NodeIdentifier;
+import org.apache.nifi.web.api.dto.provenance.LatestProvenanceEventsDTO;
+import org.apache.nifi.web.api.dto.provenance.ProvenanceEventDTO;
+import org.apache.nifi.web.api.entity.LatestProvenanceEventsEntity;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class LatestProvenanceEventsMerger implements EndpointResponseMerger {
+    public static final Pattern LATEST_EVENTS_URI = Pattern.compile("/nifi-api/provenance-events/latest/[a-f0-9\\-]{36}");
+
+    @Override
+    public boolean canHandle(final URI uri, final String method) {
+        if ("GET".equalsIgnoreCase(method) && LATEST_EVENTS_URI.matcher(uri.getPath()).matches()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public NodeResponse merge(final URI uri, final String method, final Set<NodeResponse> successfulResponses, final Set<NodeResponse> problematicResponses, final NodeResponse clientResponse) {
+        if (!canHandle(uri, method)) {
+            throw new IllegalArgumentException("Cannot use Endpoint Mapper of type " + getClass().getSimpleName() + " to map responses for URI " + uri + ", HTTP Method " + method);
+        }
+
+        final LatestProvenanceEventsEntity responseEntity = clientResponse.getClientResponse().readEntity(LatestProvenanceEventsEntity.class);
+        final LatestProvenanceEventsDTO dto = responseEntity.getLatestProvenanceEvents();
+        final List<ProvenanceEventDTO> mergedEvents = new ArrayList<>();
+
+        for (final NodeResponse nodeResponse : successfulResponses) {
+            final NodeIdentifier nodeId = nodeResponse.getNodeId();
+
+            final LatestProvenanceEventsEntity nodeResponseEntity = nodeResponse.getClientResponse().readEntity(LatestProvenanceEventsEntity.class);
+            final List<ProvenanceEventDTO> nodeEvents = nodeResponseEntity.getLatestProvenanceEvents().getProvenanceEvents();
+
+            // if the cluster node id or node address is not set, then we need to populate them. If they
+            // are already set, we don't want to populate them because it will be the case that they were populated
+            // by the Cluster Coordinator when it federated the request, and we are now just receiving the response
+            // from the Cluster Coordinator.
+            for (final ProvenanceEventDTO eventDto : nodeEvents) {
+                if (eventDto.getClusterNodeId() == null || eventDto.getClusterNodeAddress() == null) {
+                    eventDto.setClusterNodeId(nodeId.getId());
+                    eventDto.setClusterNodeAddress(nodeId.getApiAddress() + ":" + nodeId.getApiPort());
+                }
+            }
+
+            mergedEvents.addAll(nodeEvents);
+        }
+
+        dto.setProvenanceEvents(mergedEvents);
+
+        return new NodeResponse(clientResponse, responseEntity);
+    }
+
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/provenance/MockProvenanceRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/provenance/MockProvenanceRepository.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -92,8 +91,8 @@ public class MockProvenanceRepository implements ProvenanceRepository {
     }
 
     @Override
-    public Optional<ProvenanceEventRecord> getLatestCachedEvent(final String componentId) throws IOException {
-        return Optional.empty();
+    public List<ProvenanceEventRecord> getLatestCachedEvents(final String componentId) {
+        return List.of();
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -114,6 +114,7 @@ import org.apache.nifi.web.api.entity.FlowRegistryBucketEntity;
 import org.apache.nifi.web.api.entity.FlowRegistryClientEntity;
 import org.apache.nifi.web.api.entity.FunnelEntity;
 import org.apache.nifi.web.api.entity.LabelEntity;
+import org.apache.nifi.web.api.entity.LatestProvenanceEventsEntity;
 import org.apache.nifi.web.api.entity.NarDetailsEntity;
 import org.apache.nifi.web.api.entity.NarSummaryEntity;
 import org.apache.nifi.web.api.entity.ParameterContextEntity;
@@ -321,6 +322,13 @@ public interface NiFiServiceFacade {
      * @return event
      */
     ProvenanceEventDTO getProvenanceEvent(Long id);
+
+    /**
+     * Gets the latest provenance events for the specified component.
+     * @param componentId the ID of the components to retrieve the latest events for
+     * @return the latest provenance events
+     */
+    LatestProvenanceEventsEntity getLatestProvenanceEvents(String componentId);
 
     /**
      * Gets the configuration for this controller.

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -280,6 +280,7 @@ import org.apache.nifi.web.api.dto.diagnostics.JVMDiagnosticsDTO;
 import org.apache.nifi.web.api.dto.diagnostics.JVMDiagnosticsSnapshotDTO;
 import org.apache.nifi.web.api.dto.diagnostics.ProcessorDiagnosticsDTO;
 import org.apache.nifi.web.api.dto.flow.FlowDTO;
+import org.apache.nifi.web.api.dto.provenance.LatestProvenanceEventsDTO;
 import org.apache.nifi.web.api.dto.provenance.ProvenanceDTO;
 import org.apache.nifi.web.api.dto.provenance.ProvenanceEventDTO;
 import org.apache.nifi.web.api.dto.provenance.ProvenanceOptionsDTO;
@@ -325,6 +326,7 @@ import org.apache.nifi.web.api.entity.FlowRegistryBucketEntity;
 import org.apache.nifi.web.api.entity.FlowRegistryClientEntity;
 import org.apache.nifi.web.api.entity.FunnelEntity;
 import org.apache.nifi.web.api.entity.LabelEntity;
+import org.apache.nifi.web.api.entity.LatestProvenanceEventsEntity;
 import org.apache.nifi.web.api.entity.NarDetailsEntity;
 import org.apache.nifi.web.api.entity.NarSummaryEntity;
 import org.apache.nifi.web.api.entity.ParameterContextEntity;
@@ -3654,6 +3656,15 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     @Override
     public ProvenanceEventDTO getProvenanceEvent(final Long id) {
         return controllerFacade.getProvenanceEvent(id);
+    }
+
+    @Override
+    public LatestProvenanceEventsEntity getLatestProvenanceEvents(final String componentId) {
+        final LatestProvenanceEventsDTO dto = controllerFacade.getLatestProvenanceEvents(componentId);
+
+        final LatestProvenanceEventsEntity entity = new LatestProvenanceEventsEntity();
+        entity.setLatestProvenanceEvents(dto);
+        return entity;
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProvenanceResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProvenanceResource.java
@@ -16,10 +16,6 @@
  */
 package org.apache.nifi.web.api;
 
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -54,6 +50,10 @@ import org.apache.nifi.web.api.entity.ComponentEntity;
 import org.apache.nifi.web.api.entity.LineageEntity;
 import org.apache.nifi.web.api.entity.ProvenanceEntity;
 import org.apache.nifi.web.api.entity.ProvenanceOptionsEntity;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/repository/StatelessProvenanceRepository.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/repository/StatelessProvenanceRepository.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -154,8 +153,8 @@ public class StatelessProvenanceRepository implements ProvenanceRepository {
     }
 
     @Override
-    public Optional<ProvenanceEventRecord> getLatestCachedEvent(final String componentId) throws IOException {
-        return Optional.empty();
+    public List<ProvenanceEventRecord> getLatestCachedEvents(final String componentId) {
+        return List.of();
     }
 
     @Override

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/provenance/ClusteredGetLatestProvenanceEventsIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/provenance/ClusteredGetLatestProvenanceEventsIT.java
@@ -15,20 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.nifi.provenance.index.lucene;
+package org.apache.nifi.tests.system.provenance;
 
-import org.apache.nifi.provenance.ProvenanceEventRecord;
-import org.apache.nifi.provenance.search.Query;
-import org.apache.nifi.provenance.serialization.StorageSummary;
+import org.apache.nifi.tests.system.NiFiInstanceFactory;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+public class ClusteredGetLatestProvenanceEventsIT extends GetLatestProvenanceEventsIT {
 
-public interface CachedQuery {
-
-    void update(Map<ProvenanceEventRecord, StorageSummary> events);
-
-    Optional<List<Long>> evaluate(Query query);
-
+    @Override
+    public NiFiInstanceFactory getInstanceFactory() {
+        return createTwoNodeInstanceFactory();
+    }
 }

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/provenance/GetLatestProvenanceEventsIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/provenance/GetLatestProvenanceEventsIT.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.tests.system.provenance;
+
+import org.apache.nifi.tests.system.NiFiSystemIT;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
+import org.apache.nifi.web.api.dto.provenance.ProvenanceEventDTO;
+import org.apache.nifi.web.api.entity.LatestProvenanceEventsEntity;
+import org.apache.nifi.web.api.entity.ProcessorEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class GetLatestProvenanceEventsIT extends NiFiSystemIT {
+
+    @Test
+    public void testSingleEvent() throws NiFiClientException, IOException, InterruptedException {
+        runTest(false);
+    }
+
+    @Test
+    public void testMultipleEvents() throws NiFiClientException, IOException, InterruptedException {
+        runTest(true);
+    }
+
+    private void runTest(final boolean autoTerminateReverse) throws NiFiClientException, IOException, InterruptedException {
+        final ProcessorEntity generate = getClientUtil().createProcessor("GenerateFlowFile");
+        final ProcessorEntity reverse = getClientUtil().createProcessor("ReverseContents");
+
+        if (autoTerminateReverse) {
+            getClientUtil().setAutoTerminatedRelationships(reverse, Set.of("success", "failure"));
+        } else {
+            final ProcessorEntity terminate = getClientUtil().createProcessor("TerminateFlowFile");
+            getClientUtil().createConnection(reverse, terminate, "success");
+            getClientUtil().setAutoTerminatedRelationships(reverse, "failure");
+        }
+
+        getClientUtil().createConnection(generate, reverse, "success");
+        getClientUtil().updateProcessorProperties(generate, Map.of("Text", "Hello, World!"));
+
+        getClientUtil().startProcessor(generate);
+        getClientUtil().startProcessor(reverse);
+
+        final int expectedEventCount = getNumberOfNodes() * (autoTerminateReverse ? 2 : 1);
+        waitFor(() -> {
+            final LatestProvenanceEventsEntity entity = getNifiClient().getProvenanceClient().getLatestEvents(reverse.getId());
+            final List<ProvenanceEventDTO> events = entity.getLatestProvenanceEvents().getProvenanceEvents();
+            return events.size() == expectedEventCount;
+        });
+
+        final LatestProvenanceEventsEntity entity = getNifiClient().getProvenanceClient().getLatestEvents(reverse.getId());
+        final List<ProvenanceEventDTO> events = entity.getLatestProvenanceEvents().getProvenanceEvents();
+        final Map<String, Integer> countsByEventType = new HashMap<>();
+        for (final ProvenanceEventDTO event : events) {
+            assertEquals(reverse.getId(), event.getComponentId());
+            final String eventType = event.getEventType();
+            countsByEventType.put(eventType, countsByEventType.getOrDefault(eventType, 0) + 1);
+
+            if (getNumberOfNodes() > 1) {
+                assertNotNull(event.getClusterNodeId());
+            }
+        }
+
+        if (autoTerminateReverse) {
+            assertEquals(getNumberOfNodes(), countsByEventType.get("DROP").intValue());
+        }
+        assertEquals(getNumberOfNodes(), countsByEventType.get("CONTENT_MODIFIED").intValue());
+    }
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProvenanceClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProvenanceClient.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.toolkit.cli.impl.client.nifi;
 
+import org.apache.nifi.web.api.entity.LatestProvenanceEventsEntity;
 import org.apache.nifi.web.api.entity.LineageEntity;
 import org.apache.nifi.web.api.entity.ProvenanceEntity;
 import org.apache.nifi.web.api.entity.ReplayLastEventResponseEntity;
@@ -36,6 +37,8 @@ public interface ProvenanceClient {
     LineageEntity deleteLineageRequest(String lineageRequestId) throws NiFiClientException, IOException;
 
     ReplayLastEventResponseEntity replayLastEvent(String processorId, ReplayEventNodes replayEventNodes) throws NiFiClientException, IOException;
+
+    LatestProvenanceEventsEntity getLatestEvents(String processorId) throws NiFiClientException, IOException;
 
     enum ReplayEventNodes {
         PRIMARY,

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyProvenanceClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyProvenanceClient.java
@@ -16,18 +16,19 @@
  */
 package org.apache.nifi.toolkit.cli.impl.client.nifi.impl;
 
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.ProvenanceClient;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.RequestConfig;
+import org.apache.nifi.web.api.entity.LatestProvenanceEventsEntity;
 import org.apache.nifi.web.api.entity.LineageEntity;
 import org.apache.nifi.web.api.entity.ProvenanceEntity;
 import org.apache.nifi.web.api.entity.ReplayLastEventRequestEntity;
 import org.apache.nifi.web.api.entity.ReplayLastEventResponseEntity;
 
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.Objects;
 
@@ -136,6 +137,18 @@ public class JerseyProvenanceClient extends AbstractJerseyClient implements Prov
             return getRequestBuilder(target).post(
                 Entity.entity(requestEntity, MediaType.APPLICATION_JSON_TYPE),
                 ReplayLastEventResponseEntity.class);
+        });
+    }
+
+    @Override
+    public LatestProvenanceEventsEntity getLatestEvents(final String processorId) throws NiFiClientException, IOException {
+        if (StringUtils.isBlank(processorId)) {
+            throw new IllegalArgumentException("Processor ID must be specified");
+        }
+
+        return executeAction("Error getting latest events for Processor " + processorId, () -> {
+            final WebTarget target = provenanceEventsTarget.path("/latest/").path(processorId);
+            return getRequestBuilder(target).get(LatestProvenanceEventsEntity.class);
         });
     }
 }


### PR DESCRIPTION
…g the single latest event for a component, we return the events from the latest invocation / session. Added system tests to verify the behavior. Also, when replaying latest event, attempt all of those events until one succeeds or all fail

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13563](https://issues.apache.org/jira/browse/NIFI-13563)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
