### PR TITLE
Fixed flaky test testValidateJsonTimestamp

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateRecord.java
@@ -538,6 +538,7 @@ public class TestValidateRecord {
 
         // Test with an Inferred Schema.
         runner.disableControllerService(jsonReader);
+        runner.removeProperty(ValidateRecord.SCHEMA_ACCESS_STRATEGY);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaInferenceUtil.INFER_SCHEMA.getValue());
         runner.setProperty(jsonReader, DateTimeUtils.TIMESTAMP_FORMAT, "yyyy/MM/dd HH:mm:ss");
         runner.enableControllerService(jsonReader);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

The use of inferred schema combined with non-inferred schema was causing flaky test behavior. 

The setting of `SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY` to `SchemaInferenceUtil.INFER_SCHEMA.getValue()` while `ValidateRecord.SCHEMA_ACCESS_STRATEGY` is set to `SchemaAccessUtils.SCHEMA_TEXT_PROPERTY` caused tests to fail or pass unpredictably in the method: `testValidateJsonTimestamp`.

Changing `SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY` in the `// Test with an Inferred Schema.` section resolved the flakiness, but does not test for inferred schema, defeating the point of that test.

The solution was to remove `ValidateRecord.SCHEMA_ACCESS_STRATEGY`. This causes all tests to pass and uses the intended inferred schema.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Ran NonDex 10 times. Prior to the fix, the test was flaky, and would pass or fail randomly.
After the fix, the test always passes.

```
mvn -pl nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors \
    edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=org.apache.nifi.processors.standard.TestValidateRecord#testValidateJsonTimestamp -DnondexRuns=10
```

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
