### PR TITLE
NIFI-13639 Replace OkHttp with web-client-api in web-security

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
@@ -299,8 +299,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-web-client-api</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-web-client</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
@@ -73,7 +73,6 @@ import org.springframework.security.saml2.provider.service.web.authentication.lo
 import org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 import java.time.Duration;
@@ -95,8 +94,6 @@ public class SamlAuthenticationSecurityConfiguration {
 
     private final LogoutRequestManager logoutRequestManager;
 
-    private final SSLContext sslContext;
-
     private final X509ExtendedKeyManager keyManager;
 
     private final X509ExtendedTrustManager trustManager;
@@ -105,14 +102,12 @@ public class SamlAuthenticationSecurityConfiguration {
             @Autowired final NiFiProperties properties,
             @Autowired final BearerTokenProvider bearerTokenProvider,
             @Autowired final LogoutRequestManager logoutRequestManager,
-            @Autowired(required = false) final SSLContext sslContext,
             @Autowired(required = false) final X509ExtendedKeyManager keyManager,
             @Autowired(required = false) final X509ExtendedTrustManager trustManager
     ) {
         this.properties = Objects.requireNonNull(properties, "Properties required");
         this.bearerTokenProvider = Objects.requireNonNull(bearerTokenProvider, "Bearer Token Provider required");
         this.logoutRequestManager = Objects.requireNonNull(logoutRequestManager, "Logout Request Manager required");
-        this.sslContext = sslContext;
         this.keyManager = keyManager;
         this.trustManager = trustManager;
     }
@@ -320,7 +315,7 @@ public class SamlAuthenticationSecurityConfiguration {
     @Bean
     public RelyingPartyRegistrationRepository relyingPartyRegistrationRepository() {
         return properties.isSamlEnabled()
-                ? new StandardRelyingPartyRegistrationRepository(properties, sslContext, keyManager, trustManager)
+                ? new StandardRelyingPartyRegistrationRepository(properties, keyManager, trustManager)
                 : getDisabledRelyingPartyRegistrationRepository();
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/registration/StandardRelyingPartyRegistrationRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/registration/StandardRelyingPartyRegistrationRepository.java
@@ -24,7 +24,6 @@ import org.springframework.security.saml2.core.Saml2X509Credential;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
 
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 import java.security.Principal;
@@ -34,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+
 /**
  * Standard implementation of Relying Party Registration Repository based on NiFi Properties
  */
@@ -52,8 +52,6 @@ public class StandardRelyingPartyRegistrationRepository implements RelyingPartyR
 
     private final NiFiProperties properties;
 
-    private final SSLContext sslContext;
-
     private final X509ExtendedTrustManager trustManager;
 
     private final X509ExtendedKeyManager keyManager;
@@ -63,19 +61,16 @@ public class StandardRelyingPartyRegistrationRepository implements RelyingPartyR
     /**
      * Standard implementation builds a Registration based on NiFi Properties and returns the same instance for all queries
      *
-     * @param sslContext SSL Context loaded from properties
      * @param keyManager Key Manager loaded from properties
      * @param trustManager Trust manager loaded from properties
      * @param properties NiFi Application Properties
      */
     public StandardRelyingPartyRegistrationRepository(
             final NiFiProperties properties,
-            final SSLContext sslContext,
             final X509ExtendedKeyManager keyManager,
             final X509ExtendedTrustManager trustManager
     ) {
         this.properties = properties;
-        this.sslContext = sslContext;
         this.keyManager = keyManager;
         this.trustManager = trustManager;
         this.relyingPartyRegistration = getRelyingPartyRegistration();
@@ -87,7 +82,7 @@ public class StandardRelyingPartyRegistrationRepository implements RelyingPartyR
     }
 
     private RelyingPartyRegistration getRelyingPartyRegistration() {
-        final RegistrationBuilderProvider registrationBuilderProvider = new StandardRegistrationBuilderProvider(properties, sslContext, trustManager);
+        final RegistrationBuilderProvider registrationBuilderProvider = new StandardRegistrationBuilderProvider(properties, keyManager, trustManager);
         final RelyingPartyRegistration.Builder builder = registrationBuilderProvider.getRegistrationBuilder();
 
         builder.registrationId(Saml2RegistrationProperty.REGISTRATION_ID.getProperty());

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/saml2/registration/StandardRelyingPartyRegistrationRepositoryTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/saml2/registration/StandardRelyingPartyRegistrationRepositoryTest.java
@@ -18,7 +18,6 @@ package org.apache.nifi.web.security.saml2.registration;
 
 import org.apache.nifi.security.ssl.StandardKeyManagerBuilder;
 import org.apache.nifi.security.ssl.StandardKeyStoreBuilder;
-import org.apache.nifi.security.ssl.StandardSslContextBuilder;
 import org.apache.nifi.security.ssl.StandardTrustManagerBuilder;
 import org.apache.nifi.security.util.TemporaryKeyStoreBuilder;
 import org.apache.nifi.security.util.TlsConfiguration;
@@ -28,7 +27,6 @@ import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.springframework.security.saml2.core.Saml2X509Credential;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 import javax.security.auth.x500.X500Principal;
@@ -59,7 +57,7 @@ class StandardRelyingPartyRegistrationRepositoryTest {
     @Test
     void testFindByRegistrationId() {
         final NiFiProperties properties = getProperties();
-        final StandardRelyingPartyRegistrationRepository repository = new StandardRelyingPartyRegistrationRepository(properties, null, null, null);
+        final StandardRelyingPartyRegistrationRepository repository = new StandardRelyingPartyRegistrationRepository(properties, null, null);
 
         final RelyingPartyRegistration registration = repository.findByRegistrationId(Saml2RegistrationProperty.REGISTRATION_ID.getProperty());
 
@@ -81,10 +79,9 @@ class StandardRelyingPartyRegistrationRepositoryTest {
         final TlsConfiguration tlsConfiguration = new TemporaryKeyStoreBuilder().build();
         final X509ExtendedKeyManager keyManager = getKeyManager(tlsConfiguration);
         final X509ExtendedTrustManager trustManager = getTrustManager(tlsConfiguration);
-        final SSLContext sslContext = new StandardSslContextBuilder().keyManager(keyManager).trustManager(trustManager).build();
 
         final NiFiProperties properties = getSingleLogoutProperties(tlsConfiguration);
-        final StandardRelyingPartyRegistrationRepository repository = new StandardRelyingPartyRegistrationRepository(properties, sslContext, keyManager, trustManager);
+        final StandardRelyingPartyRegistrationRepository repository = new StandardRelyingPartyRegistrationRepository(properties, keyManager, trustManager);
 
         final RelyingPartyRegistration registration = repository.findByRegistrationId(Saml2RegistrationProperty.REGISTRATION_ID.getProperty());
 


### PR DESCRIPTION
# Summary

[NIFI-13639](https://issues.apache.org/jira/browse/NIFI-13639) Replaces the OkHttp client library with `nifi-web-client-api` in the `nifi-web-security` module for retrieving SAML Registration information. The `nifi-web-client` implementation now builds on the Java HttpClient class, removing the runtime dependency on OkHttp.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
