### PR TITLE
NIFI-13630 Handle map Avro type in BigQuery writing

### DIFF
--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/proto/ProtoUtils.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/proto/ProtoUtils.java
@@ -24,10 +24,8 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -52,14 +50,12 @@ public class ProtoUtils {
                    if (value instanceof Object[] arrayValue) {
                        valueMaps = Arrays.stream(arrayValue)
                                .map(item -> (Map<String, Object>) item).toList();
-                   } else if (value instanceof HashMap<?, ?> hashMapValue) {
-                       valueMaps = new ArrayList<>();
-                       for (Map.Entry<?, ?> entry : hashMapValue.entrySet()) {
-                           Map<String, Object> map = new HashMap<>();
-                           map.put("key", entry.getKey());
-                           map.put("value", entry.getValue());
-                           valueMaps.add(map);
-                       }
+                   } else if (value instanceof Map<?, ?> mapValue) {
+                       valueMaps = mapValue.entrySet().stream()
+                               .map(entry -> Map.of(
+                                       "key", entry.getKey(),
+                                       "value", entry.getValue()
+                               )).toList();
                    } else {
                        valueMaps = (Collection<Map<String, Object>>) value;
                    }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/proto/ProtoUtils.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/proto/ProtoUtils.java
@@ -24,8 +24,10 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -46,7 +48,21 @@ public class ProtoUtils {
            switch (field.getType()) {
            case MESSAGE:
                if (field.isRepeated()) {
-                   Collection collection = value.getClass().isArray() ? Arrays.asList((Object[]) value) : (Collection) value;
+                   Collection collection = null;
+                   if (value.getClass().isArray()) {
+                       collection = Arrays.asList((Object[]) value);
+                   } else if (value instanceof HashMap) {
+                       collection = new ArrayList();
+                       for (Object entryObj : ((HashMap<?, ?>) value).entrySet()) {
+                           Map.Entry<?, ?> entry = (Map.Entry<?, ?>) entryObj;
+                           Map<String, Object> map = new HashMap<>();
+                           map.put("key", entry.getKey());
+                           map.put("value", entry.getValue());
+                           collection.add(map);
+                       }
+                   } else {
+                       collection = (Collection) value;
+                   }
                    collection.forEach(act -> builder.addRepeatedField(field, createMessage(field.getMessageType(), (Map<String, Object>) act, tableSchema)));
                } else {
                    builder.setField(field, createMessage(field.getMessageType(), (Map<String, Object>) value, tableSchema));

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/proto/ProtoUtils.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/proto/ProtoUtils.java
@@ -48,22 +48,22 @@ public class ProtoUtils {
            switch (field.getType()) {
            case MESSAGE:
                if (field.isRepeated()) {
-                   Collection collection = null;
-                   if (value.getClass().isArray()) {
-                       collection = Arrays.asList((Object[]) value);
-                   } else if (value instanceof HashMap) {
-                       collection = new ArrayList();
-                       for (Object entryObj : ((HashMap<?, ?>) value).entrySet()) {
-                           Map.Entry<?, ?> entry = (Map.Entry<?, ?>) entryObj;
+                   final Collection<Map<String, Object>> valueMaps;
+                   if (value instanceof Object[] arrayValue) {
+                       valueMaps = Arrays.stream(arrayValue)
+                               .map(item -> (Map<String, Object>) item).toList();
+                   } else if (value instanceof HashMap<?, ?> hashMapValue) {
+                       valueMaps = new ArrayList<>();
+                       for (Map.Entry<?, ?> entry : hashMapValue.entrySet()) {
                            Map<String, Object> map = new HashMap<>();
                            map.put("key", entry.getKey());
                            map.put("value", entry.getValue());
-                           collection.add(map);
+                           valueMaps.add(map);
                        }
                    } else {
-                       collection = (Collection) value;
+                       valueMaps = (Collection<Map<String, Object>>) value;
                    }
-                   collection.forEach(act -> builder.addRepeatedField(field, createMessage(field.getMessageType(), (Map<String, Object>) act, tableSchema)));
+                   valueMaps.forEach(act -> builder.addRepeatedField(field, createMessage(field.getMessageType(), act, tableSchema)));
                } else {
                    builder.setField(field, createMessage(field.getMessageType(), (Map<String, Object>) value, tableSchema));
                }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/bigquery/PutBigQueryTest.java
@@ -506,20 +506,21 @@ public class PutBigQueryTest {
     }
 
     private void decorateWithJsonRecordReaderWithSchema(TestRunner runner) throws InitializationException {
-        String recordReaderSchema = "{\n" +
-                "  \"name\": \"recordFormatName\",\n" +
-                "  \"namespace\": \"nifi.examples\",\n" +
-                "  \"type\": \"record\",\n" +
-                "  \"fields\": [\n" +
-                "    {\n" +
-                "      \"name\": \"field\",\n" +
-                "      \"type\": {\n" +
-                "        \"type\": \"map\",\n" +
-                "        \"values\": \"string\"\n" +
-                "      }\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
+        String recordReaderSchema = """
+                {
+                  "name": "recordFormatName",
+                  "namespace": "nifi.examples",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "field",
+                      "type": {
+                        "type": "map",
+                        "values": "string"
+                      }
+                    }
+                  ]
+                }""";
 
         JsonTreeReader jsonReader = new JsonTreeReader();
         runner.addControllerService("jsonReader", jsonReader);
@@ -586,14 +587,15 @@ public class PutBigQueryTest {
     }
 
     private String jsonContent() {
-        return "{\n" +
-                "  \"field\": {\n" +
-                "    \"FIELD_1\": \"field_1\",\n" +
-                "    \"FIELD_2\": \"field_2\",\n" +
-                "    \"FIELD_3\": \"field_3\",\n" +
-                "    \"FIELD_4\": \"field_4\",\n" +
-                "    \"FIELD_5\": \"field_5\"\n" +
-                "  }\n" +
-                "}";
+        return """
+                {
+                  "field": {
+                    "FIELD_1": "field_1",
+                    "FIELD_2": "field_2",
+                    "FIELD_3": "field_3",
+                    "FIELD_4": "field_4",
+                    "FIELD_5": "field_5"
+                  }
+                }""";
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13630](https://issues.apache.org/jira/browse/NIFI-13630)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
