### PR TITLE
NIFI-12709 Added ability to get more attributes for zip files as well as created new attributes to get for both tar and zip files.

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -67,9 +67,12 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -99,12 +102,17 @@ import java.util.regex.Pattern;
     @WritesAttribute(attribute = "fragment.count", description = "The number of unpacked FlowFiles generated from the parent FlowFile"),
     @WritesAttribute(attribute = "segment.original.filename ", description = "The filename of the parent FlowFile. Extensions of .tar, .zip or .pkg are removed because "
             + "the MergeContent processor automatically adds those extensions if it is used to rebuild the original FlowFile"),
-    @WritesAttribute(attribute = "file.lastModifiedTime", description = "The date and time that the unpacked file was last modified (tar only)."),
-    @WritesAttribute(attribute = "file.creationTime", description = "The date and time that the file was created. This attribute holds always the same value as file.lastModifiedTime (tar only)."),
-    @WritesAttribute(attribute = "file.owner", description = "The owner of the unpacked file (tar only)"),
-    @WritesAttribute(attribute = "file.group", description = "The group owner of the unpacked file (tar only)"),
-    @WritesAttribute(attribute = "file.permissions", description = "The read/write/execute permissions of the unpacked file (tar only)"),
-    @WritesAttribute(attribute = "file.encryptionMethod", description = "The encryption method for entries in Zip archives")})
+    @WritesAttribute(attribute = UnpackContent.FILE_LAST_MODIFIED_TIME_ATTRIBUTE, description = "The date and time that the unpacked file was last modified (tar and zip only)."),
+    @WritesAttribute(attribute = UnpackContent.FILE_CREATION_TIME_ATTRIBUTE, description = "The date and time that the file was created. For encrypted zip files this attribute" +
+            " always holds the same value as " + UnpackContent.FILE_LAST_MODIFIED_TIME_ATTRIBUTE + ". For tar and unencrypted zip files if available it will be returned otherwise" +
+            " this will be the same value as" + UnpackContent.FILE_LAST_MODIFIED_TIME_ATTRIBUTE + "."),
+    @WritesAttribute(attribute = UnpackContent.FILE_LAST_METADATA_CHANGE_ATTRIBUTE, description = "The date and time the file's metadata changed (tar only)."),
+    @WritesAttribute(attribute = UnpackContent.FILE_LAST_ACCESS_TIME_ATTRIBUTE, description = "The date and time the file was last accessed (tar and unencrypted zip only)"),
+    @WritesAttribute(attribute = UnpackContent.FILE_OWNER_ATTRIBUTE, description = "The owner of the unpacked file (tar only)"),
+    @WritesAttribute(attribute = UnpackContent.FILE_GROUP_ATTRIBUTE, description = "The group owner of the unpacked file (tar only)"),
+    @WritesAttribute(attribute = UnpackContent.FILE_SIZE_ATTRIBUTE, description = "The uncompressed size of the unpacked file (tar and zip only)"),
+    @WritesAttribute(attribute = UnpackContent.FILE_PERMISSIONS_ATTRIBUTE, description = "The read/write/execute permissions of the unpacked file (tar and unencrypted zip files)"),
+    @WritesAttribute(attribute = UnpackContent.FILE_ENCRYPTION_METHOD_ATTRIBUTE, description = "The encryption method for entries in Zip archives")})
 @SeeAlso(MergeContent.class)
 @UseCase(
     description = "Unpack Zip containing filenames with special characters, created on Windows with filename charset 'Cp437' or 'IBM437'.",
@@ -131,8 +139,11 @@ public class UnpackContent extends AbstractProcessor {
 
     public static final String FILE_LAST_MODIFIED_TIME_ATTRIBUTE = "file.lastModifiedTime";
     public static final String FILE_CREATION_TIME_ATTRIBUTE = "file.creationTime";
+    public static final String FILE_LAST_METADATA_CHANGE_ATTRIBUTE = "file.lastMetadataChange";
+    public static final String FILE_LAST_ACCESS_TIME_ATTRIBUTE = "file.lastAccessTime";
     public static final String FILE_OWNER_ATTRIBUTE = "file.owner";
     public static final String FILE_GROUP_ATTRIBUTE = "file.group";
+    public static final String FILE_SIZE_ATTRIBUTE = "file.size";
     public static final String FILE_PERMISSIONS_ATTRIBUTE = "file.permissions";
     public static final String FILE_ENCRYPTION_METHOD_ATTRIBUTE = "file.encryptionMethod";
 
@@ -387,23 +398,37 @@ public class UnpackContent extends AbstractProcessor {
 
                         FlowFile unpackedFile = session.create(source);
                         try {
-                            final String timeAsString = DATE_TIME_FORMATTER.format(tarEntry.getModTime().toInstant());
+                            final Map<String, String> attributes = new HashMap<>();
+                            attributes.put(CoreAttributes.FILENAME.key(), file.getName());
+                            attributes.put(CoreAttributes.PATH.key(), filePathString);
+                            attributes.put(CoreAttributes.MIME_TYPE.key(), OCTET_STREAM);
 
-                            unpackedFile = session.putAllAttributes(unpackedFile, Map.of(
-                                    CoreAttributes.FILENAME.key(), file.getName(),
-                                    CoreAttributes.PATH.key(), filePathString,
-                                    CoreAttributes.MIME_TYPE.key(), OCTET_STREAM,
+                            attributes.put(FILE_PERMISSIONS_ATTRIBUTE, FileInfo.permissionToString(tarEntry.getMode()));
+                            attributes.put(FILE_OWNER_ATTRIBUTE, String.valueOf(tarEntry.getUserName()));
+                            attributes.put(FILE_GROUP_ATTRIBUTE, String.valueOf(tarEntry.getGroupName()));
+                            attributes.put(FILE_SIZE_ATTRIBUTE, String.valueOf(tarEntry.getRealSize()));
+                            String timeAsString = DATE_TIME_FORMATTER.format(tarEntry.getModTime().toInstant());
+                            attributes.put(FILE_LAST_MODIFIED_TIME_ATTRIBUTE, timeAsString);
 
-                                    FILE_PERMISSIONS_ATTRIBUTE, FileInfo.permissionToString(tarEntry.getMode()),
-                                    FILE_OWNER_ATTRIBUTE, String.valueOf(tarEntry.getUserName()),
-                                    FILE_GROUP_ATTRIBUTE, String.valueOf(tarEntry.getGroupName()),
+                            if (tarEntry.getCreationTime() != null) {
+                                timeAsString = DATE_TIME_FORMATTER.format(tarEntry.getCreationTime().toInstant());
+                            }
+                            attributes.put(FILE_CREATION_TIME_ATTRIBUTE, timeAsString);
 
-                                    FILE_LAST_MODIFIED_TIME_ATTRIBUTE, timeAsString,
-                                    FILE_CREATION_TIME_ATTRIBUTE, timeAsString,
+                            if (tarEntry.getStatusChangeTime() != null) {
+                                timeAsString = DATE_TIME_FORMATTER.format(tarEntry.getStatusChangeTime().toInstant());
+                                attributes.put(FILE_LAST_METADATA_CHANGE_ATTRIBUTE, timeAsString);
+                            }
 
-                                    FRAGMENT_ID, fragmentId,
-                                    FRAGMENT_INDEX, String.valueOf(++fragmentCount)
-                            ));
+                            if (tarEntry.getLastAccessTime() != null) {
+                                timeAsString = DATE_TIME_FORMATTER.format(tarEntry.getLastAccessTime().toInstant());
+                                attributes.put(FILE_LAST_ACCESS_TIME_ATTRIBUTE, timeAsString);
+                            }
+
+                            attributes.put(FRAGMENT_ID, fragmentId);
+                            attributes.put(FRAGMENT_INDEX, String.valueOf(++fragmentCount));
+
+                            unpackedFile = session.putAllAttributes(unpackedFile, attributes);
 
                             final long fileSize = tarEntry.getSize();
                             unpackedFile = session.write(unpackedFile, outputStream -> StreamUtils.copy(tarIn, outputStream, fileSize));
@@ -435,6 +460,11 @@ public class UnpackContent extends AbstractProcessor {
             } else {
                 session.read(source, new EncryptedZipInputStreamCallback(fileFilter, session, source, unpacked, fragmentId, password, filenameEncoding));
             }
+        }
+
+        private record ZipInputStreamMetadata(boolean directory, String zipEntryName, EncryptionMethod encryptionMethod,
+                                               Instant creationTime, Instant lastModifiedDate, Instant lastAccessDate, int mode,
+                                               long uncompressedSize) {
         }
 
         private abstract static class ZipInputStreamCallback implements InputStreamCallback {
@@ -470,22 +500,40 @@ public class UnpackContent extends AbstractProcessor {
                 return !directory && (fileFilter == null || fileFilter.matcher(fileName).find());
             }
 
-            protected void processEntry(final InputStream zipInputStream, final boolean directory, final String zipEntryName, final EncryptionMethod encryptionMethod) {
-                if (isFileEntryMatched(directory, zipEntryName)) {
-                    final File file = new File(zipEntryName);
+            protected void processEntry(final InputStream zipInputStream, ZipInputStreamMetadata metadata) {
+                if (isFileEntryMatched(metadata.directory(), metadata.zipEntryName())) {
+                    final File file = new File(metadata.zipEntryName());
                     final String parentDirectory = (file.getParent() == null) ? PATH_SEPARATOR : file.getParent();
 
                     FlowFile unpackedFile = session.create(sourceFlowFile);
                     try {
-                        unpackedFile = session.putAllAttributes(unpackedFile, Map.of(
-                                CoreAttributes.FILENAME.key(), file.getName(),
-                                CoreAttributes.PATH.key(), parentDirectory,
-                                CoreAttributes.MIME_TYPE.key(), OCTET_STREAM,
-                                FILE_ENCRYPTION_METHOD_ATTRIBUTE, encryptionMethod.toString(),
+                        final Map<String, String> attributes = new HashMap<>();
+                        attributes.put(CoreAttributes.FILENAME.key(), file.getName());
+                        attributes.put(CoreAttributes.PATH.key(), parentDirectory);
+                        attributes.put(CoreAttributes.MIME_TYPE.key(), OCTET_STREAM);
+                        attributes.put(FILE_ENCRYPTION_METHOD_ATTRIBUTE, metadata.encryptionMethod().toString());
+                        attributes.put(FILE_SIZE_ATTRIBUTE, String.valueOf(metadata.uncompressedSize()));
+                        String timeAsString = DATE_TIME_FORMATTER.format(metadata.lastModifiedDate());
+                        attributes.put(FILE_LAST_MODIFIED_TIME_ATTRIBUTE, timeAsString);
 
-                                FRAGMENT_ID, fragmentId,
-                                FRAGMENT_INDEX, String.valueOf(++fragmentIndex)
-                        ));
+                        if (metadata.creationTime() != null) {
+                            timeAsString = DATE_TIME_FORMATTER.format(metadata.creationTime());
+                        }
+                        attributes.put(FILE_CREATION_TIME_ATTRIBUTE, timeAsString);
+
+                        if (metadata.lastAccessDate() != null) {
+                            timeAsString = DATE_TIME_FORMATTER.format(metadata.lastAccessDate());
+                            attributes.put(FILE_LAST_ACCESS_TIME_ATTRIBUTE, timeAsString);
+                        }
+
+                        if (metadata.mode() > -1) {
+                            attributes.put(FILE_PERMISSIONS_ATTRIBUTE, FileInfo.permissionToString(metadata.mode()));
+                        }
+
+                        attributes.put(FRAGMENT_ID, fragmentId);
+                        attributes.put(FRAGMENT_INDEX, String.valueOf(++fragmentIndex));
+
+                        unpackedFile = session.putAllAttributes(unpackedFile, attributes);
                         unpackedFile = session.write(unpackedFile, outputStream -> StreamUtils.copy(zipInputStream, outputStream));
                     } finally {
                         unpacked.add(unpackedFile);
@@ -519,7 +567,14 @@ public class UnpackContent extends AbstractProcessor {
                     filenameEncoding.toString(), true, allowStoredEntriesWithDataDescriptor)) {
                     ZipArchiveEntry zipEntry;
                     while ((zipEntry = zipInputStream.getNextEntry()) != null) {
-                        processEntry(zipInputStream, zipEntry.isDirectory(), zipEntry.getName(), EncryptionMethod.NONE);
+                        // NOTE: Per javadocs, ZipArchiveEntry can return -1 for getTime() if its not specified
+                        // and getLastAccessTime() can return null if it is not specified.
+                        Instant creationTime = zipEntry.getTime() > 0 ? new Date(zipEntry.getTime()).toInstant() : null;
+                        Instant lastModifiedDate = zipEntry.getLastModifiedDate().toInstant();
+                        Instant lastAccessTime = zipEntry.getLastAccessTime() != null ? zipEntry.getLastAccessTime().toInstant() : null;
+                        ZipInputStreamMetadata zipInputStreamMetadata = new ZipInputStreamMetadata(zipEntry.isDirectory(), zipEntry.getName(),
+                                EncryptionMethod.NONE, creationTime, lastModifiedDate, lastAccessTime, zipEntry.getUnixMode(), zipEntry.getSize());
+                        processEntry(zipInputStream, zipInputStreamMetadata);
                     }
                 }
             }
@@ -548,7 +603,11 @@ public class UnpackContent extends AbstractProcessor {
                 try (final ZipInputStream zipInputStream = new ZipInputStream(new BufferedInputStream(inputStream), password, filenameEncoding)) {
                     LocalFileHeader zipEntry;
                     while ((zipEntry = zipInputStream.getNextEntry()) != null) {
-                        processEntry(zipInputStream, zipEntry.isDirectory(), zipEntry.getFileName(), zipEntry.getEncryptionMethod());
+                        //NOTE: LocalFileHeader has no methods to return creation time and the mode.
+                        Instant lastModifiedDate = zipEntry.getLastModifiedTime() > 0 ? new Date(zipEntry.getLastModifiedTime()).toInstant() : null;
+                        ZipInputStreamMetadata zipInputStreamMetadata = new ZipInputStreamMetadata(zipEntry.isDirectory(), zipEntry.getFileName(),
+                                zipEntry.getEncryptionMethod(), null, lastModifiedDate, null, -1, zipEntry.getUncompressedSize());
+                        processEntry(zipInputStream, zipInputStreamMetadata);
                     }
                 }
             }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -402,27 +402,28 @@ public class UnpackContent extends AbstractProcessor {
                             attributes.put(CoreAttributes.FILENAME.key(), file.getName());
                             attributes.put(CoreAttributes.PATH.key(), filePathString);
                             attributes.put(CoreAttributes.MIME_TYPE.key(), OCTET_STREAM);
-
                             attributes.put(FILE_PERMISSIONS_ATTRIBUTE, FileInfo.permissionToString(tarEntry.getMode()));
                             attributes.put(FILE_OWNER_ATTRIBUTE, String.valueOf(tarEntry.getUserName()));
                             attributes.put(FILE_GROUP_ATTRIBUTE, String.valueOf(tarEntry.getGroupName()));
                             attributes.put(FILE_SIZE_ATTRIBUTE, String.valueOf(tarEntry.getRealSize()));
-                            String timeAsString = DATE_TIME_FORMATTER.format(tarEntry.getModTime().toInstant());
-                            attributes.put(FILE_LAST_MODIFIED_TIME_ATTRIBUTE, timeAsString);
+                            String lastModified = DATE_TIME_FORMATTER.format(tarEntry.getModTime().toInstant());
+                            attributes.put(FILE_LAST_MODIFIED_TIME_ATTRIBUTE, lastModified);
 
                             if (tarEntry.getCreationTime() != null) {
-                                timeAsString = DATE_TIME_FORMATTER.format(tarEntry.getCreationTime().toInstant());
+                                final String creationTime = DATE_TIME_FORMATTER.format(tarEntry.getCreationTime().toInstant());
+                                attributes.put(FILE_CREATION_TIME_ATTRIBUTE, creationTime);
+                            } else {
+                                attributes.put(FILE_CREATION_TIME_ATTRIBUTE, lastModified);
                             }
-                            attributes.put(FILE_CREATION_TIME_ATTRIBUTE, timeAsString);
 
                             if (tarEntry.getStatusChangeTime() != null) {
-                                timeAsString = DATE_TIME_FORMATTER.format(tarEntry.getStatusChangeTime().toInstant());
-                                attributes.put(FILE_LAST_METADATA_CHANGE_ATTRIBUTE, timeAsString);
+                                final String metadataChangeTime = DATE_TIME_FORMATTER.format(tarEntry.getStatusChangeTime().toInstant());
+                                attributes.put(FILE_LAST_METADATA_CHANGE_ATTRIBUTE, metadataChangeTime);
                             }
 
                             if (tarEntry.getLastAccessTime() != null) {
-                                timeAsString = DATE_TIME_FORMATTER.format(tarEntry.getLastAccessTime().toInstant());
-                                attributes.put(FILE_LAST_ACCESS_TIME_ATTRIBUTE, timeAsString);
+                                final String lastAccesTime = DATE_TIME_FORMATTER.format(tarEntry.getLastAccessTime().toInstant());
+                                attributes.put(FILE_LAST_ACCESS_TIME_ATTRIBUTE, lastAccesTime);
                             }
 
                             attributes.put(FRAGMENT_ID, fragmentId);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -107,11 +107,11 @@ import java.util.regex.Pattern;
             " always holds the same value as " + UnpackContent.FILE_LAST_MODIFIED_TIME_ATTRIBUTE + ". For tar and unencrypted zip files if available it will be returned otherwise" +
             " this will be the same value as" + UnpackContent.FILE_LAST_MODIFIED_TIME_ATTRIBUTE + "."),
     @WritesAttribute(attribute = UnpackContent.FILE_LAST_METADATA_CHANGE_ATTRIBUTE, description = "The date and time the file's metadata changed (tar only)."),
-    @WritesAttribute(attribute = UnpackContent.FILE_LAST_ACCESS_TIME_ATTRIBUTE, description = "The date and time the file was last accessed (tar and unencrypted zip only)"),
+    @WritesAttribute(attribute = UnpackContent.FILE_LAST_ACCESS_TIME_ATTRIBUTE, description = "The date and time the file was last accessed (tar and unencrypted zip files only)"),
     @WritesAttribute(attribute = UnpackContent.FILE_OWNER_ATTRIBUTE, description = "The owner of the unpacked file (tar only)"),
     @WritesAttribute(attribute = UnpackContent.FILE_GROUP_ATTRIBUTE, description = "The group owner of the unpacked file (tar only)"),
     @WritesAttribute(attribute = UnpackContent.FILE_SIZE_ATTRIBUTE, description = "The uncompressed size of the unpacked file (tar and zip only)"),
-    @WritesAttribute(attribute = UnpackContent.FILE_PERMISSIONS_ATTRIBUTE, description = "The read/write/execute permissions of the unpacked file (tar and unencrypted zip files)"),
+    @WritesAttribute(attribute = UnpackContent.FILE_PERMISSIONS_ATTRIBUTE, description = "The read/write/execute permissions of the unpacked file (tar and unencrypted zip files only)"),
     @WritesAttribute(attribute = UnpackContent.FILE_ENCRYPTION_METHOD_ATTRIBUTE, description = "The encryption method for entries in Zip archives")})
 @SeeAlso(MergeContent.class)
 @UseCase(

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -528,7 +528,7 @@ public class UnpackContent extends AbstractProcessor {
                         }
 
                         if (metadata.lastAccessDate() != null) {
-                            final String lastAccessDate  = DATE_TIME_FORMATTER.format(metadata.lastAccessDate());
+                            final String lastAccessDate = DATE_TIME_FORMATTER.format(metadata.lastAccessDate());
                             attributes.put(FILE_LAST_ACCESS_TIME_ATTRIBUTE, lastAccessDate);
                         }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -514,23 +514,22 @@ public class UnpackContent extends AbstractProcessor {
                         attributes.put(FILE_ENCRYPTION_METHOD_ATTRIBUTE, metadata.encryptionMethod().toString());
                         attributes.put(FILE_SIZE_ATTRIBUTE, String.valueOf(metadata.uncompressedSize()));
 
-                        String timeAsString = null;
+                        String lastModifiedDate = null;
                         if (metadata.lastModifiedDate() != null) {
-                            timeAsString = DATE_TIME_FORMATTER.format(metadata.lastModifiedDate());
-                            attributes.put(FILE_LAST_MODIFIED_TIME_ATTRIBUTE, timeAsString);
+                            lastModifiedDate = DATE_TIME_FORMATTER.format(metadata.lastModifiedDate());
+                            attributes.put(FILE_LAST_MODIFIED_TIME_ATTRIBUTE, lastModifiedDate);
                         }
 
                         if (metadata.creationTime() != null) {
-                            timeAsString = DATE_TIME_FORMATTER.format(metadata.creationTime());
-                        }
-
-                        if (timeAsString != null) {
-                            attributes.put(FILE_CREATION_TIME_ATTRIBUTE, timeAsString);
+                            final String creationTime = DATE_TIME_FORMATTER.format(metadata.creationTime());
+                            attributes.put(FILE_CREATION_TIME_ATTRIBUTE, creationTime);
+                        } else if (lastModifiedDate != null) {
+                            attributes.put(FILE_CREATION_TIME_ATTRIBUTE, lastModifiedDate);
                         }
 
                         if (metadata.lastAccessDate() != null) {
-                            timeAsString = DATE_TIME_FORMATTER.format(metadata.lastAccessDate());
-                            attributes.put(FILE_LAST_ACCESS_TIME_ATTRIBUTE, timeAsString);
+                            final String lastAccessDate  = DATE_TIME_FORMATTER.format(metadata.lastAccessDate());
+                            attributes.put(FILE_LAST_ACCESS_TIME_ATTRIBUTE, lastAccessDate);
                         }
 
                         if (metadata.mode() > -1) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -513,13 +513,20 @@ public class UnpackContent extends AbstractProcessor {
                         attributes.put(CoreAttributes.MIME_TYPE.key(), OCTET_STREAM);
                         attributes.put(FILE_ENCRYPTION_METHOD_ATTRIBUTE, metadata.encryptionMethod().toString());
                         attributes.put(FILE_SIZE_ATTRIBUTE, String.valueOf(metadata.uncompressedSize()));
-                        String timeAsString = DATE_TIME_FORMATTER.format(metadata.lastModifiedDate());
-                        attributes.put(FILE_LAST_MODIFIED_TIME_ATTRIBUTE, timeAsString);
+
+                        String timeAsString = null;
+                        if (metadata.lastModifiedDate() != null) {
+                            timeAsString = DATE_TIME_FORMATTER.format(metadata.lastModifiedDate());
+                            attributes.put(FILE_LAST_MODIFIED_TIME_ATTRIBUTE, timeAsString);
+                        }
 
                         if (metadata.creationTime() != null) {
                             timeAsString = DATE_TIME_FORMATTER.format(metadata.creationTime());
                         }
-                        attributes.put(FILE_CREATION_TIME_ATTRIBUTE, timeAsString);
+
+                        if (timeAsString != null) {
+                            attributes.put(FILE_CREATION_TIME_ATTRIBUTE, timeAsString);
+                        }
 
                         if (metadata.lastAccessDate() != null) {
                             timeAsString = DATE_TIME_FORMATTER.format(metadata.lastAccessDate());
@@ -606,7 +613,7 @@ public class UnpackContent extends AbstractProcessor {
                         //NOTE: LocalFileHeader has no methods to return creation time and the mode.
                         Instant lastModifiedDate = zipEntry.getLastModifiedTime() > 0 ? new Date(zipEntry.getLastModifiedTime()).toInstant() : null;
                         ZipInputStreamMetadata zipInputStreamMetadata = new ZipInputStreamMetadata(zipEntry.isDirectory(), zipEntry.getFileName(),
-                                zipEntry.getEncryptionMethod(), null, lastModifiedDate, null, -1, zipEntry.getUncompressedSize());
+                                zipEntry.getEncryptionMethod(), lastModifiedDate, lastModifiedDate, null, -1, zipEntry.getUncompressedSize());
                         processEntry(zipInputStream, zipInputStreamMetadata);
                     }
                 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 
 import static org.apache.nifi.processors.standard.SplitContent.FRAGMENT_COUNT;
 import static org.apache.nifi.processors.standard.SplitContent.FRAGMENT_ID;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -88,13 +89,11 @@ public class TestUnpackContent {
             assertEquals("rw-r--r--", flowFile.getAttribute("file.permissions"));
             assertEquals("jmcarey", flowFile.getAttribute("file.owner"));
             assertEquals("mkpasswd", flowFile.getAttribute("file.group"));
+
             String modifiedTimeAsString = flowFile.getAttribute("file.lastModifiedTime");
-
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").parse(modifiedTimeAsString);
-
+            assertDoesNotThrow(() -> DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").parse(modifiedTimeAsString));
             String creationTimeAsString = flowFile.getAttribute("file.creationTime");
-
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").parse(creationTimeAsString);
+            assertDoesNotThrow(() -> DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").parse(creationTimeAsString));
 
             assertTrue(Files.exists(path));
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
@@ -83,12 +83,17 @@ public class TestUnpackContent {
         final List<MockFlowFile> unpacked = unpackRunner.getFlowFilesForRelationship(UnpackContent.REL_SUCCESS);
 
         for (final MockFlowFile flowFile : unpacked) {
+            System.err.println(flowFile.getAttributes());
+            assertTrue(flowFile.getAttributes().keySet().containsAll(List.of(UnpackContent.FRAGMENT_ID, UnpackContent.FRAGMENT_INDEX,
+                    UnpackContent.FRAGMENT_COUNT, UnpackContent.SEGMENT_ORIGINAL_FILENAME, UnpackContent.FILE_SIZE_ATTRIBUTE)));
+
             final String filename = flowFile.getAttribute(CoreAttributes.FILENAME.key());
             final String folder = flowFile.getAttribute(CoreAttributes.PATH.key());
             final Path path = dataPath.resolve(folder).resolve(filename);
-            assertEquals("rw-r--r--", flowFile.getAttribute("file.permissions"));
-            assertEquals("jmcarey", flowFile.getAttribute("file.owner"));
-            assertEquals("mkpasswd", flowFile.getAttribute("file.group"));
+
+            assertEquals("rw-r--r--", flowFile.getAttribute(UnpackContent.FILE_PERMISSIONS_ATTRIBUTE));
+            assertEquals("jmcarey", flowFile.getAttribute(UnpackContent.FILE_OWNER_ATTRIBUTE));
+            assertEquals("mkpasswd", flowFile.getAttribute(UnpackContent.FILE_GROUP_ATTRIBUTE));
 
             String modifiedTimeAsString = flowFile.getAttribute("file.lastModifiedTime");
             assertDoesNotThrow(() -> DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ").parse(modifiedTimeAsString));
@@ -182,6 +187,10 @@ public class TestUnpackContent {
 
         final List<MockFlowFile> unpacked = unpackRunner.getFlowFilesForRelationship(UnpackContent.REL_SUCCESS);
         for (final MockFlowFile flowFile : unpacked) {
+            assertTrue(flowFile.getAttributes().keySet().containsAll(List.of(CoreAttributes.FILENAME.key(), CoreAttributes.PATH.key(),
+                    UnpackContent.FRAGMENT_ID, UnpackContent.FRAGMENT_INDEX, UnpackContent.FRAGMENT_COUNT,
+                    UnpackContent.SEGMENT_ORIGINAL_FILENAME, UnpackContent.FILE_SIZE_ATTRIBUTE, UnpackContent.FILE_CREATION_TIME_ATTRIBUTE,
+                    UnpackContent.FILE_LAST_MODIFIED_TIME_ATTRIBUTE, UnpackContent.FILE_PERMISSIONS_ATTRIBUTE)));
             final String filename = flowFile.getAttribute(CoreAttributes.FILENAME.key());
             final String folder = flowFile.getAttribute(CoreAttributes.PATH.key());
             final Path path = dataPath.resolve(folder).resolve(filename);
@@ -217,7 +226,6 @@ public class TestUnpackContent {
         final List<MockFlowFile> unpacked = unpackRunner.getFlowFilesForRelationship(UnpackContent.REL_FAILURE);
         for (final MockFlowFile flowFile : unpacked) {
             final String filename = flowFile.getAttribute(CoreAttributes.FILENAME.key());
-           // final String folder = flowFile.getAttribute(CoreAttributes.PATH.key());
             final Path path = dataPath.resolve(filename);
             assertTrue(Files.exists(path));
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
@@ -83,7 +83,6 @@ public class TestUnpackContent {
         final List<MockFlowFile> unpacked = unpackRunner.getFlowFilesForRelationship(UnpackContent.REL_SUCCESS);
 
         for (final MockFlowFile flowFile : unpacked) {
-            System.err.println(flowFile.getAttributes());
             assertTrue(flowFile.getAttributes().keySet().containsAll(List.of(UnpackContent.FRAGMENT_ID, UnpackContent.FRAGMENT_INDEX,
                     UnpackContent.FRAGMENT_COUNT, UnpackContent.SEGMENT_ORIGINAL_FILENAME, UnpackContent.FILE_SIZE_ATTRIBUTE)));
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary
Three attributes `file.lastMetadataChange`, `file.lastAccessTime` and `file.size` have been added and other values for existing attributes have been made available (`file.creationTime` and `file.permissions`) . Below is a chart of all attributes the UnpackContent processor now has and the ones in bold are the ones which have been added. For tar files the `file.creationTime` before this PR used the `file.lastModifiedTime` but now if the  actual `file.creationTime` is available it is used and only defaults to using the `file.lastModifiedTime` if the `file.creationTime` is not available (this same logic is now employed for unencrypted zip files). For enrypted zip files the value for `file.lastModifiedTime` is used for the attribute `file.lastModifiedTime` and `file.creationTime`.

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">

<html>
<body>

Java Variable | Attribute Name | Tar | Unencrypted Zip | Encrypted Zip
-- | -- | -- | -- | --
FILE_LAST_MODIFIED_TIME_ATTRIBUTE | file.lastModifiedTime | Y | Y | Y
FILE_CREATION_TIME_ATTRIBUTE | file.creationTime | **Y** | **Y** | **Y**
**FILE_LAST_METADATA_CHANGE_ATTRIBUTE** | **file.lastMetadataChange** | **Y** | N | N
**FILE_LAST_ACCESS_TIME_ATTRIBUTE** | **file.lastAccessTime** | **Y** | **Y** | N
FILE_OWNER_ATTRIBUTE | file.owner | Y | N | N
FILE_GROUP_ATTRIBUTE | file.group | Y | N | N
**FILE_SIZE_ATTRIBUTE** | **file.size** | **Y** | **Y** | **Y**
FILE_PERMISSIONS_ATTRIBUTE | file.permissions | Y | **Y** | N
FILE_ENCRYPTION_METHOD_ATTRIBUTE | file.encryptionMethod | N | Y | Y


</body>

</html>

Currently Zip4j the implementation used for encrypted zip files does not have access methods for `file.permissions` `file.creationTime` and `file.lastAccessTime`. A [request](https://github.com/srikanth-lingala/zip4j/issues/557) has been made to add these.
 
[NIFI-12709](https://issues.apache.org/jira/browse/NIFI-12709)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
