### PR TITLE
NIFI-13695: Appending a trailing slash when opening a custom ui and i…

### DIFF
--- a/nifi-commons/nifi-web-servlet-shared/src/main/java/org/apache/nifi/web/servlet/filter/QueryStringToFragmentFilter.java
+++ b/nifi-commons/nifi-web-servlet-shared/src/main/java/org/apache/nifi/web/servlet/filter/QueryStringToFragmentFilter.java
@@ -40,7 +40,8 @@ public class QueryStringToFragmentFilter implements Filter {
             // Some NiFi front ends use hash based routing, so they don't need to know the baseHref. With hash based
             // routing query parameters are implemented within the URL fragment. Because of this any query parameters on the
             // original URL are not considered. This filter captures those and adds them to the fragment.
-            final RequestUriBuilder requestUriBuilder = RequestUriBuilder.fromHttpServletRequest(httpServletRequest).path(httpServletRequest.getContextPath()).fragment("/?" + queryString);
+            final String contextPath = httpServletRequest.getContextPath() + "/";
+            final RequestUriBuilder requestUriBuilder = RequestUriBuilder.fromHttpServletRequest(httpServletRequest).path(contextPath).fragment("/?" + queryString);
             final URI redirectUri = requestUriBuilder.build();
 
             final HttpServletResponse httpServletResponse = (HttpServletResponse) response;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/advanced-ui/advanced-ui.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/advanced-ui/advanced-ui.component.ts
@@ -81,7 +81,7 @@ export class AdvancedUi {
             .set('editable', params.editable)
             .set('disconnectedNodeAcknowledged', params.disconnectedNodeAcknowledged)
             .toString();
-        const url = `${params.url}?${queryParams}`;
+        const url = `${params.url}/?${queryParams}`;
 
         const sanitizedUrl = this.domSanitizer.sanitize(SecurityContext.URL, url);
 


### PR DESCRIPTION
…n the query string to fragment filter to avoid a jetty based redirect that could lead to losing the proxy path.