### PR TITLE
NIFI-13697 Clarify documentation in ProcessSession regarding StateManager interactions

### DIFF
--- a/nifi-api/src/main/java/org/apache/nifi/processor/ProcessSession.java
+++ b/nifi-api/src/main/java/org/apache/nifi/processor/ProcessSession.java
@@ -848,7 +848,7 @@ public interface ProcessSession {
     /**
      * Updates the value of the component's state, setting it to given value.
      * <p>
-     * This method does update the remote State Provider immediately but rather caches the value until the session is committed.
+     * This method does not update the remote State Provider immediately but rather caches the value until the session is committed.
      * At that point, it will publish the state to the remote State Provider, if the state is the latest according to the remote State Provider.
      *
      * @param state the value to change the state to
@@ -876,7 +876,7 @@ public interface ProcessSession {
      * The oldValue will be compared against the value of the state as it is known to {@code this} {@link ProcessSession}.
      * If the Process Session does not currently know the state, it will be fetched from the StateProvider.
      * <p>
-     * This method does update the remote State Provider immediately but rather caches the value until the session is committed.
+     * This method does not update the remote State Provider immediately but rather caches the value until the session is committed.
      * At that point, it will publish the state to the remote State Provider, if the state is the latest according to the remote State Provider.
      *
      * @param oldValue the value to compare the state's current value against
@@ -891,7 +891,7 @@ public interface ProcessSession {
     /**
      * Clears all keys and values from the component's state.
      * <p>
-     * This method does update the remote State Provider immediately but rather caches the value until the session is committed.
+     * This method does not update the remote State Provider immediately but rather caches the value until the session is committed.
      * At that point, it will publish the state to the remote State Provider, if the state is the latest according to the remote State Provider.
      *
      * @param scope the {@link Scope} to use for clearing the state


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13697](https://issues.apache.org/jira/browse/NIFI-13697)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
