### PR TITLE
NIFI-13604: Python Source processors can be triggered without creatin…

### DIFF
--- a/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/python-developer-guide.adoc
@@ -323,6 +323,8 @@ Each processor based on the `FlowFileSource` API has a `success` relationship an
 created in the Processor's Python code. `attributes` and `contents` are both optional. If `attributes` is not provided,
 the FlowFile will still have the usual `filename`, `path` and `uuid` attributes, but no additional ones.
 If `contents` is not provided, a FlowFile with no contents (only attributes) will be created.
+In case there is no useful information to return from the `create` method, `return None` can be used instead of returning an
+empty `FlowFileSourceResult`. When `create` returns with `None`, the processor does not produce any output.
 
 
 

--- a/nifi-extension-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/python/processor/FlowFileSourceProxy.java
+++ b/nifi-extension-bundles/nifi-py4j-bundle/nifi-py4j-bridge/src/main/java/org/apache/nifi/python/processor/FlowFileSourceProxy.java
@@ -49,6 +49,9 @@ public class FlowFileSourceProxy extends PythonProcessorProxy<FlowFileSource> {
         final FlowFileSourceResult result;
         try {
             result = getTransform().createFlowFile();
+            if (result == null) {
+                return;
+            }
         } catch (final Py4JNetworkException e) {
             throw new ProcessException("Failed to communicate with Python Process", e);
         } catch (final Exception e) {

--- a/nifi-extension-bundles/nifi-py4j-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
+++ b/nifi-extension-bundles/nifi-py4j-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
@@ -595,6 +595,21 @@ public class PythonControllerInteractionIT {
                 multiLineContent.getBytes(StandardCharsets.UTF_8));
     }
 
+    @Test
+    public void testCreateNothing() throws IOException {
+        /* Test the use-case where the source processor returns with None.
+           (The case must not result in Java NullPointerException.) */
+
+        final String processorName = "CreateNothing";
+        final String relationshipSuccess = "success";
+
+        final TestRunner runner = createProcessor(processorName);
+        waitForValid(runner);
+        runner.run();
+
+        runner.assertTransferCount(relationshipSuccess, 0);
+    }
+
     public interface StringLookupService extends ControllerService {
         Optional<String> lookup(Map<String, String> coordinates);
     }

--- a/nifi-extension-bundles/nifi-py4j-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
+++ b/nifi-extension-bundles/nifi-py4j-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
@@ -596,18 +596,13 @@ public class PythonControllerInteractionIT {
     }
 
     @Test
-    public void testCreateNothing() throws IOException {
-        /* Test the use-case where the source processor returns with None.
-           (The case must not result in Java NullPointerException.) */
-
-        final String processorName = "CreateNothing";
-        final String relationshipSuccess = "success";
-
-        final TestRunner runner = createProcessor(processorName);
+    public void testCreateNothing() {
+        // Test the use-case where the source processor returns with None.
+        final TestRunner runner = createProcessor("CreateNothing");
         waitForValid(runner);
         runner.run();
 
-        runner.assertTransferCount(relationshipSuccess, 0);
+        runner.assertTransferCount("success", 0);
     }
 
     public interface StringLookupService extends ControllerService {

--- a/nifi-extension-bundles/nifi-py4j-bundle/nifi-python-test-extensions/src/main/resources/extensions/CreateNothing.py
+++ b/nifi-extension-bundles/nifi-py4j-bundle/nifi-python-test-extensions/src/main/resources/extensions/CreateNothing.py
@@ -1,0 +1,32 @@
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from nifiapi.flowfilesource import FlowFileSource
+
+class CreateNothing(FlowFileSource):
+    class Java:
+        implements = ['org.apache.nifi.python.processor.FlowFileSource']
+
+    class ProcessorDetails:
+        version = '0.0.1-SNAPSHOT'
+        description = '''A Python processor for testing a use-case where the Source processor 
+                         does not create any output.'''
+        tags = ['test', 'python', 'source']
+
+    def __init__(self, **kwargs):
+        pass
+
+    def create(self, context):
+        return None


### PR DESCRIPTION
…g new FlowFiles

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13604](https://issues.apache.org/jira/browse/NIFI-13604)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
