### PR TITLE
NIFI-13689 Add Watch Delay to Bootstrap Start Command

### DIFF
--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/command/StandardBootstrapCommandProvider.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/command/StandardBootstrapCommandProvider.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -68,6 +69,8 @@ public class StandardBootstrapCommandProvider implements BootstrapCommandProvide
     private static final int DAYS_PATH_ARGUMENTS = 3;
 
     private static final int DAYS_REQUESTED_DEFAULT = 1;
+
+    private static final Duration START_WATCH_DELAY = Duration.ofSeconds(60);
 
     private static final BootstrapArgumentParser bootstrapArgumentParser = new StandardBootstrapArgumentParser();
 
@@ -114,7 +117,7 @@ public class StandardBootstrapCommandProvider implements BootstrapCommandProvide
             final BootstrapCommand runBootstrapCommand = new RunBootstrapCommand(configurationProvider, processHandleProvider);
             final ProcessHandle currentProcessHandle = ProcessHandle.current();
             final BootstrapCommand statusBootstrapCommand = new ApplicationProcessStatusBootstrapCommand(currentProcessHandle);
-            bootstrapCommand = new StartBootstrapCommand(runBootstrapCommand, statusBootstrapCommand);
+            bootstrapCommand = new StartBootstrapCommand(runBootstrapCommand, statusBootstrapCommand, START_WATCH_DELAY);
         } else if (BootstrapArgument.STATUS == bootstrapArgument) {
             bootstrapCommand = new ManagementServerBootstrapCommand(processHandleProvider, HEALTH, commandLoggerStreamHandler);
         } else if (BootstrapArgument.STATUS_HISTORY == bootstrapArgument) {


### PR DESCRIPTION
# Summary

[NIFI-13689](https://issues.apache.org/jira/browse/NIFI-13689) Adds a watch delay of 60 seconds to the NiFi Bootstrap Start Command to avoid launching the monitoring command when the application process fails on initial launch. This approach is similar to the previous implementation that waited up to 60 seconds for a successful launch. The implementation expects that application configuration problems will cause the application launch failures before the watch delay expires.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
