### PR TITLE
NIFI-13625 Removed System.out.println from unit and integration test either entirely or replaced them with logging statements.

### DIFF
--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/RestChangeIngestorCommonTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/RestChangeIngestorCommonTest.java
@@ -20,7 +20,6 @@ package org.apache.nifi.minifi.bootstrap.configuration.ingestors;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
-import okhttp3.Headers;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -68,11 +67,6 @@ public abstract class RestChangeIngestorCommonTest {
                 throw new IOException("Unexpected code " + response);
             }
 
-            Headers responseHeaders = response.headers();
-            for (int i = 0; i < responseHeaders.size(); i++) {
-                System.out.println(responseHeaders.name(i) + ": " + responseHeaders.value(i));
-            }
-
             assertEquals(RestChangeIngestor.GET_TEXT, response.body().string());
             verify(testNotifier, Mockito.never()).notifyListeners(Mockito.any(ByteBuffer.class));
         }
@@ -91,11 +85,6 @@ public abstract class RestChangeIngestorCommonTest {
         try (Response response = client.newCall(request).execute()) {
             if (!response.isSuccessful()) {
                 throw new IOException("Unexpected code " + response);
-            }
-
-            Headers responseHeaders = response.headers();
-            for (int i = 0; i < responseHeaders.size(); i++) {
-                System.out.println(responseHeaders.name(i) + ": " + responseHeaders.value(i));
             }
 
             assertEquals("The result of notifying listeners:\nMockChangeListener successfully handled the configuration change\n", response.body().string());
@@ -117,11 +106,6 @@ public abstract class RestChangeIngestorCommonTest {
         try (Response response = client.newCall(request).execute()) {
             if (response.isSuccessful()) {
                 throw new IOException("Unexpected code " + response);
-            }
-
-            Headers responseHeaders = response.headers();
-            for (int i = 0; i < responseHeaders.size(); i++) {
-                System.out.println(responseHeaders.name(i) + ": " + responseHeaders.value(i));
             }
 
             assertEquals("Request received but instance is already running this config.", response.body().string());

--- a/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/OrderedPropertiesTest.java
+++ b/minifi/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/OrderedPropertiesTest.java
@@ -50,8 +50,6 @@ public class OrderedPropertiesTest {
                 String actualLine = actualReader.readLine();
                 if (!"#Tue Feb 21 11:03:08 EST 2017".equals(expectedLine)) {
                     assertEquals(expectedLine, actualLine);
-                } else {
-                    System.out.println("Skipping timestamp comment line");
                 }
             }
             assertNull(actualReader.readLine());

--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestStandardPreparedQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestStandardPreparedQuery.java
@@ -21,6 +21,8 @@ import org.apache.nifi.parameter.ParameterDescriptor;
 import org.apache.nifi.parameter.ParameterLookup;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,6 +40,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestStandardPreparedQuery {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestStandardPreparedQuery.class);
 
     @Test
     public void testSimpleReference() {
@@ -69,7 +73,7 @@ public class TestStandardPreparedQuery {
             assertEquals("world", prepared.evaluateExpressions(new StandardEvaluationContext(attrs), null));
         }
         final long nanos = System.nanoTime() - start;
-        System.out.println(TimeUnit.NANOSECONDS.toMillis(nanos));
+        logger.info("{}", TimeUnit.NANOSECONDS.toMillis(nanos));
     }
 
     @Test
@@ -83,8 +87,7 @@ public class TestStandardPreparedQuery {
             assertEquals("world", Query.evaluateExpressions("${xx}", attrs, ParameterLookup.EMPTY));
         }
         final long nanos = System.nanoTime() - start;
-        System.out.println(TimeUnit.NANOSECONDS.toMillis(nanos));
-
+        logger.info("{}", TimeUnit.NANOSECONDS.toMillis(nanos));
     }
 
     @Test

--- a/nifi-commons/nifi-hl7-query-language/src/test/java/org/apache/nifi/hl7/query/TestHL7Query.java
+++ b/nifi-commons/nifi-hl7-query-language/src/test/java/org/apache/nifi/hl7/query/TestHL7Query.java
@@ -89,10 +89,6 @@ public class TestHL7Query {
         possibleValueMap.put("C", valuesC);
         possibleValueMap.put("D", valuesD);
 
-        for (int i = 0; i < valuesA.size() * valuesB.size() * valuesC.size() * valuesD.size(); i++) {
-            System.out.println(i + " : " + HL7Query.assignAliases(possibleValueMap, i));
-        }
-
         verifyAssignments(HL7Query.assignAliases(possibleValueMap, 0), "a", "d", "e", "g");
         verifyAssignments(HL7Query.assignAliases(possibleValueMap, 1), "b", "d", "e", "g");
         verifyAssignments(HL7Query.assignAliases(possibleValueMap, 2), "c", "d", "e", "g");

--- a/nifi-commons/nifi-security-kerberos/src/test/java/org/apache/nifi/security/krb/KerberosUserIT.java
+++ b/nifi-commons/nifi-security-kerberos/src/test/java/org/apache/nifi/security/krb/KerberosUserIT.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosPrincipal;
@@ -42,6 +44,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KerberosUserIT {
+    private static final Logger logger = LoggerFactory.getLogger(KerberosUserIT.class);
+
     private static KDCServer kdc;
 
     private static KerberosPrincipal principal1;
@@ -155,11 +159,11 @@ public class KerberosUserIT {
         boolean performedRelogin = false;
         for (int i = 0; i < 30; i++) {
             Thread.sleep(1000);
-            System.out.println("checkTGTAndRelogin #" + i);
+            logger.info("checkTGTAndRelogin #{}", i);
             performedRelogin = user1.checkTGTAndRelogin();
 
             if (performedRelogin) {
-                System.out.println("Performed relogin!");
+                logger.info("Performed relogin!");
                 break;
             }
         }
@@ -179,7 +183,7 @@ public class KerberosUserIT {
         long currentTimeMillis = System.currentTimeMillis();
         long startMilli = kerberosTicket.getStartTime().toInstant().toEpochMilli();
         long endMilli = kerberosTicket.getEndTime().toInstant().toEpochMilli();
-        System.out.println("New ticket is valid for " + TimeUnit.MILLISECONDS.toSeconds(endMilli - startMilli) + " seconds");
+        logger.info("New ticket is valid for {}", TimeUnit.MILLISECONDS.toSeconds(endMilli - startMilli) + " seconds");
         assertTrue(startMilli < currentTimeMillis);
         assertTrue(endMilli > currentTimeMillis);
     }

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/stream/io/TestLeakyBucketThrottler.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/stream/io/TestLeakyBucketThrottler.java
@@ -19,6 +19,8 @@ package org.apache.nifi.stream.io;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -34,6 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Disabled("Tests are time-based")
 public class TestLeakyBucketThrottler {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestLeakyBucketThrottler.class);
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
@@ -144,7 +148,7 @@ public class TestLeakyBucketThrottler {
             long millisElapsed = now - startMillis;
             bytesWritten += data.length;
             float bytesPerSec = (float) bytesWritten / (float) millisElapsed * 1000F;
-            System.out.println(idx + " : copied data at a rate of " + bytesPerSec + " bytes/sec");
+            logger.info("{} : copied data at a rate of {} bytes/sec", idx, bytesPerSec);
         }
     }
 

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/stream/io/util/TestLineDemarcator.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/stream/io/util/TestLineDemarcator.java
@@ -19,6 +19,8 @@ package org.apache.nifi.stream.io.util;
 import org.apache.nifi.stream.io.RepeatingInputStream;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -35,6 +37,8 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 
 public class TestLineDemarcator {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestLineDemarcator.class);
 
     @Test
     public void testSingleCharacterLines() throws IOException {
@@ -120,7 +124,7 @@ public class TestLineDemarcator {
             }
 
             final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-            System.out.println("Took " + millis + " millis to demarcate " + count + " lines");
+            logger.info("Took {} millis to demarcate {} lines", millis, count);
         }
     }
 

--- a/nifi-commons/nifi-write-ahead-log/src/test/java/org/apache/nifi/wali/TestSequentialAccessWriteAheadLog.java
+++ b/nifi-commons/nifi-write-ahead-log/src/test/java/org/apache/nifi/wali/TestSequentialAccessWriteAheadLog.java
@@ -20,6 +20,8 @@ package org.apache.nifi.wali;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wali.DummyRecord;
 import org.wali.DummyRecordSerde;
 import org.wali.SerDeFactory;
@@ -50,6 +52,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestSequentialAccessWriteAheadLog {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestSequentialAccessWriteAheadLog.class);
+
     @Test
     public void testUpdateWithExternalFile(TestInfo testInfo) throws IOException {
         final DummyRecordSerde serde = new DummyRecordSerde();
@@ -369,11 +374,11 @@ public class TestSequentialAccessWriteAheadLog {
             final String bps = NumberFormat.getInstance().format(bytesPerSecond);
 
             if (j == 0) {
-                System.out.println(millis + " ms to insert " + updateCountPerThread * numThreads + " updates using " + numThreads
-                    + " threads, *as a warmup!*  " + eps + " events per second, " + bps + " bytes per second");
+                logger.info("{} ms to insert {} updates using {} threads, *as a warmup!* {} events per second, {} bytes per second",
+                        millis, updateCountPerThread * numThreads, numThreads, eps, bps);
             } else {
-                System.out.println(millis + " ms to insert " + updateCountPerThread * numThreads + " updates using " + numThreads
-                    + " threads, " + eps + " events per second, " + bps + " bytes per second");
+                logger.info("{} ms to insert {} updates using {} threads, {} events per second, {} bytes per second",
+                        millis, updateCountPerThread * numThreads, numThreads, eps, bps);
             }
         }
     }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/dynamodb/PutDynamoDBTest.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/dynamodb/PutDynamoDBTest.java
@@ -169,7 +169,6 @@ public class PutDynamoDBTest extends AbstractDynamoDBTest {
 
         final List<MockFlowFile> flowFiles = putRunner.getFlowFilesForRelationship(AbstractDynamoDBProcessor.REL_SUCCESS);
         for (final MockFlowFile flowFile : flowFiles) {
-            System.out.println(flowFile.getAttributes());
             assertEquals(document, new String(flowFile.toByteArray()));
         }
     }
@@ -191,14 +190,12 @@ public class PutDynamoDBTest extends AbstractDynamoDBTest {
 
         final List<MockFlowFile> flowFilesFailed = putRunner.getFlowFilesForRelationship(AbstractDynamoDBProcessor.REL_FAILURE);
         for (final MockFlowFile flowFile : flowFilesFailed) {
-            System.out.println(flowFile.getAttributes());
             flowFile.assertAttributeExists(PutDynamoDB.AWS_DYNAMO_DB_ITEM_SIZE_ERROR);
             assertEquals(item.length, flowFile.getSize());
         }
 
         final List<MockFlowFile> flowFilesSuccessful = putRunner.getFlowFilesForRelationship(AbstractDynamoDBProcessor.REL_SUCCESS);
         for (final MockFlowFile flowFile : flowFilesSuccessful) {
-            System.out.println(flowFile.getAttributes());
             assertEquals(document, new String(flowFile.toByteArray()));
         }
     }
@@ -221,14 +218,12 @@ public class PutDynamoDBTest extends AbstractDynamoDBTest {
 
         final List<MockFlowFile> flowFilesFailed = putRunner.getFlowFilesForRelationship(AbstractDynamoDBProcessor.REL_FAILURE);
         for (final MockFlowFile flowFile : flowFilesFailed) {
-            System.out.println(flowFile.getAttributes());
             flowFile.assertAttributeExists(PutDynamoDB.AWS_DYNAMO_DB_ITEM_SIZE_ERROR);
             assertEquals(item.length, flowFile.getSize());
         }
 
         final List<MockFlowFile> flowFilesSuccessful = putRunner.getFlowFilesForRelationship(AbstractDynamoDBProcessor.REL_SUCCESS);
         for (final MockFlowFile flowFile : flowFilesSuccessful) {
-            System.out.println(flowFile.getAttributes());
             assertEquals(document, new String(flowFile.toByteArray()));
         }
     }
@@ -250,7 +245,6 @@ public class PutDynamoDBTest extends AbstractDynamoDBTest {
         final List<MockFlowFile> flowFiles = putRunner.getFlowFilesForRelationship(AbstractDynamoDBProcessor.REL_FAILURE);
         assertEquals(1, flowFiles.size());
         for (final MockFlowFile flowFile : flowFiles) {
-            System.out.println(flowFile.getAttributes());
             flowFile.assertAttributeExists(PutDynamoDB.AWS_DYNAMO_DB_ITEM_SIZE_ERROR);
             assertEquals(item.length, flowFile.getSize());
         }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITFetchS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITFetchS3Object.java
@@ -23,6 +23,8 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -35,6 +37,8 @@ import java.util.Map;
  * Provides integration level testing with actual AWS S3 resources for {@link FetchS3Object} and requires additional configuration and resources to work.
  */
 public class ITFetchS3Object extends AbstractS3IT {
+    private static final Logger logger = LoggerFactory.getLogger(ITFetchS3Object.class);
+
     @Test
     public void testSimpleGet() throws IOException {
         putTestFile("test-file", getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME));
@@ -125,7 +129,7 @@ public class ITFetchS3Object extends AbstractS3IT {
         out.assertContentEquals(new String(expectedBytes));
 
         for (final Map.Entry<String, String> entry : out.getAttributes().entrySet()) {
-            System.out.println(entry.getKey() + " : " + entry.getValue());
+            logger.info("{}:{}", entry.getKey(), entry.getValue());
         }
     }
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/ITPutS3Object.java
@@ -44,6 +44,8 @@ import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -81,7 +83,7 @@ public class ITPutS3Object extends AbstractS3IT {
 
     final static Pattern reS3ETag = Pattern.compile("[0-9a-fA-f]{32}(-[0-9]+)?");
 
-
+    private static final Logger logger = LoggerFactory.getLogger(ITPutS3Object.class);
     private static String kmsKeyId = "";
     private static String randomKeyMaterial = "";
 
@@ -710,7 +712,7 @@ public class ITPutS3Object extends AbstractS3IT {
             tempByteCount += megabyte.length;
         }
         tempOut.close();
-        System.out.println("file size: " + tempByteCount);
+        logger.info("file size: {}", tempByteCount);
         assertTrue(tempByteCount < S3_MINIMUM_PART_SIZE);
 
         assertTrue(megabyte.length < S3_MINIMUM_PART_SIZE);
@@ -754,7 +756,7 @@ public class ITPutS3Object extends AbstractS3IT {
             tempByteCount += megabyte.length;
         }
         tempOut.close();
-        System.out.println("file size: " + tempByteCount);
+        logger.info("file size: {}", tempByteCount);
         assertTrue(tempByteCount > S3_MINIMUM_PART_SIZE && tempByteCount < S3_MAXIMUM_OBJECT_SIZE);
         assertTrue(tempByteCount > TEST_PARTSIZE_LONG);
 
@@ -806,7 +808,7 @@ public class ITPutS3Object extends AbstractS3IT {
         List<Tag> objectTags = result.getTagSet();
 
         for (Tag tag : objectTags) {
-            System.out.println("Tag Key : " + tag.getKey() + ", Tag Value : " + tag.getValue());
+            logger.info("Tag Key : {}, Tag Value : {}", tag.getKey(), tag.getValue());
         }
 
         assertEquals(1, objectTags.size());

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/test/java/org/apache/nifi/reporting/azure/loganalytics/TestMetricsFactory.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/test/java/org/apache/nifi/reporting/azure/loganalytics/TestMetricsFactory.java
@@ -64,8 +64,6 @@ public class TestMetricsFactory {
     public void testGetVirtualMachineMetrics() {
         JvmMetrics virtualMachineMetrics = JmxJvmMetrics.getInstance();
         List<Metric> metrics = AzureLogAnalyticsMetricsFactory.getJvmMetrics(virtualMachineMetrics, "testcase", "tests");
-        String metricsInString = gson.toJson(metrics);
-        System.out.println(metricsInString);
         TestVerification.assertJVMMetrics(metrics);
     }
 

--- a/nifi-extension-bundles/nifi-compress-bundle/nifi-compress-processors/src/test/java/org/apache/nifi/processors/compress/TestModifyCompression.java
+++ b/nifi-extension-bundles/nifi-compress-bundle/nifi-compress-processors/src/test/java/org/apache/nifi/processors/compress/TestModifyCompression.java
@@ -248,7 +248,6 @@ class TestModifyCompression {
 
         runner.assertAllFlowFilesTransferred(ModifyCompression.REL_SUCCESS, 1);
         MockFlowFile flowFile = runner.getFlowFilesForRelationship(ModifyCompression.REL_SUCCESS).getFirst();
-        System.err.println(new String(flowFile.toByteArray()));
         flowFile.assertContentEquals(getSamplePath("SampleFile.txt"));
         flowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), "SampleFile.txt");
     }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcClobReadable.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcClobReadable.java
@@ -125,7 +125,6 @@ public class TestJdbcClobReadable {
 
         final byte[] serializedBytes = outStream.toByteArray();
         assertNotNull(serializedBytes);
-        System.out.println("Avro serialized result size in bytes: " + serializedBytes.length);
 
         st.close();
         con.close();
@@ -140,7 +139,6 @@ public class TestJdbcClobReadable {
             while (dataFileReader.hasNext()) {
                 record = dataFileReader.next(record);
                 assertEquals(someClob, record.get("SOMECLOB").toString(), "Unreadable code for this Clob value.");
-                System.out.println(record);
             }
         }
     }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcCommon.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcCommon.java
@@ -240,24 +240,8 @@ public class TestJdbcCommon {
 
         final byte[] serializedBytes = outStream.toByteArray();
         assertNotNull(serializedBytes);
-        System.out.println("Avro serialized result size in bytes: " + serializedBytes.length);
 
         st.close();
-
-        // Deserialize bytes to records
-        final InputStream instream = new ByteArrayInputStream(serializedBytes);
-
-        final DatumReader<GenericRecord> datumReader = new GenericDatumReader<>();
-        try (final DataFileStream<GenericRecord> dataFileReader = new DataFileStream<>(instream, datumReader)) {
-            GenericRecord record = null;
-            while (dataFileReader.hasNext()) {
-                // Reuse record object by passing it to next(). This saves us from
-                // allocating and garbage collecting many objects for files with
-                // many items.
-                record = dataFileReader.next(record);
-                System.out.println(record);
-            }
-        }
     }
 
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcHugeStream.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcHugeStream.java
@@ -121,7 +121,6 @@ public class TestJdbcHugeStream {
                         record = dataFileReader.next(record);
                         recordsFromStream += 1;
                     }
-                    System.out.println("total nr of records from stream: " + recordsFromStream);
                     assertEquals(nrOfRows, recordsFromStream);
                 }
             }
@@ -139,10 +138,6 @@ public class TestJdbcHugeStream {
     static String createRelationships = "create table relationships (id integer,name varchar(100), code integer)";
 
     static public void loadTestData2Database(Connection con, int nrOfPersons, int nrOfProducts, int nrOfRels) throws ClassNotFoundException, SQLException {
-
-        System.out.println(createRandomName());
-        System.out.println(createRandomName());
-        System.out.println(createRandomName());
 
         final Statement st = con.createStatement();
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcTypesH2.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcTypesH2.java
@@ -16,21 +16,15 @@
  */
 package org.apache.nifi.util.db;
 
-import org.apache.avro.file.DataFileStream;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.DatumReader;
 import org.apache.nifi.util.file.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -84,7 +78,7 @@ public class TestJdbcTypesH2 {
     }
 
     @Test
-    public void testSQLTypesMapping() throws ClassNotFoundException, SQLException, IOException {
+    public void testSQLTypesMapping() throws SQLException, IOException {
         final Connection con = createConnection(dbPath);
         final Statement st = con.createStatement();
 
@@ -106,26 +100,9 @@ public class TestJdbcTypesH2 {
 
         final byte[] serializedBytes = outStream.toByteArray();
         Assertions.assertNotNull(serializedBytes);
-        System.out.println("Avro serialized result size in bytes: " + serializedBytes.length);
 
         st.close();
         con.close();
-
-        // Deserialize bytes to records
-
-        final InputStream instream = new ByteArrayInputStream(serializedBytes);
-
-        final DatumReader<GenericRecord> datumReader = new GenericDatumReader<>();
-        try (final DataFileStream<GenericRecord> dataFileReader = new DataFileStream<>(instream, datumReader)) {
-            GenericRecord record = null;
-            while (dataFileReader.hasNext()) {
-                // Reuse record object by passing it to next(). This saves us from
-                // allocating and garbage collecting many objects for files with
-                // many items.
-                record = dataFileReader.next(record);
-                System.out.println(record);
-            }
-        }
     }
 
     // verify H2 driver loading and get Connections works

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
@@ -58,6 +58,8 @@ import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.type.RecordDataType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -67,6 +69,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestAvroTypeUtil {
+    private static final Logger logger = LoggerFactory.getLogger(TestAvroTypeUtil.class);
 
     @Test
     @EnabledIfSystemProperty(
@@ -104,7 +107,7 @@ public class TestAvroTypeUtil {
             }
 
             final long millis = System.currentTimeMillis() - start;
-            System.out.println(millis);
+            logger.info("{}", millis);
         }
     }
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/test/java/org/apache/nifi/schema/validation/TestStandardSchemaValidator.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/src/test/java/org/apache/nifi/schema/validation/TestStandardSchemaValidator.java
@@ -343,7 +343,6 @@ public class TestStandardSchemaValidator {
         assertEquals(1, validationErrors.size());
         final ValidationError validationError = validationErrors.iterator().next();
         assertEquals("/name", validationError.getFieldName().get());
-        System.out.println(validationError);
     }
 
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/FetchGCSObjectIT.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/FetchGCSObjectIT.java
@@ -20,6 +20,8 @@ import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class FetchGCSObjectIT extends AbstractGCSIT {
     static final String KEY = "delete-me";
     static final byte[] CONTENT = {10, 11, 12};
+    private static final Logger logger = LoggerFactory.getLogger(FetchGCSObjectIT.class);
 
     @Test
     public void testSimpleFetch() throws Exception {
@@ -60,7 +63,7 @@ public class FetchGCSObjectIT extends AbstractGCSIT {
         ff.assertAttributeNotExists(StorageAttributes.ENCRYPTION_SHA256_ATTR);
 
         for (final Map.Entry<String, String> entry : ff.getAttributes().entrySet()) {
-            System.out.println(entry.getKey() + ":" + entry.getValue());
+            logger.info("{}:{}", entry.getKey(), entry.getValue());
         }
     }
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/PutGCSObjectIT.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/PutGCSObjectIT.java
@@ -22,6 +22,8 @@ import com.google.cloud.storage.BlobId;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -32,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Integration tests for {@link PutGCSObject} which actually use Google Cloud resources.
  */
 public class PutGCSObjectIT extends AbstractGCSIT {
+    private static final Logger logger = LoggerFactory.getLogger(PutGCSObjectIT.class);
     private static final String KEY = "delete-me";
     private static final byte[] CONTENT = {12, 13, 14};
 
@@ -52,7 +55,7 @@ public class PutGCSObjectIT extends AbstractGCSIT {
         flowFile.assertAttributeNotExists(ENCRYPTION_ALGORITHM_ATTR);
 
         for (Map.Entry<String, String> entry : flowFile.getAttributes().entrySet()) {
-            System.out.println(entry.getKey() + ":" + entry.getValue());
+           logger.info("{}:{}", entry.getKey(), entry.getValue());
         }
     }
 
@@ -74,7 +77,7 @@ public class PutGCSObjectIT extends AbstractGCSIT {
         flowFile.assertAttributeExists(ENCRYPTION_ALGORITHM_ATTR);
 
         for (Map.Entry<String, String> entry : flowFile.getAttributes().entrySet()) {
-            System.out.println(entry.getKey() + ":" + entry.getValue());
+            logger.info("{}:{}", entry.getKey(), entry.getValue());
         }
     }
 

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/AbstractTestRecordReaderWriter.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/AbstractTestRecordReaderWriter.java
@@ -162,7 +162,6 @@ public abstract class AbstractTestRecordReaderWriter {
             final RecordReader reader = createReader(fis, journalFile.getName(), tocReader, 2048)) {
             for (int i = 0; i < 10; i++) {
                 final StandardProvenanceEventRecord recovered = reader.nextRecord();
-                System.out.println(recovered);
                 assertNotNull(recovered);
                 assertEquals(i, recovered.getEventId());
                 assertEquals("nifi://unit-test", recovered.getTransitUri());
@@ -204,8 +203,6 @@ public abstract class AbstractTestRecordReaderWriter {
             final RecordReader reader = createReader(fis, journalFile.getName(), tocReader, 2048)) {
 
             for (int i = 0; i < numEvents; i++) {
-                System.out.println(i);
-
                 final Optional<ProvenanceEventRecord> eventOption = reader.skipToEvent(i);
                 assertTrue(eventOption.isPresent());
                 assertEquals(i, eventOption.get().getEventId());

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/TestEventIdFirstSchemaRecordReaderWriter.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/TestEventIdFirstSchemaRecordReaderWriter.java
@@ -28,6 +28,8 @@ import org.apache.nifi.util.file.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -47,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestEventIdFirstSchemaRecordReaderWriter extends AbstractTestRecordReaderWriter {
+    private static final Logger logger = LoggerFactory.getLogger(TestEventIdFirstSchemaRecordReaderWriter.class);
     private final AtomicLong idGenerator = new AtomicLong(0L);
     private File journalFile;
     private File tocFile;
@@ -452,7 +455,7 @@ public class TestEventIdFirstSchemaRecordReaderWriter extends AbstractTestRecord
             }
 
             final long ms = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-            System.out.println(ms + " ms total");
+            logger.info("{} ms total", ms);
         }
     }
 

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/TestSchemaRecordReaderWriter.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/TestSchemaRecordReaderWriter.java
@@ -62,8 +62,11 @@ import org.apache.nifi.stream.io.NullOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestSchemaRecordReaderWriter extends AbstractTestRecordReaderWriter {
+    private static final Logger logger = LoggerFactory.getLogger(TestSchemaRecordReaderWriter.class);
     private final AtomicLong idGenerator = new AtomicLong(0L);
     private File journalFile;
     private File tocFile;
@@ -110,7 +113,7 @@ public class TestSchemaRecordReaderWriter extends AbstractTestRecordReaderWriter
             }
 
             final long ms = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-            System.out.println(ms + " ms total");
+            logger.info("{} ms total", ms);
         }
     }
 
@@ -307,7 +310,7 @@ public class TestSchemaRecordReaderWriter extends AbstractTestRecordReaderWriter
 
         final long nanos = System.nanoTime() - startNanos;
         final long millis = TimeUnit.NANOSECONDS.toMillis(nanos);
-        System.out.println("Took " + millis + " millis to write " + numEvents + " events");
+        logger.info("Took {} millis to write {} events", millis, numEvents);
     }
 
     @Test
@@ -358,7 +361,7 @@ public class TestSchemaRecordReaderWriter extends AbstractTestRecordReaderWriter
         final double seconds = millis / 1000D;
         final long bytesPerSecond = (long) (totalRecordBytes / seconds);
         final long megaBytesPerSecond = bytesPerSecond / 1024 / 1024;
-        System.out.println("Took " + millis + " millis to read " + numEvents + " events or " + megaBytesPerSecond + " MB/sec");
+        logger.info("Took {} millis to read {} events or {} MB/sec", millis, numEvents, megaBytesPerSecond);
     }
 
 

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/store/TestPartitionedWriteAheadEventStore.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/store/TestPartitionedWriteAheadEventStore.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,6 +65,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
 public class TestPartitionedWriteAheadEventStore {
+    private static final Logger logger = LoggerFactory.getLogger(TestPartitionedWriteAheadEventStore.class);
     private static final RecordWriterFactory writerFactory = (file, idGen, compress, createToc) -> RecordWriters.newSchemaRecordWriter(file, idGen, compress, createToc);
     private static final RecordReaderFactory readerFactory = (file, logs, maxChars) -> RecordReaders.newRecordReader(file, logs, maxChars);
 
@@ -108,7 +111,7 @@ public class TestPartitionedWriteAheadEventStore {
         task.call();
         final long nanos = System.nanoTime() - start;
         final long millis = TimeUnit.NANOSECONDS.toMillis(nanos);
-        System.out.println("Took " + millis + " ms to " + taskDescription);
+        logger.info("Took {} ms to {}", millis, taskDescription);
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/store/iterator/TestSelectiveRecordReaderEventIterator.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/store/iterator/TestSelectiveRecordReaderEventIterator.java
@@ -45,8 +45,11 @@ import org.apache.nifi.provenance.toc.TocUtil;
 import org.apache.nifi.provenance.toc.TocWriter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestSelectiveRecordReaderEventIterator {
+    private static final Logger logger = LoggerFactory.getLogger(TestSelectiveRecordReaderEventIterator.class);
 
     private RecordWriter createWriter(final File file, final TocWriter tocWriter, final boolean compressed, final int uncompressedBlockSize) throws IOException {
         return new EventIdFirstSchemaRecordWriter(file, new AtomicLong(0L), tocWriter, compressed, uncompressedBlockSize, IdentifierLookup.EMPTY);
@@ -146,7 +149,7 @@ public class TestSelectiveRecordReaderEventIterator {
             }
 
             final long ms = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-            System.out.println(ms + " ms total");
+            logger.info("{} ms total", ms);
         }
     }
 

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/test/java/org/apache/nifi/provenance/TestVolatileProvenanceRepository.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/test/java/org/apache/nifi/provenance/TestVolatileProvenanceRepository.java
@@ -116,9 +116,6 @@ public class TestVolatileProvenanceRepository {
         }
 
         assertEquals(10, submission.getResult().getMatchingEvents().size());
-        for (final ProvenanceEventRecord match : submission.getResult().getMatchingEvents()) {
-            System.out.println(match);
-        }
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestCompressContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestCompressContent.java
@@ -260,7 +260,6 @@ public class TestCompressContent {
 
         runner.assertAllFlowFilesTransferred(CompressContent.REL_SUCCESS, 1);
         MockFlowFile flowFile = runner.getFlowFilesForRelationship(CompressContent.REL_SUCCESS).get(0);
-        System.err.println(new String(flowFile.toByteArray()));
         flowFile.assertContentEquals(Paths.get("src/test/resources/CompressedData/SampleFile.txt"));
         flowFile.assertAttributeEquals("filename", "SampleFile.txt");
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDistributeLoad.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestDistributeLoad.java
@@ -106,7 +106,6 @@ public class TestDistributeLoad {
         testRunner.assertQueueEmpty();
 
         for (int i = 1; i <= 100; i++) {
-            System.out.println(i);
             testRunner.assertTransferCount(String.valueOf(i), (i == 50) ? 0 : 1);
         }
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteProcess.java
@@ -97,8 +97,6 @@ public class TestExecuteProcess {
 
         final List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ExecuteProcess.REL_SUCCESS);
         for (final MockFlowFile flowFile : flowFiles) {
-            System.out.println(flowFile);
-            System.out.println(new String(flowFile.toByteArray()));
             flowFile.assertAttributeNotExists(CoreAttributes.MIME_TYPE.key());
         }
     }
@@ -145,14 +143,12 @@ public class TestExecuteProcess {
         runner.setProperty(ExecuteProcess.WORKING_DIR, workingDirName);
 
         File inFile = new File(workingDirName, testFile);
-        System.out.println(inFile.getAbsolutePath());
 
         runner.run();
 
         final List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ExecuteProcess.REL_SUCCESS);
         long totalFlowFilesSize = 0;
         for (final MockFlowFile flowFile : flowFiles) {
-            System.out.println(flowFile);
             totalFlowFilesSize += flowFile.getSize();
         }
 
@@ -175,9 +171,6 @@ public class TestExecuteProcess {
         runner.setProperty(ExecuteProcess.BATCH_DURATION, "150 millis");
 
         File inFile = new File(workingDirName, testFile);
-        System.out.println(inFile.getAbsolutePath());
-
-        // runner.run(1,false,true);
 
         ProcessContext processContext = runner.getProcessContext();
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLookupRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLookupRecord.java
@@ -956,7 +956,6 @@ public class TestLookupRecord {
 
         runner.assertAllFlowFilesTransferred(LookupRecord.REL_UNMATCHED);
         final MockFlowFile out = runner.getFlowFilesForRelationship(LookupRecord.REL_UNMATCHED).get(0);
-        System.out.println(out.getContent());
         out.assertContentEquals(new File("src/test/resources/TestLookupRecord/lookup-array-output-unmatched.json").toPath());
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestModifyBytes.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestModifyBytes.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -89,8 +88,6 @@ public class TestModifyBytes {
 
         runner.assertAllFlowFilesTransferred(ModifyBytes.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ModifyBytes.REL_SUCCESS).get(0);
-        final String outContent = new String(out.toByteArray(), StandardCharsets.UTF_8);
-        System.out.println(outContent);
         out.assertContentEquals(noHeaderFile);
     }
 
@@ -107,8 +104,6 @@ public class TestModifyBytes {
 
         runner.assertAllFlowFilesTransferred(ModifyBytes.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ModifyBytes.REL_SUCCESS).get(0);
-        final String outContent = new String(out.toByteArray(), StandardCharsets.UTF_8);
-        System.out.println(outContent);
         out.assertContentEquals(noHeaderFile);
     }
 
@@ -123,8 +118,6 @@ public class TestModifyBytes {
 
         runner.assertAllFlowFilesTransferred(ModifyBytes.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ModifyBytes.REL_SUCCESS).get(0);
-        final String outContent = new String(out.toByteArray(), StandardCharsets.UTF_8);
-        System.out.println(outContent);
         out.assertContentEquals("<<<FOOTER>>>".getBytes("UTF-8"));
     }
 
@@ -169,8 +162,6 @@ public class TestModifyBytes {
 
         runner.assertAllFlowFilesTransferred(ModifyBytes.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ModifyBytes.REL_SUCCESS).get(0);
-        final String outContent = new String(out.toByteArray(), StandardCharsets.UTF_8);
-        System.out.println(outContent);
         out.assertContentEquals(noFooterFile);
     }
 
@@ -185,8 +176,6 @@ public class TestModifyBytes {
 
         runner.assertAllFlowFilesTransferred(ModifyBytes.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ModifyBytes.REL_SUCCESS).get(0);
-        final String outContent = new String(out.toByteArray(), StandardCharsets.UTF_8);
-        System.out.println(outContent);
         out.assertContentEquals(noFooterNoHeaderFile);
     }
 
@@ -215,8 +204,6 @@ public class TestModifyBytes {
 
         runner.assertAllFlowFilesTransferred(ModifyBytes.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ModifyBytes.REL_SUCCESS).get(0);
-        final String outContent = new String(out.toByteArray(), StandardCharsets.UTF_8);
-        System.out.println(outContent);
         out.assertContentEquals("Dew".getBytes("UTF-8"));
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestQueryRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestQueryRecord.java
@@ -905,7 +905,6 @@ public class TestQueryRecord {
         runner.assertTransferCount(REL_NAME, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(REL_NAME).get(0);
         out.assertAttributeEquals(QueryRecord.ROUTE_ATTRIBUTE_KEY, REL_NAME);
-        System.out.println(new String(out.toByteArray()));
         out.assertContentEquals("\"name\",\"points\"\n\"Tom\",\"49\"\n");
     }
 
@@ -941,7 +940,6 @@ public class TestQueryRecord {
         runner.assertTransferCount(REL_NAME, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(REL_NAME).get(0);
         out.assertAttributeEquals(QueryRecord.ROUTE_ATTRIBUTE_KEY, REL_NAME);
-        System.out.println(new String(out.toByteArray()));
         out.assertContentEquals("\"name\",\"points\"\n\"Tom\",\"49\"\n\"Alice\",\n,\"36\"\n");
     }
 
@@ -975,7 +973,6 @@ public class TestQueryRecord {
         runner.assertTransferCount(REL_NAME, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(REL_NAME).get(0);
         out.assertAttributeEquals(QueryRecord.ROUTE_ATTRIBUTE_KEY, REL_NAME);
-        System.out.println(new String(out.toByteArray()));
         out.assertContentEquals("\"name\",\"points\"\n\"Tom\",\"49\"\n");
     }
 
@@ -1004,7 +1001,6 @@ public class TestQueryRecord {
         runner.assertTransferCount(REL_NAME, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(REL_NAME).get(0);
         out.assertAttributeEquals(QueryRecord.ROUTE_ATTRIBUTE_KEY, REL_NAME);
-        System.out.println(new String(out.toByteArray()));
         out.assertContentEquals("\"name\",\"age\"\n");
     }
 
@@ -1244,9 +1240,7 @@ public class TestQueryRecord {
 
                     // Iterate over the rest of the records to ensure that we read the entire stream. If we don't
                     // do this, we won't consume all of the data and as a result we will not close the stream properly
-                    Record record;
-                    while ((record = rs.next()) != null) {
-                        System.out.println(record);
+                    while (rs.next() != null) {
                     }
 
                     return WriteResult.of(0, Collections.emptyMap());

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestReplaceText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestReplaceText.java
@@ -560,7 +560,6 @@ public class TestReplaceText {
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
         final String actual = new String(out.toByteArray(), StandardCharsets.UTF_8);
-        System.out.println(actual);
         assertEquals(expected, actual);
     }
 
@@ -831,7 +830,6 @@ public class TestReplaceText {
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
         final String outContent = new String(out.toByteArray(), StandardCharsets.UTF_8);
         assertTrue(outContent.startsWith("abc.txt\t"));
-        System.out.println(outContent);
         assertTrue(outContent.endsWith("13\n"));
     }
 
@@ -852,7 +850,6 @@ public class TestReplaceText {
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
         final String outContent = new String(out.toByteArray(), StandardCharsets.UTF_8);
         assertTrue(outContent.equals("attribute header\n\nabc.txt\n\ndata header\n\nHello\nWorld!\n\nfooter"));
-        System.out.println(outContent);
     }
 
     @Test
@@ -1437,7 +1434,6 @@ public class TestReplaceText {
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
         final String outContent = translateNewLines(new String(out.toByteArray(), StandardCharsets.UTF_8));
         assertTrue(outContent.startsWith("abc.txt\t"));
-        System.out.println(outContent);
         assertTrue(outContent.endsWith("193\n") || outContent.endsWith("203\r\n"));
     }
 
@@ -1457,7 +1453,6 @@ public class TestReplaceText {
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
         final String outContent = new String(out.toByteArray(), StandardCharsets.UTF_8);
-        System.out.println(outContent);
         final String expectedContent = "attribute header\n\nabc.txt\n\ndata header\n\nHello\n\n\nfooter\n"
                 + "attribute header\n\nabc.txt\n\ndata header\n\nWorld!\n\nfooter\n";
         assertEquals(expectedContent, outContent);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTailFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestTailFile.java
@@ -34,8 +34,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
@@ -65,7 +63,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @DisabledOnOs({ OS.WINDOWS })
 public class TestTailFile {
-    private static final Logger logger = LoggerFactory.getLogger(TestTailFile.class);
 
     private File file;
     private File existingFile;
@@ -79,7 +76,6 @@ public class TestTailFile {
 
     @BeforeEach
     public void setup() throws IOException {
-        System.setProperty("org.slf4j.simpleLogger.log.org.apache.nifi.processors.standard", "TRACE");
         clean();
 
         file = new File("target/log.txt");
@@ -352,8 +348,6 @@ public class TestTailFile {
         assertTrue(renamed);
         raf.getChannel().force(true);
 
-        System.out.println("Wrote d\\n and rolled file");
-
         // Create the new file
         final RandomAccessFile newFile = new RandomAccessFile(new File("target/log.txt"), "rw");
         newFile.write("new file\n".getBytes()); // This should not get consumed until the old file's last modified date indicates it's complete
@@ -367,7 +361,6 @@ public class TestTailFile {
 
         // Write to the file and trigger again.
         raf.write("e\nf".getBytes());
-        System.out.println("Wrote e\\nf");
         runner.run(1, false, false);
 
         runner.assertAllFlowFilesTransferred(TailFile.REL_SUCCESS, 1);
@@ -379,7 +372,6 @@ public class TestTailFile {
         raf.write(0);
         raf.write(0);
         raf.write(0);
-        System.out.println("Wrote \\n\\0\\0\\0");
 
         runner.run(1, false, false);
         runner.assertAllFlowFilesTransferred(TailFile.REL_SUCCESS, 1);
@@ -389,7 +381,6 @@ public class TestTailFile {
         // Truncate the NUL bytes and replace with additional data, ending with a new line. This should ingest the entire line of text.
         raf.setLength(raf.length() - 3);
         raf.write("g\nh".getBytes());
-        System.out.println("Truncated the NUL bytes and replaced with g\\nh");
 
         runner.run(1, false, false);
         runner.assertAllFlowFilesTransferred(TailFile.REL_SUCCESS, 1);
@@ -405,7 +396,6 @@ public class TestTailFile {
 
         // Set last modified time so that processor believes file to have not been modified in a very long time, then run again.
         assertTrue(rolledFile.setLastModified(500L));
-        System.out.println("Set lastModified on " + rolledFile + " to 500");
         runner.run(1, false, false);
 
         // Verify results
@@ -429,14 +419,12 @@ public class TestTailFile {
         runner.run();
         runner.assertAllFlowFilesTransferred(TailFile.REL_SUCCESS, 1);
         runner.getFlowFilesForRelationship(TailFile.REL_SUCCESS).get(0).assertContentEquals("hello\n");
-        System.out.println("Ingested 6 bytes");
         runner.clearTransferState();
 
         // roll over the file
         raf.close();
         file.renameTo(new File(file.getParentFile(), file.getName() + ".previous"));
         raf = new RandomAccessFile(file, "rw");
-        System.out.println("Rolled over file to " + file.getName() + ".previous");
 
         // truncate file
         raf.setLength(0L);
@@ -447,7 +435,6 @@ public class TestTailFile {
         Thread.sleep(1000L); // we need to wait at least one second because of the granularity of timestamps on many file systems.
         raf.write("HELLO\n".getBytes());
 
-        System.out.println("Wrote out 6 bytes to tailed file");
         runner.run();
         runner.assertAllFlowFilesTransferred(TailFile.REL_SUCCESS, 1);
         runner.getFlowFilesForRelationship(TailFile.REL_SUCCESS).get(0).assertContentEquals("HELLO\n");
@@ -876,7 +863,6 @@ public class TestTailFile {
         runner.clearTransferState();
 
         for (int i = 0; i < 10; i++) {
-            logger.info("i = {}", i);
             raf.write(String.valueOf(i).getBytes());
             raf.write("\n".getBytes());
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/TestMonitorDiskUsage.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-reporting-tasks/src/test/java/org/apache/nifi/controller/TestMonitorDiskUsage.java
@@ -33,8 +33,6 @@ public class TestMonitorDiskUsage {
 
         final ComponentLog logger = Mockito.mock(ComponentLog.class);
         Mockito.doAnswer(invocation -> {
-            final String message = (String) invocation.getArguments()[0];
-            System.out.println(message);
             callCounter.incrementAndGet();
             return null;
         }).when(logger).warn(Mockito.anyString());

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestWriteAvroResultWithoutSchema.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestWriteAvroResultWithoutSchema.java
@@ -39,6 +39,8 @@ import org.apache.nifi.stream.io.NullOutputStream;
 import org.apache.nifi.util.MockComponentLog;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestWriteAvroResultWithoutSchema extends TestWriteAvroResult {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestWriteAvroResultWithoutSchema.class);
     private final BlockingQueue<BinaryEncoder> encoderPool = new LinkedBlockingQueue<>(32);
 
     @Override
@@ -121,6 +124,6 @@ public class TestWriteAvroResultWithoutSchema extends TestWriteAvroResult {
         }
 
         final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-        System.out.println(millis);
+        LOGGER.info("{}", millis);
     }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestInferJsonSchemaAccessStrategy.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestInferJsonSchemaAccessStrategy.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -53,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestInferJsonSchemaAccessStrategy {
 
+    private static final Logger logger = LoggerFactory.getLogger(TestInferJsonSchemaAccessStrategy.class);
     private final SchemaInferenceEngine<JsonNode> timestampInference = new JsonSchemaInference(new TimeValueInference("yyyy-MM-dd", "HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
     private final SchemaInferenceEngine<JsonNode> noTimestampInference = new JsonSchemaInference(new TimeValueInference("yyyy-MM-dd", "HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
 
@@ -81,7 +84,7 @@ class TestInferJsonSchemaAccessStrategy {
             }
 
             final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-            System.out.println(millis);
+            logger.info("{}", millis);
         }
     }
 
@@ -109,7 +112,7 @@ class TestInferJsonSchemaAccessStrategy {
             }
 
             final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-            System.out.println(millis);
+            logger.info("{}", millis);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
@@ -38,6 +38,8 @@ import org.apache.nifi.util.EqualsWrapper;
 import org.apache.nifi.util.MockComponentLog;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -69,6 +71,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class TestJsonTreeRowRecordReader {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestJsonTreeRowRecordReader.class);
     private final String dateFormat = RecordFieldType.DATE.getDefaultFormat();
     private final String timeFormat = RecordFieldType.TIME.getDefaultFormat();
     private final String timestampFormat = RecordFieldType.TIMESTAMP.getDefaultFormat();
@@ -155,7 +158,7 @@ class TestJsonTreeRowRecordReader {
             }
             final long nanos = System.nanoTime() - start;
             final long millis = TimeUnit.NANOSECONDS.toMillis(nanos);
-            System.out.println("Took " + millis + " millis to read " + recordCount + " records");
+            LOGGER.info("Took {} millis to read {} records", millis, recordCount);
         }
     }
 
@@ -184,7 +187,7 @@ class TestJsonTreeRowRecordReader {
             }
             final long nanos = System.nanoTime() - start;
             final long millis = TimeUnit.NANOSECONDS.toMillis(nanos);
-            System.out.println("Took " + millis + " millis to read " + recordCount + " records");
+            LOGGER.info("Took {} millis to read {} records", millis, recordCount);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/syslog/TestSyslogRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/syslog/TestSyslogRecordReader.java
@@ -17,7 +17,6 @@
 
 package org.apache.nifi.syslog;
 
-import org.apache.nifi.avro.AvroTypeUtil;
 import org.apache.nifi.serialization.MalformedRecordException;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.syslog.attributes.SyslogAttributes;
@@ -188,11 +187,5 @@ public class TestSyslogRecordReader {
             assertNull(deserializer.nextRecord());
             deserializer.close();
         }
-    }
-
-    public void writeSchema() {
-        String s = SyslogReader.createRecordSchema().toString();
-        System.out.println(s);
-        System.out.println(AvroTypeUtil.extractAvroSchema( SyslogReader.createRecordSchema() ).toString(true));
     }
 }

--- a/nifi-extension-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-processors/src/test/java/org/apache/nifi/processors/stateful/analysis/AttributeRollingWindowIT.java
+++ b/nifi-extension-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-processors/src/test/java/org/apache/nifi/processors/stateful/analysis/AttributeRollingWindowIT.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.condition.OS;
 import org.opentest4j.AssertionFailedError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -44,8 +46,9 @@ import static org.apache.nifi.processors.stateful.analysis.AttributeRollingWindo
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AttributeRollingWindowIT {
-
+    private static final Logger logger = LoggerFactory.getLogger(AttributeRollingWindowIT.class);
     private static final double EPSILON = 0.000001d; // "Error" threshold for floating-point arithmetic
+
     @Test
     public void testFailureDueToBadAttribute() {
         final TestRunner runner = TestRunners.newTestRunner(AttributeRollingWindow.class);
@@ -238,7 +241,7 @@ public class AttributeRollingWindowIT {
             try {
                 assertTrue(Precision.equals(variance.getResult(), Double.parseDouble(flowFile.getAttribute(ROLLING_WINDOW_VARIANCE_KEY)), EPSILON));
             } catch (AssertionFailedError ae) {
-                System.err.println("Error at " + i + ": " + variance.getResult() + " != " + Double.parseDouble(flowFile.getAttribute(ROLLING_WINDOW_VARIANCE_KEY)));
+                logger.error("Error at {}: {} != {}", i, variance.getResult(), Double.parseDouble(flowFile.getAttribute(ROLLING_WINDOW_VARIANCE_KEY)));
             }
             assertTrue(Precision.equals(Math.sqrt(variance.getResult()), Double.parseDouble(flowFile.getAttribute(ROLLING_WINDOW_STDDEV_KEY)), EPSILON));
             Thread.sleep(10L);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/controller/repository/TestRingBufferEventRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/controller/repository/TestRingBufferEventRepository.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRingBufferEventRepository {
 
@@ -45,9 +45,10 @@ public class TestRingBufferEventRepository {
         final long queryStart = System.nanoTime();
         final StandardRepositoryStatusReport report = repo.reportTransferEvents(System.currentTimeMillis());
         final long queryNanos = System.nanoTime() - queryStart;
-        System.out.println(report);
-        System.out.println("Insert: " + TimeUnit.MILLISECONDS.convert(insertNanos, TimeUnit.NANOSECONDS));
-        System.out.println("Query: " + TimeUnit.MILLISECONDS.convert(queryNanos, TimeUnit.NANOSECONDS));
+        assertNotNull(report);
+        assertTrue(TimeUnit.MILLISECONDS.convert(insertNanos, TimeUnit.NANOSECONDS) > 0L);
+        assertTrue(TimeUnit.MILLISECONDS.convert(queryNanos, TimeUnit.NANOSECONDS) >= 0L);
+
         repo.close();
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/TestSwappablePriorityQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/queue/clustered/TestSwappablePriorityQueue.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -54,6 +56,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestSwappablePriorityQueue {
+    private static final Logger logger = LoggerFactory.getLogger(TestSwappablePriorityQueue.class);
 
     private MockSwapManager swapManager;
     private final List<String> events = new ArrayList<>();
@@ -136,7 +139,7 @@ public class TestSwappablePriorityQueue {
         queue.setPriorities(Collections.singletonList(iAttributePrioritizer));
 
         for (final int queueSize : new int[] {1, 9999, 10_000, 10_001, 19_999, 20_000, 20_001}) {
-            System.out.println("Queue Size: " + queueSize);
+            logger.info("Queue Size: {}", queueSize);
 
             for (int i = 0; i < queueSize; i++) {
                 final MockFlowFileRecord flowFile = new MockFlowFileRecord(Map.of("i", String.valueOf(i)), i);
@@ -253,7 +256,7 @@ public class TestSwappablePriorityQueue {
         }
 
         ffs.forEach(queue::put);
-        System.out.println(StringUtils.join(attrs, ", "));
+        logger.info(StringUtils.join(attrs, ", "));
     }
 
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/StandardProcessSessionIT.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/StandardProcessSessionIT.java
@@ -68,6 +68,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -123,6 +125,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class StandardProcessSessionIT {
+    private static final Logger logger = LoggerFactory.getLogger(StandardProcessSessionIT.class);
     private static final Relationship FAKE_RELATIONSHIP = new Relationship.Builder().name("FAKE").build();
 
     private StandardProcessSession session;
@@ -1793,11 +1796,11 @@ public class StandardProcessSessionIT {
             try {
                 standardProcessSessions[i].read(flowFile, in -> StreamUtils.fillBuffer(in, buff));
             } catch (Exception e) {
-                System.out.println("Failed at file:" + i);
+                logger.error("Failed at file:{}", i);
                 throw e;
             }
             if (i % 1000 == 0) {
-                System.out.println("i:" + i);
+                logger.info("i:{}", i);
             }
         }
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestFileSystemRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestFileSystemRepository.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -70,6 +72,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestFileSystemRepository {
 
     public static final File helloWorldFile = new File("src/test/resources/hello.txt");
+    private static final Logger logger = LoggerFactory.getLogger(TestFileSystemRepository.class);
 
     private FileSystemRepository repository = null;
     private StandardResourceClaimManager claimManager = null;
@@ -117,8 +120,8 @@ public class TestFileSystemRepository {
         final long mb = bytesToWrite / (1024 * 1024);
         final long seconds = millis / 1000L;
         final double mbps = (double) mb / (double) seconds;
-        System.out.println("Took " + millis + " millis to write " + contentSize + " bytes " + iterations + " times (total of "
-                + NumberFormat.getNumberInstance(Locale.US).format(bytesToWrite) + " bytes) for a write rate of " + mbps + " MB/s");
+        logger.info("Took {} millis to write {} bytes {} times (total of {} bytes) for a write rate of {} MB/s",
+                millis, contentSize, iterations, NumberFormat.getNumberInstance(Locale.US).format(bytesToWrite), mbps);
     }
 
     @Test

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestWriteAheadFlowFileRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/repository/TestWriteAheadFlowFileRepository.java
@@ -51,6 +51,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wali.WriteAheadRepository;
 
 import java.io.File;
@@ -79,7 +81,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 public class TestWriteAheadFlowFileRepository {
-
+    private static final Logger logger = LoggerFactory.getLogger(TestWriteAheadFlowFileRepository.class);
     private static NiFiProperties niFiProperties;
 
     @BeforeEach
@@ -408,9 +410,11 @@ public class TestWriteAheadFlowFileRepository {
 
             final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
             if (j == 0) {
-                System.out.println(millis + " ms to insert " + updateCountPerThread * numThreads + " updates using " + numPartitions + " partitions and " + numThreads + " threads, *as a warmup!*");
+                logger.info("{} ms to insert {} updates using {} partitions and {} threads, *as a warmup!*",
+                        millis, updateCountPerThread * numThreads, numPartitions, numThreads);
             } else {
-                System.out.println(millis + " ms to insert " + updateCountPerThread * numThreads + " updates using " + numPartitions + " partitions and " + numThreads + " threads");
+                logger.info("{} ms to insert {} updates using {} partitions and {} threads",
+                        millis, updateCountPerThread * numThreads, numPartitions, numThreads);
             }
         }
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/swap/TestSchemaSwapSerializerDeserializer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/swap/TestSchemaSwapSerializerDeserializer.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -55,6 +57,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestSchemaSwapSerializerDeserializer {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestSchemaSwapSerializerDeserializer.class);
 
     @BeforeEach
     public void setup() {
@@ -194,6 +198,6 @@ public class TestSchemaSwapSerializerDeserializer {
         }
 
         final long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-        System.out.println("Wrote " + iterations + " Swap Files in " + millis + " millis");
+        logger.info("Wrote {} Swap Files in {} millis", iterations, millis);
     }
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/serialization/jaxb/TestJAXBVersionedProcessGroupSerializer.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/serialization/jaxb/TestJAXBVersionedProcessGroupSerializer.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -47,9 +46,6 @@ public class TestJAXBVersionedProcessGroupSerializer {
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         serializer.serialize(1, processGroup1, out);
-
-        final String snapshotStr = new String(out.toByteArray(), StandardCharsets.UTF_8);
-        //System.out.println(snapshotStr);
 
         final ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
         in.mark(1024);

--- a/nifi-system-tests/nifi-stateless-system-test-suite/src/test/java/org/apache/nifi/stateless/performance/StatelessPerformanceIT.java
+++ b/nifi-system-tests/nifi-stateless-system-test-suite/src/test/java/org/apache/nifi/stateless/performance/StatelessPerformanceIT.java
@@ -25,11 +25,15 @@ import org.apache.nifi.stateless.flow.StatelessDataflow;
 import org.apache.nifi.stateless.flow.TriggerResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class StatelessPerformanceIT extends StatelessSystemIT {
+    private static final Logger logger = LoggerFactory.getLogger(StatelessPerformanceIT.class);
+
     @Test
     @EnabledIfSystemProperty(named = "nifi.test.performance", matches = "true")
     public void testCreateDestroyPerf() throws InterruptedException {
@@ -58,7 +62,7 @@ public class StatelessPerformanceIT extends StatelessSystemIT {
                             result.acknowledge();
                         }
                         final long millis = System.currentTimeMillis() - start;
-                        System.out.println("Took " + millis + " millis to run " + iterations + " iterations");
+                        logger.info("Took {} millis to run {} iterations", millis, iterations);
                     } catch (final Exception e) {
                         e.printStackTrace();
                     }

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/nar/NarUploadPythonIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/nar/NarUploadPythonIT.java
@@ -94,7 +94,7 @@ public class NarUploadPythonIT extends NiFiSystemIT {
         assertNotNull(processorTypeFromUploadedNar);
 
         final BundleDTO processorBundle = processorTypeFromUploadedNar.getBundle();
-        System.out.println(processorBundle.getGroup() + " - " + processorBundle.getArtifact() + " - " + processorBundle.getVersion());
+        logger.info("{} - {} - {}", processorBundle.getGroup(), processorBundle.getArtifact(), processorBundle.getVersion());
 
         // Create instance of the WriteBech32Charset processor, and connect a GenerateFlowFile to it
         final ProcessorEntity generateProcessor = getClientUtil().createProcessor("GenerateFlowFile");

--- a/nifi-toolkit/nifi-toolkit-cli/src/test/java/org/apache/nifi/toolkit/cli/impl/result/TestBucketsResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/test/java/org/apache/nifi/toolkit/cli/impl/result/TestBucketsResult.java
@@ -66,7 +66,6 @@ public class TestBucketsResult {
         result.write(printStream);
 
         final String resultOut = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
-        //System.out.println(resultOut);
 
         final String expected = "\n" +
                 "#   Name       Id                                     Description        \n" +


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13625](https://issues.apache.org/jira/browse/NIFI-13625)

Some files remain with `System.out.println` statements but they are not unit tests

```
1. nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/TestDynamicEnvironment.java
2. nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/TestIngestAndUpdate.java
3. nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/TestLogStdErr.java
4. nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/TestSuccess.java
5. nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/util/LogGenerator.java

```
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
