### PR TITLE
NIFI-13690 Backport of updated dependencies as prudent

### DIFF
--- a/nifi-commons/nifi-metrics/pom.xml
+++ b/nifi-commons/nifi-metrics/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jvm</artifactId>
-            <version>4.2.25</version>
+            <version>4.2.27</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -198,7 +198,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.6.8</version>
+            <version>3.6.9</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-compress-bundle/nifi-compress-processors/pom.xml
@@ -46,7 +46,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.aayushatharva.brotli4j</groupId>
             <artifactId>brotli4j</artifactId>
-            <version>1.16.0</version>
+            <version>1.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.tukaani</groupId>

--- a/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <iceberg.version>1.6.0</iceberg.version>
+        <iceberg.version>1.6.1</iceberg.version>
         <hive.version>3.1.3</hive.version>
     </properties>
 

--- a/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.slack.api</groupId>
             <artifactId>bolt-socket-mode</artifactId>
-            <version>1.40.3</version>
+            <version>1.42.0</version>
         </dependency>
         <!-- Required by bolt-socket-mode but the library itself doesn't have the dependency. -->
         <dependency>

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.2</version>
+            <version>42.7.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -104,15 +104,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
-        <com.amazonaws.version>1.12.767</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.27.1</software.amazon.awssdk.version>
+        <com.amazonaws.version>1.12.770</com.amazonaws.version>
+        <software.amazon.awssdk.version>2.27.14</software.amazon.awssdk.version>
         <gson.version>2.10.1</gson.version>
         <kotlin.version>1.9.25</kotlin.version>
         <okhttp.version>4.12.0</okhttp.version>
         <okio.version>3.9.0</okio.version>
-        <org.apache.commons.cli.version>1.7.0</org.apache.commons.cli.version>
+        <org.apache.commons.cli.version>1.9.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.17.1</org.apache.commons.codec.version>
-        <org.apache.commons.compress.version>1.27.0</org.apache.commons.compress.version>
+        <org.apache.commons.compress.version>1.27.1</org.apache.commons.compress.version>
         <com.github.luben.zstd-jni.version>1.5.6-4</com.github.luben.zstd-jni.version>
         <org.apache.commons.lang3.version>3.16.0</org.apache.commons.lang3.version>
         <org.apache.commons.net.version>3.10.0</org.apache.commons.net.version>


### PR DESCRIPTION
# Summary

[NIFI-13690](https://issues.apache.org/jira/browse/NIFI-13690) This PR updates as many of the same libraries as prudent from #9206 . Some are major versions ahead so those were not updated.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `support/nifi-1.x` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
