### PR TITLE
NIFI-13763 HashSet filtering can not be set for DeduplicateRecord pro…

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeduplicateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeduplicateRecord.java
@@ -391,7 +391,7 @@ public class DeduplicateRecord extends AbstractProcessor {
     private FilterWrapper getFilter(ProcessContext context) {
         if (useInMemoryStrategy) {
             boolean useHashSet = context.getProperty(FILTER_TYPE).getValue()
-                    .equals(context.getProperty(HASH_SET_VALUE.getValue()).getValue());
+                    .equals(HASH_SET_VALUE.getValue());
             final int filterCapacity = context.getProperty(FILTER_CAPACITY_HINT).asInteger();
             return useHashSet
                     ? new HashSetFilterWrapper(new HashSet<>(filterCapacity))


### PR DESCRIPTION
…cessor

The following calculation determines which filtering method should be used:

```
boolean useHashSet = context.getProperty(FILTER_TYPE).getValue()
.equals(context.getProperty(HASH_SET_VALUE.getValue()).getValue());
```

As HASH_SET_VALUE is an Allowable value not a PropertyDescriptor, this boolean will always be false, so in all cases Bloom Filter will be used.

[NIFI-13763](https://issues.apache.org/jira/browse/NIFI-13763)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
