### PR TITLE
NIFI-13729 Remove deprecated property MAX_RECV_THREAD_POOL_SIZE from ListenTCP

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCP.java
@@ -37,6 +37,7 @@ import org.apache.nifi.event.transport.message.ByteArrayMessage;
 import org.apache.nifi.event.transport.netty.ByteArrayMessageNettyEventServerFactory;
 import org.apache.nifi.event.transport.netty.NettyEventServerFactory;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
@@ -112,16 +113,6 @@ public class ListenTCP extends AbstractProcessor {
             .defaultValue(ClientAuth.REQUIRED.name())
             .build();
 
-    // Deprecated
-    public static final PropertyDescriptor MAX_RECV_THREAD_POOL_SIZE = new PropertyDescriptor.Builder()
-            .name("max-receiving-threads")
-            .displayName("Max Number of Receiving Message Handler Threads")
-            .description(
-                    "This property is deprecated and no longer used.")
-            .addValidator(StandardValidators.createLongValidator(1, 65535, true))
-            .required(false)
-            .build();
-
     protected static final PropertyDescriptor POOL_RECV_BUFFERS = new PropertyDescriptor.Builder()
             .name("pool-receive-buffers")
             .displayName("Pool Receive Buffers")
@@ -152,8 +143,6 @@ public class ListenTCP extends AbstractProcessor {
             ListenerProperties.MAX_BATCH_SIZE,
             ListenerProperties.MESSAGE_DELIMITER,
             IDLE_CONNECTION_TIMEOUT,
-            // Deprecated
-            MAX_RECV_THREAD_POOL_SIZE,
             POOL_RECV_BUFFERS,
             SSL_CONTEXT_SERVICE,
             CLIENT_AUTH
@@ -176,6 +165,11 @@ public class ListenTCP extends AbstractProcessor {
     protected volatile EventServer eventServer;
     protected volatile byte[] messageDemarcatorBytes;
     protected volatile EventBatcher<ByteArrayMessage> eventBatcher;
+
+    @Override
+    public void migrateProperties(PropertyConfiguration config) {
+        config.removeProperty("max-receiving-threads");
+    }
 
     @OnScheduled
     public void onScheduled(ProcessContext context) throws IOException {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13729](https://issues.apache.org/jira/browse/NIFI-13729)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
