### PR TITLE
NIFI-13581 Remove parameter contexts and parameter providers in destr…

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -26,7 +26,7 @@ on:
       - 'nifi-system-tests/**'
       - 'nifi-api/**'
       - 'nifi-framework-api/**'
-      - 'nifi-nifi-framework-bundle/**'
+      - 'nifi-framework-bundle/**'
       - 'nifi-extension-bundles/nifi-py4j-bundle/**'
       - 'nifi-stateless/**'
   pull_request:
@@ -36,7 +36,7 @@ on:
       - 'nifi-system-tests/**'
       - 'nifi-api/**'
       - 'nifi-framework-api/**'
-      - 'nifi-nifi-framework-bundle/**'
+      - 'nifi-framework-bundle/**'
       - 'nifi-extension-bundles/nifi-py4j-bundle/**'
       - 'nifi-stateless/**'
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiSystemIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiSystemIT.java
@@ -249,6 +249,8 @@ public abstract class NiFiSystemIT implements NiFiInstanceProvider {
         getClientUtil().deleteControllerLevelServices();
         getClientUtil().deleteReportingTasks();
         getClientUtil().deleteFlowAnalysisRules();
+        getClientUtil().deleteParameterContexts();
+        getClientUtil().deleteParameterProviders();
 
         logger.info("Finished destroyFlow");
     }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ParamContextClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ParamContextClient.java
@@ -32,6 +32,8 @@ public interface ParamContextClient {
 
     ParameterContextEntity deleteParamContext(String id, String version) throws NiFiClientException, IOException;
 
+    ParameterContextEntity deleteParamContext(String id, String version, boolean disconnectedNodeAcknowledged) throws NiFiClientException, IOException;
+
     ParameterContextUpdateRequestEntity updateParamContext(ParameterContextEntity paramContext) throws NiFiClientException, IOException;
 
     ParameterContextUpdateRequestEntity getParamContextUpdateRequest(String contextId, String updateRequestId) throws NiFiClientException, IOException;

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ParamProviderClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ParamProviderClient.java
@@ -32,6 +32,8 @@ public interface ParamProviderClient {
 
     ParameterProviderEntity deleteParamProvider(String id, String version) throws NiFiClientException, IOException;
 
+    ParameterProviderEntity deleteParamProvider(String id, String version, boolean disconnectedNodeAcknowledged) throws NiFiClientException, IOException;
+
     ParameterProviderEntity fetchParameters(ParameterProviderParameterFetchEntity parameterFetchEntity) throws NiFiClientException, IOException;
 
     ParameterProviderApplyParametersRequestEntity applyParameters(ParameterProviderParameterApplicationEntity parameterApplicationEntity) throws NiFiClientException, IOException;

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyParamContextClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyParamContextClient.java
@@ -83,6 +83,11 @@ public class JerseyParamContextClient extends AbstractJerseyClient implements Pa
 
     @Override
     public ParameterContextEntity deleteParamContext(final String id, final String version) throws NiFiClientException, IOException {
+        return deleteParamContext(id, version, false);
+    }
+
+    @Override
+    public ParameterContextEntity deleteParamContext(final String id, final String version, final boolean disconnectedNodeAcknowledged) throws NiFiClientException, IOException {
         if (StringUtils.isBlank(id)) {
             throw new IllegalArgumentException("Parameter context id cannot be null or blank");
         }
@@ -92,9 +97,14 @@ public class JerseyParamContextClient extends AbstractJerseyClient implements Pa
         }
 
         return executeAction("Error deleting parameter context", () -> {
-            final WebTarget target = paramContextTarget.path("{id}")
+            WebTarget target = paramContextTarget.path("{id}")
                     .resolveTemplate("id", id)
                     .queryParam("version", version);
+
+            if (disconnectedNodeAcknowledged) {
+                target = target.queryParam("disconnectedNodeAcknowledged", "true");
+            }
+
             return getRequestBuilder(target).delete(ParameterContextEntity.class);
         });
     }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyParamProviderClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyParamProviderClient.java
@@ -75,6 +75,11 @@ public class JerseyParamProviderClient extends AbstractJerseyClient implements P
 
     @Override
     public ParameterProviderEntity deleteParamProvider(final String id, final String version) throws NiFiClientException, IOException {
+        return deleteParamProvider(id, version, false);
+    }
+
+    @Override
+    public ParameterProviderEntity deleteParamProvider(final String id, final String version, final boolean disconnectedNodeAcknowledged) throws NiFiClientException, IOException {
         if (StringUtils.isBlank(id)) {
             throw new IllegalArgumentException("Parameter provider id cannot be null or blank");
         }
@@ -84,9 +89,14 @@ public class JerseyParamProviderClient extends AbstractJerseyClient implements P
         }
 
         return executeAction("Error deleting parameter provider", () -> {
-            final WebTarget target = paramProviderTarget.path("{id}")
+            WebTarget target = paramProviderTarget.path("{id}")
                     .resolveTemplate("id", id)
                     .queryParam("version", version);
+
+            if (disconnectedNodeAcknowledged) {
+                target = target.queryParam("disconnectedNodeAcknowledged", "true");
+            }
+
             return getRequestBuilder(target).delete(ParameterProviderEntity.class);
         });
     }


### PR DESCRIPTION
…oyFlow method of NiFiSystemIT

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13581](https://issues.apache.org/jira/browse/NIFI-13581)

Fixes intermittent issue with system tests where parameters and parameter providers can be left over from previous tests.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
