### PR TITLE
NIFI-13611 Reuse shared proxy header handling for Content Viewer

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/pom.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/pom.xml
@@ -73,6 +73,11 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope> <!-- expected to be provided by parent classloader -->
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-web-servlet-shared</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/src/main/java/org/apache/nifi/web/ContentViewerController.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-content-viewer/src/main/java/org/apache/nifi/web/ContentViewerController.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.authorization.AccessDeniedException;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.apache.nifi.web.ViewableContent.DisplayMode;
+import org.apache.nifi.web.servlet.shared.RequestUriBuilder;
 import org.apache.tika.detect.DefaultDetector;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -57,11 +58,7 @@ public class ContentViewerController extends HttpServlet {
     // 1.5kb - multiple of 12 (3 bytes = 4 base 64 encoded chars)
     private final static int BUFFER_LENGTH = 1536;
 
-    private static final String PROXY_CONTEXT_PATH_HTTP_HEADER = "X-ProxyContextPath";
-    private static final String FORWARDED_CONTEXT_HTTP_HEADER = "X-Forwarded-Context";
-    private static final String FORWARDED_PREFIX_HTTP_HEADER = "X-Forwarded-Prefix";
-
-  /**
+    /**
      * Gets the content and defers to registered viewers to generate the markup.
      *
      * @param request servlet request
@@ -263,23 +260,11 @@ public class ContentViewerController extends HttpServlet {
      */
     private ContentRequestContext getContentRequest(final HttpServletRequest request) {
         final String ref = request.getParameter("ref");
+        final URI inputRefUri = UriBuilder.fromUri(ref).build();
+        final URI dataUri = RequestUriBuilder.fromHttpServletRequest(request).path(inputRefUri.getPath()).build();
+
         final String clientId = request.getParameter("clientId");
-
-        final UriBuilder refUriBuilder = UriBuilder.fromUri(ref);
-
-        // base the data ref on the request parameter but ensure the scheme is based off the incoming request...
-        // this is necessary for scenario's where the NiFi instance is behind a proxy running a different scheme
-        refUriBuilder.scheme(request.getScheme());
-
-        // If there is path context from a proxy, remove it since this request will be used inside the cluster
-        final String proxyContextPath = getFirstHeaderValue(request, PROXY_CONTEXT_PATH_HTTP_HEADER, FORWARDED_CONTEXT_HTTP_HEADER, FORWARDED_PREFIX_HTTP_HEADER);
-        if (StringUtils.isNotBlank(proxyContextPath)) {
-            refUriBuilder.replacePath(StringUtils.substringAfter(UriBuilder.fromUri(ref).build().getPath(), proxyContextPath));
-        }
-
-        final URI refUri = refUriBuilder.build();
-
-        final String query = refUri.getQuery();
+        final String query = inputRefUri.getQuery();
 
         String rawClusterNodeId = null;
         if (query != null) {
@@ -296,7 +281,7 @@ public class ContentViewerController extends HttpServlet {
         return new ContentRequestContext() {
             @Override
             public String getDataUri() {
-                return refUri.toString();
+                return dataUri.toString();
             }
 
             @Override
@@ -309,30 +294,5 @@ public class ContentViewerController extends HttpServlet {
                 return clientId;
             }
         };
-    }
-
-    /**
-     * Returns the value for the first key discovered when inspecting the current request. Will
-     * return null if there are no keys specified or if none of the specified keys are found.
-     *
-     * @param keys http header keys
-     * @return the value for the first key found
-     */
-    private String getFirstHeaderValue(HttpServletRequest httpServletRequest, final String... keys) {
-        if (keys == null) {
-            return null;
-        }
-
-        for (final String key : keys) {
-            final String value = httpServletRequest.getHeader(key);
-
-            // if we found an entry for this key, return the value
-            if (value != null) {
-                return value;
-            }
-        }
-
-        // unable to find any matching keys
-        return null;
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-13611](https://issues.apache.org/jira/browse/NIFI-13611) Refactors the `ContentViewerController` to use the shared `RequestUriBuilder` from `nifi-web-servlet-shared` to prepare the data reference URI. This avoids duplicate code and ensures consistent handling when NiFi is running behind a reverse proxy server.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
