### PR TITLE
NIFI-13622 Correct Logout Complete Redirect for Proxies

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/pom.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/pom.xml
@@ -86,6 +86,11 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-web-servlet-shared</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/filter/LogoutCompleteRedirectFilter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/filter/LogoutCompleteRedirectFilter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.server.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.nifi.web.servlet.shared.RequestUriBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Logout Complete Redirect Filter for web user interface integration with fragment-based routing
+ */
+public class LogoutCompleteRedirectFilter implements Filter {
+    private static final String LOGOUT_COMPLETE_PATH = "/nifi/logout-complete";
+
+    private static final String USER_INTERFACE_PATH = "/nifi/";
+
+    private static final String FRAGMENT_PATH = "/logout-complete";
+
+    @Override
+    public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse, final FilterChain filterChain) throws IOException, ServletException {
+        if (servletRequest instanceof HttpServletRequest httpServletRequest) {
+            final String requestUri = httpServletRequest.getRequestURI();
+            if (requestUri.endsWith(LOGOUT_COMPLETE_PATH)) {
+                final HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
+                doRedirect(httpServletRequest, httpServletResponse);
+            } else {
+                filterChain.doFilter(servletRequest, servletResponse);
+            }
+        } else {
+            filterChain.doFilter(servletRequest, servletResponse);
+        }
+    }
+
+    private void doRedirect(final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse) throws IOException {
+        final URI redirectUri = RequestUriBuilder.fromHttpServletRequest(httpServletRequest)
+                .path(USER_INTERFACE_PATH)
+                .fragment(FRAGMENT_PATH)
+                .build();
+        final String redirectLocation = redirectUri.toString();
+        httpServletResponse.sendRedirect(redirectLocation);
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/filter/LogoutCompleteRedirectFilterTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/filter/LogoutCompleteRedirectFilterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.server.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class LogoutCompleteRedirectFilterTest {
+    private static final String LOGOUT_COMPLETE_URI = "/nifi/logout-complete";
+
+    private static final String ROOT_URI = "/nifi/";
+
+    private static final String ALLOWED_CONTEXT_PATHS_PARAMETER = "allowedContextPaths";
+
+    private static final String FORWARDED_PATH = "/forwarded";
+
+    private static final String LOGOUT_COMPLETE_EXPECTED = "/forwarded/nifi/#/logout-complete";
+
+    private static final String CONTEXT_PATH_HEADER = "X-ProxyContextPath";
+
+    @Mock
+    private ServletContext servletContext;
+
+    @Mock
+    private FilterConfig filterConfig;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Captor
+    private ArgumentCaptor<String> redirectCaptor;
+
+    private LogoutCompleteRedirectFilter filter;
+
+    @BeforeEach
+    public void setFilter() throws ServletException {
+        filter = new LogoutCompleteRedirectFilter();
+        filter.init(filterConfig);
+    }
+
+    @Test
+    public void testDoFilter() throws ServletException, IOException {
+        when(request.getRequestURI()).thenReturn(ROOT_URI);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(response, never()).sendRedirect(anyString());
+    }
+
+    @Test
+    public void testDoFilterLogoutComplete() throws ServletException, IOException {
+        when(request.getRequestURI()).thenReturn(LOGOUT_COMPLETE_URI);
+        when(request.getServletContext()).thenReturn(servletContext);
+        when(servletContext.getInitParameter(eq(ALLOWED_CONTEXT_PATHS_PARAMETER))).thenReturn(FORWARDED_PATH);
+        when(request.getHeader(eq(CONTEXT_PATH_HEADER))).thenReturn(FORWARDED_PATH);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(response).sendRedirect(redirectCaptor.capture());
+
+        final String redirect = redirectCaptor.getValue();
+        assertEquals(LOGOUT_COMPLETE_EXPECTED, redirect);
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-13622](https://issues.apache.org/jira/browse/NIFI-13622) Corrects core framework redirect handling for logout completion requests when NiFi is deployed behind a reverse proxy server with an alternative context path.

The initial implementation works as expected when the context path is unchanged, but the Jetty Redirect Pattern Rule does not account for the custom forwarded context path headers. Refactoring the approach to use a Servlet Filter based on the shared `RedirectUriHandler` from `nifi-web-servlet-shared` ensures correct redirect URI construction.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
