### PR TITLE
NIFI-13782 Limit count of split FlowFiles from SplitRecord for large record sets (support/nifi-1.x)

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitRecord.java
@@ -36,7 +36,6 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.processor.io.InputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
 import org.apache.nifi.serialization.MalformedRecordException;
@@ -54,6 +53,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -67,54 +67,86 @@ import java.util.UUID;
 @SideEffectFree
 @Tags({"split", "generic", "schema", "json", "csv", "avro", "log", "logs", "freeform", "text"})
 @WritesAttributes({
-    @WritesAttribute(attribute = "mime.type", description = "Sets the mime.type attribute to the MIME Type specified by the Record Writer for the FlowFiles routed to the 'splits' Relationship."),
-    @WritesAttribute(attribute = "record.count", description = "The number of records in the FlowFile. This is added to FlowFiles that are routed to the 'splits' Relationship."),
-    @WritesAttribute(attribute = "fragment.identifier", description = "All split FlowFiles produced from the same parent FlowFile will have the same randomly generated UUID added for this attribute"),
-    @WritesAttribute(attribute = "fragment.index", description = "A one-up number that indicates the ordering of the split FlowFiles that were created from a single parent FlowFile"),
-    @WritesAttribute(attribute = "fragment.count", description = "The number of split FlowFiles generated from the parent FlowFile"),
-    @WritesAttribute(attribute = "segment.original.filename ", description = "The filename of the parent FlowFile")
+        @WritesAttribute(attribute = "mime.type",
+                description = "Sets the mime.type attribute to the MIME Type specified by the Record Writer for the FlowFiles routed to the 'splits' Relationship."),
+        @WritesAttribute(attribute = "record.count",
+                description = "The number of records in the FlowFile. This is added to FlowFiles that are routed to the 'splits' Relationship."),
+        @WritesAttribute(attribute = "fragment.identifier",
+                description = "All split FlowFiles produced from the same parent FlowFile will have the same randomly generated UUID added for this attribute"),
+        @WritesAttribute(attribute = "fragment.index",
+                description = "A one-up number that indicates the ordering of the split FlowFiles that were created from a single parent FlowFile"),
+        @WritesAttribute(attribute = "fragment.count", description = "The number of split FlowFiles generated from the parent FlowFile"),
+        @WritesAttribute(attribute = "segment.original.filename ", description = "The filename of the parent FlowFile")
 })
 @CapabilityDescription("Splits up an input FlowFile that is in a record-oriented data format into multiple smaller FlowFiles")
 public class SplitRecord extends AbstractProcessor {
+
+    private static final int UNKNOWN_RECORD_COUNT = -1;
 
     public static final String FRAGMENT_ID = FragmentAttributes.FRAGMENT_ID.key();
     public static final String FRAGMENT_INDEX = FragmentAttributes.FRAGMENT_INDEX.key();
     public static final String FRAGMENT_COUNT = FragmentAttributes.FRAGMENT_COUNT.key();
     public static final String SEGMENT_ORIGINAL_FILENAME = FragmentAttributes.SEGMENT_ORIGINAL_FILENAME.key();
 
+    private static final String SPLIT_IDENTIFIER = "split.identifier";
+    private static final String SPLIT_FRAGMENT_INDEX = "split.fragmentIndex";
+    private static final String SPLIT_RECORD_COUNT = "split.recordCount";
+    private static final Set<String> SPLIT_ATTRIBUTE_KEYS;
+
+    static {
+        Set<String> splitAttributeKeys = new HashSet<>();
+        splitAttributeKeys.add(SPLIT_IDENTIFIER);
+        splitAttributeKeys.add(SPLIT_FRAGMENT_INDEX);
+        splitAttributeKeys.add(SPLIT_RECORD_COUNT);
+        SPLIT_ATTRIBUTE_KEYS = Collections.unmodifiableSet(splitAttributeKeys);
+    }
+
     static final PropertyDescriptor RECORD_READER = new PropertyDescriptor.Builder()
-        .name("Record Reader")
-        .description("Specifies the Controller Service to use for reading incoming data")
-        .identifiesControllerService(RecordReaderFactory.class)
-        .required(true)
-        .build();
+            .name("Record Reader")
+            .description("Specifies the Controller Service to use for reading incoming data")
+            .identifiesControllerService(RecordReaderFactory.class)
+            .required(true)
+            .build();
     static final PropertyDescriptor RECORD_WRITER = new PropertyDescriptor.Builder()
-        .name("Record Writer")
-        .description("Specifies the Controller Service to use for writing out the records")
-        .identifiesControllerService(RecordSetWriterFactory.class)
-        .required(true)
-        .build();
+            .name("Record Writer")
+            .description("Specifies the Controller Service to use for writing out the records")
+            .identifiesControllerService(RecordSetWriterFactory.class)
+            .required(true)
+            .build();
     static final PropertyDescriptor RECORDS_PER_SPLIT = new PropertyDescriptor.Builder()
-        .name("Records Per Split")
-        .description("Specifies how many records should be written to each 'split' or 'segment' FlowFile")
-        .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
-        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
-        .required(true)
-        .build();
+            .name("Records Per Split")
+            .description("Specifies how many records should be written to each 'split' or 'segment' FlowFile")
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .required(true)
+            .build();
+    static final PropertyDescriptor MAXIMUM_SPLITS_PER_INVOCATION = new PropertyDescriptor.Builder()
+            .name("Maximum Splits Per Invocation")
+            .description("Specifies how many 'split' or 'segment' FlowFiles can be created on each invocation. " +
+                    "In case splitting up the record set requires more FlowFiles than configured, " +
+                    "up to the defined count of 'split' FlowFiles are transferred to the 'splits' relationship " +
+                    "and the FlowFile is pushed back to the upstream queue for the next invocation. " +
+                    "On the next invocation, the missing records are split accordingly. " +
+                    "Once all records have been split, the FlowFile is transferred to the 'original' relationship. ")
+            .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .required(true)
+            .defaultValue("10000")
+            .build();
 
     static final Relationship REL_SPLITS = new Relationship.Builder()
-        .name("splits")
-        .description("The individual 'segments' of the original FlowFile will be routed to this relationship.")
-        .build();
+            .name("splits")
+            .description("The individual 'segments' of the original FlowFile will be routed to this relationship.")
+            .build();
     static final Relationship REL_ORIGINAL = new Relationship.Builder()
-        .name("original")
-        .description("Upon successfully splitting an input FlowFile, the original FlowFile will be sent to this relationship.")
-        .build();
+            .name("original")
+            .description("Upon successfully splitting an input FlowFile, the original FlowFile will be sent to this relationship.")
+            .build();
     static final Relationship REL_FAILURE = new Relationship.Builder()
-        .name("failure")
-        .description("If a FlowFile cannot be transformed from the configured input format to the configured output format, "
-            + "the unchanged FlowFile will be routed to this relationship.")
-        .build();
+            .name("failure")
+            .description("If a FlowFile cannot be transformed from the configured input format to the configured output format, "
+                    + "the unchanged FlowFile will be routed to this relationship.")
+            .build();
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -122,6 +154,7 @@ public class SplitRecord extends AbstractProcessor {
         properties.add(RECORD_READER);
         properties.add(RECORD_WRITER);
         properties.add(RECORDS_PER_SPLIT);
+        properties.add(MAXIMUM_SPLITS_PER_INVOCATION);
         return properties;
     }
 
@@ -143,77 +176,133 @@ public class SplitRecord extends AbstractProcessor {
 
         final RecordReaderFactory readerFactory = context.getProperty(RECORD_READER).asControllerService(RecordReaderFactory.class);
         final RecordSetWriterFactory writerFactory = context.getProperty(RECORD_WRITER).asControllerService(RecordSetWriterFactory.class);
+        final int maxRecordsPerSplit = context.getProperty(RECORDS_PER_SPLIT).evaluateAttributeExpressions(original).asInteger();
+        final int maximumSplits = context.getProperty(MAXIMUM_SPLITS_PER_INVOCATION).evaluateAttributeExpressions(original).asInteger();
 
-        final int maxRecords = Math.max(1, context.getProperty(RECORDS_PER_SPLIT).evaluateAttributeExpressions(original).asInteger());
+        final Map<String, String> originalAttributes = original.getAttributes();
+        final String fragmentId = loadOrGenerateFragmentId(originalAttributes);
+
+        int fragmentIndex = determineFragmentIndex(originalAttributes);
+        int totalRecordCount = loadCachedRecordCount(originalAttributes);
 
         final List<FlowFile> splits = new ArrayList<>();
-        final Map<String, String> originalAttributes = original.getAttributes();
-        final String fragmentId = UUID.randomUUID().toString();
-        try {
-            session.read(original, new InputStreamCallback() {
-                @Override
-                public void process(final InputStream in) throws IOException {
-                    try (final RecordReader reader = readerFactory.createRecordReader(originalAttributes, in, original.getSize(), getLogger())) {
+        try (final InputStream inputStream = session.read(original);
+             final RecordReader reader = readerFactory.createRecordReader(originalAttributes, inputStream, original.getSize(), getLogger())) {
+            final RecordSchema schema = writerFactory.getSchema(originalAttributes, reader.getSchema());
 
-                        final RecordSchema schema = writerFactory.getSchema(originalAttributes, reader.getSchema());
+            final RecordSet recordSet = reader.createRecordSet();
+            final PushBackRecordSet pushbackSet = new PushBackRecordSet(recordSet);
 
-                        final RecordSet recordSet = reader.createRecordSet();
-                        final PushBackRecordSet pushbackSet = new PushBackRecordSet(recordSet);
+            skipRecords(pushbackSet, fragmentIndex);
 
-                        int fragmentIndex = 0;
-                        while (pushbackSet.isAnotherRecord()) {
-                            FlowFile split = session.create(original);
+            while (pushbackSet.isAnotherRecord() && splits.size() < maximumSplits) {
+                FlowFile split = session.create(original);
 
-                            try {
-                                final Map<String, String> attributes = new HashMap<>();
-                                final WriteResult writeResult;
+                try {
+                    final Map<String, String> attributes = new HashMap<>();
 
-                                try (final OutputStream out = session.write(split);
-                                    final RecordSetWriter writer = writerFactory.createWriter(getLogger(), schema, out, split)) {
-                                        if (maxRecords == 1) {
-                                            final Record record = pushbackSet.next();
-                                            writeResult = writer.write(record);
-                                        } else {
-                                            final RecordSet limitedSet = pushbackSet.limit(maxRecords);
-                                            writeResult = writer.write(limitedSet);
-                                        }
-
-                                        attributes.put("record.count", String.valueOf(writeResult.getRecordCount()));
-                                        attributes.put(CoreAttributes.MIME_TYPE.key(), writer.getMimeType());
-                                        attributes.put(FRAGMENT_INDEX, String.valueOf(fragmentIndex));
-                                        attributes.put(FRAGMENT_ID, fragmentId);
-                                        attributes.put(SEGMENT_ORIGINAL_FILENAME, original.getAttribute(CoreAttributes.FILENAME.key()));
-                                        attributes.putAll(writeResult.getAttributes());
-
-                                        session.adjustCounter("Records Split", writeResult.getRecordCount(), false);
-                                }
-
-                                split = session.putAllAttributes(split, attributes);
-                            } finally {
-                                splits.add(split);
-                            }
-                            fragmentIndex++;
+                    try (final OutputStream outputStream = session.write(split);
+                         final RecordSetWriter writer = writerFactory.createWriter(getLogger(), schema, outputStream, split)) {
+                        final WriteResult writeResult;
+                        if (maxRecordsPerSplit == 1) {
+                            final Record record = pushbackSet.next();
+                            writeResult = writer.write(record);
+                        } else {
+                            final RecordSet limitedSet = pushbackSet.limit(maxRecordsPerSplit);
+                            writeResult = writer.write(limitedSet);
                         }
-                    } catch (final SchemaNotFoundException | MalformedRecordException e) {
-                        throw new ProcessException("Failed to parse incoming data", e);
+
+                        attributes.put("record.count", String.valueOf(writeResult.getRecordCount()));
+                        attributes.put(CoreAttributes.MIME_TYPE.key(), writer.getMimeType());
+                        attributes.put(FRAGMENT_INDEX, String.valueOf(fragmentIndex));
+                        attributes.put(FRAGMENT_ID, fragmentId);
+                        attributes.put(SEGMENT_ORIGINAL_FILENAME, original.getAttribute(CoreAttributes.FILENAME.key()));
+                        attributes.putAll(writeResult.getAttributes());
+
+                        session.adjustCounter("Records Split", writeResult.getRecordCount(), false);
                     }
+
+                    split = session.putAllAttributes(split, attributes);
+                } finally {
+                    splits.add(split);
                 }
-            });
-        } catch (final ProcessException pe) {
-            getLogger().error("Failed to split {}", original, pe);
+
+                fragmentIndex += 1;
+            }
+
+            if (totalRecordCount == UNKNOWN_RECORD_COUNT) {
+                totalRecordCount = fragmentIndex + countRemainingRecords(pushbackSet);
+            }
+        } catch (final SchemaNotFoundException | MalformedRecordException | IOException e) {
+            getLogger().error("Failed to split {}", original, e);
             session.remove(splits);
             session.transfer(original, REL_FAILURE);
             return;
         }
 
-        final FlowFile originalFlowFile = FragmentAttributes.copyAttributesToOriginal(session, original, fragmentId, splits.size());
-        session.transfer(originalFlowFile, REL_ORIGINAL);
+        final int fragmentCount = ceilDiv(totalRecordCount, maxRecordsPerSplit);
+        final boolean hasRecordsLeft = fragmentIndex < totalRecordCount;
+
+        if (hasRecordsLeft) {
+            Map<String, String> splitAttributes = new HashMap<>();
+            splitAttributes.put(SPLIT_IDENTIFIER, fragmentId);
+            splitAttributes.put(SPLIT_FRAGMENT_INDEX, String.format("%d", fragmentIndex));
+            splitAttributes.put(SPLIT_RECORD_COUNT, String.format("%d", totalRecordCount));
+            final FlowFile adjustedOriginalFlowFile = session.putAllAttributes(original, splitAttributes);
+
+            session.transfer(adjustedOriginalFlowFile);
+        } else {
+            final FlowFile adjustedOriginalFlowFile = FragmentAttributes.copyAttributesToOriginal(session, original, fragmentId, fragmentCount);
+            session.removeAllAttributes(adjustedOriginalFlowFile, SPLIT_ATTRIBUTE_KEYS);
+            session.transfer(adjustedOriginalFlowFile, REL_ORIGINAL);
+        }
+
         // Add the fragment count to each split
-        for(FlowFile split : splits) {
-            session.putAttribute(split, FRAGMENT_COUNT, String.valueOf(splits.size()));
+        for (FlowFile split : splits) {
+            session.putAttribute(split, FRAGMENT_COUNT, String.valueOf(fragmentCount));
         }
         session.transfer(splits, REL_SPLITS);
-        getLogger().info("Successfully split {} into {} FlowFiles, each containing up to {} records", original, splits.size(), maxRecords);
+        getLogger().info("Successfully split {} into {} FlowFiles, each containing up to {} records", original, splits.size(), maxRecordsPerSplit);
     }
 
+    private static String loadOrGenerateFragmentId(Map<String, String> attributes) {
+        if (attributes.containsKey(SPLIT_IDENTIFIER)) {
+            return attributes.get(SPLIT_IDENTIFIER);
+        }
+        return UUID.randomUUID().toString();
+    }
+
+    private static int determineFragmentIndex(Map<String, String> attributes) {
+        if (attributes.containsKey(SPLIT_FRAGMENT_INDEX)) {
+            return Integer.parseInt(attributes.get(SPLIT_FRAGMENT_INDEX));
+        }
+        return 0;
+    }
+
+    private int loadCachedRecordCount(Map<String, String> attributes) {
+        if (attributes.containsKey(SPLIT_RECORD_COUNT)) {
+            return Integer.parseInt(attributes.get(SPLIT_RECORD_COUNT));
+        }
+        return UNKNOWN_RECORD_COUNT;
+    }
+
+    private void skipRecords(final RecordSet recordSet, final int recordsToSkip) throws IOException {
+        int skipped = 0;
+
+        while (skipped < recordsToSkip && recordSet.next() != null) {
+            skipped += 1;
+        }
+    }
+
+    private int countRemainingRecords(final RecordSet recordSet) throws IOException {
+        int count = 0;
+        while (recordSet.next() != null) {
+            count += 1;
+        }
+        return count;
+    }
+
+    private int ceilDiv(int x, int y) {
+        return (x + y - 1) / y;
+    }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13782](https://issues.apache.org/jira/browse/NIFI-13782)

Backport of [NIFI-4146](https://issues.apache.org/jira/browse/NIFI-4146)  / #9293 for `support/nifi-1.x`.
Maybe we can include this bugfix into the upcoming 1.28.0 release as well, @ferencerdei?

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK ~~21~~ 8

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
