### PR TITLE
NIFI-13409 Enforcing lexiographical order of the identity mappings to match documentation

### DIFF
--- a/nifi-commons/nifi-security-identity/src/main/java/org/apache/nifi/authorization/util/IdentityMappingUtil.java
+++ b/nifi-commons/nifi-security-identity/src/main/java/org/apache/nifi/authorization/util/IdentityMappingUtil.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.apache.nifi.util.NiFiProperties.SECURITY_GROUP_MAPPING_PATTERN_PREFIX;
 import static org.apache.nifi.util.NiFiProperties.SECURITY_GROUP_MAPPING_TRANSFORM_PREFIX;
@@ -140,8 +141,12 @@ public class IdentityMappingUtil {
      * @return the mapped identity, or the same identity if no mappings matched
      */
     public static String mapIdentity(final String identity, List<IdentityMapping> mappings) {
-        for (IdentityMapping mapping : mappings) {
-            Matcher m = mapping.getPattern().matcher(identity);
+        final List<String> keys = mappings.stream().map(m -> m.getKey()).collect(Collectors.toList());
+        Collections.sort(keys);
+
+        for (final String key : keys) {
+            final IdentityMapping mapping = mappings.stream().filter(m -> m.getKey().equals(key)).findFirst().orElseThrow();
+            final Matcher m = mapping.getPattern().matcher(identity);
             if (m.matches()) {
                 final String pattern = mapping.getPattern().pattern();
                 final String replacementValue = escapeLiteralBackReferences(mapping.getReplacementValue(), m.groupCount());

--- a/nifi-commons/nifi-security-identity/src/test/java/org/apache/nifi/authorization/util/IdentityMappingUtilTest.java
+++ b/nifi-commons/nifi-security-identity/src/test/java/org/apache/nifi/authorization/util/IdentityMappingUtilTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.authorization.util;
+
+import org.apache.nifi.util.NiFiProperties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+class IdentityMappingUtilTest {
+
+    @Test
+    public void testIdentityMappingGeneration() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.putAll(getDnProperties());
+        properties.putAll(getLdapProperties("UPPER"));
+        final NiFiProperties niFiProperties = new NiFiProperties(properties);
+        final List<IdentityMapping> identityMappings = IdentityMappingUtil.getIdentityMappings(niFiProperties);
+
+        final Optional<IdentityMapping> dnMapping = identityMappings.stream().filter(im -> im.getKey().equals("dn")).findFirst();
+        final Optional<IdentityMapping> ldapMapping = identityMappings.stream().filter(im -> im.getKey().equals("ldap")).findFirst();
+
+        Assertions.assertTrue(dnMapping.isPresent());
+        Assertions.assertEquals("NONE", dnMapping.get().getTransform().name());
+
+        Assertions.assertTrue(ldapMapping.isPresent());
+        Assertions.assertEquals("UPPER", ldapMapping.get().getTransform().name());
+    }
+
+    // NIFI-13409 TC1
+    @Test
+    public void testMappingIdentity() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.putAll(getDnProperties());
+        properties.putAll(getLdapProperties("UPPER"));
+        final NiFiProperties niFiProperties = new NiFiProperties(properties);
+
+        final List<IdentityMapping> identityMappings = IdentityMappingUtil.getIdentityMappings(niFiProperties);
+        Assertions.assertEquals("nifi-node1", IdentityMappingUtil.mapIdentity("CN=nifi-node1, ST=MD, C=US", identityMappings));
+        Assertions.assertEquals("NIFIADMIN", IdentityMappingUtil.mapIdentity("nifiadmin", identityMappings));
+    }
+
+    // NIFI-13409 TC2
+    @Test
+    public void testMappingIdentityWithTwoInclusiveMappings() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.putAll(getDnProperties());
+        properties.putAll(getLdapProperties("UPPER"));
+        properties.putAll(getUsernameProperties("LOWER"));
+        final NiFiProperties niFiProperties = new NiFiProperties(properties);
+
+        final List<IdentityMapping> identityMappings = IdentityMappingUtil.getIdentityMappings(niFiProperties);
+        Assertions.assertEquals("nifi-node1", IdentityMappingUtil.mapIdentity("CN=nifi-node1, ST=MD, C=US", identityMappings));
+        Assertions.assertEquals("NIFIADMIN", IdentityMappingUtil.mapIdentity("nifiadmin", identityMappings));
+    }
+
+    // NIFI-13409 TC3
+    @Test
+    public void testMappingIdentityWithTwoInclusiveMappingsReversed() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.putAll(getDnProperties());
+        properties.putAll(getLdapProperties("LOWER"));
+        properties.putAll(getUsernameProperties("UPPER"));
+        final NiFiProperties niFiProperties = new NiFiProperties(properties);
+
+        final List<IdentityMapping> identityMappings = IdentityMappingUtil.getIdentityMappings(niFiProperties);
+        Assertions.assertEquals("nifi-node1", IdentityMappingUtil.mapIdentity("CN=nifi-node1, ST=MD, C=US", identityMappings));
+        Assertions.assertEquals("nifiadmin", IdentityMappingUtil.mapIdentity("nifiadmin", identityMappings));
+    }
+
+    // NIFI-13409 TC4
+    @Test
+    public void testMappingIdentityWithPrefixedMapping() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.putAll(getDnProperties());
+        properties.putAll(getLdapPropertiesWithPrefix("LOWER"));
+        properties.putAll(getUsernameProperties("UPPER"));
+        final NiFiProperties niFiProperties = new NiFiProperties(properties);
+
+        final List<IdentityMapping> identityMappings = IdentityMappingUtil.getIdentityMappings(niFiProperties);
+        Assertions.assertEquals("nifi-node1", IdentityMappingUtil.mapIdentity("CN=nifi-node1, ST=MD, C=US", identityMappings));
+        Assertions.assertEquals("NIFIADMIN", IdentityMappingUtil.mapIdentity("nifiadmin", identityMappings));
+    }
+
+    // NIFI-13409 TC5
+    @Test
+    public void testMappingIdentityWithThreeDifferentMappings() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.putAll(getDnProperties());
+        properties.putAll(getLdapPropertiesWithPrefix("LOWER"));
+        properties.putAll(getUsernamePropertiesWithPostfix("UPPER"));
+        final NiFiProperties niFiProperties = new NiFiProperties(properties);
+
+        final List<IdentityMapping> identityMappings = IdentityMappingUtil.getIdentityMappings(niFiProperties);
+        Assertions.assertEquals("nifi-node1", IdentityMappingUtil.mapIdentity("CN=nifi-node1, ST=MD, C=US", identityMappings));
+        Assertions.assertEquals("NIFIADMIN.TEST", IdentityMappingUtil.mapIdentity("nifiadmin", identityMappings));
+    }
+
+    private static Map<String, String> getDnProperties() {
+        final Map<String, String> values = new HashMap<>();
+        values.put("nifi.security.identity.mapping.pattern.dn", "^CN=(.*?),\\s{0,1}.+$");
+        values.put("nifi.security.identity.mapping.transform.dn", "NONE");
+        values.put("nifi.security.identity.mapping.value.dn", "$1");
+        return values;
+    }
+
+    private static Map<String, String> getLdapProperties(final String transform) {
+        final Map<String, String> values = new HashMap<>();
+        values.put("nifi.security.identity.mapping.pattern.ldap", "^(.*)$");
+        values.put("nifi.security.identity.mapping.transform.ldap", transform);
+        values.put("nifi.security.identity.mapping.value.ldap", "$1");
+        return values;
+    }
+
+    private static Map<String, String> getLdapPropertiesWithPrefix(final String transform) {
+        final Map<String, String> values = new HashMap<>();
+        values.put("nifi.security.identity.mapping.pattern.ldap", "^ldap(.*?)$");
+        values.put("nifi.security.identity.mapping.transform.ldap", transform);
+        values.put("nifi.security.identity.mapping.value.ldap", "$1");
+        return values;
+    }
+
+    private static Map<String, String> getUsernameProperties(String transform) {
+        final Map<String, String> values = new HashMap<>();
+        values.put("nifi.security.identity.mapping.pattern.username", "^(.*)$");
+        values.put("nifi.security.identity.mapping.transform.username", transform);
+        values.put("nifi.security.identity.mapping.value.username", "$1");
+        return values;
+    }
+
+    private static Map<String, String> getUsernamePropertiesWithPostfix(String transform) {
+        final Map<String, String> values = new HashMap<>();
+        values.put("nifi.security.identity.mapping.pattern.username", "^(.*)$");
+        values.put("nifi.security.identity.mapping.transform.username", transform);
+        values.put("nifi.security.identity.mapping.value.username", "$1.test");
+        return values;
+    }
+}


### PR DESCRIPTION
# Summary

Referred documentation: https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#identity-mapping-properties

[NIFI-13409](https://issues.apache.org/jira/browse/NIFI-13409)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
