### PR TITLE
NIFI-13734 Remove getTook assertions from Elasticsearch Test

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchClientService_IT.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchClientService_IT.java
@@ -427,12 +427,10 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         // delete the scroll
         DeleteOperationResponse deleteResponse = service.deleteScroll(scrollResponse.getScrollId());
         assertNotNull(deleteResponse, "Delete Response was null");
-        assertTrue(deleteResponse.getTook() > 0);
 
         // delete scroll again (should now be unknown but the 404 caught and ignored)
         deleteResponse = service.deleteScroll(scrollResponse.getScrollId());
         assertNotNull(deleteResponse, "Delete Response was null");
-        assertEquals(0L, deleteResponse.getTook());
     }
 
     @Test
@@ -559,12 +557,10 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         // delete pitId
         DeleteOperationResponse deleteResponse = service.deletePointInTime(pitId);
         assertNotNull(deleteResponse, "Delete Response was null");
-        assertTrue(deleteResponse.getTook() > 0);
 
         // delete pitId again (should now be unknown but the 404 caught and ignored)
         deleteResponse = service.deletePointInTime(pitId);
         assertNotNull(deleteResponse, "Delete Response was null");
-        assertEquals(0L, deleteResponse.getTook());
     }
 
     @Test
@@ -575,7 +571,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
                                 .build()).build());
         final DeleteOperationResponse response = service.deleteByQuery(query, INDEX, type, null);
         assertNotNull(response);
-        assertTrue(response.getTook() > 0);
     }
 
     @Test
@@ -588,7 +583,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         parameters.put("refresh", "true");
         final DeleteOperationResponse response = service.deleteByQuery(query, INDEX, type, parameters);
         assertNotNull(response);
-        assertTrue(response.getTook() > 0);
     }
 
     @Test
@@ -599,7 +593,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
                         .build()).build());
         final UpdateOperationResponse response = service.updateByQuery(query, INDEX, type, null);
         assertNotNull(response);
-        assertTrue(response.getTook() > 0);
     }
 
     @Test
@@ -613,7 +606,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         parameters.put("slices", "1");
         final UpdateOperationResponse response = service.updateByQuery(query, INDEX, type, parameters);
         assertNotNull(response);
-        assertTrue(response.getTook() > 0);
     }
 
     @Test
@@ -623,7 +615,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         try {
             final DeleteOperationResponse response = service.deleteById(INDEX, type, ID, null);
             assertNotNull(response);
-            assertTrue(response.getTook() > 0);
             final ElasticsearchException ee = assertThrows(ElasticsearchException.class, () ->
                 service.get(INDEX, type, ID, null));
             assertTrue(ee.isNotFound());
@@ -755,7 +746,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
                 null
         );
         assertNotNull(response);
-        assertTrue(response.getTook() > 0);
         waitForIndexRefresh();
 
         Map<String, Object> result = service.get("nulls", type, "1", null);
@@ -765,7 +755,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         suppressNulls(true);
         response = service.bulk(Collections.singletonList(new IndexOperationRequest("nulls", type, "2", doc, IndexOperationRequest.Operation.Index, null, false, null, null)), null);
         assertNotNull(response);
-        assertTrue(response.getTook() > 0);
         waitForIndexRefresh();
 
         result = service.get("nulls", type, "2", null);
@@ -801,7 +790,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         }
         final IndexOperationResponse response = service.bulk(payload, createParameters("refresh", "true"));
         assertNotNull(response);
-        assertTrue(response.getTook() > 0);
         waitForIndexRefresh();
 
         /*
@@ -839,7 +827,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         }
         final IndexOperationResponse response = service.bulk(payload, createParameters("refresh", "true"));
         assertNotNull(response);
-        assertTrue(response.getTook() > 0);
 
         /*
          * Now, check to ensure that all indices got populated and refreshed appropriately.
@@ -882,7 +869,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
 
         final IndexOperationResponse response = service.bulk(payload, createParameters("refresh", "true"));
         assertNotNull(response);
-        assertTrue(response.getTook() > 0);
 
         /*
          * Now, check the dynamic_template was applied


### PR DESCRIPTION
# Summary

[NIFI-13734](https://issues.apache.org/jira/browse/NIFI-13734) Removes assertions for values of `getTook()` from the Elasticsearch Client Integration Test, which can fail intermittently based on development environment behavior.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
