### PR TITLE
NIFI-12762 allow for increasing max size of request headers in ListenHTTP and HandleHttpRequest

### DIFF
--- a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
+++ b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
@@ -68,7 +68,7 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
 
     private String[] includeSecurityProtocols = INCLUDE_ALL_SECURITY_PROTOCOLS;
 
-    private int maxRequestHeaderSize = 8192;
+    private int requestHeaderSize = 8192;
 
     /**
      * Standard Server Connector Factory Constructor with required properties
@@ -173,12 +173,12 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
     }
 
     /**
-     * Set the maximum HTTP request headers size. The default is 8 KB.
+     * Set the maximum HTTP request header size. The default is 8 KB.
      *
-     * @param requestHeaderSize maximum HTTP request headers size
+     * @param requestHeaderSize maximum HTTP request header size
      */
-    public void setMaxRequestHeaderSize(int requestHeaderSize) {
-        this.maxRequestHeaderSize = requestHeaderSize;
+    public void setRequestHeaderSize(int requestHeaderSize) {
+        this.requestHeaderSize = requestHeaderSize;
     }
 
     protected Server getServer() {
@@ -187,7 +187,7 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
 
     protected HttpConfiguration getHttpConfiguration() {
         final HttpConfiguration httpConfiguration = new HttpConfiguration();
-        httpConfiguration.setRequestHeaderSize(maxRequestHeaderSize);
+        httpConfiguration.setRequestHeaderSize(requestHeaderSize);
 
         if (sslContext != null) {
             httpConfiguration.setSecurePort(port);

--- a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
+++ b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
@@ -68,6 +68,8 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
 
     private String[] includeSecurityProtocols = INCLUDE_ALL_SECURITY_PROTOCOLS;
 
+    private int maxRequestHeaderSize = 8192;
+
     /**
      * Standard Server Connector Factory Constructor with required properties
      *
@@ -170,12 +172,22 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
         this.applicationLayerProtocols = applicationLayerProtocols;
     }
 
+    /**
+     * Set the maximum HTTP request headers size. The default is 8 KB.
+     *
+     * @param requestHeaderSize maximum HTTP request headers size
+     */
+    public void setMaxRequestHeaderSize(int requestHeaderSize) {
+        this.maxRequestHeaderSize = requestHeaderSize;
+    }
+
     protected Server getServer() {
         return server;
     }
 
     protected HttpConfiguration getHttpConfiguration() {
         final HttpConfiguration httpConfiguration = new HttpConfiguration();
+        httpConfiguration.setRequestHeaderSize(maxRequestHeaderSize);
 
         if (sslContext != null) {
             httpConfiguration.setSecurePort(port);

--- a/nifi-commons/nifi-jetty-configuration/src/test/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactoryTest.java
+++ b/nifi-commons/nifi-jetty-configuration/src/test/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactoryTest.java
@@ -56,7 +56,20 @@ class StandardServerConnectorFactoryTest {
 
         final ServerConnector serverConnector = factory.getServerConnector();
 
-        assertHttpConnectionFactoryFound(serverConnector);
+        final HttpConnectionFactory httpConnectionFactory = assertHttpConnectionFactoryFound(serverConnector);
+        assertEquals(8192, httpConnectionFactory.getHttpConfiguration().getRequestHeaderSize());
+    }
+
+    @Test
+    void testGetServerConnectorWithMaxRequestHeaderSize() {
+        final Server server = new Server();
+        final StandardServerConnectorFactory factory = new StandardServerConnectorFactory(server, HTTP_PORT);
+        factory.setMaxRequestHeaderSize(16000);
+
+        final ServerConnector serverConnector = factory.getServerConnector();
+
+        final HttpConnectionFactory httpConnectionFactory = assertHttpConnectionFactoryFound(serverConnector);
+        assertEquals(16000, httpConnectionFactory.getHttpConfiguration().getRequestHeaderSize());
     }
 
     @Test

--- a/nifi-commons/nifi-jetty-configuration/src/test/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactoryTest.java
+++ b/nifi-commons/nifi-jetty-configuration/src/test/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactoryTest.java
@@ -61,10 +61,10 @@ class StandardServerConnectorFactoryTest {
     }
 
     @Test
-    void testGetServerConnectorWithMaxRequestHeaderSize() {
+    void testGetServerConnectorWithRequestHeaderSize() {
         final Server server = new Server();
         final StandardServerConnectorFactory factory = new StandardServerConnectorFactory(server, HTTP_PORT);
-        factory.setMaxRequestHeaderSize(16000);
+        factory.setRequestHeaderSize(16000);
 
         final ServerConnector serverConnector = factory.getServerConnector();
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
@@ -280,8 +280,8 @@ public class HandleHttpRequest extends AbstractProcessor {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .build();
-    public static final PropertyDescriptor REQUEST_HEADERS_MAX_SIZE = new PropertyDescriptor.Builder()
-            .name("HTTP Headers Maximum Size")
+    public static final PropertyDescriptor REQUEST_HEADER_MAX_SIZE = new PropertyDescriptor.Builder()
+            .name("Request Header Maximum Size")
             .description("The maximum supported size of HTTP headers in requests sent to this processor")
             .required(true)
             .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
@@ -340,7 +340,7 @@ public class HandleHttpRequest extends AbstractProcessor {
             MULTIPART_REQUEST_MAX_SIZE,
             MULTIPART_READ_BUFFER_SIZE,
             PARAMETERS_TO_ATTRIBUTES,
-            REQUEST_HEADERS_MAX_SIZE
+            REQUEST_HEADER_MAX_SIZE
     );
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -388,9 +388,9 @@ public class HandleHttpRequest extends AbstractProcessor {
         final String clientAuthValue = context.getProperty(CLIENT_AUTH).getValue();
         final Server server = createServer(context);
 
-        final int requestMaxHeaderSize = context.getProperty(REQUEST_HEADERS_MAX_SIZE).asDataSize(DataUnit.B).intValue();
+        final int requestHeaderSize = context.getProperty(REQUEST_HEADER_MAX_SIZE).asDataSize(DataUnit.B).intValue();
         final StandardServerConnectorFactory serverConnectorFactory = new StandardServerConnectorFactory(server, port);
-        serverConnectorFactory.setMaxRequestHeaderSize(requestMaxHeaderSize);
+        serverConnectorFactory.setRequestHeaderSize(requestHeaderSize);
 
         final boolean needClientAuth = CLIENT_NEED.getValue().equals(clientAuthValue);
         serverConnectorFactory.setNeedClientAuth(needClientAuth);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
@@ -265,6 +265,13 @@ public class HandleHttpRequest extends AbstractProcessor {
             .defaultValue("200")
             .addValidator(StandardValidators.createLongValidator(8, 1000, true))
             .build();
+    public static final PropertyDescriptor REQUEST_HEADER_MAX_SIZE = new PropertyDescriptor.Builder()
+            .name("Request Header Maximum Size")
+            .description("The maximum supported size of HTTP headers in requests sent to this processor")
+            .required(true)
+            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
+            .defaultValue("8 KB")
+            .build();
     public static final PropertyDescriptor ADDITIONAL_METHODS = new PropertyDescriptor.Builder()
             .name("Additional HTTP Methods")
             .description("A comma-separated list of non-standard HTTP Methods that should be allowed")
@@ -279,13 +286,6 @@ public class HandleHttpRequest extends AbstractProcessor {
             .required(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
-            .build();
-    public static final PropertyDescriptor REQUEST_HEADER_MAX_SIZE = new PropertyDescriptor.Builder()
-            .name("Request Header Maximum Size")
-            .description("The maximum supported size of HTTP headers in requests sent to this processor")
-            .required(true)
-            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
-            .defaultValue("8 KB")
             .build();
     public static final PropertyDescriptor CLIENT_AUTH = new PropertyDescriptor.Builder()
             .name("Client Authentication")
@@ -334,13 +334,13 @@ public class HandleHttpRequest extends AbstractProcessor {
             ALLOW_HEAD,
             ALLOW_OPTIONS,
             MAXIMUM_THREADS,
+            REQUEST_HEADER_MAX_SIZE,
             ADDITIONAL_METHODS,
             CLIENT_AUTH,
             CONTAINER_QUEUE_SIZE,
             MULTIPART_REQUEST_MAX_SIZE,
             MULTIPART_READ_BUFFER_SIZE,
-            PARAMETERS_TO_ATTRIBUTES,
-            REQUEST_HEADER_MAX_SIZE
+            PARAMETERS_TO_ATTRIBUTES
     );
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
@@ -200,8 +200,8 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
         .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
         .required(false)
         .build();
-    public static final PropertyDescriptor REQUEST_HEADERS_MAX_SIZE = new PropertyDescriptor.Builder()
-        .name("HTTP Headers Maximum Size")
+    public static final PropertyDescriptor REQUEST_HEADER_MAX_SIZE = new PropertyDescriptor.Builder()
+        .name("Request Header Maximum Size")
         .description("The maximum supported size of HTTP headers in requests sent to this processor")
         .required(true)
         .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
@@ -288,7 +288,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
             AUTHORIZED_ISSUER_DN_PATTERN,
             MAX_UNCONFIRMED_TIME,
             HEADERS_AS_ATTRIBUTES_REGEX,
-            REQUEST_HEADERS_MAX_SIZE,
+            REQUEST_HEADER_MAX_SIZE,
             RETURN_CODE,
             MULTIPART_REQUEST_MAX_SIZE,
             MULTIPART_READ_BUFFER_SIZE,
@@ -405,7 +405,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
         final long requestMaxSize = context.getProperty(MULTIPART_REQUEST_MAX_SIZE).asDataSize(DataUnit.B).longValue();
         final int readBufferSize = context.getProperty(MULTIPART_READ_BUFFER_SIZE).asDataSize(DataUnit.B).intValue();
         final int maxThreadPoolSize = context.getProperty(MAX_THREAD_POOL_SIZE).asInteger();
-        final int requestMaxHeaderSize = context.getProperty(REQUEST_HEADERS_MAX_SIZE).asDataSize(DataUnit.B).intValue();
+        final int requestHeaderSize = context.getProperty(REQUEST_HEADER_MAX_SIZE).asDataSize(DataUnit.B).intValue();
         throttlerRef.set(streamThrottler);
 
         final PropertyValue clientAuthenticationProperty = context.getProperty(CLIENT_AUTHENTICATION);
@@ -423,7 +423,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
         final HttpProtocolStrategy httpProtocolStrategy = context.getProperty(HTTP_PROTOCOL_STRATEGY).asAllowableValue(HttpProtocolStrategy.class);
         final ServerConnector connector = createServerConnector(server,
                 port,
-                requestMaxHeaderSize,
+                requestHeaderSize,
                 sslContextService,
                 clientAuthentication,
                 httpProtocolStrategy
@@ -435,7 +435,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
         if (healthCheckPort != null) {
             final ServerConnector healthCheckConnector = createServerConnector(server,
                     healthCheckPort,
-                    requestMaxHeaderSize,
+                    requestHeaderSize,
                     sslContextService,
                     ClientAuthentication.NONE,
                     httpProtocolStrategy
@@ -520,7 +520,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
                                                   final HttpProtocolStrategy httpProtocolStrategy
     ) {
         final StandardServerConnectorFactory serverConnectorFactory = new StandardServerConnectorFactory(server, port);
-        serverConnectorFactory.setMaxRequestHeaderSize(requestMaxHeaderSize);
+        serverConnectorFactory.setRequestHeaderSize(requestMaxHeaderSize);
 
         final SSLContext sslContext = sslContextService == null ? null : sslContextService.createContext();
         serverConnectorFactory.setSslContext(sslContext);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
@@ -785,9 +785,9 @@ public class TestListenHTTP {
 
     @Test
     public void testLargeHTTPRequestHeader() throws Exception {
-        // default Jetty maximum HTTP header size is 8192
-        // test that NiFiProperties nifi.web.max.header.size (default 16384) is used instead
-        String largeHeaderValue = "A".repeat(8193);
+        runner.setProperty(ListenHTTP.REQUEST_HEADERS_MAX_SIZE, "16 KB");
+
+        String largeHeaderValue = "A".repeat(9 * 1024);
 
         final int port = startWebServer();
         OkHttpClient client = getOkHttpClient(false, false);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
@@ -785,7 +785,7 @@ public class TestListenHTTP {
 
     @Test
     public void testLargeHTTPRequestHeader() throws Exception {
-        runner.setProperty(ListenHTTP.REQUEST_HEADERS_MAX_SIZE, "16 KB");
+        runner.setProperty(ListenHTTP.REQUEST_HEADER_MAX_SIZE, "16 KB");
 
         String largeHeaderValue = "A".repeat(9 * 1024);
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListenHTTP.java
@@ -783,6 +783,26 @@ public class TestListenHTTP {
         assertEquals(0, multiPartTempFiles, multiPartMessage);
     }
 
+    @Test
+    public void testLargeHTTPRequestHeader() throws Exception {
+        // default Jetty maximum HTTP header size is 8192
+        // test that NiFiProperties nifi.web.max.header.size (default 16384) is used instead
+        String largeHeaderValue = "A".repeat(8193);
+
+        final int port = startWebServer();
+        OkHttpClient client = getOkHttpClient(false, false);
+        final String url = buildUrl(false, port);
+        Request request = new Request.Builder()
+                .url(url)
+                .addHeader("Large-Header", largeHeaderValue)
+                .method("HEAD", null)
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            int responseCode = response.code();
+            assertEquals(200, responseCode, "Expected 200 response code with large header.");
+        }
+    }
+
     private byte[] generateRandomBinaryData() {
         byte[] bytes = new byte[100];
         new Random().nextBytes(bytes);


### PR DESCRIPTION
# Summary

[NIFI-12762](https://issues.apache.org/jira/browse/NIFI-12762)
Allow for increasing max size of accepted request headers in ListenHTTP and HandleHttpRequest.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
