### PR TITLE
NIFI-13575 Improve Jetty Server handling of Web App Exceptions

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -202,7 +202,7 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
     private UiExtensionMapping componentUiExtensions;
     private Collection<WebAppContext> componentUiExtensionWebContexts;
 
-    private Map<BundleCoordinate, List<App>> appsByBundleCoordinate = new ConcurrentHashMap<>();
+    private final Map<BundleCoordinate, List<App>> appsByBundleCoordinate = new ConcurrentHashMap<>();
 
     /**
      * Default no-arg constructor for ServiceLoader
@@ -630,6 +630,7 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
         webappContext.setAttribute(MetaInfConfiguration.CONTAINER_JAR_PATTERN, CONTAINER_JAR_PATTERN);
         webappContext.setErrorHandler(getErrorHandler());
         webappContext.setTempDirectory(getWebAppTempDirectory(warFile));
+        webappContext.setThrowUnavailableOnStartupException(true);
 
         final List<FilterHolder> requestFilters = CONTEXT_PATH_NIFI_API.equals(contextPath)
                 ? REST_API_REQUEST_FILTER_PROVIDER.getFilters(props)
@@ -833,7 +834,7 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
 
             // Additionally loaded NARs and collected flow resources must be in place before starting the flows
             narProviderService = new ExternalResourceProviderServiceBuilder("NAR Auto-Loader Provider", extensionManager)
-                    .providers(buildExternalResourceProviders(sslContext, extensionManager, NAR_PROVIDER_PREFIX, descriptor -> descriptor.getLocation().toLowerCase().endsWith(".nar")))
+                    .providers(buildExternalResourceProviders(sslContext, extensionManager, descriptor -> descriptor.getLocation().toLowerCase().endsWith(".nar")))
                     .targetDirectory(new File(props.getProperty(NiFiProperties.NAR_LIBRARY_AUTOLOAD_DIRECTORY, NiFiProperties.DEFAULT_NAR_LIBRARY_AUTOLOAD_DIR)))
                     .conflictResolutionStrategy(props.getProperty(NAR_PROVIDER_CONFLICT_RESOLUTION, DEFAULT_NAR_PROVIDER_CONFLICT_RESOLUTION))
                     .pollInterval(props.getProperty(NAR_PROVIDER_POLL_INTERVAL_PROPERTY, DEFAULT_NAR_PROVIDER_POLL_INTERVAL))
@@ -859,20 +860,7 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
             narAutoLoader = new NarAutoLoader(props, narLoader);
             narAutoLoader.start();
 
-            // start the server
             server.start();
-
-            // ensure everything started successfully
-            for (Handler handler : server.getHandlers()) {
-                // see if the handler is a web app
-                if (handler instanceof final WebAppContext context) {
-                    // see if this webapp had any exceptions that would
-                    // cause it to be unavailable
-                    if (context.getUnavailableException() != null) {
-                        startUpFailure(context.getUnavailableException());
-                    }
-                }
-            }
 
             // ensure the appropriate wars deployed successfully before injecting the NiFi context and security filters
             // this must be done after starting the server (and ensuring there were no start up failures)
@@ -977,22 +965,21 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
     private Map<String, ExternalResourceProvider> buildExternalResourceProviders(
             final SSLContext sslContext,
             final ExtensionManager extensionManager,
-            final String providerPropertyPrefix,
             final Predicate<ExternalResourceDescriptor> filter
     )
         throws ClassNotFoundException, InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
 
         final Map<String, ExternalResourceProvider> result = new HashMap<>();
-        final Set<String> externalSourceNames = props.getDirectSubsequentTokens(providerPropertyPrefix);
+        final Set<String> externalSourceNames = props.getDirectSubsequentTokens(NAR_PROVIDER_PREFIX);
 
         for (final String externalSourceName : externalSourceNames) {
             logger.info("External resource provider '{}' found in configuration", externalSourceName);
 
-            final String providerClass = props.getProperty(providerPropertyPrefix + externalSourceName + "." + NAR_PROVIDER_IMPLEMENTATION_PROPERTY);
+            final String providerClass = props.getProperty(NAR_PROVIDER_PREFIX + externalSourceName + "." + NAR_PROVIDER_IMPLEMENTATION_PROPERTY);
             final String providerId = UUID.randomUUID().toString();
 
             final ExternalResourceProviderInitializationContext context
-                    = new PropertyBasedExternalResourceProviderInitializationContext(sslContext, props, providerPropertyPrefix + externalSourceName + ".", filter);
+                    = new PropertyBasedExternalResourceProviderInitializationContext(sslContext, props, NAR_PROVIDER_PREFIX + externalSourceName + ".", filter);
             result.put(providerId, createProviderInstance(extensionManager, providerClass, providerId, context));
         }
 
@@ -1071,10 +1058,8 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
         }
     }
 
-    private void startUpFailure(Throwable t) {
-        System.err.println("Failed to start web server: " + t.getMessage());
-        System.err.println("Shutting down...");
-        logger.error("Failed to start web server... shutting down.", t);
+    private void startUpFailure(final Throwable t) {
+        logger.error("Failed to start Server", t);
         System.exit(1);
     }
 
@@ -1092,8 +1077,8 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
     public void stop() {
         try {
             server.stop();
-        } catch (Exception ex) {
-            logger.warn("Failed to stop web server", ex);
+        } catch (final Exception e) {
+            logger.warn("Failed to stop Server", e);
         }
 
         try {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -153,6 +153,12 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
     private static final String CONTEXT_PATH_NIFI_API = "/nifi-api";
     private static final String CONTEXT_PATH_NIFI_CONTENT_VIEWER = "/nifi-content-viewer";
     private static final String CONTEXT_PATH_NIFI_DOCS = "/nifi-docs";
+    private static final Set<String> REQUIRED_CONTEXT_PATHS = Set.of(
+            CONTEXT_PATH_NIFI,
+            CONTEXT_PATH_NIFI_API,
+            CONTEXT_PATH_NIFI_CONTENT_VIEWER,
+            CONTEXT_PATH_NIFI_DOCS
+    );
 
     private static final RequestFilterProvider REQUEST_FILTER_PROVIDER = new StandardRequestFilterProvider();
     private static final RequestFilterProvider REST_API_REQUEST_FILTER_PROVIDER = new RestApiRequestFilterProvider();
@@ -630,7 +636,9 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
         webappContext.setAttribute(MetaInfConfiguration.CONTAINER_JAR_PATTERN, CONTAINER_JAR_PATTERN);
         webappContext.setErrorHandler(getErrorHandler());
         webappContext.setTempDirectory(getWebAppTempDirectory(warFile));
-        webappContext.setThrowUnavailableOnStartupException(true);
+
+        final boolean throwUnavailableOnStartupException = REQUIRED_CONTEXT_PATHS.contains(contextPath);
+        webappContext.setThrowUnavailableOnStartupException(throwUnavailableOnStartupException);
 
         final List<FilterHolder> requestFilters = CONTEXT_PATH_NIFI_API.equals(contextPath)
                 ? REST_API_REQUEST_FILTER_PROVIDER.getFilters(props)


### PR DESCRIPTION
# Summary

[NIFI-13575](https://issues.apache.org/jira/browse/NIFI-13575) Enables the `throwUnavailableOnStartupException` property for configured Web Applications in the framework Jetty Server. This property instructs Jetty to throw exceptions caught when starting a configured Web Applications, instead of just capturing and storing the exception. This approach removes the need for iterating over configured Jetty Server Handlers, and avoids potential issues related to nested handlers, ensuring that a Web Application exception will cause the Jetty Server to shutdown instead of continuing the startup process.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
