### PR TITLE
NIFI-13719 allow Elasticsearch response to contain Long values for the took field

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/IndexOperationResponse.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/IndexOperationResponse.java
@@ -46,7 +46,8 @@ public class IndexOperationResponse implements OperationResponse {
     @SuppressWarnings("unchecked")
     public static IndexOperationResponse fromJsonResponse(final String response) throws IOException {
         final Map<String, Object> parsedResponse = OBJECT_MAPPER.readValue(response, Map.class);
-        final int took = (int) parsedResponse.get("took");
+        // took should be an int, but could be a long (bg in Elasticsearch 8.15.0)
+        final long took = Long.parseLong(String.valueOf(parsedResponse.get("took")));
         final boolean hasErrors = (boolean) parsedResponse.get("errors");
         final List<Map<String, Object>> items = (List<Map<String, Object>>) parsedResponse.get("items");
 

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/SearchResponse.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/SearchResponse.java
@@ -24,7 +24,7 @@ public class SearchResponse implements OperationResponse {
     private final List<Map<String, Object>> hits;
     private final Map<String, Object> aggregations;
     private final long numberOfHits;
-    private final int took;
+    private final long took;
     private final boolean timedOut;
     private final String pitId;
     private final String scrollId;
@@ -32,7 +32,7 @@ public class SearchResponse implements OperationResponse {
     private final List<String> warnings;
 
     public SearchResponse(final List<Map<String, Object>> hits, final Map<String, Object> aggregations, final String pitId,
-                          final String scrollId, final String searchAfter, final int numberOfHits, final int took, final boolean timedOut,
+                          final String scrollId, final String searchAfter, final int numberOfHits, final long took, final boolean timedOut,
                           final List<String> warnings) {
         this.hits = hits;
         this.aggregations = aggregations;

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/IndexOperationResponseTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/IndexOperationResponseTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.elasticsearch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IndexOperationResponseTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void testTook() {
+        long took = 100;
+        final IndexOperationResponse response = new IndexOperationResponse(took);
+        assertEquals(took, response.getTook());
+    }
+
+    @Test
+    void testFromJson() throws Exception {
+        final long took    = 100;
+        final boolean errors = false;
+        final List<Map<String, Object>> items = Collections.emptyList();
+
+        final Map<String, Object> responseMap = Map.of(
+                "took", Long.valueOf(took).intValue(),
+                "errors", errors,
+                "items", items
+        );
+        final String responseJson = OBJECT_MAPPER.writeValueAsString(responseMap);
+        final IndexOperationResponse response = IndexOperationResponse.fromJsonResponse(responseJson);
+
+        assertEquals(took, response.getTook());
+        assertEquals(errors, response.hasErrors());
+        assertEquals(items, response.getItems());
+    }
+
+    @Test
+    void testLongTookTime() {
+        final long took    = 34493262031L; // example "took" from Elasticsearch 8.15.0
+        final IndexOperationResponse response = new IndexOperationResponse(took);
+        assertEquals(took, response.getTook());
+    }
+
+    @Test
+    void testFromJsonLongTook() throws Exception {
+        final long took    = 34493262031L; // example "took" from Elasticsearch 8.15.0
+        final boolean errors = true;
+        final List<Map<String, Object>> items = Collections.singletonList(Collections.emptyMap());
+
+        final Map<String, Object> responseMap = Map.of(
+            "took", took,
+            "errors", errors,
+            "items", items
+        );
+        final String responseJson = OBJECT_MAPPER.writeValueAsString(responseMap);
+        final IndexOperationResponse response = IndexOperationResponse.fromJsonResponse(responseJson);
+
+        assertEquals(took, response.getTook());
+        assertEquals(errors, response.hasErrors());
+        assertEquals(items, response.getItems());
+    }
+}

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/SearchResponseTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/SearchResponseTest.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SearchResponseTest {
+class SearchResponseTest {
     @Test
     void test() {
         final List<Map<String, Object>> results = new ArrayList<>();
@@ -37,7 +37,7 @@ public class SearchResponseTest {
         final String scrollId = "scrollId";
         final String searchAfter = "searchAfter";
         final int num     = 10;
-        final int took    = 100;
+        final long took    = 100;
         final boolean timeout = false;
         final List<String> warnings = Collections.singletonList("auth");
         final SearchResponse response = new SearchResponse(results, aggs, pitId, scrollId, searchAfter, num, took, timeout, warnings);
@@ -60,5 +60,21 @@ public class SearchResponseTest {
         assertTrue(str.contains("took"));
         assertTrue(str.contains("timedOut"));
         assertTrue(str.contains("warnings"));
+    }
+
+    @Test
+    void testLongTookTime() {
+        final List<Map<String, Object>> results = new ArrayList<>();
+        final Map<String, Object> aggs    = new HashMap<>();
+        final String pitId = "pitId";
+        final String scrollId = "scrollId";
+        final String searchAfter = "searchAfter";
+        final int num     = 10;
+        final long took    = 34493262031L; // example "took" from Elasticsearch 8.15.0
+        final boolean timeout = false;
+        final List<String> warnings = Collections.singletonList("auth");
+        final SearchResponse response = new SearchResponse(results, aggs, pitId, scrollId, searchAfter, num, took, timeout, warnings);
+
+        assertEquals(took, response.getTook());
     }
 }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
@@ -52,7 +52,7 @@ import static org.apache.http.auth.AuthScope.ANY;
 public abstract class AbstractElasticsearchITBase {
     // default Elasticsearch version should (ideally) match that in the nifi-elasticsearch-bundle#pom.xml for the integration-tests profile
     protected static final DockerImageName IMAGE = DockerImageName
-            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.13.3"));
+            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.15.1"));
     protected static final String ELASTIC_USER_PASSWORD = System.getProperty("elasticsearch.elastic_user.password", RandomStringUtils.randomAlphanumeric(10, 20));
     private static final int PORT = 9200;
     protected static final ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer(IMAGE)

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>8.15.0</elasticsearch.client.version>
+        <elasticsearch.client.version>8.15.1</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>
@@ -88,7 +88,7 @@ language governing permissions and limitations under the License. -->
             </activation>
             <properties>
                 <!-- also update the default Elasticsearch version in nifi-elasticsearch-test-utils#src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java-->
-                <elasticsearch_docker_image>8.15.0</elasticsearch_docker_image>
+                <elasticsearch_docker_image>${elasticsearch.client.version}</elasticsearch_docker_image>
                 <elasticsearch.elastic.password>s3cret</elasticsearch.elastic.password>
             </properties>
             <build>
@@ -119,7 +119,7 @@ language governing permissions and limitations under the License. -->
         <profile>
             <id>elasticsearch7</id>
             <properties>
-                <elasticsearch_docker_image>7.17.21</elasticsearch_docker_image>
+                <elasticsearch_docker_image>7.17.23</elasticsearch_docker_image>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
# Summary

[NIFI-13719](https://issues.apache.org/jira/browse/NIFI-13719) allow Elasticsearch response to contain Long values for the took field

While documented as an Integer, the Elasticsearch `took` field value can extend beyond the maximum allowed Integer value of Java, so NiFi should allow for Long values (or Integers) in the parsed response JSON of Search and _bulk API index operations.

This affects use of Elasticsearch 8.15.0 - https://github.com/elastic/elasticsearch/issues/111854

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- ~~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~~
- ~~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~~

### Documentation

- ~~[ ] Documentation formatting appears as expected in rendered files~~
