### PR TITLE
NIFI-13125: Add view for comparing different versions of registered flows

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/pages/canvas.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/pages/canvas.jsp
@@ -127,6 +127,7 @@
         <jsp:include page="/WEB-INF/partials/canvas/import-flow-version-dialog.jsp"/>
         <jsp:include page="/WEB-INF/partials/canvas/revert-local-changes-dialog.jsp"/>
         <jsp:include page="/WEB-INF/partials/canvas/show-local-changes-dialog.jsp"/>
+        <jsp:include page="/WEB-INF/partials/canvas/show-flow-changes-dialog.jsp"/>
         <jsp:include page="/WEB-INF/partials/canvas/registry-configuration-dialog.jsp"/>
         <jsp:include page="/WEB-INF/partials/canvas/new-registry-client-dialog.jsp"/>
         <div id="canvas-container" class="unselectable"></div>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/show-flow-changes-dialog.jsp
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/WEB-INF/partials/canvas/show-flow-changes-dialog.jsp
@@ -1,0 +1,36 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ page contentType="text/html" pageEncoding="UTF-8" session="false" %>
+<div id="show-flow-changes-dialog" layout="column" class="hidden large-dialog">
+    <div class="dialog-content">
+        <div id="show-flow-changes-empty-message">No differences to display.</div>
+        <div class="setting flow-changes-message">
+            <span id="show-flow-changes-message"></span>
+        </div>
+        <div id="show-flow-changes-filter-controls">
+            <div id="show-flow-changes-filter-container">
+                <input type="text" id="show-flow-changes-filter" class="show-flow-changes-filter" placeholder="Filter"/>
+            </div>
+            <div class="editable setting-field show-flow-changes-current-version-combo-container">
+                <div id="show-flow-changes-current-version-combo" class="show-flow-changes-current-version-combo"></div>
+            </div>
+            <div class="editable setting-field show-flow-changes-selected-version-combo-container">
+                <div id="show-flow-changes-selected-version-combo" class="show-flow-changes-selected-version-combo"></div>
+            </div>
+        </div>
+        <div id="show-flow-changes-table" class="show-flow-changes-table"></div>
+
+    </div>
+</div>

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/dialog.css
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/css/dialog.css
@@ -307,7 +307,7 @@ div.progress-label {
     height: 350px;
 }
 
-#revert-local-changes-filter, #show-local-changes-filter {
+#revert-local-changes-filter, #show-local-changes-filter, #show-flow-changes-dialog {
     width: 173px;
 }
 
@@ -522,4 +522,42 @@ div.fetch-parameters-step {
     height: 16px;
     background-color: transparent;
     float: right;
+}
+
+.show-flow-changes-table {
+    height: 300px;
+    overflow-y: scroll;
+}
+
+#show-flow-changes-filter-controls {
+    display: flex;
+}
+
+#show-flow-changes-filter-controls > *:not(:last-child) {
+    margin-right: 3px;
+}
+
+#show-flow-changes-filter-controls setting-field {
+    max-width: 200px;
+    width: 173px;
+}
+
+#show-flow-changes-filter,
+#show-flow-changes-filter-controls .show-flow-changes-current-version-combo-container,
+#show-flow-changes-filter-controls .show-flow-changes-selected-version-combo-container {
+    width: 173px;
+}
+
+.show-flow-changes-current-version-combo,
+.show-flow-changes-selected-version-combo {
+    width: 153px;
+}
+
+.show-flow-changes-empty-message {
+    color: #262626;
+    font-family: Roboto Slab;
+    font-size: 12px;
+    font-weight: 500;
+    padding-bottom: 4px;
+    text-transform: capitalize;
 }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-flow-version.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-flow-version.js
@@ -722,7 +722,7 @@
         var formattedChanges = [];
         // unique ids are needed for each item in the table
         var index = 0;
