### PR TITLE
NIFI-13684 Set Cluster Status HTTP Code based on Connection

### DIFF
--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/command/ManagementServerBootstrapCommand.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/command/ManagementServerBootstrapCommand.java
@@ -141,6 +141,7 @@ class ManagementServerBootstrapCommand implements BootstrapCommand {
         } else {
             commandStatus = CommandStatus.COMMUNICATION_FAILED;
             getCommandLogger().warn("Application Process [{}] Command Status [{}] HTTP {}", pid, commandStatus, statusCode);
+            responseStreamHandler.onResponseStream(responseStream);
         }
     }
 

--- a/nifi-bootstrap/src/test/java/org/apache/nifi/bootstrap/command/ManagementServerBootstrapCommandTest.java
+++ b/nifi-bootstrap/src/test/java/org/apache/nifi/bootstrap/command/ManagementServerBootstrapCommandTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.bootstrap.command;
+
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.nifi.bootstrap.command.io.LoggerResponseStreamHandler;
+import org.apache.nifi.bootstrap.command.io.ResponseStreamHandler;
+import org.apache.nifi.bootstrap.command.process.ProcessHandleProvider;
+import org.apache.nifi.bootstrap.configuration.ManagementServerPath;
+import org.apache.nifi.bootstrap.configuration.SystemProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ManagementServerBootstrapCommandTest {
+    private static final Logger logger = LoggerFactory.getLogger(ManagementServerBootstrapCommandTest.class);
+
+    private static final String LOCALHOST = "127.0.0.1";
+
+    private static final int RANDOM_PORT = 0;
+
+    private static final int BACKLOG = 10;
+
+    private static final int STOP_DELAY = 0;
+
+    private static final String ADDRESS_ARGUMENT = "-D%s=%s:%d";
+
+    private static final String RESPONSE_STATUS = "Status";
+
+    @Mock
+    private ProcessHandleProvider processHandleProvider;
+
+    @Mock
+    private ProcessHandle processHandle;
+
+    @Mock
+    private ProcessHandle.Info processHandleInfo;
+
+    @Test
+    void testStopped() {
+        final ResponseStreamHandler responseStreamHandler = new LoggerResponseStreamHandler(logger);
+
+        final ManagementServerBootstrapCommand command = new ManagementServerBootstrapCommand(processHandleProvider, ManagementServerPath.HEALTH_CLUSTER, responseStreamHandler);
+
+        command.run();
+
+        final CommandStatus commandStatus = command.getCommandStatus();
+        assertEquals(CommandStatus.STOPPED, commandStatus);
+    }
+
+    @Test
+    void testClusterHealthStatusConnected() throws IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        final ResponseStreamHandler responseStreamHandler = responseStream -> {
+            try {
+                responseStream.transferTo(outputStream);
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+
+        final HttpServer httpServer = startServer(HttpURLConnection.HTTP_OK);
+
+        final ManagementServerBootstrapCommand command = new ManagementServerBootstrapCommand(processHandleProvider, ManagementServerPath.HEALTH_CLUSTER, responseStreamHandler);
+        command.run();
+
+        final CommandStatus commandStatus = command.getCommandStatus();
+        assertEquals(CommandStatus.SUCCESS, commandStatus);
+        assertEquals(RESPONSE_STATUS, outputStream.toString());
+
+        httpServer.stop(STOP_DELAY);
+    }
+
+    @Test
+    void testClusterHealthStatusDisconnected() throws IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        final ResponseStreamHandler responseStreamHandler = responseStream -> {
+            try {
+                responseStream.transferTo(outputStream);
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+
+        final HttpServer httpServer = startServer(HttpURLConnection.HTTP_UNAVAILABLE);
+
+        final ManagementServerBootstrapCommand command = new ManagementServerBootstrapCommand(processHandleProvider, ManagementServerPath.HEALTH_CLUSTER, responseStreamHandler);
+        command.run();
+
+        final CommandStatus commandStatus = command.getCommandStatus();
+        assertEquals(CommandStatus.COMMUNICATION_FAILED, commandStatus);
+        assertEquals(RESPONSE_STATUS, outputStream.toString());
+
+        httpServer.stop(STOP_DELAY);
+    }
+
+    private HttpServer startServer(final int responseCode) throws IOException {
+        final InetSocketAddress bindAddress = new InetSocketAddress(LOCALHOST, RANDOM_PORT);
+        final HttpServer httpServer = HttpServer.create(bindAddress, BACKLOG);
+        final HttpHandler httpHandler = exchange -> {
+            exchange.sendResponseHeaders(responseCode, RESPONSE_STATUS.length());
+            try (OutputStream responseBody = exchange.getResponseBody()) {
+                responseBody.write(RESPONSE_STATUS.getBytes(StandardCharsets.UTF_8));
+            }
+        };
+        httpServer.createContext(ManagementServerPath.HEALTH_CLUSTER.getPath(), httpHandler);
+        httpServer.start();
+
+        final InetSocketAddress serverAddress = httpServer.getAddress();
+        final String addressArgument = ADDRESS_ARGUMENT.formatted(SystemProperty.MANAGEMENT_SERVER_ADDRESS.getProperty(), LOCALHOST, serverAddress.getPort());
+        final String[] arguments = new String[]{addressArgument};
+
+        when(processHandleProvider.findApplicationProcessHandle()).thenReturn(Optional.of(processHandle));
+        when(processHandle.info()).thenReturn(processHandleInfo);
+        when(processHandleInfo.arguments()).thenReturn(Optional.of(arguments));
+
+        return httpServer;
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-13684](https://issues.apache.org/jira/browse/NIFI-13684) Updates the `nifi-runtime` Management Server `/health/cluster` HTTP response to return HTTP 503 when the cluster connection state is not `CONNECTED` or `CONNECTING`. This change preserves the current behavior of the `nifi.sh cluster-status` command to return the information to the console, but provides an HTTP response code that corresponds to the content of the connection state.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
