### PR TITLE
NIFI-13692 (1.X) Widened the exception handling in ResizeImage

### DIFF
--- a/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ResizeImage.java
+++ b/nifi-nar-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ResizeImage.java
@@ -23,7 +23,6 @@ import java.awt.Image;
 import java.awt.Transparency;
 import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -171,7 +170,7 @@ public class ResizeImage extends AbstractProcessor {
                 reader.setInput(iis, true);
                 image = reader.read(0);
             }
-        } catch (final IOException | RuntimeException ex) {
+        } catch (final Exception ex) {
             getLogger().error("Failed to read {} due to {}", flowFile, ex);
             session.transfer(flowFile, REL_FAILURE);
             return;
@@ -190,8 +189,8 @@ public class ResizeImage extends AbstractProcessor {
                 height = finalDimension.height;
             }
 
-        } catch (final NumberFormatException nfe) {
-            getLogger().error("Failed to resize {} due to {}", flowFile, nfe);
+        } catch (final Exception ex) {
+            getLogger().error("Failed to resize {} due to {}", flowFile, ex);
             session.transfer(flowFile, REL_FAILURE);
             return;
         }
@@ -218,7 +217,7 @@ public class ResizeImage extends AbstractProcessor {
             }
 
             ImageIO.write(scaledBufferedImg, formatName, out);
-        } catch (final IOException | NegativeArraySizeException ex) {
+        } catch (final Exception ex) {
             getLogger().error("Failed to write {} due to {}", flowFile, ex);
             session.transfer(flowFile, REL_FAILURE);
             return;


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
