### PR TITLE
For 1.x added more meaningful message when validation fails with non-compliant XML and no schema is provided.

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateXml.java
@@ -230,7 +230,7 @@ public class ValidateXml extends AbstractProcessor {
                     reader.next();
                 }
             } catch (final XMLStreamException e) {
-                throw new ProcessingException("Reading stream failed", e);
+                throw new ProcessingException("Reading stream failed: " + e.getMessage(), e);
             }
         } else {
             final XMLStreamReaderProvider readerProvider = new StandardXMLStreamReaderProvider();

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateXml.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateXml.java
@@ -168,6 +168,8 @@ public class TestValidateXml {
 
         runner.assertAllFlowFilesTransferred(ValidateXml.REL_INVALID, 1);
         runner.assertAllFlowFilesContainAttribute(ValidateXml.REL_INVALID, ValidateXml.ERROR_ATTRIBUTE_KEY);
+        String errorAttribute = runner.getFlowFilesForRelationship(ValidateXml.REL_INVALID).get(0).getAttribute(ValidateXml.ERROR_ATTRIBUTE_KEY);
+        assertTrue(errorAttribute.contains("ParseError"));
     }
 
     @Test
@@ -191,5 +193,7 @@ public class TestValidateXml {
 
         runner.assertAllFlowFilesTransferred(ValidateXml.REL_INVALID, 1);
         runner.assertAllFlowFilesContainAttribute(ValidateXml.REL_INVALID, ValidateXml.ERROR_ATTRIBUTE_KEY);
+        String errorAttribute = runner.getFlowFilesForRelationship(ValidateXml.REL_INVALID).get(0).getAttribute(ValidateXml.ERROR_ATTRIBUTE_KEY);
+        assertTrue(errorAttribute.contains("ParseError"));
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13709](https://issues.apache.org/jira/browse/NIFI-13709)
The same fix was done for 2.x in #9229 and this fix is for 1.x

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK ~21~ 8

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
