### PR TITLE
NIFI-12855: Add previous event IDs to provenance events to facilitate full graph traversal

### DIFF
--- a/minifi/minifi-nar-bundles/minifi-provenance-repository-bundle/minifi-provenance-repositories/src/main/java/org/apache/nifi/provenance/NoOpProvenanceRepository.java
+++ b/minifi/minifi-nar-bundles/minifi-provenance-repository-bundle/minifi-provenance-repositories/src/main/java/org/apache/nifi/provenance/NoOpProvenanceRepository.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import static java.util.Collections.EMPTY_SET;
 import static java.util.Collections.emptyList;
 
 /**
@@ -36,7 +35,7 @@ import static java.util.Collections.emptyList;
  * store events.
  *
  */
-public class NoOpProvenanceRepository implements ProvenanceRepository {
+public class NoOpProvenanceRepository extends AbstractProvenanceRepository {
 
   @Override
   public void initialize(EventReporter eventReporter, Authorizer authorizer,
@@ -134,7 +133,7 @@ public class NoOpProvenanceRepository implements ProvenanceRepository {
 
   @Override
   public Set<String> getContainerNames() {
-    return EMPTY_SET;
+    return Set.of();
   }
 
   @Override

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventBuilder.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventBuilder.java
@@ -18,6 +18,8 @@ package org.apache.nifi.provenance;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.Relationship;
@@ -273,7 +275,7 @@ public interface ProvenanceEventBuilder {
     ProvenanceEventBuilder setDetails(String details);
 
     /**
-     * Sets the to which the FlowFile was routed for
+     * Sets the relationship to which the FlowFile was routed for
      * {@link ProvenanceEventType#ROUTE} events. This is valid only for
      * {@link ProvenanceEventType#ROUTE} events and will be ignored for any
      * other event types.
@@ -282,6 +284,13 @@ public interface ProvenanceEventBuilder {
      * @return the builder
      */
     ProvenanceEventBuilder setRelationship(Relationship relationship);
+
+    /**
+     * Sets the IDs for the event that happened previously to this event for the given FlowFile
+     * @param previousEventIds The previous event IDs (usually one except for JOIN events and such)
+     * @return the builder
+     */
+    ProvenanceEventBuilder setPreviousEventIds(Set<Long> previousEventIds);
 
     /**
      * Populates the builder with as much information as it can from the given
@@ -297,7 +306,7 @@ public interface ProvenanceEventBuilder {
      * {@link ProvenanceEventRecord#getEventId()} on the
      * {@link ProvenanceEventRecord} that is returned will yield
      * <code>-1</code>. This is because the implementation of the Event may
-     * depend on the {@link ProvevenanceEventRepository} to generate the unique
+     * depend on the {@link ProvenanceEventRepository} to generate the unique
      * identifier.
      *
      * @return the event

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventRecord.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventRecord.java
@@ -18,6 +18,7 @@ package org.apache.nifi.provenance;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Describes an event that happened to a FlowFile.
@@ -33,6 +34,12 @@ public interface ProvenanceEventRecord {
      * added to the {@link ProvenanceEventRepository}
      */
     long getEventId();
+
+    /**
+     * @return a unique ID for the "parent" Provenance Event, namely the one that came directly before this event
+     * for the given FlowFile. For source events such as CREATE, this value should be set to -1
+     */
+    Set<Long> getPreviousEventIds();
 
     /**
      * @return the time at which this Provenance Event was created, as the
@@ -149,14 +156,14 @@ public interface ProvenanceEventRecord {
     /**
      * @return the UUID's of all Parent FlowFiles. This is applicable only when
      * the {@link ProvenanceEventType} is of type
-     * {@link ProvenanceEventType#SPAWN SPAWN}
+     * {@link ProvenanceEventType#JOIN JOIN}
      */
     List<String> getParentUuids();
 
     /**
      * @return the UUID's of all Child FlowFiles. This is applicable only when
      * the {@link ProvenanceEventType} is of type
-     * {@link ProvenanceEventType#SPAWN SPAWN}
+     * {@link ProvenanceEventType#FORK FORK}
      */
     List<String> getChildUuids();
 

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventRepository.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/ProvenanceEventRepository.java
@@ -18,6 +18,7 @@ package org.apache.nifi.provenance;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This Repository houses Provenance Events. The repository is responsible for
@@ -93,5 +94,18 @@ public interface ProvenanceEventRepository {
      */
     void close() throws IOException;
 
+    /**
+     * Returns the previous provenance event IDs for the given FlowFile
+     * @param flowFileUUID the UUID of the FlowFile
+     * @return the previous event IDs for the given FlowFile
+     */
+    Set<Long> getPreviousEventIds(String flowFileUUID);
 
+    /**
+     * Updates the previous provenance event IDs for the given event
+     *
+     * @param record The record for which to update the previous event IDs
+     * @param previousIds the list of previous event IDs to set for the record, or null to remove
+     */
+    void updatePreviousEventIds(ProvenanceEventRecord record, Set<Long> previousIds);
 }

--- a/nifi-api/src/main/java/org/apache/nifi/provenance/UpdateableProvenanceEventRecord.java
+++ b/nifi-api/src/main/java/org/apache/nifi/provenance/UpdateableProvenanceEventRecord.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.provenance;
+
+import java.util.Set;
+
+public interface UpdateableProvenanceEventRecord extends ProvenanceEventRecord {
+
+    void setEventId(final long eventId);
+
+    void setPreviousEventIds(Set<Long> previousEventIds);
+}

--- a/nifi-commons/nifi-data-provenance-utils/src/main/java/org/apache/nifi/provenance/PlaceholderProvenanceEvent.java
+++ b/nifi-commons/nifi-data-provenance-utils/src/main/java/org/apache/nifi/provenance/PlaceholderProvenanceEvent.java
@@ -20,20 +20,23 @@ package org.apache.nifi.provenance;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A Provenance Event that is used to replace another Provenance Event when authorizations
  * are not granted for the original Provenance Event
  */
-public class PlaceholderProvenanceEvent implements ProvenanceEventRecord {
+public class PlaceholderProvenanceEvent implements UpdateableProvenanceEventRecord {
     private final String componentId;
-    private final long eventId;
+    private long eventId;
+    private Set<Long> previousEventIds;
     private final long eventTime;
     private final String flowFileUuid;
 
     public PlaceholderProvenanceEvent(final ProvenanceEventRecord original) {
         this.componentId = original.getComponentId();
         this.eventId = original.getEventId();
+        this.previousEventIds = original.getPreviousEventIds();
         this.eventTime = original.getEventTime();
         this.flowFileUuid = original.getFlowFileUuid();
     }
@@ -43,6 +46,20 @@ public class PlaceholderProvenanceEvent implements ProvenanceEventRecord {
         return eventId;
     }
 
+    @Override
+    public void setEventId(long eventId) {
+        this.eventId = eventId;
+    }
+
+    @Override
+    public Set<Long> getPreviousEventIds() {
+        return previousEventIds;
+    }
+
+    @Override
+    public void setPreviousEventIds(Set<Long> previousEventIds) {
+        this.previousEventIds = previousEventIds;
+    }
     @Override
     public long getEventTime() {
         return eventTime;

--- a/nifi-commons/nifi-data-provenance-utils/src/main/java/org/apache/nifi/provenance/SearchableFields.java
+++ b/nifi-commons/nifi-data-provenance-utils/src/main/java/org/apache/nifi/provenance/SearchableFields.java
@@ -57,6 +57,9 @@ public class SearchableFields {
     public static final SearchableField SourceQueueIdentifier
             = new NamedSearchableField("SourceQueueIdentifier", "sourceQueueIdentifier", "Source Queue Identifier", false, SearchableFieldType.STRING);
 
+    public static final SearchableField PreviousEventIdentifiers
+            = new NamedSearchableField("PreviousEventIdentifiers", "previousEventIdentifiers", "Previous Event Identifiers", false, SearchableFieldType.LONG);
+
     private static final Map<String, SearchableField> standardFields;
 
     static {
@@ -64,7 +67,7 @@ public class SearchableFields {
             EventTime, FlowFileUUID, Filename, EventType, TransitURI,
             ComponentID, AlternateIdentifierURI, FileSize, Relationship, Details,
             LineageStartDate, LineageIdentifier, ContentClaimSection, ContentClaimContainer, ContentClaimIdentifier,
-            ContentClaimOffset, SourceQueueIdentifier};
+            ContentClaimOffset, SourceQueueIdentifier, PreviousEventIdentifiers};
 
         final Map<String, SearchableField> fields = new HashMap<>();
         for (final SearchableField field : searchableFields) {

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/ResultSetRecordSet.java
@@ -157,12 +157,12 @@ public class ResultSetRecordSet implements RecordSet, Closeable {
             return null;
         }
 
-        if (value instanceof List) {
-            return ((List) value).toArray();
+        if (value instanceof Set) {
+            return ((Set) value).toArray();
         }
 
-        if (value instanceof Array) {
-            return ((Array) value).getArray();
+        if (value instanceof List) {
+            return ((List) value).toArray();
         }
 
         return value;

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/pom.xml
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/pom.xml
@@ -51,5 +51,11 @@
             <artifactId>lucene-backward-codecs</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-framework-core-api</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/WriteAheadProvenanceRepository.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/WriteAheadProvenanceRepository.java
@@ -87,7 +87,7 @@ import java.util.Set;
  * across disks for far greater performance.
  * </p>
  */
-public class WriteAheadProvenanceRepository implements ProvenanceRepository {
+public class WriteAheadProvenanceRepository extends AbstractProvenanceRepository {
     private static final Logger logger = LoggerFactory.getLogger(WriteAheadProvenanceRepository.class);
     static final int BLOCK_SIZE = 1024 * 32;
     public static final String EVENT_CATEGORY = "Provenance Repository";

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/ConvertEventToLuceneDocument.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/ConvertEventToLuceneDocument.java
@@ -94,6 +94,15 @@ public class ConvertEventToLuceneDocument {
         // be stored so that we know how to lookup the event in the store.
         doc.add(new UnIndexedLongField(SearchableFields.Identifier.getSearchableFieldName(), eventId));
 
+        final Set<Long> previousEventIDs = record.getPreviousEventIds();
+        if (previousEventIDs != null) {
+            for (Long previousEventID : previousEventIDs) {
+                doc.add(new StringField(SearchableFields.PreviousEventIdentifiers.getSearchableFieldName(), String.valueOf(previousEventID), Store.YES));
+            }
+        } else {
+            doc.add(new StringField(SearchableFields.PreviousEventIdentifiers.getSearchableFieldName(), "-1", Store.YES));
+        }
+
         // If it's event is a FORK, or JOIN, add the FlowFileUUID for all child/parent UUIDs.
         final ProvenanceEventType eventType = record.getEventType();
         if (eventType == ProvenanceEventType.FORK || eventType == ProvenanceEventType.CLONE || eventType == ProvenanceEventType.REPLAY) {
@@ -141,7 +150,7 @@ public class ConvertEventToLuceneDocument {
 
         public UnIndexedLongField(String name, long value) {
             super(name, TYPE);
-            fieldsData = Long.valueOf(value);
+            fieldsData = value;
         }
     }
 }

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/EventFieldNames.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/EventFieldNames.java
@@ -19,6 +19,7 @@ package org.apache.nifi.provenance.schema;
 
 public class EventFieldNames {
     public static final String EVENT_IDENTIFIER = "Event ID";
+    public static final String PREVIOUS_EVENT_IDENTIFIERS = "Previous Event IDs";
     public static final String EVENT_TYPE = "Event Type";
     public static final String EVENT_TIME = "Event Time";
     public static final String FLOWFILE_ENTRY_DATE = "FlowFile Entry Date";

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/EventRecord.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/EventRecord.java
@@ -20,6 +20,8 @@ package org.apache.nifi.provenance.schema;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
@@ -111,6 +113,8 @@ public class EventRecord implements Record {
                 return event.getTransitUri();
             case EventFieldNames.UPDATED_ATTRIBUTES:
                 return event.getUpdatedAttributes();
+            case EventFieldNames.PREVIOUS_EVENT_IDENTIFIERS:
+                return event.getPreviousEventIds();
         }
 
         return null;
@@ -157,6 +161,11 @@ public class EventRecord implements Record {
                 (Long) currentClaimRecord.getFieldValue(EventFieldNames.CONTENT_CLAIM_SIZE));
         }
 
+        final Set<Long> previousEventIDs = (Set<Long>) record.getFieldValue(EventFieldNames.PREVIOUS_EVENT_IDENTIFIERS);
+        if (previousEventIDs != null) {
+            builder.setPreviousEventIds(previousEventIDs);
+        }
+
         final Record previousClaimRecord = (Record) record.getFieldValue(EventFieldNames.PREVIOUS_CONTENT_CLAIM);
         if (previousClaimRecord != null) {
             builder.setPreviousContentClaim(
@@ -177,7 +186,7 @@ public class EventRecord implements Record {
 
         // Check if any attribute value exceeds the attribute length
         final boolean anyExceedsLength = attributes.values().stream()
-            .filter(value -> value != null)
+            .filter(Objects::nonNull)
             .anyMatch(value -> value.length() > maxAttributeLength);
 
         if (!anyExceedsLength) {

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventRecord.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventRecord.java
@@ -17,10 +17,13 @@
 
 package org.apache.nifi.provenance.schema;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
@@ -224,6 +227,8 @@ public class LookupTableEventRecord implements Record {
                 return event.getUpdatedAttributes();
             case EventFieldNames.FLOWFILE_UUID:
                 return event.getAttribute(CoreAttributes.UUID.key());
+            case EventFieldNames.PREVIOUS_EVENT_IDENTIFIERS:
+                return event.getPreviousEventIds();
         }
 
         return null;
@@ -353,6 +358,11 @@ public class LookupTableEventRecord implements Record {
             }
         }
 
+        final Collection<Long> previousEventIDsRecordField = (Collection<Long>) record.getFieldValue(EventFieldNames.PREVIOUS_EVENT_IDENTIFIERS);
+        if (previousEventIDsRecordField != null) {
+            final Set<Long> previousEventIDs = new HashSet<>(previousEventIDsRecordField);
+            builder.setPreviousEventIds(previousEventIDs);
+        }
         return builder.build();
     }
 

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventRecordFields.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventRecordFields.java
@@ -33,6 +33,7 @@ public class LookupTableEventRecordFields {
 
     // General Event fields.
     public static final RecordField RECORD_IDENTIFIER_OFFSET = new SimpleRecordField(EventFieldNames.EVENT_IDENTIFIER, FieldType.INT, EXACTLY_ONE);
+    public static final RecordField PREVIOUS_EVENT_IDENTIFIERS = new SimpleRecordField(EventFieldNames.PREVIOUS_EVENT_IDENTIFIERS, FieldType.LONG, ZERO_OR_MORE);
     public static final RecordField EVENT_TYPE_ORDINAL = new SimpleRecordField(EventFieldNames.EVENT_TYPE, FieldType.INT, EXACTLY_ONE);
     public static final RecordField EVENT_TIME_OFFSET = new SimpleRecordField(EventFieldNames.EVENT_TIME, FieldType.INT, EXACTLY_ONE);
     public static final RecordField FLOWFILE_ENTRY_DATE_OFFSET = new SimpleRecordField(EventFieldNames.FLOWFILE_ENTRY_DATE, FieldType.INT, EXACTLY_ONE);

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventSchema.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/schema/LookupTableEventSchema.java
@@ -34,6 +34,7 @@ import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.NO_
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.PARENT_UUIDS;
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.PREVIOUS_ATTRIBUTES;
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.PREVIOUS_CONTENT_CLAIM;
+import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.PREVIOUS_EVENT_IDENTIFIERS;
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.RECORD_IDENTIFIER_OFFSET;
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.RELATIONSHIP;
 import static org.apache.nifi.provenance.schema.LookupTableEventRecordFields.SOURCE_QUEUE_ID;
@@ -64,6 +65,7 @@ public class LookupTableEventSchema {
             fields.add(RECORD_IDENTIFIER_OFFSET);
         }
 
+        fields.add(PREVIOUS_EVENT_IDENTIFIERS);
         fields.add(EVENT_TYPE_ORDINAL);
         fields.add(EVENT_TIME_OFFSET);
         fields.add(FLOWFILE_ENTRY_DATE_OFFSET);

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/util/StorageSummaryEvent.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/util/StorageSummaryEvent.java
@@ -19,11 +19,14 @@ package org.apache.nifi.provenance.util;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.provenance.UpdateableProvenanceEventRecord;
 import org.apache.nifi.provenance.serialization.StorageSummary;
 
-public class StorageSummaryEvent implements ProvenanceEventRecord {
+public class StorageSummaryEvent implements UpdateableProvenanceEventRecord {
     private final ProvenanceEventRecord event;
     private final StorageSummary storageSummary;
 
@@ -35,6 +38,25 @@ public class StorageSummaryEvent implements ProvenanceEventRecord {
     @Override
     public long getEventId() {
         return storageSummary.getEventId();
+    }
+
+    @Override
+    public void setEventId(long eventId) {
+        if (event instanceof UpdateableProvenanceEventRecord) {
+            ((UpdateableProvenanceEventRecord) event).setEventId(eventId);
+        }
+    }
+
+    @Override
+    public Set<Long> getPreviousEventIds() {
+        return event.getPreviousEventIds();
+    }
+
+    @Override
+    public void setPreviousEventIds(Set<Long> previousEventIds) {
+        if (event instanceof UpdateableProvenanceEventRecord) {
+            ((UpdateableProvenanceEventRecord) event).setPreviousEventIds(previousEventIds);
+        }
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/main/java/org/apache/nifi/provenance/VolatileProvenanceRepository.java
+++ b/nifi-extension-bundles/nifi-provenance-repository-bundle/nifi-volatile-provenance-repository/src/main/java/org/apache/nifi/provenance/VolatileProvenanceRepository.java
@@ -63,7 +63,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
-public class VolatileProvenanceRepository implements ProvenanceRepository {
+public class VolatileProvenanceRepository extends AbstractProvenanceRepository {
 
     // properties
     public static final String BUFFER_SIZE = "nifi.provenance.repository.buffer.size";
@@ -786,7 +786,7 @@ public class VolatileProvenanceRepository implements ProvenanceRepository {
         }
     }
 
-    private static class IdEnrichedProvEvent implements ProvenanceEventRecord {
+    private static class IdEnrichedProvEvent implements UpdateableProvenanceEventRecord {
 
         private final ProvenanceEventRecord record;
         private final long id;
@@ -799,6 +799,25 @@ public class VolatileProvenanceRepository implements ProvenanceRepository {
         @Override
         public long getEventId() {
             return id;
+        }
+
+        @Override
+        public void setEventId(long eventId) {
+            if (record instanceof UpdateableProvenanceEventRecord) {
+                ((UpdateableProvenanceEventRecord) record).setEventId(eventId);
+            }
+        }
+
+        @Override
+        public Set<Long> getPreviousEventIds() {
+            return record.getPreviousEventIds();
+        }
+
+        @Override
+        public void setPreviousEventIds(Set<Long> previousEventIds) {
+            if (record instanceof UpdateableProvenanceEventRecord) {
+                ((UpdateableProvenanceEventRecord) record).setPreviousEventIds(previousEventIds);
+            }
         }
 
         @Override

--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteProvenanceReportingTask.java
+++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/SiteToSiteProvenanceReportingTask.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -384,6 +385,15 @@ public class SiteToSiteProvenanceReportingTask extends AbstractSiteToSiteReporti
         addField(builder, "alternateIdentifier", event.getAlternateIdentifierUri(), allowNullValues);
         addField(builder, "platform", platform, allowNullValues);
         addField(builder, "application", applicationName, allowNullValues);
+        List<String> previousEventIdsList = null;
+        Set<Long> previousEventIds = event.getPreviousEventIds();
+        if (previousEventIds != null) {
+            previousEventIdsList = new ArrayList<>(previousEventIds.size());
+            for (Long previousEventId : previousEventIds) {
+                previousEventIdsList.add(String.valueOf(previousEventId));
+            }
+        }
+        addField(builder, factory, "previousEventIds", previousEventIdsList, allowNullValues);
 
         return builder.build();
     }

--- a/nifi-extension-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/datasources/ProvenanceDataSource.java
+++ b/nifi-extension-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/datasources/ProvenanceDataSource.java
@@ -38,6 +38,7 @@ public class ProvenanceDataSource implements ResettableDataSource {
 
     public static final NiFiTableSchema SCHEMA = new NiFiTableSchema(List.of(
         new ColumnSchema("eventId", long.class, false),
+        new ColumnSchema("previousEventIds", new ArrayType(ScalarType.LONG), true),
         new ColumnSchema("eventType", String.class, false),
         new ColumnSchema("timestampMillis", long.class, true),
         new ColumnSchema("durationMillis", long.class, true),
@@ -118,6 +119,7 @@ public class ProvenanceDataSource implements ResettableDataSource {
 
         final ArrayList<Object> rowList = new ArrayList<>();
         rowList.add(provenanceEvent.getEventId());
+        rowList.add(provenanceEvent.getPreviousEventIds().toArray(new Long[provenanceEvent.getPreviousEventIds().size()]));
         rowList.add(provenanceEvent.getEventType().name());
         rowList.add(provenanceEvent.getEventTime());
         rowList.add(provenanceEvent.getEventDuration());

--- a/nifi-framework-api/src/main/java/org/apache/nifi/provenance/AbstractProvenanceRepository.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/provenance/AbstractProvenanceRepository.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.provenance;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class AbstractProvenanceRepository implements ProvenanceRepository {
+
+    protected final Map<String, Set<Long>> previousEventIdsMap = new HashMap<>();
+
+    @Override
+    public Set<Long> getPreviousEventIds(String flowFileUUID) {
+        return previousEventIdsMap.get(flowFileUUID);
+    }
+
+    @Override
+    public void updatePreviousEventIds(ProvenanceEventRecord record, Set<Long> previousIds) {
+        if (previousIds == null) {
+            previousEventIdsMap.remove(record.getFlowFileUuid());
+        } else {
+            previousEventIdsMap.put(record.getFlowFileUuid(), previousIds);
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProvenanceReporter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/StandardProvenanceReporter.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.controller.repository;
 
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.FlowFileHandlingException;
 import org.apache.nifi.provenance.InternalProvenanceReporter;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -115,7 +117,7 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
     }
 
     /**
-     * Generates a Fork event for the given child and parents but does not register the event. This is useful so that a ProcessSession has the ability to de-dupe events, since one or more events may
+     * Generates a Join event for the given child and parents but does not register the event. This is useful so that a ProcessSession has the ability to de-dupe events, since one or more events may
      * be created by the session itself, as well as by the Processor
      *
      * @param parents parents
@@ -127,16 +129,59 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         final ProvenanceEventBuilder eventBuilder = build(child, ProvenanceEventType.JOIN);
         eventBuilder.addChildFlowFile(child);
 
+        Set<Long> parentEventIds = new HashSet<>(parents.size());
         for (final FlowFile parent : parents) {
             eventBuilder.addParentFlowFile(parent);
+            parentEventIds.addAll(repository.getPreviousEventIds(parent.getAttribute(CoreAttributes.UUID.key())));
         }
+        eventBuilder.setPreviousEventIds(parentEventIds);
 
-        return eventBuilder.build();
+        ProvenanceEventRecord record = eventBuilder.build();
+        repository.updatePreviousEventIds(record, parentEventIds);
+        return record;
     }
 
     @Override
     public ProvenanceEventRecord generateDropEvent(final FlowFile flowFile, final String details) {
-        return build(flowFile, ProvenanceEventType.DROP).setDetails(details).build();
+        final String flowFileUUID = flowFile.getAttribute(CoreAttributes.UUID.key());
+        final ProvenanceEventRecord record =  build(flowFile, ProvenanceEventType.DROP)
+                .setDetails(details)
+                .setPreviousEventIds(repository.getPreviousEventIds(flowFileUUID))
+                .build();
+        repository.updatePreviousEventIds(record, null);
+        return record;
+    }
+
+    @Override
+    public ProvenanceEventRecord generateModifyContentEvent(final FlowFile flowFile, final String details) {
+        final String flowFileUUID = flowFile.getAttribute(CoreAttributes.UUID.key());
+        final ProvenanceEventRecord record =  build(flowFile, ProvenanceEventType.CONTENT_MODIFIED)
+                .setDetails(details)
+                .setPreviousEventIds(repository.getPreviousEventIds(flowFileUUID))
+                .build();
+        repository.updatePreviousEventIds(record, Collections.singleton(record.getEventId()));
+        return record;
+    }
+
+    @Override
+    public ProvenanceEventRecord generateModifyAttributesEvent(final FlowFile flowFile, final String details) {
+        final String flowFileUUID = flowFile.getAttribute(CoreAttributes.UUID.key());
+        final ProvenanceEventRecord record =  build(flowFile, ProvenanceEventType.ATTRIBUTES_MODIFIED)
+                .setDetails(details)
+                .setPreviousEventIds(repository.getPreviousEventIds(flowFileUUID))
+                .build();
+        repository.updatePreviousEventIds(record, Collections.singleton(record.getEventId()));
+        return record;
+    }
+
+    @Override
+    public ProvenanceEventRecord generateCreateEvent(final FlowFile flowFile, final String details) {
+        final ProvenanceEventRecord record =  build(flowFile, ProvenanceEventType.CREATE)
+                .setDetails(details)
+                .setPreviousEventIds(Collections.emptySet())
+                .build();
+        repository.updatePreviousEventIds(record, Collections.singleton(record.getEventId()));
+        return record;
     }
 
     private void verifyFlowFileKnown(final FlowFile flowFile) {
@@ -170,13 +215,15 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
-            final ProvenanceEventBuilder builder = build(flowFile, ProvenanceEventType.RECEIVE);
-            builder.setTransitUri(transitUri);
-            builder.setSourceSystemFlowFileIdentifier(sourceSystemFlowFileIdentifier);
-            builder.setEventDuration(transmissionMillis);
-            builder.setDetails(details);
-            final ProvenanceEventRecord record = builder.build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.RECEIVE)
+                    .setTransitUri(transitUri)
+                    .setSourceSystemFlowFileIdentifier(sourceSystemFlowFileIdentifier)
+                    .setEventDuration(transmissionMillis)
+                    .setDetails(details)
+                    .setPreviousEventIds(Collections.singleton(-1L))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singleton(record.getEventId()));
 
             bytesReceived += flowFile.getSize();
             flowFilesReceived++;
@@ -200,13 +247,16 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
+            final String flowFileUUID = flowFile.getAttribute(CoreAttributes.UUID.key());
             final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.FETCH)
                     .setTransitUri(transitUri)
                     .setEventDuration(transmissionMillis)
                     .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFileUUID))
                     .build();
 
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singleton(record.getEventId()));
 
             bytesFetched += flowFile.getSize();
             flowFilesFetched++;
@@ -253,7 +303,12 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
     @Override
     public void send(final FlowFile flowFile, final String transitUri, final String details, final long transmissionMillis, final boolean force) {
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.SEND).setTransitUri(transitUri).setEventDuration(transmissionMillis).setDetails(details).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.SEND)
+                    .setTransitUri(transitUri)
+                    .setEventDuration(transmissionMillis)
+                    .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             // If the transmissionMillis field has been populated, use zero as the value of commitNanos (the call to System.nanoTime() is expensive but the value will be ignored).
             final long commitNanos = transmissionMillis < 0 ? System.nanoTime() : 0L;
             final ProvenanceEventRecord enriched = eventEnricher == null ? record : eventEnricher.enrich(record, flowFile, commitNanos);
@@ -263,6 +318,7 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
             } else {
                 events.add(enriched);
             }
+            repository.updatePreviousEventIds(enriched, enriched.getPreviousEventIds());
 
             bytesSent += flowFile.getSize();
             flowFilesSent++;
@@ -311,7 +367,10 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
     public void invokeRemoteProcess(FlowFile flowFile, String transitUri, String details) {
         try {
             final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.REMOTE_INVOCATION)
-                    .setTransitUri(transitUri).setDetails(details).build();
+                    .setTransitUri(transitUri)
+                    .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event", e);
@@ -335,8 +394,12 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
             }
 
             final String alternateIdentifierUri = trimmedNamespace + ":" + trimmedIdentifier;
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ADDINFO).setAlternateIdentifierUri(alternateIdentifierUri).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ADDINFO)
+                    .setAlternateIdentifierUri(alternateIdentifierUri)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singleton(record.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event", e);
         }
@@ -349,8 +412,11 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
             if (reason != null) {
                 builder.setDetails("Discard reason: " + reason);
             }
+            builder.setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())));
+
             final ProvenanceEventRecord record = builder.build();
             events.add(record);
+            repository.updatePreviousEventIds(record, null);
             return record;
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event", e);
@@ -361,8 +427,12 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
     @Override
     public void expire(final FlowFile flowFile, final String details) {
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.EXPIRE).setDetails(details).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.EXPIRE)
+                    .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, null);
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event", e);
         }
@@ -403,6 +473,15 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
             }
 
             events.add(eventBuilder.build());
+            final ProvenanceEventRecord record = eventBuilder.build();
+            events.add(record);
+            // TODO is this right?
+            for (final FlowFile child : children) {
+                // Add the child FlowFiles to the previous event ID map with the parent's entry in the map
+                repository.updatePreviousEventIds(
+                        record,
+                        repository.getPreviousEventIds(child.getAttribute(CoreAttributes.UUID.key())));
+            }
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event", e);
         }
@@ -431,12 +510,20 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
             final ProvenanceEventBuilder eventBuilder = build(child, ProvenanceEventType.JOIN);
             eventBuilder.addChildFlowFile(child);
             eventBuilder.setDetails(details);
+            Set<Long> parentEventIds = new HashSet<>(parents.size());
 
             for (final FlowFile parent : parents) {
                 eventBuilder.addParentFlowFile(parent);
+                Set<Long> previousEventIds = repository.getPreviousEventIds(parent.getAttribute(CoreAttributes.UUID.key()));
+                if (previousEventIds != null) {
+                    parentEventIds.addAll(previousEventIds);
+                }
             }
+            eventBuilder.setPreviousEventIds(parentEventIds);
 
-            events.add(eventBuilder.build());
+            final ProvenanceEventRecord record = eventBuilder.build();
+            events.add(record);
+            repository.updatePreviousEventIds(record, parentEventIds);
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event", e);
         }
@@ -455,9 +542,13 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
 
         try {
             final ProvenanceEventBuilder eventBuilder = build(parent, ProvenanceEventType.CLONE);
-            eventBuilder.addChildFlowFile(child);
-            eventBuilder.addParentFlowFile(parent);
-            events.add(eventBuilder.build());
+            final ProvenanceEventRecord event = eventBuilder
+                    .addChildFlowFile(child)
+                    .addParentFlowFile(parent)
+                    .setPreviousEventIds(repository.getPreviousEventIds(parent.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
+            events.add(event);
+            repository.updatePreviousEventIds(event, Collections.singleton(event.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event", e);
         }
@@ -483,8 +574,13 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.CONTENT_MODIFIED).setEventDuration(processingMillis).setDetails(details).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.CONTENT_MODIFIED)
+                    .setEventDuration(processingMillis)
+                    .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singleton(record.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event", e);
         }
@@ -500,8 +596,12 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ATTRIBUTES_MODIFIED).setDetails(details).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ATTRIBUTES_MODIFIED)
+                    .setDetails(details)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singleton(record.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event", e);
         }
@@ -527,8 +627,13 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ROUTE).setRelationship(relationship).setDetails(details).setEventDuration(processingDuration).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.ROUTE).setRelationship(relationship)
+                    .setDetails(details)
+                    .setEventDuration(processingDuration)
+                    .setPreviousEventIds(repository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())))
+                    .build();
             events.add(record);
+            repository.updatePreviousEventIds(record, Collections.singleton(record.getEventId()));
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event", e);
         }
@@ -544,7 +649,10 @@ public class StandardProvenanceReporter implements InternalProvenanceReporter {
         verifyFlowFileKnown(flowFile);
 
         try {
-            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.CREATE).setDetails(details).build();
+            final ProvenanceEventRecord record = build(flowFile, ProvenanceEventType.CREATE)
+                    .setDetails(details)
+                    .setPreviousEventIds(Collections.emptySet())
+                    .build();
             events.add(record);
         } catch (final Exception e) {
             logger.error("Failed to generate Provenance Event", e);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/provenance/InternalProvenanceReporter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/provenance/InternalProvenanceReporter.java
@@ -33,6 +33,12 @@ public interface InternalProvenanceReporter extends ProvenanceReporter {
 
     ProvenanceEventRecord generateJoinEvent(Collection<FlowFile> parents, FlowFile child);
 
+    ProvenanceEventRecord generateModifyContentEvent(FlowFile flowFile, String explanation);
+
+    ProvenanceEventRecord generateCreateEvent(FlowFile flowFile, String explanation);
+
+    ProvenanceEventRecord generateModifyAttributesEvent(FlowFile flowFile, String explanation);
+
     void remove(ProvenanceEventRecord event);
 
     void removeEventsForFlowFile(String uuid);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/AbstractFlowFileQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/AbstractFlowFileQueue.java
@@ -423,6 +423,7 @@ public abstract class AbstractFlowFileQueue implements FlowFileQueue {
             builder.setPreviousContentClaim(resourceClaim.getContainer(), resourceClaim.getSection(), resourceClaim.getId(), contentClaim.getOffset(), flowFile.getSize());
         }
 
+        builder.setPreviousEventIds(provRepository.getPreviousEventIds(flowFile.getAttribute(CoreAttributes.UUID.key())));
         return builder.build();
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/provenance/MockProvenanceRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/provenance/MockProvenanceRepository.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class MockProvenanceRepository implements ProvenanceRepository {
+public class MockProvenanceRepository extends AbstractProvenanceRepository {
     private final List<ProvenanceEventRecord> records = new ArrayList<>();
     private final AtomicLong idGenerator = new AtomicLong(0L);
 

--- a/nifi-mock/src/main/java/org/apache/nifi/provenance/MockProvenanceEvent.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/provenance/MockProvenanceEvent.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class MockProvenanceEvent implements ProvenanceEventRecord {
@@ -64,6 +65,7 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
     private final Map<String, String> updatedAttributes;
 
     private volatile long eventId = -1L;
+    private volatile Set<Long> previousEventIds;
 
     private MockProvenanceEvent(final Builder builder) {
         this.eventTime = builder.eventTime;
@@ -102,6 +104,8 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
         if (builder.eventId != null) {
             eventId = builder.eventId;
         }
+
+        previousEventIds = builder.previousEventIds;
     }
 
 
@@ -112,6 +116,15 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
     @Override
     public long getEventId() {
         return eventId;
+    }
+
+    @Override
+    public Set<Long> getPreviousEventIds() {
+        return previousEventIds;
+    }
+
+    public void setPreviousEventIds(Set<Long> previousEventIds) {
+        this.previousEventIds = previousEventIds;
     }
 
     @Override
@@ -440,6 +453,7 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
         private String relationship = null;
         private long eventDuration = -1L;
         private Long eventId = eventIdGenerator.getAndIncrement();
+        private Set<Long> previousEventIds;
 
         private String contentClaimSection;
         private String contentClaimContainer;
@@ -492,6 +506,8 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
 
             sourceQueueIdentifier = event.getSourceQueueIdentifier();
 
+            previousEventIds = event.getPreviousEventIds();
+
             return this;
         }
 
@@ -542,6 +558,10 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
             copy.previousSize = previousSize;
 
             copy.sourceQueueIdentifier = sourceQueueIdentifier;
+
+            if (previousEventIds != null) {
+                copy.previousEventIds = previousEventIds;
+            }
 
             return copy;
         }
@@ -672,6 +692,12 @@ public class MockProvenanceEvent implements ProvenanceEventRecord {
         @Override
         public Builder setDetails(String details) {
             this.details = details;
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setPreviousEventIds(Set<Long> previousEventIds) {
+            this.previousEventIds = previousEventIds;
             return this;
         }
 


### PR DESCRIPTION

# Summary

[NIFI-12855](https://issues.apache.org/jira/browse/NIFI-12855) This PR adds "previousEventIds" to provenance events. This can help graph-based applications/databases provide correct lineage more quickly (namely, without having to sort the events by timestamp)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
