### PR TITLE
NIFI-13757 Improve handling when a NAR contains an extension that pro…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/DocGenerator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-documentation/src/main/java/org/apache/nifi/documentation/DocGenerator.java
@@ -114,13 +114,15 @@ public class DocGenerator {
                         }
                     }
                     case JAVA -> {
-                        final Class<?> extensionClass = extensionManager.getClass(extensionDefinition);
-                        final Class<? extends ConfigurableComponent> componentClass = extensionClass.asSubclass(ConfigurableComponent.class);
+                        // Catch Throwable here to protect against an extension that may have been registered, but throws an Error when attempting to access the Class,
+                        // this method is called during start-up, and we don't want to fail starting just because one bad extension class can't be loaded
                         try {
+                            final Class<?> extensionClass = extensionManager.getClass(extensionDefinition);
+                            final Class<? extends ConfigurableComponent> componentClass = extensionClass.asSubclass(ConfigurableComponent.class);
                             logger.debug("Documentation generation started: Component Class [{}]", componentClass);
                             document(extensionManager, componentDirectory, componentClass, coordinate);
-                        } catch (Exception e) {
-                            logger.warn("Documentation generation failed: Component Class [{}]", componentClass, e);
+                        } catch (Throwable t) {
+                            logger.warn("Documentation generation failed: Component Class [{}]", extensionDefinition.getImplementationClassName(), t);
                         }
                     }
                 }


### PR DESCRIPTION
…duces an Error

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13757](https://issues.apache.org/jira/browse/NIFI-13757)

This PR ensures that the install task for an uploaded NAR will correctly set the state to FAILED if one of the extensions from the NAR produces an Error when attempting to access the Class.

In addition, it improves the handling of doc generation so that we don't fail start up if an Error is encountered when trying to document the component, as well as no longer failing to retrieve the available component types when one component's class produces an Error.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
