### PR TITLE
NIFI-13643 mapOf returns a FieldValue with a Map instead of a Record

### DIFF
--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/MapOf.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/MapOf.java
@@ -17,21 +17,16 @@
 
 package org.apache.nifi.record.path.functions;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.stream.Stream;
-
 import org.apache.nifi.record.path.FieldValue;
 import org.apache.nifi.record.path.RecordPathEvaluationContext;
 import org.apache.nifi.record.path.StandardFieldValue;
 import org.apache.nifi.record.path.paths.RecordPathSegment;
-import org.apache.nifi.serialization.SimpleRecordSchema;
-import org.apache.nifi.serialization.record.MapRecord;
-import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
-import org.apache.nifi.serialization.record.RecordSchema;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
 
 public class MapOf extends RecordPathSegment {
     private final RecordPathSegment[] valuePaths;
@@ -43,22 +38,17 @@ public class MapOf extends RecordPathSegment {
 
     @Override
     public Stream<FieldValue> evaluate(final RecordPathEvaluationContext context) {
-
-        final List<RecordField> fields = new ArrayList<>();
-        final java.util.Map<String, Object> values = new HashMap<>();
+        final Map<String, Object> values = new HashMap<>();
 
         for (int i = 0; i + 1 < valuePaths.length; i += 2) {
             final String key = valuePaths[i].evaluate(context).findFirst().get().toString();
             final String value = valuePaths[i + 1].evaluate(context).findFirst().get().toString();
-            fields.add(new RecordField(key, RecordFieldType.STRING.getDataType()));
             values.put(key, value);
         }
 
-        final RecordSchema schema = new SimpleRecordSchema(fields);
-        final Record record = new MapRecord(schema, values);
         final RecordField field = new RecordField("mapOf", RecordFieldType.MAP.getMapDataType(RecordFieldType.STRING.getDataType()));
+        final FieldValue responseValue = new StandardFieldValue(values, field, null);
 
-        final FieldValue responseValue = new StandardFieldValue(record, field, null);
         return Stream.of(responseValue);
     }
 

--- a/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
+++ b/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/TestRecordPath.java
@@ -1391,23 +1391,24 @@ public class TestRecordPath {
         return new MapRecord(schema, values);
     }
 
-
     @Test
     public void testMapOf() {
         final List<RecordField> fields = new ArrayList<>();
-        fields.add(new RecordField("fullName", RecordFieldType.INT.getDataType()));
-        fields.add(new RecordField("lastName", RecordFieldType.STRING.getDataType()));
-        fields.add(new RecordField("firstName", RecordFieldType.LONG.getDataType()));
+        fields.add(new RecordField("id", RecordFieldType.INT.getDataType()));
+        fields.add(new RecordField("name", RecordFieldType.STRING.getDataType()));
+        fields.add(new RecordField("balance", RecordFieldType.DOUBLE.getDataType()));
+        fields.add(new RecordField("missing", RecordFieldType.STRING.getDataType()));
 
         final RecordSchema schema = new SimpleRecordSchema(fields);
 
         final Map<String, Object> values = new HashMap<>();
-        values.put("lastName", "Doe");
-        values.put("firstName", "John");
+        values.put("id", 83);
+        values.put("name", "John Doe");
+        values.put("balance", 123.45);
         final Record record = new MapRecord(schema, values);
-        final FieldValue fv = RecordPath.compile("mapOf('firstName', /firstName, 'lastName', /lastName)").evaluate(record).getSelectedFields().findFirst().get();
-        assertTrue(fv.getField().getDataType().getFieldType().equals(RecordFieldType.MAP.getMapDataType(RecordFieldType.STRING.getDataType()).getFieldType()));
-        assertEquals("MapRecord[{firstName=John, lastName=Doe}]", fv.getValue().toString());
+        final FieldValue fv = RecordPath.compile("mapOf('id', /id, 'name', /name, 'money', /balance, 'nullableString', /missing)").evaluate(record).getSelectedFields().findFirst().get();
+        assertEquals(fv.getField().getDataType().getFieldType(), RecordFieldType.MAP.getMapDataType(RecordFieldType.STRING.getDataType()).getFieldType());
+        assertEquals(Map.of("id", "83", "name", "John Doe", "money", "123.45", "nullableString", "null"), fv.getValue());
 
         assertThrows(RecordPathException.class, () -> RecordPath.compile("mapOf('firstName', /firstName, 'lastName')").evaluate(record));
     }
@@ -2294,8 +2295,8 @@ public class TestRecordPath {
         final FieldValue singleArgumentFieldValue = evaluateSingleFieldValue("escapeJson(/)", record);
         assertEquals("{\"id\":48,\"name\":\"John Doe\",\"missing\":null}", singleArgumentFieldValue.getValue());
         final FieldValue multipleArgumentsFieldValue = evaluateSingleFieldValue("mapOf(\"copy\",/)", record);
-        assertInstanceOf(MapRecord.class, multipleArgumentsFieldValue.getValue());
-        assertEquals(record.toString(), ((MapRecord) multipleArgumentsFieldValue.getValue()).getValue("copy"));
+        assertInstanceOf(Map.class, multipleArgumentsFieldValue.getValue());
+        assertEquals(record.toString(), ((Map<?, ?>) multipleArgumentsFieldValue.getValue()).get("copy"));
     }
 
     private List<RecordField> getDefaultFields() {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13643](https://issues.apache.org/jira/browse/NIFI-13643)

While working on [NIFI-12852](https://issues.apache.org/jira/browse/NIFI-12852) I noticed that `mapOf` falsely returns a `FieldValue` that contains a `Record` instead of a `Map<String, String>` as indicated by [the declared `RecordFieldType.MAP`](https://github.com/apache/nifi/blob/38292762bd2872db47561ae3796a8adb8aaa27ac/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/MapOf.java#L59).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
