### PR TITLE
NIFI-13609 Correct Component Search Configuration

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/WebApplicationConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/WebApplicationConfiguration.java
@@ -50,7 +50,6 @@ import org.apache.nifi.web.dao.AccessPolicyDAO;
 import org.apache.nifi.web.dao.impl.ComponentDAO;
 import org.apache.nifi.web.revision.RevisionManager;
 import org.apache.nifi.web.search.query.RegexSearchQueryParser;
-import org.apache.nifi.web.search.resultenrichment.ComponentSearchResultEnricherFactory;
 import org.apache.nifi.web.util.ClusterReplicationComponentLifecycle;
 import org.apache.nifi.web.util.LocalComponentLifecycle;
 import org.apache.nifi.web.util.ParameterContextNameCollisionResolver;
@@ -97,6 +96,8 @@ public class WebApplicationConfiguration {
 
     private final RuntimeManifestService runtimeManifestService;
 
+    private final ControllerSearchService controllerSearchService;
+
     private ClusterCoordinator clusterCoordinator;
 
     private RequestReplicator requestReplicator;
@@ -113,7 +114,8 @@ public class WebApplicationConfiguration {
             final FlowService flowService,
             final NiFiProperties properties,
             final RevisionManager revisionManager,
-            final RuntimeManifestService runtimeManifestService
+            final RuntimeManifestService runtimeManifestService,
+            final ControllerSearchService controllerSearchService
     ) {
         this.authorizer = authorizer;
         this.accessPolicyDao = accessPolicyDao;
@@ -125,6 +127,7 @@ public class WebApplicationConfiguration {
         this.properties = properties;
         this.revisionManager = revisionManager;
         this.runtimeManifestService = runtimeManifestService;
+        this.controllerSearchService = controllerSearchService;
     }
 
     @Autowired(required = false)
@@ -233,24 +236,8 @@ public class WebApplicationConfiguration {
     }
 
     @Bean
-    public ComponentSearchResultEnricherFactory resultEnricherFactory() {
-        final ComponentSearchResultEnricherFactory factory = new ComponentSearchResultEnricherFactory();
-        factory.setAuthorizer(authorizer);
-        return factory;
-    }
-
-    @Bean
     public StandardReloadComponent reloadComponent() {
         return new StandardReloadComponent(flowController);
-    }
-
-    @Bean
-    public ControllerSearchService controllerSearchService() {
-        final ControllerSearchService controllerSearchService = new ControllerSearchService();
-        controllerSearchService.setAuthorizer(authorizer);
-        controllerSearchService.setFlowController(flowController);
-        controllerSearchService.setResultEnricherFactory(resultEnricherFactory());
-        return controllerSearchService;
     }
 
     @Bean
@@ -276,6 +263,7 @@ public class WebApplicationConfiguration {
         controllerFacade.setProperties(properties);
         controllerFacade.setFlowService(flowService);
         controllerFacade.setRuntimeManifestService(runtimeManifestService);
+        controllerFacade.setControllerSearchService(controllerSearchService);
         controllerFacade.setSearchQueryParser(searchQueryParser());
         return controllerFacade;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/WebSearchConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/WebSearchConfiguration.java
@@ -142,6 +142,9 @@ public class WebSearchConfiguration {
                         new PortScheduledStateMatcher()
                 )
         ));
+
+        final SearchableMatcher searchableMatcher = new SearchableMatcher();
+        searchableMatcher.setFlowController(flowController);
         controllerSearchService.setMatcherForProcessor(factory.getInstanceForConnectable(
                 List.of(
                         new ExtendedMatcher<>(),
@@ -151,7 +154,7 @@ public class WebSearchConfiguration {
                         new RelationshipMatcher<>(),
                         new ProcessorMetadataMatcher(),
                         new PropertyMatcher<>(),
-                        new SearchableMatcher()
+                        searchableMatcher
                 )
         ));
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/WebSearchConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/WebSearchConfiguration.java
@@ -58,16 +58,19 @@ public class WebSearchConfiguration {
 
     private final FlowController flowController;
 
-    private final ComponentSearchResultEnricherFactory resultEnricherFactory;
-
     public WebSearchConfiguration(
             final Authorizer authorizer,
-            final FlowController flowController,
-            final ComponentSearchResultEnricherFactory resultEnricherFactory
+            final FlowController flowController
     ) {
         this.authorizer = authorizer;
         this.flowController = flowController;
-        this.resultEnricherFactory = resultEnricherFactory;
+    }
+
+    @Bean
+    public ComponentSearchResultEnricherFactory resultEnricherFactory() {
+        final ComponentSearchResultEnricherFactory factory = new ComponentSearchResultEnricherFactory();
+        factory.setAuthorizer(authorizer);
+        return factory;
     }
 
     @Bean
@@ -76,7 +79,7 @@ public class WebSearchConfiguration {
 
         controllerSearchService.setAuthorizer(authorizer);
         controllerSearchService.setFlowController(flowController);
-        controllerSearchService.setResultEnricherFactory(resultEnricherFactory);
+        controllerSearchService.setResultEnricherFactory(resultEnricherFactory());
         final ComponentMatcherFactory factory = new ComponentMatcherFactory();
 
         controllerSearchService.setMatcherForConnection(factory.getInstanceForConnection(


### PR DESCRIPTION
# Summary

[NIFI-13609](https://issues.apache.org/jira/browse/NIFI-13609) Corrects the Component Search configuration definitions to avoid failures when using the search field in the web user interface.

Changes include removing a duplicate Controller Search Service bean definition and wiring in the correct Controller Search Service to the Controller Facade bean definition.

This issue does not impact released versions and was a result of recent changes with Spring Framework configuration refactoring.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
