### PR TITLE
NIFI-13664 allow bundle id to be searchable

### DIFF
--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -2069,7 +2069,7 @@ image:align-horizontally-after.png["Align Horizontally Example Before"]
 [[search]]
 == Search Components in DataFlow
 
-NiFi UI provides searching functionality in order to help easily find components on the canvas. You can use search to find components by name, type, identifier, configuration properties, and their values. Search also makes it possible to refine and narrow the search result based on certain conditions using Filters and Keywords.
+NiFi UI provides searching functionality in order to help easily find components on the canvas. You can use search to find components by name, type, identifier, bundle, configuration properties, and configuration values. Search also makes it possible to refine and narrow the search result based on certain conditions using Filters and Keywords.
 
 [caption="Example 1: "]
 .The result will contain components that match for "processor1".

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/WebSearchConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/configuration/WebSearchConfiguration.java
@@ -22,6 +22,7 @@ import org.apache.nifi.web.controller.ControllerSearchService;
 import org.apache.nifi.web.search.ComponentMatcherFactory;
 import org.apache.nifi.web.search.attributematchers.BackPressureMatcher;
 import org.apache.nifi.web.search.attributematchers.BasicMatcher;
+import org.apache.nifi.web.search.attributematchers.BundleMatcher;
 import org.apache.nifi.web.search.attributematchers.ConnectionMatcher;
 import org.apache.nifi.web.search.attributematchers.ConnectionRelationshipMatcher;
 import org.apache.nifi.web.search.attributematchers.ConnectivityMatcher;
@@ -95,6 +96,7 @@ public class WebSearchConfiguration {
         controllerSearchService.setMatcherForControllerServiceNode(factory.getInstanceForControllerServiceNode(
                 List.of(
                         new ControllerServiceNodeMatcher(),
+                        new BundleMatcher<>(),
                         new PropertyMatcher<>()
                 )
         ));
@@ -153,6 +155,7 @@ public class WebSearchConfiguration {
                         new ScheduledStateMatcher(),
                         new RelationshipMatcher<>(),
                         new ProcessorMetadataMatcher(),
+                        new BundleMatcher<>(),
                         new PropertyMatcher<>(),
                         searchableMatcher
                 )

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/search/attributematchers/BundleMatcher.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/search/attributematchers/BundleMatcher.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.search.attributematchers;
+
+import org.apache.nifi.controller.ComponentNode;
+import org.apache.nifi.web.search.query.SearchQuery;
+
+import java.util.List;
+
+public class BundleMatcher <T extends ComponentNode> implements AttributeMatcher<T> {
+    private static final String BUNDLE = "Bundle";
+
+    @Override
+    public void match(T component, SearchQuery query, List<String> matches) {
+        final String searchTerm = query.getTerm();
+        AttributeMatcher.addIfMatching(searchTerm, component.getBundleCoordinate().getId(), BUNDLE, matches);
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/search/attributematchers/BundleMatcherTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/search/attributematchers/BundleMatcherTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.search.attributematchers;
+
+import org.apache.nifi.bundle.BundleCoordinate;
+import org.apache.nifi.controller.ComponentNode;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+public class BundleMatcherTest extends AbstractAttributeMatcherTest {
+
+    @Mock
+    private ComponentNode component;
+
+    @Test
+    public void testMatch() {
+        givenBundleId("nifi-lorem-nar");
+        givenDefaultSearchTerm();
+
+        BundleMatcher<ComponentNode> testSubject = new BundleMatcher<>();
+        testSubject.match(component, searchQuery, matches);
+
+        thenMatchConsistsOf("Bundle: nifi-lorem-nar");
+    }
+
+    @Test
+    public void testNoMatches() {
+        givenBundleId("nifi-standard-nar");
+        givenDefaultSearchTerm();
+
+        BundleMatcher<ComponentNode> testSubject = new BundleMatcher<>();
+        testSubject.match(component, searchQuery, matches);
+
+        thenNoMatches();
+    }
+
+    private void givenBundleId(String id) {
+        BundleCoordinate coordinate = new BundleCoordinate(null, id, null);
+        Mockito.when(component.getBundleCoordinate()).thenReturn(coordinate);
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-13664](https://issues.apache.org/jira/browse/NIFI-13664)

Improved the component Search capability by allowing user to type all or part of a Bundle ID (NAR name) to find matching components.  Updated the User Guide.

For example, if you type "nifi-slack" in the Search Bar, it will show "Bundle: nifi-slack-nar" from matching components.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
