### PR TITLE
NIFI-13577 Correct null handling in Parameter Value Mapper

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterValueMapper.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterValueMapper.java
@@ -48,7 +48,9 @@ public class StandardParameterValueMapper implements ParameterValueMapper {
         final ParameterDescriptor descriptor = parameter.getDescriptor();
         final String mapped;
 
-        if (parameter.isProvided()) {
+        if (value == null) {
+            mapped = null;
+        } else if (parameter.isProvided()) {
             mapped = PROVIDED_MAPPING;
         } else if (descriptor.isSensitive()) {
             if (sensitiveValueEncryptor == null) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/parameter/TestStandardParameterValueMapper.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/parameter/TestStandardParameterValueMapper.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(MockitoExtension.class)
 class TestStandardParameterValueMapper {
@@ -77,6 +78,15 @@ class TestStandardParameterValueMapper {
 
         assertNotEquals(VALUE, mapped);
         assertNotEquals(StandardParameterValueMapper.PROVIDED_MAPPING, mapped);
+    }
+
+    @Test
+    void testGetMappedSensitiveNotProvidedNullValue() {
+        final Parameter parameter = getParameter(true, false);
+
+        final String mapped = mapper.getMapped(parameter, null);
+
+        assertNull(mapped);
     }
 
     private Parameter getParameter(final boolean sensitive, final boolean provided) {


### PR DESCRIPTION
# Summary

[NIFI-13577](https://issues.apache.org/jira/browse/NIFI-13577) Corrects `null` value handling in the `StandardParameterValueMapper` used to serialize values prior to writing the flow configuration. This change ensures that the Mapper returns a `null` when the input value is `null` instead of passing the value the configured value encryptor. This correction is required for the main branch, following the changes merged but not yet released under [NIFI-13560](https://issues.apache.org/jira/browse/NIFI-13560)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
