### PR TITLE
NIFI-13705 Refactor Stateless Engine using Web Client Service API

### DIFF
--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/pom.xml
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/pom.xml
@@ -99,11 +99,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-security-utils</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-parameter</artifactId>
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
@@ -116,8 +111,19 @@
             <artifactId>nifi-python-framework-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-security-ssl</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-web-client-api</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-web-client</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/config/SslConfigurationUtil.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/config/SslConfigurationUtil.java
@@ -17,14 +17,58 @@
 
 package org.apache.nifi.stateless.config;
 
-import org.apache.nifi.security.util.SslContextFactory;
-import org.apache.nifi.security.util.StandardTlsConfiguration;
-import org.apache.nifi.security.util.TlsConfiguration;
+import org.apache.nifi.security.ssl.StandardKeyManagerBuilder;
+import org.apache.nifi.security.ssl.StandardKeyStoreBuilder;
+import org.apache.nifi.security.ssl.StandardSslContextBuilder;
+import org.apache.nifi.security.ssl.StandardTrustManagerBuilder;
 import org.apache.nifi.security.util.TlsPlatform;
+import org.apache.nifi.web.client.ssl.TlsContext;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.util.Optional;
 
 public class SslConfigurationUtil {
+
+    public static TlsContext createTlsContext(final SslContextDefinition sslContextDefinition) throws StatelessConfigurationException {
+        final X509ExtendedKeyManager keyManager;
+        if (sslContextDefinition.getKeystoreFile() == null) {
+            keyManager = null;
+        } else {
+            final KeyStore keyStore = getKeyStore(sslContextDefinition);
+            final char[] keyStorePass = sslContextDefinition.getKeystorePass().toCharArray();
+            keyManager = new StandardKeyManagerBuilder().keyStore(keyStore).keyPassword(keyStorePass).build();
+        }
+
+        final KeyStore trustStore = getTrustStore(sslContextDefinition);
+        final X509ExtendedTrustManager trustManager = new StandardTrustManagerBuilder().trustStore(trustStore).build();
+
+        return new TlsContext() {
+            @Override
+            public String getProtocol() {
+                return TlsPlatform.getLatestProtocol();
+            }
+
+            @Override
+            public X509TrustManager getTrustManager() {
+                return trustManager;
+            }
+
+            @Override
+            public Optional<X509KeyManager> getKeyManager() {
+                return Optional.ofNullable(keyManager);
+            }
+        };
+    }
+
     public static SSLContext createSslContext(final SslContextDefinition sslContextDefinition) throws StatelessConfigurationException {
         if (sslContextDefinition == null) {
             return null;
@@ -33,23 +77,49 @@ public class SslConfigurationUtil {
             return null;
         }
 
-        final TlsConfiguration tlsConfiguration = createTlsConfiguration(sslContextDefinition);
+        final StandardSslContextBuilder sslContextBuilder = new StandardSslContextBuilder();
 
-        try {
-            return SslContextFactory.createSslContext(tlsConfiguration);
+        final KeyStore trustStore = getTrustStore(sslContextDefinition);
+        final X509ExtendedTrustManager trustManager = new StandardTrustManagerBuilder().trustStore(trustStore).build();
+        sslContextBuilder.trustManager(trustManager);
+
+        if (sslContextDefinition.getKeystoreFile() != null) {
+            final KeyStore keyStore = getKeyStore(sslContextDefinition);
+            final char[] keyStorePass = sslContextDefinition.getKeystorePass().toCharArray();
+            final X509ExtendedKeyManager keyManager = new StandardKeyManagerBuilder().keyStore(keyStore).keyPassword(keyStorePass).build();
+            sslContextBuilder.keyManager(keyManager);
+        }
+
+        return sslContextBuilder.build();
+    }
+
+    private static KeyStore getTrustStore(final SslContextDefinition sslContextDefinition) throws StatelessConfigurationException {
+        final char[] trustStorePass = sslContextDefinition.getTruststorePass().toCharArray();
+        final StandardKeyStoreBuilder builder = new StandardKeyStoreBuilder()
+                .type(sslContextDefinition.getTruststoreType())
+                .password(trustStorePass);
+
+        final Path trustStorePath = Paths.get(sslContextDefinition.getTruststoreFile());
+        try (InputStream inputStream = Files.newInputStream(trustStorePath)) {
+            builder.inputStream(inputStream);
+            return builder.build();
         } catch (final Exception e) {
-            throw new StatelessConfigurationException("Failed to create SSL Context", e);
+            throw new StatelessConfigurationException("Load Trust Store [%s] failed".formatted(trustStorePath), e);
         }
     }
 
-    public static TlsConfiguration createTlsConfiguration(final SslContextDefinition sslContextDefinition) {
-        return new StandardTlsConfiguration(sslContextDefinition.getKeystoreFile(),
-            sslContextDefinition.getKeystorePass(),
-            sslContextDefinition.getKeyPass(),
-            sslContextDefinition.getKeystoreType(),
-            sslContextDefinition.getTruststoreFile(),
-            sslContextDefinition.getTruststorePass(),
-            sslContextDefinition.getTruststoreType(),
-            TlsPlatform.getLatestProtocol());
+    private static KeyStore getKeyStore(final SslContextDefinition sslContextDefinition) throws StatelessConfigurationException {
+        final char[] keyStorePass = sslContextDefinition.getKeystorePass().toCharArray();
+        final StandardKeyStoreBuilder builder = new StandardKeyStoreBuilder()
+                .type(sslContextDefinition.getKeystoreType())
+                .password(keyStorePass);
+
+        final Path keyStorePath = Paths.get(sslContextDefinition.getKeystoreFile());
+        try (InputStream inputStream = Files.newInputStream(keyStorePath)) {
+            builder.inputStream(inputStream);
+            return builder.build();
+        } catch (final Exception e) {
+            throw new StatelessConfigurationException("Load Key Store [%s] failed".formatted(keyStorePath), e);
+        }
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-13705](https://issues.apache.org/jira/browse/NIFI-13705) Refactors the NiFi Stateless Engine module to use the `nifi-web-client-api` module instead of the OkHttp library for retrieving flow definitions and extensions.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
