### PR TITLE
NIFI-13593 PutIceberg issue with decimal scale

### DIFF
--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
@@ -189,6 +189,11 @@ public class GenericDataConverters {
                 return null;
             }
             if (data instanceof BigDecimal bigDecimal) {
+
+                if (bigDecimal.scale() < scale) {
+                    bigDecimal = bigDecimal.setScale(scale);
+                }
+
                 Validate.isTrue(bigDecimal.scale() == scale, "Cannot write value as decimal(%s,%s), wrong scale %s for value: %s", precision, scale, bigDecimal.scale(), data);
                 Validate.isTrue(bigDecimal.precision() <= precision, "Cannot write value as decimal(%s,%s), invalid precision %s for value: %s",
                         precision, scale, bigDecimal.precision(), data);

--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
@@ -188,18 +188,17 @@ public class GenericDataConverters {
             if (data == null) {
                 return null;
             }
-            if (data instanceof BigDecimal bigDecimal) {
 
-                if (bigDecimal.scale() < scale) {
-                    bigDecimal = bigDecimal.setScale(scale);
-                }
+            BigDecimal bigDecimal = DataTypeUtils.toBigDecimal(data, null);
 
-                Validate.isTrue(bigDecimal.scale() == scale, "Cannot write value as decimal(%s,%s), wrong scale %s for value: %s", precision, scale, bigDecimal.scale(), data);
-                Validate.isTrue(bigDecimal.precision() <= precision, "Cannot write value as decimal(%s,%s), invalid precision %s for value: %s",
-                        precision, scale, bigDecimal.precision(), data);
-                return bigDecimal;
+            if (bigDecimal.scale() < scale) {
+                bigDecimal = bigDecimal.setScale(scale);
             }
-            return DataTypeUtils.toBigDecimal(data, null);
+
+            Validate.isTrue(bigDecimal.scale() == scale, "Cannot write value as decimal(%s,%s), wrong scale %s for value: %s", precision, scale, bigDecimal.scale(), data);
+            Validate.isTrue(bigDecimal.precision() <= precision, "Cannot write value as decimal(%s,%s), invalid precision %s for value: %s",
+                    precision, scale, bigDecimal.precision(), data);
+            return bigDecimal;
         }
     }
 

--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
@@ -156,16 +156,17 @@ public class TestIcebergRecordConverter {
             Types.NestedField.optional(3, "long", Types.LongType.get()),
             Types.NestedField.optional(4, "double", Types.DoubleType.get()),
             Types.NestedField.optional(5, "decimal", Types.DecimalType.of(10, 2)),
-            Types.NestedField.optional(6, "boolean", Types.BooleanType.get()),
-            Types.NestedField.optional(7, "fixed", Types.FixedType.ofLength(5)),
-            Types.NestedField.optional(8, "binary", Types.BinaryType.get()),
-            Types.NestedField.optional(9, "date", Types.DateType.get()),
-            Types.NestedField.optional(10, "time", Types.TimeType.get()),
-            Types.NestedField.optional(11, "timestamp", Types.TimestampType.withZone()),
-            Types.NestedField.optional(12, "timestampTz", Types.TimestampType.withoutZone()),
-            Types.NestedField.optional(13, "uuid", Types.UUIDType.get()),
-            Types.NestedField.optional(14, "choice", Types.IntegerType.get()),
-            Types.NestedField.optional(15, "enum", Types.StringType.get())
+            Types.NestedField.optional(6, "decimalLessScore", Types.DecimalType.of(10, 2)),
+            Types.NestedField.optional(7, "boolean", Types.BooleanType.get()),
+            Types.NestedField.optional(8, "fixed", Types.FixedType.ofLength(5)),
+            Types.NestedField.optional(9, "binary", Types.BinaryType.get()),
+            Types.NestedField.optional(10, "date", Types.DateType.get()),
+            Types.NestedField.optional(11, "time", Types.TimeType.get()),
+            Types.NestedField.optional(12, "timestamp", Types.TimestampType.withZone()),
+            Types.NestedField.optional(13, "timestampTz", Types.TimestampType.withoutZone()),
+            Types.NestedField.optional(14, "uuid", Types.UUIDType.get()),
+            Types.NestedField.optional(15, "choice", Types.IntegerType.get()),
+            Types.NestedField.optional(16, "enum", Types.StringType.get())
     );
 
     private static final Schema PRIMITIVES_SCHEMA_WITH_REQUIRED_FIELDS = new Schema(
@@ -284,6 +285,7 @@ public class TestIcebergRecordConverter {
         fields.add(new RecordField("long", RecordFieldType.LONG.getDataType()));
         fields.add(new RecordField("double", RecordFieldType.DOUBLE.getDataType()));
         fields.add(new RecordField("decimal", RecordFieldType.DECIMAL.getDecimalDataType(10, 2)));
+        fields.add(new RecordField("decimalLessScore", RecordFieldType.DECIMAL.getDecimalDataType(10, 2)));
         fields.add(new RecordField("boolean", RecordFieldType.BOOLEAN.getDataType()));
         fields.add(new RecordField("fixed", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType())));
         fields.add(new RecordField("binary", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType())));
@@ -460,6 +462,7 @@ public class TestIcebergRecordConverter {
         values.put("long", 42L);
         values.put("double", 3.14159D);
         values.put("decimal", new BigDecimal("12345678.12"));
+        values.put("decimalLessScore", new BigDecimal("12345678.1"));
         values.put("boolean", true);
         values.put("fixed", "hello".getBytes());
         values.put("binary", "hello".getBytes());
@@ -583,20 +586,21 @@ public class TestIcebergRecordConverter {
         assertEquals(Long.valueOf(42L), resultRecord.get(3, Long.class));
         assertEquals(Double.valueOf(3.14159D), resultRecord.get(4, Double.class));
         assertEquals(new BigDecimal("12345678.12"), resultRecord.get(5, BigDecimal.class));
-        assertEquals(Boolean.TRUE, resultRecord.get(6, Boolean.class));
-        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(7, byte[].class));
-        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(8, ByteBuffer.class).array());
-        assertEquals(LocalDate.of(2017, 4, 4), resultRecord.get(9, LocalDate.class));
-        assertEquals(LocalTime.of(14, 20, 33), resultRecord.get(10, LocalTime.class));
-        assertEquals(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC), resultRecord.get(11, OffsetDateTime.class));
-        assertEquals(LOCAL_DATE_TIME, resultRecord.get(12, LocalDateTime.class));
-        assertEquals(Integer.valueOf(10), resultRecord.get(14, Integer.class));
-        assertEquals("blue", resultRecord.get(15, String.class));
+        assertEquals(new BigDecimal("12345678.10"), resultRecord.get(6, BigDecimal.class));
+        assertEquals(Boolean.TRUE, resultRecord.get(7, Boolean.class));
+        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(8, byte[].class));
+        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(9, ByteBuffer.class).array());
+        assertEquals(LocalDate.of(2017, 4, 4), resultRecord.get(10, LocalDate.class));
+        assertEquals(LocalTime.of(14, 20, 33), resultRecord.get(11, LocalTime.class));
+        assertEquals(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC), resultRecord.get(12, OffsetDateTime.class));
+        assertEquals(LOCAL_DATE_TIME, resultRecord.get(13, LocalDateTime.class));
+        assertEquals(Integer.valueOf(10), resultRecord.get(15, Integer.class));
+        assertEquals("blue", resultRecord.get(16, String.class));
 
         if (format.equals(PARQUET)) {
-            assertArrayEquals(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, resultRecord.get(13, byte[].class));
+            assertArrayEquals(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, resultRecord.get(14, byte[].class));
         } else {
-            assertEquals(UUID.fromString("0000-00-00-00-000000"), resultRecord.get(13, UUID.class));
+            assertEquals(UUID.fromString("0000-00-00-00-000000"), resultRecord.get(14, UUID.class));
         }
     }
 
