### PR TITLE
NIFI-13677 Remove install command from nifi.sh

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -49,10 +49,6 @@ NOTE: Under sustained and extremely high throughput the CodeCache settings may n
 *** `stop`: stops NiFi that is running in the background
 *** `status`: provides the current status of NiFi
 *** `run`: runs NiFi in the foreground and waits for a Ctrl-C to initiate shutdown of NiFi
-*** `install`: installs NiFi as a service that can then be controlled via
-**** `service nifi start`
-**** `service nifi stop`
-**** `service nifi status`
 
 * Windows
 ** Decompress into the desired installation directory


### PR DESCRIPTION
# Summary

[NIFI-13677](https://issues.apache.org/jira/browse/NIFI-13677) Removes the `install` command from the `nifi.sh` script as it does not align with supported packaging options. RPM packaging support is no longer supported in the build process and Linux distributions have different approaches for installing and maintaining system services, which are outside the scope of the nifi.sh script.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
