### PR TITLE
NIFI-13703 Remove deprecated property DISTRIBUTED_CACHE_SERVICE in AbstractListProcessor

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFTP.java
@@ -81,7 +81,6 @@ public class ListFTP extends ListFileTransfer {
             FTPTransfer.PASSWORD,
             REMOTE_PATH,
             RECORD_WRITER,
-            DISTRIBUTED_CACHE_SERVICE,
             FTPTransfer.RECURSIVE_SEARCH,
             FTPTransfer.FOLLOW_SYMLINK,
             FTPTransfer.FILE_FILTER_REGEX,

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
@@ -89,7 +89,6 @@ public class ListSFTP extends ListFileTransfer {
             SFTPTransfer.PRIVATE_KEY_PASSPHRASE,
             REMOTE_PATH,
             RECORD_WRITER,
-            DISTRIBUTED_CACHE_SERVICE,
             SFTPTransfer.RECURSIVE_SEARCH,
             SFTPTransfer.FOLLOW_SYMLINK,
             SFTPTransfer.FILE_FILTER_REGEX,

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListFile.java
@@ -116,17 +116,8 @@ public class TestListFile {
         resetAges();
     }
 
-    public void tearDown() throws Exception {
+    public void tearDown() {
         deleteDirectory(testDir);
-        File tempFile = processor.getPersistenceFile();
-        if (tempFile.exists()) {
-            File[] stateFiles = tempFile.getParentFile().listFiles();
-            if (stateFiles != null) {
-                for (File stateFile : stateFiles) {
-                    assertTrue(stateFile.delete());
-                }
-            }
-        }
     }
 
     private List<File> listFiles(final File file) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13703](https://issues.apache.org/jira/browse/NIFI-13703)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