-        if (flowDiff.componentDifferences.length < 0) {
+        if (flowDiff.componentDifferences.length > 0) {
             $('#show-flow-changes-empty-message').hide();
             flowDiff.componentDifferences.forEach(function (component) {
                 component.differences.forEach(function (difference) {

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-flow-version.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-flow-version.js
@@ -718,6 +718,7 @@
 
         // hold onto an instance of the grid
         flowChangesTable.data('gridInstance', flowChangesGrid);
+        flowChangesTable.data('dataViewInstance', flowChangesData);
 
         var formattedChanges = [];
         // unique ids are needed for each item in the table
@@ -761,7 +762,32 @@
                 var selectedVersionComboVal = $('#show-flow-changes-selected-version-combo').combo('getSelectedOption');
                 if (selectedVersionComboVal) {
                     loadDiffDetails(versionControlInformation.registryId, versionControlInformation.bucketId, versionControlInformation.flowId, encodeURIComponent(option.value), encodeURIComponent(selectedVersionComboVal.value)).done(function (flowDiff) {
-                        initFlowDiffTable(flowDiff);
+                        var changesDataView = $('#show-flow-changes-table').data("dataViewInstance");
+                        if (flowDiff.componentDifferences.length > 0) {
+                            $('#show-flow-changes-empty-message').hide();
+                            var formattedChanges = [];
+                            // unique ids are needed for each item in the table
+                            var index = 0;
+                            flowDiff.componentDifferences.forEach(function (component) {
+                                component.differences.forEach(function (difference) {
+                                    var newObj = {
+                                        id: index,
+                                        componentName: component.componentName,
+                                        differenceType: difference.differenceType,
+                                        difference: difference.difference
+                                    };
+                                    index++;
+                                    formattedChanges.push(newObj);
+                                });
+                            });
+                        } else {
+                            $('#show-flow-changes-empty-message').show();
+                        }
+                        
+                        changesDataView.beginUpdate();
+                        changesDataView.setItems(formattedChanges || []);
+                        changesDataView.endUpdate();
+                        changesDataView.refresh();
                     });
                 }
             }
@@ -776,7 +802,32 @@
                 var currentVersionComboVal = $('#show-flow-changes-current-version-combo').combo('getSelectedOption');
                 if (currentVersionComboVal) {
                     loadDiffDetails(versionControlInformation.registryId, versionControlInformation.bucketId, versionControlInformation.flowId, encodeURIComponent(currentVersionComboVal.value), encodeURIComponent(option.value)).done(function (flowDiff) {
-                        initFlowDiffTable(flowDiff);
+                        var changesDataView = $('#show-flow-changes-table').data("dataViewInstance");
+                        if (flowDiff.componentDifferences.length > 0) {
+                            $('#show-flow-changes-empty-message').hide();
+                            var formattedChanges = [];
+                            // unique ids are needed for each item in the table
+                            var index = 0;
+                            flowDiff.componentDifferences.forEach(function (component) {
+                                component.differences.forEach(function (difference) {
+                                    var newObj = {
+                                        id: index,
+                                        componentName: component.componentName,
+                                        differenceType: difference.differenceType,
+                                        difference: difference.difference
+                                    };
+                                    index++;
+                                    formattedChanges.push(newObj);
+                                });
+                            });
+                        } else {
+                            $('#show-flow-changes-empty-message').show();
+                        }
+
+                        changesDataView.beginUpdate();
+                        changesDataView.setItems(formattedChanges || []);
+                        changesDataView.endUpdate();
+                        changesDataView.refresh();
                     });
                 }
             }

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-flow-version.js
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-ui/src/main/webapp/js/nf/canvas/nf-flow-version.js
@@ -1057,7 +1057,7 @@
     var loadDiffDetails = function (registryIdentifier, bucketIdentifier, flowIdentifier, versionA, versionB) {
         return $.ajax({
             type: 'GET',
-            url: '../nifi-api/flow/registries/' + encodeURIComponent(registryIdentifier) + '/buckets/' + encodeURIComponent(bucketIdentifier) + '/flows/' + encodeURIComponent(flowIdentifier) + '/diff/' + encodeURIComponent(versionA) + '/' + encodeURIComponent(versionB),
+            url: '../nifi-api/flow/registries/' + encodeURIComponent(registryIdentifier) + '/buckets/' + encodeURIComponent(bucketIdentifier) + '/flows/' + encodeURIComponent(flowIdentifier) + '/' + encodeURIComponent(versionA) + '/diff/' + encodeURIComponent(versionB),
             dataType: 'json'
         }).done(function () {
         }).fail(nfErrorHandler.handleAjaxError);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13125](https://issues.apache.org/jira/browse/NIFI-13125)

### Testing
1. Start NiFi Registry and create a bucket. Import a flow to that bucket. 
2. Open the controller settings modal in the NiFi UI and add a registry client. Point the url to the NiFi Registry url. 
3. Add a Process Group and import the flow you just created in registry. 
4. Make some changes to the flow (can be as simple as renaming a processor). Right click on the process group and select Version > Commit local changes. Save your changes.
5. Repeat step 4 so you have another set of committed changes (so 3 versions total, though you could do more if you’d like).
6. Right click on the process group and select Version > Change version
7. You’ll see a new icon to the left of the Version column in the versions table (see 1st image below). Click on an icon that isn’t the current version. You should see a modal launch listing the differences between the two versions (see 2nd image below). 
8. Try adjusting the version selection dropdowns. If you compare the same version, you should see a message informing you that there are no differences (see 3rd image below).
9. The filter should apply whatever input it has across the 3 columns (component name, change type, and difference).

![Screenshot 2024-07-24 at 4 49 06 PM](https://github.com/user-attachments/assets/cbc41afc-e4aa-4bea-9401-cae4d5f796c1)

![Screenshot 2024-07-24 at 4 49 19 PM](https://github.com/user-attachments/assets/bf915755-1761-4d41-8751-f764e5cd8f17)

![Screenshot 2024-07-24 at 4 49 24 PM](https://github.com/user-attachments/assets/2bbe6bc8-b070-4c65-8ed5-a8b5e8ef3a5a)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