@@ -626,14 +630,14 @@ public class TestIcebergRecordConverter {
         assertNull(resultRecord.get(3, Long.class));
         assertEquals(Double.valueOf(3.14159D), resultRecord.get(4, Double.class));
         assertEquals(new BigDecimal("12345678.12"), resultRecord.get(5, BigDecimal.class));
-        assertEquals(Boolean.TRUE, resultRecord.get(6, Boolean.class));
-        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(7, byte[].class));
-        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(8, ByteBuffer.class).array());
-        assertEquals(LocalDate.of(2017, 4, 4), resultRecord.get(9, LocalDate.class));
-        assertEquals(LocalTime.of(14, 20, 33), resultRecord.get(10, LocalTime.class));
-        assertEquals(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC), resultRecord.get(11, OffsetDateTime.class));
-        assertEquals(LOCAL_DATE_TIME, resultRecord.get(12, LocalDateTime.class));
-        assertEquals(Integer.valueOf(10), resultRecord.get(14, Integer.class));
+        assertEquals(Boolean.TRUE, resultRecord.get(7, Boolean.class));
+        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(8, byte[].class));
+        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(9, ByteBuffer.class).array());
+        assertEquals(LocalDate.of(2017, 4, 4), resultRecord.get(10, LocalDate.class));
+        assertEquals(LocalTime.of(14, 20, 33), resultRecord.get(11, LocalTime.class));
+        assertEquals(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC), resultRecord.get(12, OffsetDateTime.class));
+        assertEquals(LOCAL_DATE_TIME, resultRecord.get(13, LocalDateTime.class));
+        assertEquals(Integer.valueOf(10), resultRecord.get(15, Integer.class));
 
         if (format.equals(FileFormat.PARQUET)) {
             // Parquet uses a conversion to the byte values of numeric characters such as "0" -> byte value 0
@@ -641,9 +645,9 @@ public class TestIcebergRecordConverter {
             ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[16]);
             byteBuffer.putLong(uuid.getMostSignificantBits());
             byteBuffer.putLong(uuid.getLeastSignificantBits());
-            assertArrayEquals(byteBuffer.array(), resultRecord.get(13, byte[].class));
+            assertArrayEquals(byteBuffer.array(), resultRecord.get(14, byte[].class));
         } else {
-            assertEquals(UUID.fromString("0000-00-00-00-000000"), resultRecord.get(13, UUID.class));
+            assertEquals(UUID.fromString("0000-00-00-00-000000"), resultRecord.get(14, UUID.class));
         }
 
         // Test null values
