### PR TITLE
NIFI-13649 Ensure cluster node API address is reachable before markin…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/coordination/ClusterCoordinator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/coordination/ClusterCoordinator.java
@@ -162,6 +162,14 @@ public interface ClusterCoordinator {
     boolean isBlockedByFirewall(Set<String> nodeIdentities);
 
     /**
+     * Checks if the API of the given node is reachable.
+     *
+     * @param nodeId the node id to check
+     * @return true if the API is reachable, false otherwise
+     */
+    boolean isApiReachable(NodeIdentifier nodeId);
+
+    /**
      * Reports that some event occurred that is relevant to the cluster
      *
      * @param nodeId the identifier of the node that the event pertains to, or <code>null</code> if not applicable

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
@@ -30,8 +30,6 @@ import org.apache.nifi.util.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.time.Duration;

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/AbstractHeartbeatMonitor.java
@@ -30,17 +30,12 @@ import org.apache.nifi.util.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public abstract class AbstractHeartbeatMonitor implements HeartbeatMonitor {
-
-    private static final Duration NODE_API_TIMEOUT = Duration.ofSeconds(10);
 
     private final int heartbeatIntervalMillis;
     private final int missableHeartbeatCount;
@@ -293,7 +288,7 @@ public abstract class AbstractHeartbeatMonitor implements HeartbeatMonitor {
                 return;
             }
 
-            if (!isNodeApiReachable(nodeId)) {
+            if (!clusterCoordinator.isApiReachable(nodeId)) {
                 logger.info("Node API Address [{}] not reachable: cluster connection request deferred pending successful network connection", nodeId);
                 return;
             }
@@ -304,20 +299,6 @@ public abstract class AbstractHeartbeatMonitor implements HeartbeatMonitor {
         }
 
         clusterCoordinator.validateHeartbeat(heartbeat);
-    }
-
-    private boolean isNodeApiReachable(final NodeIdentifier nodeIdentifier) {
-        final String apiAddress = nodeIdentifier.getApiAddress();
-        final int apiPort = nodeIdentifier.getApiPort();
-        try {
-            try (final Socket soc = new Socket()) {
-                soc.connect(new InetSocketAddress(apiAddress, apiPort), (int) NODE_API_TIMEOUT.toMillis());
-            }
-            return true;
-        } catch (final Exception e) {
-            logger.debug("Node is not reachable at API address {} and port {}", apiAddress, apiPort, e);
-            return false;
-        }
     }
 
     /**

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/heartbeat/TestAbstractHeartbeatMonitor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/heartbeat/TestAbstractHeartbeatMonitor.java
@@ -173,6 +173,39 @@ public class TestAbstractHeartbeatMonitor {
         assertTrue(requestedToConnect.isEmpty());
     }
 
+    @Test
+    public void testConnectingNodeNotMarkedConnectedWhenHeartbeatReceivedAndApiUnreachable() throws InterruptedException {
+        final Set<NodeIdentifier> requestedToConnect = Collections.synchronizedSet(new HashSet<>());
+        final Set<NodeIdentifier> connected = Collections.synchronizedSet(new HashSet<>());
+        final ClusterCoordinatorAdapter adapter = new ClusterCoordinatorAdapter() {
+            @Override
+            public synchronized void requestNodeConnect(final NodeIdentifier nodeId) {
+                super.requestNodeConnect(nodeId);
+                requestedToConnect.add(nodeId);
+            }
+
+            @Override
+            public synchronized void finishNodeConnection(final NodeIdentifier nodeId) {
+                super.finishNodeConnection(nodeId);
+                connected.add(nodeId);
+            }
+
+            @Override
+            public boolean isApiReachable(final NodeIdentifier nodeId) {
+                return false;
+            }
+        };
+
+        final TestFriendlyHeartbeatMonitor monitor = createMonitor(adapter);
+
+        adapter.requestNodeConnect(nodeId); // set state to 'connecting'
+        requestedToConnect.clear();
+
+        monitor.addHeartbeat(createHeartbeat(nodeId, NodeConnectionState.CONNECTED));
+        monitor.waitForProcessed();
+
+        assertEquals(0, connected.size());
+    }
 
     private NodeHeartbeat createHeartbeat(final NodeIdentifier nodeId, final NodeConnectionState state) {
         final NodeConnectionStatus status = new NodeConnectionStatus(nodeId, state);
@@ -257,6 +290,11 @@ public class TestAbstractHeartbeatMonitor {
         @Override
         public synchronized boolean isBlockedByFirewall(Set<String> nodeIds) {
             return false;
+        }
+
+        @Override
+        public boolean isApiReachable(final NodeIdentifier nodeId) {
+            return true;
         }
 
         @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-runtime/src/main/java/org/apache/nifi/BootstrapListener.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-runtime/src/main/java/org/apache/nifi/BootstrapListener.java
@@ -210,6 +210,7 @@ public class BootstrapListener {
                                     case CLUSTER_STATUS:
                                         logger.info("Received CLUSTER_STATUS request from Bootstrap");
                                         final String clusterStatus = getClusterStatus();
+                                        logger.debug("Responding to CLUSTER_STATUS request from Bootstrap with {}", clusterStatus);
                                         sendAnswer(socket.getOutputStream(), clusterStatus);
                                         break;
                                     case DECOMMISSION:


### PR DESCRIPTION
…g CONNECTED

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13649](https://issues.apache.org/jira/browse/NIFI-13649)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
