### PR TITLE
NIFI-13742: Normalize column names in SelectHiveQL processors

### DIFF
--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/util/hive/HiveJdbcCommon.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive-processors/src/main/java/org/apache/nifi/util/hive/HiveJdbcCommon.java
@@ -235,6 +235,9 @@ public class HiveJdbcCommon {
             // Hive returns table.column for column name. Grab the column name as the string after the last period
             int columnNameDelimiter = columnNameFromMeta.lastIndexOf(".");
             String columnName = columnNameFromMeta.substring(columnNameDelimiter + 1);
+            if (convertNames) {
+                columnName = normalizeNameForAvro(columnName);
+            }
             switch (meta.getColumnType(i)) {
                 case CHAR:
                 case LONGNVARCHAR:

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/util/hive/HiveJdbcCommon.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive3-processors/src/main/java/org/apache/nifi/util/hive/HiveJdbcCommon.java
@@ -255,6 +255,9 @@ public class HiveJdbcCommon {
             // Hive returns table.column for column name. Grab the column name as the string after the last period
             int columnNameDelimiter = columnNameFromMeta.lastIndexOf(".");
             String columnName = columnNameFromMeta.substring(columnNameDelimiter + 1);
+            if (convertNames) {
+                columnName = normalizeNameForAvro(columnName);
+            }
             switch (meta.getColumnType(i)) {
                 case CHAR:
                 case LONGNVARCHAR:

--- a/nifi-nar-bundles/nifi-hive-bundle/nifi-hive_1_1-processors/src/main/java/org/apache/nifi/util/hive/HiveJdbcCommon.java
+++ b/nifi-nar-bundles/nifi-hive-bundle/nifi-hive_1_1-processors/src/main/java/org/apache/nifi/util/hive/HiveJdbcCommon.java
@@ -235,6 +235,9 @@ public class HiveJdbcCommon {
             // Hive returns table.column for column name. Grab the column name as the string after the last period
             int columnNameDelimiter = columnNameFromMeta.lastIndexOf(".");
             String columnName = columnNameFromMeta.substring(columnNameDelimiter + 1);
+            if (convertNames) {
+                columnName = normalizeNameForAvro(columnName);
+            }
             switch (meta.getColumnType(i)) {
                 case CHAR:
                 case LONGNVARCHAR:


### PR DESCRIPTION
# Summary

[NIFI-13742](https://issues.apache.org/jira/browse/NIFI-13742) This PR adds calls to normalize the column names when SelectHiveQL processors produce Avro output. No unit tests are provided as Derby does not allow column names that start with numeric characters.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `support/nifi-1.x` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 8

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
