### PR TITLE
NIFI-13770 Remove Placeholder Prefix from Python Component Types

### DIFF
--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework-api/src/main/java/org/apache/nifi/python/processor/PythonProcessorBridge.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework-api/src/main/java/org/apache/nifi/python/processor/PythonProcessorBridge.java
@@ -36,7 +36,7 @@ public interface PythonProcessorBridge {
     void replaceController(PythonController controller);
 
     /**
-     * @return the name of the Processor implementation. This will not contain a 'python.' prefix.
+     * @return the name of the Processor implementation.
      */
     String getProcessorType();
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/ExtensionBuilder.java
@@ -263,7 +263,7 @@ public class ExtensionBuilder {
 
        final String componentType;
        if (PythonBundle.isPythonCoordinate(bundleCoordinate)) {
-           componentType = type.substring("python.".length());
+           componentType = type;
        } else if (creationSuccessful) {
            componentType = loggableComponent.getComponent().getClass().getSimpleName();
        } else {
@@ -896,9 +896,7 @@ public class ExtensionBuilder {
                classloaderIsolationKey);
            Thread.currentThread().setContextClassLoader(detectedClassLoader);
 
-           // TODO: This is a hack because there's a bug in the UI that causes it to not load extensions that don't have a `.` in the type.
-           final String processorType = type.startsWith("python.") ? type.substring("python.".length()) : type;
-           final Processor processor = pythonBridge.createProcessor(identifier, processorType, bundleCoordinate.getVersion(), true, true);
+           final Processor processor = pythonBridge.createProcessor(identifier, type, bundleCoordinate.getVersion(), true, true);
 
            final ComponentLog componentLog = new SimpleProcessLogger(identifier, processor, new StandardLoggingContext(null));
            final TerminationAwareLogger terminationAwareLogger = new TerminationAwareLogger(componentLog);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/nar/ComponentNodeDefinitionPredicate.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/nar/ComponentNodeDefinitionPredicate.java
@@ -50,8 +50,7 @@ class ComponentNodeDefinitionPredicate implements Predicate<ComponentNode> {
 
         if (PythonBundle.isPythonCoordinate(componentCoordinate)) {
             final String componentType = componentNode.getComponentType();
-            final String pythonComponentType = "python." + componentType;
-            return pythonComponentType.equals(extensionDefinitionClassName) && componentCoordinate.equals(extensionDefinitionCoordinate);
+            return componentType.equals(extensionDefinitionClassName) && componentCoordinate.equals(extensionDefinitionCoordinate);
         } else if (componentNode.isExtensionMissing()) {
             return componentClassName.equals(extensionDefinitionClassName)
                     && componentCoordinate.getGroup().equals(extensionDefinitionCoordinate.getGroup())

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/nar/ComponentNodeDefinitionPredicateTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/nar/ComponentNodeDefinitionPredicateTest.java
@@ -40,7 +40,6 @@ public class ComponentNodeDefinitionPredicateTest {
     private static final BundleCoordinate STANDARD_BUNDLE_COORDINATE_V2 = new BundleCoordinate("org.apache.nifi", "my-processors-nar", "2.0.0");
 
     private static final String PYTHON_PROCESSOR_TYPE = "PythonProcessor";
-    private static final String FULL_PYTHON_PROCESSOR_TYPE = "python." + PYTHON_PROCESSOR_TYPE;
     private static final String OTHER_PYTHON_PROCESSOR_TYPE = "OtherPythonProcessor";
     private static final BundleCoordinate PYTHON_BUNDLE_COORDINATE = new BundleCoordinate(PythonBundle.GROUP_ID, PythonBundle.ARTIFACT_ID, "0.0.1");
 
@@ -66,7 +65,7 @@ public class ComponentNodeDefinitionPredicateTest {
         when(pythonBundle.getBundleDetails()).thenReturn(pythonBundleDetails);
 
         pythonProcessorDefinition = mock(ExtensionDefinition.class);
-        when(pythonProcessorDefinition.getImplementationClassName()).thenReturn(FULL_PYTHON_PROCESSOR_TYPE);
+        when(pythonProcessorDefinition.getImplementationClassName()).thenReturn(PYTHON_PROCESSOR_TYPE);
         when(pythonProcessorDefinition.getBundle()).thenReturn(pythonBundle);
     }
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/prioritizers/prioritizers.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/prioritizers/prioritizers.component.ts
@@ -125,7 +125,7 @@ export class Prioritizers implements ControlValueAccessor {
     }
 
     getPrioritizerLabel(entity: DocumentedType): string {
-        return this.nifiCommon.substringAfterLast(entity.type, '.');
+        return this.nifiCommon.getComponentTypeLabel(entity.type);
     }
 
     hasDescription(entity: DocumentedType): boolean {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/registry-clients/create-registry-client/create-registry-client.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/registry-clients/create-registry-client/create-registry-client.component.ts
@@ -80,7 +80,7 @@ export class CreateRegistryClient extends CloseOnEscapeDialog {
     }
 
     formatType(option: DocumentedType): string {
-        return this.nifiCommon.substringAfterLast(option.type, '.');
+        return this.nifiCommon.getComponentTypeLabel(option.type);
     }
 
     createRegistryClientClicked() {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/change-component-version-dialog/change-component-version-dialog.ts
@@ -77,7 +77,7 @@ export class ChangeComponentVersionDialog extends CloseOnEscapeDialog {
     }
 
     getName(selected: DocumentedType | null): string {
-        return this.nifiCommon.substringAfterLast(selected?.type || '', '.');
+        return this.nifiCommon.getComponentTypeLabel(selected?.type || '');
     }
 
     protected readonly TextTip = TextTip;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/extension-creation/extension-creation.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/extension-creation/extension-creation.component.ts
@@ -82,7 +82,7 @@ export class ExtensionCreation extends CloseOnEscapeDialog {
 
     formatType(documentedType: DocumentedType): string {
         if (documentedType) {
-            return this.nifiCommon.substringAfterLast(documentedType.type, '.');
+            return this.nifiCommon.getComponentTypeLabel(documentedType.type);
         }
         return '';
     }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/services/nifi-common.service.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/services/nifi-common.service.ts
@@ -40,6 +40,8 @@ export class NiFiCommon {
     public static readonly BYTES_IN_GIGABYTE: number = 1073741824;
     public static readonly BYTES_IN_TERABYTE: number = 1099511627776;
 
+    public static readonly PACKAGE_SEPARATOR: string = '.';
+
     private policyTypeListing: SelectOption[] = [
         {
             text: 'view the user interface',
@@ -174,6 +176,22 @@ export class NiFiCommon {
     }
 
     /**
+     * Get the label for a Component Type using the simple name from a qualified class
+     *
+     * @argument {string} componentType Qualified class name or simple name
+     */
+    public getComponentTypeLabel(componentType: string): string {
+        let label = componentType;
+
+        const separatorIndex = componentType.indexOf(NiFiCommon.PACKAGE_SEPARATOR);
+        if (separatorIndex >= 0) {
+            label = this.substringAfterLast(componentType, NiFiCommon.PACKAGE_SEPARATOR);
+        }
+
+        return label;
+    }
+
+    /**
      * Determines whether the specified string is blank (or null or undefined).
      *
      * @argument {string} str   The string to test
@@ -268,7 +286,7 @@ export class NiFiCommon {
      * @param dataContext component datum
      */
     public formatClassName(dataContext: any): string {
-        return this.substringAfterLast(dataContext.type, '.');
+        return this.getComponentTypeLabel(dataContext.type);
     }
 
     /**

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
@@ -177,7 +177,7 @@ public class NiFiClientUtil {
     }
 
     public ProcessorEntity createPythonProcessor(final String typeName) throws NiFiClientException, IOException {
-        return createProcessor( "python." + typeName, NiFiSystemIT.NIFI_GROUP_ID, NiFiSystemIT.TEST_PYTHON_EXTENSIONS_ARTIFACT_ID, "0.0.1-SNAPSHOT");
+        return createProcessor(typeName, NiFiSystemIT.NIFI_GROUP_ID, NiFiSystemIT.TEST_PYTHON_EXTENSIONS_ARTIFACT_ID, "0.0.1-SNAPSHOT");
     }
 
     public ProcessorEntity createProcessor(final String simpleTypeName) throws NiFiClientException, IOException {

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/nar/NarUploadPythonIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/nar/NarUploadPythonIT.java
@@ -47,7 +47,7 @@ public class NarUploadPythonIT extends NiFiSystemIT {
     private static final Logger logger = LoggerFactory.getLogger(NarUploadPythonIT.class);
 
     private static final String PYTHON_TEXT_EXTENSIONS_NAR_ID = "nifi-python-test-extensions-nar";
-    private static final String PYTHON_WRITE_BECH_32_CHARSET = "python.WriteBech32Charset";
+    private static final String PYTHON_WRITE_BECH_32_CHARSET = "WriteBech32Charset";
     private static final String EXPECTED_FLOW_FILE_CONTENT = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 
     @Override


### PR DESCRIPTION
# Summary

[NIFI-13770](https://issues.apache.org/jira/browse/NIFI-13770) Removes the `python.` placeholder prefix from Python Processors added when loading extensions, and corrects the user interface behavior to display the component type.

The original implementation of support for Python Processors included the prefix as a workaround for UI rendering that expected a package name along with the simple class name. The updated UI function handles simple names for Python Processors as well as standard Java classes.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
