### PR TITLE
[NIFI-13621] - UI - handle backend errors when hitting the search api

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/search/search.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/search/search.component.html
@@ -20,6 +20,7 @@
     <form [formGroup]="searchForm">
         <ng-template
             cdkConnectedOverlay
+            [cdkConnectedOverlayDisableClose]="true"
             [cdkConnectedOverlayOrigin]="searchInput"
             [cdkConnectedOverlayOpen]="searching || searchingResultsVisible"
             [cdkConnectedOverlayPositions]="positions"
@@ -180,6 +181,7 @@
             matInput
             placeholder="Search"
             class="search-input surface-contrast"
+            (keydown)="onKeydown($event)"
             [class.open]="searchInputVisible"
             cdkOverlayOrigin
             #searchInput="cdkOverlayOrigin"


### PR DESCRIPTION
[NIFI-13621](https://issues.apache.org/jira/browse/NIFI-13621)

If there is an error from the search API, handle it by showing the error in a snackbar or fullscreen depending on the type.

Also fixed an issue with escape closing the search results and then not being able to open them back up again.