### PR TITLE
NIFI-12080 - Added support for KV_2 in HashiCorp Parameter Provider

### DIFF
--- a/nifi-commons/nifi-hashicorp-vault-api/src/main/java/org/apache/nifi/vault/hashicorp/HashiCorpVaultCommunicationService.java
+++ b/nifi-commons/nifi-hashicorp-vault-api/src/main/java/org/apache/nifi/vault/hashicorp/HashiCorpVaultCommunicationService.java
@@ -90,9 +90,28 @@ public interface HashiCorpVaultCommunicationService {
     Map<String, String> readKeyValueSecretMap(String keyValuePath, String secretKey);
 
     /**
+     * Reads a secret with multiple key/value pairs from Vault's Key/Value Secrets Engine.
+     *
+     * @see <a href="https://www.vaultproject.io/api-docs/secret/kv">https://www.vaultproject.io/api-docs/secret/kv</a>
+     * @param keyValuePath The Vault path to use for the configured Key/Value Secrets Engine
+     * @param secretKey The secret key
+     * @param version the Key/Vault Secrets engine version
+     * @return A map from key to value from the secret key/values, or an empty map if not found
+     */
+    Map<String, String> readKeyValueSecretMap(String keyValuePath, String secretKey, String version);
+
+    /**
      * Lists the secrets at the given Key/Value Version 1 Secrets Engine path.
      * @param keyValuePath The Vault path to list
      * @return The list of secret names
      */
     List<String> listKeyValueSecrets(String keyValuePath);
+
+    /**
+     * Lists the secrets at the given Key/Value Secrets Engine path.
+     * @param keyValuePath The Vault path to list
+     * @param version the Key/Vault Secrets engine version
+     * @return The list of secret names
+     */
+    List<String> listKeyValueSecrets(String keyValuePath, String version);
 }

