### PR TITLE
NIFI-13614: populate failure cause in ack response

### DIFF
--- a/c2/c2-client-bundle/c2-client-api/src/main/java/org/apache/nifi/c2/client/api/C2Client.java
+++ b/c2/c2-client-bundle/c2-client-api/src/main/java/org/apache/nifi/c2/client/api/C2Client.java
@@ -85,7 +85,7 @@ public interface C2Client {
      *
      * @param absoluteUrl absolute url sent by C2 server
      * @param relativeUrl relative url sent by C2 server
-     * @return an optional with content of finalised callback url
+     * @return finalised callback url
      */
-    Optional<String> getCallbackUrl(String absoluteUrl, String relativeUrl);
+    String getCallbackUrl(String absoluteUrl, String relativeUrl);
 }

--- a/c2/c2-client-bundle/c2-client-http/src/main/java/org/apache/nifi/c2/client/http/C2HttpClient.java
+++ b/c2/c2-client-bundle/c2-client-http/src/main/java/org/apache/nifi/c2/client/http/C2HttpClient.java
@@ -146,7 +146,7 @@ public class C2HttpClient implements C2Client {
     }
 
     @Override
-    public Optional<String> getCallbackUrl(String absoluteUrl, String relativeUrl) {
+    public String getCallbackUrl(String absoluteUrl, String relativeUrl) {
         return c2UrlProvider.getCallbackUrl(absoluteUrl, relativeUrl);
     }
 

--- a/c2/c2-client-bundle/c2-client-http/src/main/java/org/apache/nifi/c2/client/http/url/C2UrlProvider.java
+++ b/c2/c2-client-bundle/c2-client-http/src/main/java/org/apache/nifi/c2/client/http/url/C2UrlProvider.java
@@ -17,8 +17,6 @@
 
 package org.apache.nifi.c2.client.http.url;
 
-import java.util.Optional;
-
 public interface C2UrlProvider {
 
     /**
@@ -42,5 +40,5 @@ public interface C2UrlProvider {
      * @param relativeUrl relative url sent by the C2 server
      * @return the url of the C2 server to send requests to
      */
-    Optional<String> getCallbackUrl(String absoluteUrl, String relativeUrl);
+    String getCallbackUrl(String absoluteUrl, String relativeUrl);
 }

--- a/c2/c2-client-bundle/c2-client-http/src/main/java/org/apache/nifi/c2/client/http/url/LegacyC2UrlProvider.java
+++ b/c2/c2-client-bundle/c2-client-http/src/main/java/org/apache/nifi/c2/client/http/url/LegacyC2UrlProvider.java
@@ -45,11 +45,12 @@ public class LegacyC2UrlProvider implements C2UrlProvider {
     }
 
     @Override
-    public Optional<String> getCallbackUrl(String absoluteUrl, String relativeUrl) {
-        Optional<String> url = Optional.ofNullable(absoluteUrl).filter(StringUtils::isNotBlank);
-        if (!url.isPresent()) {
-            LOG.error("Provided absolute url was empty or null. Relative urls are not supported with this configuration");
-        }
-        return url;
+    public String getCallbackUrl(String absoluteUrl, String relativeUrl) {
+        return Optional.ofNullable(absoluteUrl)
+                   .filter(StringUtils::isNotBlank)
+                   .orElseThrow( () -> {
+                      LOG.error("Provided absolute url was empty or null. Relative urls are not supported with this configuration");
+                      throw new IllegalArgumentException("Provided absolute url was empty or null. Relative C2 urls are not supported with this configuration");
+                   });
     }
 }

--- a/c2/c2-client-bundle/c2-client-http/src/main/java/org/apache/nifi/c2/client/http/url/ProxyAwareC2UrlProvider.java
+++ b/c2/c2-client-bundle/c2-client-http/src/main/java/org/apache/nifi/c2/client/http/url/ProxyAwareC2UrlProvider.java
@@ -59,11 +59,12 @@ public class ProxyAwareC2UrlProvider implements C2UrlProvider {
     }
 
     @Override
-    public Optional<String> getCallbackUrl(String absoluteUrl, String relativeUrl) {
+    public String getCallbackUrl(String absoluteUrl, String relativeUrl) {
         return Optional.ofNullable(relativeUrl)
             .map(this::toAbsoluteUrl)
             .filter(Optional::isPresent)
-            .orElseGet(() -> Optional.ofNullable(absoluteUrl).filter(StringUtils::isNotBlank));
+            .orElseGet(() -> Optional.ofNullable(absoluteUrl).filter(StringUtils::isNotBlank))
+            .orElseThrow(() -> new IllegalArgumentException("Unable to return non empty c2 url."));
     }
 
     private Optional<String> toAbsoluteUrl(String path) {

--- a/c2/c2-client-bundle/c2-client-http/src/test/java/org/apache/nifi/c2/client/http/url/LegacyC2UrlProviderTest.java
+++ b/c2/c2-client-bundle/c2-client-http/src/test/java/org/apache/nifi/c2/client/http/url/LegacyC2UrlProviderTest.java
@@ -18,6 +18,7 @@
 package org.apache.nifi.c2.client.http.url;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -33,6 +34,9 @@ public class LegacyC2UrlProviderTest {
 
     private static final String C2_HEARTBEAT_URL = "https://host:8080/c2/api/heartbeat";
     private static final String C2_ACKNOWLEDGE_URL = "https://host:8080/c2/api/acknowledge";
+    private static final String ABSOLUTE_URL = "http://c2/api/callback";
+    private static final String RELATIVE_URL = "any_url";
+    private static final String EXPECTED_URL = "http://c2/api/callback";
 
     @Test
     public void testProviderIsCreatedAndReturnsProperHeartbeatAndAcknowledgeUrls() {
@@ -44,9 +48,15 @@ public class LegacyC2UrlProviderTest {
 
     @MethodSource("testCallbackUrlProvidedArguments")
     @ParameterizedTest(name = "{index} => absoluteUrl={0}, relativeUrl={1}, expectedCallbackUrl={2}")
-    public void testCallbackUrlProvidedFor(String absoluteUrl, String relativeUrl, Optional<String> expectedCallbackUrl) {
+    public void testCallbackUrlProvidedForInvalidInputs(String absoluteUrl, String relativeUrl) {
         LegacyC2UrlProvider testProvider = new LegacyC2UrlProvider(C2_HEARTBEAT_URL, C2_ACKNOWLEDGE_URL);
-        assertEquals(expectedCallbackUrl, testProvider.getCallbackUrl(absoluteUrl, relativeUrl));
+        assertThrows(IllegalArgumentException.class, () -> testProvider.getCallbackUrl(absoluteUrl, relativeUrl));
+    }
+
+    @Test
+    public void testCallbackUrlProvidedFor() {
+        LegacyC2UrlProvider testProvider = new LegacyC2UrlProvider(C2_HEARTBEAT_URL, C2_ACKNOWLEDGE_URL);
+        assertEquals(EXPECTED_URL, testProvider.getCallbackUrl(ABSOLUTE_URL, RELATIVE_URL));
     }
 
     private static Stream<Arguments> testCallbackUrlProvidedArguments() {
@@ -54,8 +64,7 @@ public class LegacyC2UrlProviderTest {
             Arguments.of(null, null, Optional.empty()),
             Arguments.of(null, "any_url", Optional.empty()),
             Arguments.of("", "", Optional.empty()),
-            Arguments.of("", "any_url", Optional.empty()),
-            Arguments.of("http://c2/api/callback", "any_url", Optional.of("http://c2/api/callback"))
+            Arguments.of("", "any_url", Optional.empty())
         );
     }
 }

--- a/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/c2/client/service/operation/DescribeManifestOperationHandler.java
+++ b/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/c2/client/service/operation/DescribeManifestOperationHandler.java
@@ -20,6 +20,7 @@ package org.apache.nifi.c2.client.service.operation;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.nifi.c2.protocol.api.C2OperationState.OperationState.FULLY_APPLIED;
+import static org.apache.nifi.c2.protocol.api.C2OperationState.OperationState.NOT_APPLIED;
 import static org.apache.nifi.c2.protocol.api.OperandType.MANIFEST;
 import static org.apache.nifi.c2.protocol.api.OperationType.DESCRIBE;
 
@@ -33,12 +34,16 @@ import org.apache.nifi.c2.protocol.api.C2Operation;
 import org.apache.nifi.c2.protocol.api.C2OperationAck;
 import org.apache.nifi.c2.protocol.api.OperandType;
 import org.apache.nifi.c2.protocol.api.OperationType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DescribeManifestOperationHandler implements C2OperationHandler {
 
+    private static final String ERROR_MESSAGE = "Failed to execute manifest describe operation.";
     private final C2HeartbeatFactory heartbeatFactory;
     private final Supplier<RuntimeInfoWrapper> runtimeInfoSupplier;
     private final OperandPropertiesProvider operandPropertiesProvider;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DescribeManifestOperationHandler.class);
 
     public DescribeManifestOperationHandler(C2HeartbeatFactory heartbeatFactory, Supplier<RuntimeInfoWrapper> runtimeInfoSupplier,
                                             OperandPropertiesProvider operandPropertiesProvider) {
@@ -60,15 +65,20 @@ public class DescribeManifestOperationHandler implements C2OperationHandler {
     @Override
     public C2OperationAck handle(C2Operation operation) {
         String operationId = ofNullable(operation.getIdentifier()).orElse(EMPTY);
+        C2OperationAck c2OperationAck;
+        try {
+            RuntimeInfoWrapper runtimeInfoWrapper = runtimeInfoSupplier.get();
+            C2Heartbeat heartbeat = heartbeatFactory.create(runtimeInfoWrapper);
 
-        RuntimeInfoWrapper runtimeInfoWrapper = runtimeInfoSupplier.get();
-        C2Heartbeat heartbeat = heartbeatFactory.create(runtimeInfoWrapper);
-
-        C2OperationAck c2OperationAck = operationAck(operationId, operationState(FULLY_APPLIED, EMPTY));
-        c2OperationAck.setAgentInfo(agentInfo(heartbeat, runtimeInfoWrapper));
-        c2OperationAck.setDeviceInfo(heartbeat.getDeviceInfo());
-        c2OperationAck.setFlowInfo(heartbeat.getFlowInfo());
-        c2OperationAck.setResourceInfo(heartbeat.getResourceInfo());
+            c2OperationAck = operationAck(operationId, operationState(FULLY_APPLIED, EMPTY));
+            c2OperationAck.setAgentInfo(agentInfo(heartbeat, runtimeInfoWrapper));
+            c2OperationAck.setDeviceInfo(heartbeat.getDeviceInfo());
+            c2OperationAck.setFlowInfo(heartbeat.getFlowInfo());
+            c2OperationAck.setResourceInfo(heartbeat.getResourceInfo());
+        } catch (Exception e) {
+            LOGGER.error(ERROR_MESSAGE, e);
+            c2OperationAck = operationAck(operationId, operationState(NOT_APPLIED, ERROR_MESSAGE, e));
+        }
 
         return c2OperationAck;
     }

--- a/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/c2/client/service/operation/SyncResourceStrategy.java
+++ b/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/c2/client/service/operation/SyncResourceStrategy.java
@@ -31,5 +31,5 @@ public interface SyncResourceStrategy {
 
     OperationState synchronizeResourceRepository(ResourcesGlobalHash resourcesGlobalHash, List<ResourceItem> c2ServerItems,
                                                  BiFunction<String, Function<InputStream, Optional<Path>>, Optional<Path>> resourceDownloadFunction,
-                                                 Function<String, Optional<String>> urlEnrichFunction);
+                                                 Function<String, String> urlEnrichFunction);
 }

--- a/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/c2/client/service/operation/UpdateConfigurationStrategy.java
+++ b/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/c2/client/service/operation/UpdateConfigurationStrategy.java
@@ -27,7 +27,7 @@ public interface UpdateConfigurationStrategy {
      * Updates the MiNiFi agent's flow with the flow passed as parameter
      *
      * @param flow the MiNiFi flow config JSON represented as a byte array
-     * @return true if the flow update was true, false otherwise
+     * @throw exception if update failed.
      */
-    boolean update(byte[] flow);
+    void update(byte[] flow);
 }

--- a/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/minifi/validator/ValidationException.java
+++ b/c2/c2-client-bundle/c2-client-service/src/main/java/org/apache/nifi/minifi/validator/ValidationException.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.nifi.minifi.validator;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.nifi.components.ValidationResult;
+
+public class ValidationException extends IllegalStateException {
+    private List<ValidationResult> validationResults;
+
+    public ValidationException(String message, List<ValidationResult> details) {
+        super(message);
+        this.validationResults = details;
+    }
+
+    public List<ValidationResult> getValidationResults() {
+        return validationResults;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ValidationException that = (ValidationException) o;
+        return Objects.equals(validationResults, that.validationResults);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(validationResults);
+    }
+
+    @Override
+    public String toString() {
+        return "ValidationException{" +
+                "validationResults=" + validationResults +
+                "message=" + this.getMessage() +
+                '}';
+    }
+}

--- a/c2/c2-client-bundle/c2-client-service/src/test/java/org/apache/nifi/c2/client/service/operation/TransferDebugOperationHandlerTest.java
+++ b/c2/c2-client-bundle/c2-client-service/src/test/java/org/apache/nifi/c2/client/service/operation/TransferDebugOperationHandlerTest.java
@@ -51,7 +51,6 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -139,7 +138,7 @@ public class TransferDebugOperationHandlerTest {
             .collect(toList());
         TransferDebugOperationHandler testHandler = TransferDebugOperationHandler.create(c2Client, operandPropertiesProvider, createBundleFiles, DEFAULT_CONTENT_FILTER);
         C2Operation c2Operation = operation(C2_DEBUG_UPLOAD_ENDPOINT);
-        when(c2Client.getCallbackUrl(any(), any())).thenReturn(Optional.of(C2_DEBUG_UPLOAD_ENDPOINT));
+        when(c2Client.getCallbackUrl(any(), any())).thenReturn(C2_DEBUG_UPLOAD_ENDPOINT);
 
         // when
         C2OperationAck result = testHandler.handle(c2Operation);
@@ -200,7 +199,7 @@ public class TransferDebugOperationHandlerTest {
         Predicate<String> testContentFilter = content -> !content.contains(filterKeyword);
         TransferDebugOperationHandler testHandler = TransferDebugOperationHandler.create(c2Client, operandPropertiesProvider, singletonList(bundleFile), testContentFilter);
         C2Operation c2Operation = operation(C2_DEBUG_UPLOAD_ENDPOINT);
-        when(c2Client.getCallbackUrl(any(), any())).thenReturn(Optional.of(C2_DEBUG_UPLOAD_ENDPOINT));
+        when(c2Client.getCallbackUrl(any(), any())).thenReturn(C2_DEBUG_UPLOAD_ENDPOINT);
 
         // when
         C2OperationAck result = testHandler.handle(c2Operation);

--- a/c2/c2-client-bundle/c2-client-service/src/test/java/org/apache/nifi/c2/client/service/operation/UpdateAssetOperationHandlerTest.java
+++ b/c2/c2-client-bundle/c2-client-service/src/test/java/org/apache/nifi/c2/client/service/operation/UpdateAssetOperationHandlerTest.java
@@ -94,7 +94,7 @@ public class UpdateAssetOperationHandlerTest {
 
     @BeforeEach
     public void setup() {
-        lenient().when(c2Client.getCallbackUrl(any(), any())).thenReturn(Optional.of(ASSET_URL));
+        lenient().when(c2Client.getCallbackUrl(any(), any())).thenReturn(ASSET_URL);
     }
 
     @ParameterizedTest(name = "c2Client={0} operandPropertiesProvider={1} bundleFileList={2} contentFilter={3}")
@@ -115,7 +115,7 @@ public class UpdateAssetOperationHandlerTest {
     public void testAssetUrlCanNotBeNull() {
         // given
         C2Operation operation = operation(null, ASSET_FILE_NAME, FORCE_DOWNLOAD);
-        when(c2Client.getCallbackUrl(any(), any())).thenReturn(Optional.empty());
+        when(c2Client.getCallbackUrl(any(), any())).thenThrow(new IllegalArgumentException());
 
         // when
         C2OperationAck result = testHandler.handle(operation);

--- a/c2/c2-protocol/c2-protocol-api/src/main/java/org/apache/nifi/c2/protocol/api/C2OperationState.java
+++ b/c2/c2-protocol/c2-protocol-api/src/main/java/org/apache/nifi/c2/protocol/api/C2OperationState.java
@@ -42,6 +42,17 @@ public class C2OperationState implements Serializable {
     @Schema(description = "Additional details about the state")
     private String details;
 
+    @Schema(description = "Additional details about the cause of the failure")
+    private FailureCause failureCause;
+
+    public FailureCause getFailureCause() {
+        return failureCause;
+    }
+
+    public void setFailureCause(FailureCause failureCause) {
+        this.failureCause = failureCause;
+    }
+
     public String getDetails() {
         return details;
     }
@@ -76,12 +87,12 @@ public class C2OperationState implements Serializable {
             return false;
         }
         C2OperationState that = (C2OperationState) o;
-        return state == that.state && Objects.equals(details, that.details);
+        return state == that.state && Objects.equals(details, that.details) && Objects.equals(failureCause, that.failureCause);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(state, details);
+        return Objects.hash(state, details, failureCause);
     }
 
     @Override
@@ -89,6 +100,7 @@ public class C2OperationState implements Serializable {
         return "C2OperationState{" +
             "state=" + state +
             ", details='" + details + '\'' +
+            ", failureCause='" + failureCause + '\'' +
             '}';
     }
 

--- a/c2/c2-protocol/c2-protocol-api/src/main/java/org/apache/nifi/c2/protocol/api/FailureCause.java
+++ b/c2/c2-protocol/c2-protocol-api/src/main/java/org/apache/nifi/c2/protocol/api/FailureCause.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.nifi.c2.protocol.api;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.nifi.components.ValidationResult;
+
+public class FailureCause {
+    private List<ValidationResult> validationResults;
+    private String exceptionMessage;
+    private List<String> causedByMessages;
+
+    public List<ValidationResult> getValidationResults() {
+        return validationResults;
+    }
+
+    public void setValidationResults(List<ValidationResult> validationResults) {
+        this.validationResults = validationResults;
+    }
+
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public void setExceptionMessage(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    public List<String> getCausedByMessages() {
+        return causedByMessages;
+    }
+
+    public void setCausedByMessages(List<String> causedByMessages) {
+        this.causedByMessages = causedByMessages;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FailureCause that = (FailureCause) o;
+        return Objects.equals(validationResults, that.validationResults) && Objects.equals(exceptionMessage, that.exceptionMessage) && Objects.equals(causedByMessages, that.causedByMessages);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(validationResults, exceptionMessage, causedByMessages);
+    }
+}

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/DefaultUpdateConfigurationStrategyTest.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/DefaultUpdateConfigurationStrategyTest.java
@@ -127,10 +127,9 @@ public class DefaultUpdateConfigurationStrategyTest {
         when(mockFlowManager.getRootGroup()).thenReturn(mockProcessGroup);
 
         // when
-        boolean result = testUpdateConfigurationStrategy.update(NEW_RAW_FLOW_CONFIG_CONTENT);
+        testUpdateConfigurationStrategy.update(NEW_RAW_FLOW_CONFIG_CONTENT);
 
         //then
-        assertTrue(result);
         assertTrue(exists(flowConfigurationFile));
         assertTrue(exists(rawFlowConfigurationFile));
         assertArrayEquals(NEW_ENRICHED_FLOW_CONFIG_CONTENT, readGzipFile(flowConfigurationFile));
@@ -155,19 +154,20 @@ public class DefaultUpdateConfigurationStrategyTest {
         doThrow(new IOException()).when(mockFlowService).load(null);
 
         // when
-        boolean result = testUpdateConfigurationStrategy.update(NEW_RAW_FLOW_CONFIG_CONTENT);
-
-        //then
-        assertFalse(result);
-        assertTrue(exists(flowConfigurationFile));
-        assertTrue(exists(rawFlowConfigurationFile));
-        assertArrayEquals(ORIGINAL_ENRICHED_FLOW_CONFIG_CONTENT, readGzipFile(flowConfigurationFile));
-        assertArrayEquals(ORIGINAL_RAW_FLOW_CONFIG_CONTENT, readPlainTextFile(rawFlowConfigurationFile));
-        assertFalse(exists(backupFlowConfigurationFile));
-        assertFalse(exists(backupRawFlowConfigurationFile));
-        verify(mockFlowService, times(1)).load(null);
-        verify(mockFlowController, times(0)).onFlowInitialized(true);
-        verify(mockProcessGroup, times(0)).startProcessing();
+        try {
+            testUpdateConfigurationStrategy.update(NEW_RAW_FLOW_CONFIG_CONTENT);
+        } catch (Exception e) {
+            //then
+            assertTrue(exists(flowConfigurationFile));
+            assertTrue(exists(rawFlowConfigurationFile));
+            assertArrayEquals(ORIGINAL_ENRICHED_FLOW_CONFIG_CONTENT, readGzipFile(flowConfigurationFile));
+            assertArrayEquals(ORIGINAL_RAW_FLOW_CONFIG_CONTENT, readPlainTextFile(rawFlowConfigurationFile));
+            assertFalse(exists(backupFlowConfigurationFile));
+            assertFalse(exists(backupRawFlowConfigurationFile));
+            verify(mockFlowService, times(1)).load(null);
+            verify(mockFlowController, times(0)).onFlowInitialized(true);
+            verify(mockProcessGroup, times(0)).startProcessing();
+        }
     }
 
     private void writeGzipFile(Path path, byte[] content) throws IOException {

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/syncresource/DefaultSyncResourceStrategyTest.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/syncresource/DefaultSyncResourceStrategyTest.java
@@ -70,7 +70,7 @@ public class DefaultSyncResourceStrategyTest {
         (url, persistFunction) -> url.endsWith(FAIL_DOWNLOAD_URL) ? empty() : persistFunction.apply(new ByteArrayInputStream(url.getBytes()));
 
     private static String ENRICH_PREFIX = "pre_";
-    private static final Function<String, Optional<String>> PREFIXING_ENRICH_FUNCTION = url -> ofNullable(url).map(arg -> ENRICH_PREFIX + arg);
+    private static final Function<String, String> PREFIXING_ENRICH_FUNCTION = url -> ofNullable(url).map(arg -> ENRICH_PREFIX + arg).orElse("");
 
     @Mock
     private ResourceRepository mockResourceRepository;


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13614](https://issues.apache.org/jira/browse/NIFI-13614)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
