### PR TITLE
NIFI-13601 Add code-coverage workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -179,19 +179,11 @@ jobs:
             ${{ env.DEFAULT_MAVEN_OPTS }}
             -Dfrontend.skipTests=${{ steps.changes.outputs.frontend == 'true' && 'false' || 'true' }}
         run: >
-          ${{ env.MAVEN_COMMAND }}
-          jacoco:prepare-agent
+          ${{ env.MAVEN_COMMAND }}        
           ${{ env.MAVEN_VERIFY_COMMAND }}
-          ${{ env.MAVEN_BUILD_PROFILES }}
-          -P report-code-coverage
+          ${{ env.MAVEN_BUILD_PROFILES }}        
           -P python-unit-tests
           ${{ env.MAVEN_PROJECTS }}
-      - name: Codecov
-        uses: codecov/codecov-action@v4
-        if: github.repository_owner == 'apache'
-        with:
-          files: ./nifi-code-coverage/target/site/jacoco-aggregate/jacoco.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Test Reports
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: code-coverage
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  pull_request:
+    paths:
+      - '.github/workflows/code-coverage.yml'
+
+env:
+  DEFAULT_MAVEN_OPTS: >-
+    -Xms6g
+    -Xmx6g
+    -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    timeout-minutes: 120
+    runs-on:
+      - ubuntu-latest
+    name: Ubuntu Java 21
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: 'maven'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Maven Build
+        env:
+          MAVEN_OPTS: >-
+            ${{ env.DEFAULT_MAVEN_OPTS }}
+        run: >
+          ./mvnw --fail-fast --no-snapshot-updates --no-transfer-progress --show-version
+          -D include-python-integration-tests=true
+          -P integration-tests
+          -P report-code-coverage
+          jacoco:prepare-agent
+          verify
+      - name: Codecov
+        uses: codecov/codecov-action@v4
+        if: github.repository_owner == 'apache'
+        with:
+          files: ./nifi-code-coverage/target/site/jacoco-aggregate/jacoco.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -59,6 +59,7 @@ jobs:
           ./mvnw --fail-fast --no-snapshot-updates --no-transfer-progress --show-version
           -D include-python-integration-tests=true
           -P integration-tests
+          -P nifi-registry-integration-tests
           -P report-code-coverage
           jacoco:prepare-agent
           verify

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -16,6 +16,9 @@
 name: docker-tests
 
 on:
+  # Run at 00:00 on Monday
+  schedule:
+    - cron: "0 0 * * 1"
   push:
     paths:
       - '.github/workflows/docker-tests.yml'

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -16,8 +16,6 @@
 name: docker-tests
 
 on:
-  schedule:
-    - cron: "0 2 * * *"
   push:
     paths:
       - '.github/workflows/docker-tests.yml'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,9 +16,6 @@
 name: integration-tests
 
 on:
-  # Run every day at 03:00
-  schedule:
-    - cron: "0 3 * * *"
   push:
     paths:
       - '.github/workflows/integration-tests.yml'

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -16,9 +16,6 @@
 name: system-tests
 
 on:
-  # Run every day at 00:00
-  schedule:
-    - cron: "0 0 * * *"
   push:
     paths:
       - '.github/workflows/system-tests.yml'

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![system-tests](https://github.com/apache/nifi/workflows/system-tests/badge.svg)](https://github.com/apache/nifi/actions/workflows/system-tests.yml)
 [![integration-tests](https://github.com/apache/nifi/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/apache/nifi/actions/workflows/integration-tests.yml)
 [![docker-tests](https://github.com/apache/nifi/actions/workflows/docker-tests.yml/badge.svg)](https://github.com/apache/nifi/actions/workflows/docker-tests.yml)
+[![code-coverage](https://github.com/apache/nifi/actions/workflows/code-coverage.yml/badge.svg)](https://github.com/apache/nifi/actions/workflows/code-coverage.yml)
 [![codecov](https://codecov.io/gh/apache/nifi/branch/main/graph/badge.svg)](https://codecov.io/gh/apache/nifi)
 [![Docker pulls](https://img.shields.io/docker/pulls/apache/nifi.svg)](https://hub.docker.com/r/apache/nifi/)
 [![Version](https://img.shields.io/maven-central/v/org.apache.nifi/nifi-utils.svg)](https://nifi.apache.org/download.html)


### PR DESCRIPTION
# Summary

[NIFI-13601](https://issues.apache.org/jira/browse/NIFI-13601) Adds a `code-coverage` workflow to the set of GitHub Action workflows to handle running both unit tests and integration tests on a daily schedule. The `code-coverage` workflow also handles publishing code coverage metrics to Codecov, removing this step for the `ci-workflow`.

Additional changes include removing the scheduled settings for other test workflows as this workflow covers all types of tests and provides a daily status.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
