### PR TITLE
NIFI-13706 Handle Exceptions Fetching Parameters on Startup

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
@@ -1067,8 +1067,14 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
     }
 
     private Map<String, Parameter> getProvidedParameters(final ParameterProviderNode parameterProviderNode, final String parameterGroupName) {
-        logger.debug("Fetching Parameters for Group [{}] from Provider [{}]", parameterGroupName, parameterProviderNode.getIdentifier());
-        parameterProviderNode.fetchParameters();
+        final String providerId = parameterProviderNode.getIdentifier();
+        logger.debug("Fetching Parameters for Group [{}] from Provider [{}]", parameterGroupName, providerId);
+
+        try {
+            parameterProviderNode.fetchParameters();
+        } catch (final Exception e) {
+            logger.warn("Fetching Parameters for Group [{}] from Provider [{}] failed", parameterGroupName, providerId, e);
+        }
 
         final Map<String, Parameter> parameters;
         final Optional<ParameterGroup> foundParameterGroup = parameterProviderNode.findFetchedParameterGroup(parameterGroupName);
@@ -1082,7 +1088,7 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
             parameters = Collections.emptyMap();
         }
 
-        logger.info("Fetched Parameters [{}] for Group [{}] from Provider [{}]", parameters.size(), parameterGroupName, parameterProviderNode.getIdentifier());
+        logger.info("Fetched Parameters [{}] for Group [{}] from Provider [{}]", parameters.size(), parameterGroupName, providerId);
         return parameters;
     }
 


### PR DESCRIPTION
# Summary

[NIFI-13706](https://issues.apache.org/jira/browse/NIFI-13706) Updates the flow synchronization process to catch exceptions when fetching Parameters from Parameter Providers.

The framework logs a warning when catching exceptions from a Parameter Provider, and already handles logging warnings when a Parameter Provider does not return values for a configured Parameter.

This change in the startup process allows NiFi to start even when a Parameter Provider has configuration or connectivity issues. Missing Parameter values may result in flow configuration problems, which an authorized user can correct after fixing the referenced Parameter Provider.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
