### PR TITLE
NIFI-13685 Upgrade Spring from 6.1.11 to 6.1.12

### DIFF
--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -35,7 +35,7 @@
         <module>nifi-registry-docker-maven</module>
     </modules>
     <properties>
-        <spring.boot.version>3.3.2</spring.boot.version>
+        <spring.boot.version>3.3.3</spring.boot.version>
         <flyway.version>10.17.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,8 +154,8 @@
         <snakeyaml.version>2.2</snakeyaml.version>
         <netty.4.version>4.1.112.Final</netty.4.version>
         <servlet-api.version>6.0.0</servlet-api.version>
-        <spring.version>6.1.11</spring.version>
-        <spring.security.version>6.3.1</spring.security.version>
+        <spring.version>6.1.12</spring.version>
+        <spring.security.version>6.3.3</spring.security.version>
         <swagger.annotations.version>2.2.22</swagger.annotations.version>
         <h2.version>2.3.230</h2.version>
         <zookeeper.version>3.9.2</zookeeper.version>


### PR DESCRIPTION
# Summary

[NIFI-13685](https://issues.apache.org/jira/browse/NIFI-13685) Upgrades Spring Framework dependencies from 6.1.11 to [6.1.12](https://github.com/spring-projects/spring-framework/releases/tag/v6.1.12) and Spring Security dependencies from 6.3.1 to [6.3.3](https://github.com/spring-projects/spring-security/releases/tag/6.3.3). Also upgraded Spring Boot from 3.3.2 to [3.3.3](https://github.com/spring-projects/spring-boot/releases/tag/v3.3.3) for NiFi Registry.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
