### PR TITLE
NIFI-13599 Replace Commons Codec Hex with HexFormat for Encryptor

### DIFF
--- a/nifi-commons/nifi-property-encryptor/pom.xml
+++ b/nifi-commons/nifi-property-encryptor/pom.xml
@@ -31,9 +31,5 @@
             <artifactId>nifi-security-crypto-key</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/nifi-commons/nifi-property-encryptor/src/main/java/org/apache/nifi/encrypt/CipherPropertyEncryptor.java
+++ b/nifi-commons/nifi-property-encryptor/src/main/java/org/apache/nifi/encrypt/CipherPropertyEncryptor.java
@@ -16,20 +16,20 @@
  */
 package org.apache.nifi.encrypt;
 
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.binary.Hex;
-
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
 
 /**
  * Cipher Property Encryptor provides hexadecimal encoding and decoding around cipher operations
  */
 abstract class CipherPropertyEncryptor implements PropertyEncryptor {
     private static final Charset PROPERTY_CHARSET = StandardCharsets.UTF_8;
+
+    private static final HexFormat HEX_FORMAT = HexFormat.of();
 
     /**
      * Encrypt property and encode as a hexadecimal string
@@ -45,7 +45,7 @@ abstract class CipherPropertyEncryptor implements PropertyEncryptor {
         final Cipher cipher = getEncryptionCipher(encodedParameters);
         try {
             final byte[] encrypted = cipher.doFinal(binary);
-            return Hex.encodeHexString(getConcatenatedBinary(encodedParameters, encrypted));
+            return HEX_FORMAT.formatHex(getConcatenatedBinary(encodedParameters, encrypted));
         } catch (final BadPaddingException | IllegalBlockSizeException e) {
             final String message = String.format("Encryption Failed with Algorithm [%s]", cipher.getAlgorithm());
             throw new EncryptionException(message, e);
@@ -74,8 +74,8 @@ abstract class CipherPropertyEncryptor implements PropertyEncryptor {
 
     private byte[] getDecodedBinary(final String encryptedProperty) {
         try {
-            return Hex.decodeHex(encryptedProperty);
-        } catch (final DecoderException e) {
+            return HEX_FORMAT.parseHex(encryptedProperty);
+        } catch (final IllegalArgumentException e) {
             throw new EncryptionException("Hexadecimal decoding failed", e);
         }
     }

--- a/nifi-commons/nifi-property-encryptor/src/test/java/org/apache/nifi/encrypt/KeyedCipherPropertyEncryptorTest.java
+++ b/nifi-commons/nifi-property-encryptor/src/test/java/org/apache/nifi/encrypt/KeyedCipherPropertyEncryptorTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.nifi.encrypt;
 
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.binary.Hex;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,8 +23,10 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -60,16 +60,23 @@ public class KeyedCipherPropertyEncryptorTest {
     }
 
     @Test
-    public void testEncryptHexadecimalEncoded() throws DecoderException {
+    public void testEncryptHexadecimalEncoded() {
         final String encrypted = encryptor.encrypt(PROPERTY);
-        final byte[] decoded = Hex.decodeHex(encrypted);
+        final byte[] decoded = HexFormat.of().parseHex(encrypted);
         assertEquals(ENCRYPTED_BINARY_LENGTH, decoded.length);
     }
 
     @Test
     public void testDecryptEncryptionException() {
-        final String encodedProperty = Hex.encodeHexString(PROPERTY.getBytes(DEFAULT_CHARSET));
+        final String encodedProperty = HexFormat.of().formatHex(PROPERTY.getBytes(DEFAULT_CHARSET));
         assertThrows(Exception.class, () -> encryptor.decrypt(encodedProperty));
+    }
+
+    @Test
+    public void testDecryptHexadecimalInvalid() {
+        final String invalidProperty = String.class.getName();
+        final EncryptionException exception = assertThrows(EncryptionException.class, () -> encryptor.decrypt(invalidProperty));
+        assertInstanceOf(IllegalArgumentException.class, exception.getCause());
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-13599](https://issues.apache.org/jira/browse/NIFI-13599) Replaces the Apache Commons Codec `Hex` usage with Java [HexFormat](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/HexFormat.html), introduced in Java 17. The change preserves existing behavior of encoding and decoding encrypted values in a hexadecimal format, but removes the need for the `commons-codec` dependency in `nifi-property-encryptor`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