--- a/nifi-commons/nifi-hashicorp-vault/src/main/java/org/apache/nifi/vault/hashicorp/StandardHashiCorpVaultCommunicationService.java
+++ b/nifi-commons/nifi-hashicorp-vault/src/main/java/org/apache/nifi/vault/hashicorp/StandardHashiCorpVaultCommunicationService.java
@@ -136,17 +136,23 @@ public class StandardHashiCorpVaultCommunicationService implements HashiCorpVaul
 
     @Override
     public Map<String, String> readKeyValueSecretMap(final String keyValuePath, final String key) {
-        final VaultKeyValueOperations keyValueOperations = keyValueOperationsMap
-                .computeIfAbsent(keyValuePath, path -> vaultTemplate.opsForKeyValue(path, keyValueBackend));
-        final VaultResponseSupport<Map> response = keyValueOperations.get(key, Map.class);
+        return readKeyValueSecretMap(keyValuePath, key, keyValueBackend.name());
+    }
+
+    @Override
+    public Map<String, String> readKeyValueSecretMap(final String keyValuePath, final String key, final String version) {
+        final VaultResponseSupport<Map> response = vaultTemplate.opsForKeyValue(keyValuePath, KeyValueBackend.valueOf(version)).get(key, Map.class);
         return response == null ? Collections.emptyMap() : (Map<String, String>) response.getRequiredData();
     }
 
     @Override
     public List<String> listKeyValueSecrets(final String keyValuePath) {
-        final VaultKeyValueOperations keyValueOperations = keyValueOperationsMap
-                .computeIfAbsent(keyValuePath, path -> vaultTemplate.opsForKeyValue(path, KeyValueBackend.KV_1));
-        return keyValueOperations.list("/");
+        return listKeyValueSecrets(keyValuePath, KeyValueBackend.KV_1.name());
+    }
+
+    @Override
+    public List<String> listKeyValueSecrets(final String keyValuePath, final String version) {
+        return vaultTemplate.opsForKeyValue(keyValuePath, KeyValueBackend.valueOf(version)).list("/");
     }
 
     private static class SecretData {

--- a/nifi-extension-bundles/nifi-hashicorp-vault-bundle/nifi-hashicorp-vault-parameter-provider/src/test/java/org/apache/nifi/vault/hashicorp/TestHashiCorpVaultParameterProvider.java
+++ b/nifi-extension-bundles/nifi-hashicorp-vault-bundle/nifi-hashicorp-vault-parameter-provider/src/test/java/org/apache/nifi/vault/hashicorp/TestHashiCorpVaultParameterProvider.java
@@ -84,10 +84,12 @@ public class TestHashiCorpVaultParameterProvider {
 
     @Test
     public void testFetchParameters() {
-        mockSecrets("kv2", mockedGroups);
+        final String kvVersion = "KV_1";
+        mockSecrets("kv2", kvVersion, mockedGroups);
 
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         properties.put(HashiCorpVaultParameterProvider.KV_PATH, "kv2");
+        properties.put(HashiCorpVaultParameterProvider.KV_VERSION, kvVersion);
         properties.put(HashiCorpVaultParameterProvider.VAULT_CLIENT_SERVICE, "service");
         properties.put(HashiCorpVaultParameterProvider.SECRET_NAME_PATTERN, ".*");
         final ConfigurationContext context = mockContext(properties);
@@ -101,10 +103,12 @@ public class TestHashiCorpVaultParameterProvider {
 
     @Test
     public void testFetchParametersSecretRegex() {
-        mockSecrets("kv2", mockedGroups);
+        final String kvVersion = "KV_2";
+        mockSecrets("kv2", kvVersion, mockedGroups);
 
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         properties.put(HashiCorpVaultParameterProvider.KV_PATH, "kv2");
+        properties.put(HashiCorpVaultParameterProvider.KV_VERSION, kvVersion);
         properties.put(HashiCorpVaultParameterProvider.VAULT_CLIENT_SERVICE, "service");
         properties.put(HashiCorpVaultParameterProvider.SECRET_NAME_PATTERN, ".*A");
         final ConfigurationContext context = mockContext(properties);
@@ -118,10 +122,12 @@ public class TestHashiCorpVaultParameterProvider {
 
     @Test
     public void testVerifyParameters() {
-        mockSecrets("kv2", mockedGroups);
+        final String kvVersion = "KV_1";
+        mockSecrets("kv2", kvVersion, mockedGroups);
 
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         properties.put(HashiCorpVaultParameterProvider.KV_PATH, "kv2");
+        properties.put(HashiCorpVaultParameterProvider.KV_VERSION, kvVersion);
         properties.put(HashiCorpVaultParameterProvider.VAULT_CLIENT_SERVICE, "service");
         properties.put(HashiCorpVaultParameterProvider.SECRET_NAME_PATTERN, ".*");
         final ConfigurationContext context = mockContext(properties);
@@ -145,13 +151,13 @@ public class TestHashiCorpVaultParameterProvider {
         lenient().when(context.getProperty(descriptor)).thenReturn(propertyValue);
     }
 
-    private void mockSecrets(final String kvPath, final List<ParameterGroup> parameterGroups) {
-        when(vaultCommunicationService.listKeyValueSecrets(kvPath))
+    private void mockSecrets(final String kvPath, final String kvVersion, final List<ParameterGroup> parameterGroups) {
+        when(vaultCommunicationService.listKeyValueSecrets(kvPath, kvVersion))
                 .thenReturn(parameterGroups.stream().map(group -> group.getGroupName()).collect(Collectors.toList()));
         for (final ParameterGroup parameterGroup : parameterGroups) {
             final Map<String, String> keyValues = parameterGroup.getParameters().stream()
                     .collect(Collectors.toMap(parameter -> parameter.getDescriptor().getName(), parameter -> parameter.getValue()));
-            lenient().when(vaultCommunicationService.readKeyValueSecretMap(kvPath, parameterGroup.getGroupName())).thenReturn(keyValues);
+            lenient().when(vaultCommunicationService.readKeyValueSecretMap(kvPath, parameterGroup.getGroupName(), kvVersion)).thenReturn(keyValues);
         }
     }
 


### PR DESCRIPTION
# Summary

[NIFI-12080](https://issues.apache.org/jira/browse/NIFI-12080) - Added support for KV_2 in HashiCorp Parameter Provider

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