@@ -711,14 +715,14 @@ public class TestIcebergRecordConverter {
         assertNull(resultRecord.get(3, Long.class));
         assertEquals(Double.valueOf(3.14159D), resultRecord.get(4, Double.class));
         assertEquals(new BigDecimal("12345678.12"), resultRecord.get(5, BigDecimal.class));
-        assertEquals(Boolean.TRUE, resultRecord.get(6, Boolean.class));
-        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(7, byte[].class));
-        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(8, ByteBuffer.class).array());
-        assertEquals(LocalDate.of(2017, 4, 4), resultRecord.get(9, LocalDate.class));
-        assertEquals(LocalTime.of(14, 20, 33), resultRecord.get(10, LocalTime.class));
-        assertEquals(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC), resultRecord.get(11, OffsetDateTime.class));
-        assertEquals(LOCAL_DATE_TIME, resultRecord.get(12, LocalDateTime.class));
-        assertEquals(Integer.valueOf(10), resultRecord.get(14, Integer.class));
+        assertEquals(Boolean.TRUE, resultRecord.get(7, Boolean.class));
+        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(8, byte[].class));
+        assertArrayEquals(new byte[]{104, 101, 108, 108, 111}, resultRecord.get(9, ByteBuffer.class).array());
+        assertEquals(LocalDate.of(2017, 4, 4), resultRecord.get(10, LocalDate.class));
+        assertEquals(LocalTime.of(14, 20, 33), resultRecord.get(11, LocalTime.class));
+        assertEquals(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC), resultRecord.get(12, OffsetDateTime.class));
+        assertEquals(LOCAL_DATE_TIME, resultRecord.get(13, LocalDateTime.class));
+        assertEquals(Integer.valueOf(10), resultRecord.get(15, Integer.class));
 
         if (format.equals(FileFormat.PARQUET)) {
             // Parquet uses a conversion to the byte values of numeric characters such as "0" -> byte value 0
@@ -726,9 +730,9 @@ public class TestIcebergRecordConverter {
             ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[16]);
             byteBuffer.putLong(uuid.getMostSignificantBits());
             byteBuffer.putLong(uuid.getLeastSignificantBits());
-            assertArrayEquals(byteBuffer.array(), resultRecord.get(13, byte[].class));
+            assertArrayEquals(byteBuffer.array(), resultRecord.get(14, byte[].class));
         } else {
-            assertEquals(UUID.fromString("0000-00-00-00-000000"), resultRecord.get(13, UUID.class));
+            assertEquals(UUID.fromString("0000-00-00-00-000000"), resultRecord.get(14, UUID.class));
         }
     }
 

--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
@@ -156,7 +156,7 @@ public class TestIcebergRecordConverter {
             Types.NestedField.optional(3, "long", Types.LongType.get()),
             Types.NestedField.optional(4, "double", Types.DoubleType.get()),
             Types.NestedField.optional(5, "decimal", Types.DecimalType.of(10, 2)),
-            Types.NestedField.optional(6, "decimalLessScore", Types.DecimalType.of(10, 2)),
+            Types.NestedField.optional(6, "decimalLowerScore", Types.DecimalType.of(10, 2)),
             Types.NestedField.optional(7, "boolean", Types.BooleanType.get()),
             Types.NestedField.optional(8, "fixed", Types.FixedType.ofLength(5)),
             Types.NestedField.optional(9, "binary", Types.BinaryType.get()),
@@ -285,7 +285,7 @@ public class TestIcebergRecordConverter {
         fields.add(new RecordField("long", RecordFieldType.LONG.getDataType()));
         fields.add(new RecordField("double", RecordFieldType.DOUBLE.getDataType()));
         fields.add(new RecordField("decimal", RecordFieldType.DECIMAL.getDecimalDataType(10, 2)));
-        fields.add(new RecordField("decimalLessScore", RecordFieldType.DECIMAL.getDecimalDataType(10, 2)));
+        fields.add(new RecordField("decimalLowerScore", RecordFieldType.DECIMAL.getDecimalDataType(10, 2)));
         fields.add(new RecordField("boolean", RecordFieldType.BOOLEAN.getDataType()));
         fields.add(new RecordField("fixed", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType())));
         fields.add(new RecordField("binary", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType())));
@@ -462,7 +462,7 @@ public class TestIcebergRecordConverter {
         values.put("long", 42L);
         values.put("double", 3.14159D);
         values.put("decimal", new BigDecimal("12345678.12"));
-        values.put("decimalLessScore", new BigDecimal("12345678.1"));
+        values.put("decimalLowerScore", 12345678.1);
         values.put("boolean", true);
         values.put("fixed", "hello".getBytes());
         values.put("binary", "hello".getBytes());


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13593](https://issues.apache.org/jira/browse/NIFI-13593)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
