### PR TITLE
NIFI-13802: Renamed system tests to ensure that they end in IT. Also …

### DIFF
--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiSystemIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiSystemIT.java
@@ -623,7 +623,9 @@ public abstract class NiFiSystemIT implements NiFiInstanceProvider {
         final ClusterEntity clusterEntity = getNifiClient().getControllerClient().getNodes();
         final int expectedPort = getClientApiPort() + nodeIndex - 1;
 
+        final List<Integer> nodePorts = new ArrayList<>();
         for (final NodeDTO nodeDto : clusterEntity.getCluster().getNodes()) {
+            nodePorts.add(nodeDto.getApiPort());
             if (nodeDto.getApiPort() == expectedPort) {
                 final NodeEntity nodeEntity = new NodeEntity();
                 nodeEntity.setNode(nodeDto);
@@ -631,7 +633,7 @@ public abstract class NiFiSystemIT implements NiFiInstanceProvider {
             }
         }
 
-        throw new IllegalStateException("Could not find node with API Port of " + expectedPort);
+        throw new IllegalStateException("Could not find node with API Port of " + expectedPort + "; found nodes: " + nodePorts);
     }
 
     protected void waitForNodeState(final int nodeIndex, final NodeConnectionState... nodeStates) throws InterruptedException {

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/JoinClusterWithMissingConnectionNoDataIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/JoinClusterWithMissingConnectionNoDataIT.java
@@ -22,7 +22,7 @@ import org.apache.nifi.tests.system.NiFiSystemIT;
 import org.apache.nifi.tests.system.SpawnedClusterNiFiInstanceFactory;
 import org.junit.jupiter.api.Test;
 
-public class JoinClusterWithMissingConnectionNoData extends NiFiSystemIT {
+public class JoinClusterWithMissingConnectionNoDataIT extends NiFiSystemIT {
     @Override
     public NiFiInstanceFactory getInstanceFactory() {
         return new SpawnedClusterNiFiInstanceFactory(

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/JoinClusterWithMissingConnectionWithDataIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/JoinClusterWithMissingConnectionWithDataIT.java
@@ -28,10 +28,14 @@ import org.apache.nifi.web.api.entity.ConnectionEntity;
 import org.apache.nifi.web.api.entity.NodeEntity;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-public class JoinClusterWithMissingConnectionWithData extends NiFiSystemIT {
+public class JoinClusterWithMissingConnectionWithDataIT extends NiFiSystemIT {
+    private static final Logger logger = LoggerFactory.getLogger(JoinClusterWithMissingConnectionWithDataIT.class);
+
     private static final String GENERATE_UUID = "6be9a7e7-016e-1000-0000-00004700499d";
     private static final String CONNECTION_UUID = "6be9a991-016e-1000-ffff-fffffebf0217";
 
@@ -135,8 +139,8 @@ public class JoinClusterWithMissingConnectionWithData extends NiFiSystemIT {
         final FlowDTO flowDto;
         try {
             flowDto = getNifiClient().getFlowClient().getProcessGroup("root").getProcessGroupFlow().getFlow();
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (final Exception e) {
+            logger.error("Failed to retrieve flow", e);
             return false;
         }
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/RestartWithDifferentPortIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/RestartWithDifferentPortIT.java
@@ -33,10 +33,17 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class RestartWithDifferentPort extends NiFiSystemIT {
+public class RestartWithDifferentPortIT extends NiFiSystemIT {
     @Override
     public NiFiInstanceFactory getInstanceFactory() {
         return createTwoNodeInstanceFactory();
+    }
+
+    @Override
+    protected boolean isAllowFactoryReuse() {
+        // Do not allow reuse of the factory because we are changing the port that node 2 starts on, which can then cause
+        // subsequent tests to fail, if they are attempting to get node by port number.
+        return false;
     }
 
     @Test


### PR DESCRIPTION
…a bit of cleanup in the system tests and ensure that the RestartWithDifferentPort test does not allow instance reuse, since it changes the nifi port, which can cause subsequent tests to fail if they use that same instance

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
