### PR TITLE
NIFI-13532 Fixed Flow Configuration History Sorting when Filtered

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-administration/src/main/java/org/apache/nifi/admin/service/EntityStoreAuditService.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-administration/src/main/java/org/apache/nifi/admin/service/EntityStoreAuditService.java
@@ -336,10 +336,7 @@ public class EntityStoreAuditService implements AuditService, Closeable {
             endTimestamp = endDate.getTime();
         }
 
-        final ActionEntity sortEntityProperty = getSortEntityProperty(actionQuery);
-        final boolean ascending = isAscending(actionQuery);
-        final EntityIterable sorted = storeTransaction.sort(EntityType.ACTION.getEntityType(), sortEntityProperty.getProperty(), ascending);
-        final EntityIterable entities = sorted.intersect(storeTransaction.find(EntityType.ACTION.getEntityType(), ActionEntity.TIMESTAMP.getProperty(), startTimestamp, endTimestamp));
+        final EntityIterable entities = storeTransaction.find(EntityType.ACTION.getEntityType(), ActionEntity.TIMESTAMP.getProperty(), startTimestamp, endTimestamp);
 
         final EntityIterable sourceEntities;
         final String sourceId = actionQuery.getSourceId();
@@ -359,7 +356,9 @@ public class EntityStoreAuditService implements AuditService, Closeable {
             filteredEntities = sourceEntities.intersect(identityFiltered);
         }
 
-        return filteredEntities;
+        final ActionEntity sortEntityProperty = getSortEntityProperty(actionQuery);
+        final boolean ascending = isAscending(actionQuery);
+        return storeTransaction.sort(EntityType.ACTION.getEntityType(), sortEntityProperty.getProperty(), filteredEntities, ascending);
     }
 
     private boolean isAscending(final HistoryQuery historyQuery) {


### PR DESCRIPTION
# Summary

[NIFI-13532](https://issues.apache.org/jira/browse/NIFI-13532) Corrects the behavior of the Flow Configuration History REST API to maintain the sort direction when filtering on user identity or source identifier.

The Entity Store implementation based on JetBrains Xodus supports sorting, which works as expected without applying any filters. The initial implementation applied sorting prior to filtering, resulting in unsorted results when with a filter entered. The corrected approach applies sorting after any filters, ensuring the correct sorting behavior in all scenarios.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
