### PR TITLE
NIFI-13810 Handle Trailing Separator for Encoded Paths in URI Builder

### DIFF
--- a/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardHttpUriBuilder.java
+++ b/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardHttpUriBuilder.java
@@ -41,6 +41,8 @@ public class StandardHttpUriBuilder implements HttpUriBuilder {
 
     private static final int MAXIMUM_PORT = 65535;
 
+    private static final char PATH_SEGMENT_SEPARATOR_CHARACTER = '/';
+
     private static final String PATH_SEGMENT_SEPARATOR = "/";
 
     private static final String QUERY_PARAMETER_SEPARATOR = "&";
@@ -132,6 +134,16 @@ public class StandardHttpUriBuilder implements HttpUriBuilder {
         }
 
         if (!pathSegments.isEmpty()) {
+            final int pathBuilderLength = pathBuilder.length();
+            if (pathBuilderLength > 0) {
+                // Append Path Segment Separator after encodedPath and before pathSegments when not found in encodedPath
+                final int lastIndex = pathBuilderLength - 1;
+                final char lastCharacter = pathBuilder.charAt(lastIndex);
+                if (PATH_SEGMENT_SEPARATOR_CHARACTER != lastCharacter) {
+                    pathBuilder.append(PATH_SEGMENT_SEPARATOR_CHARACTER);
+                }
+            }
+
             final String separatedPath = String.join(PATH_SEGMENT_SEPARATOR, pathSegments);
             pathBuilder.append(separatedPath);
         }

--- a/nifi-commons/nifi-web-client/src/test/java/org/apache/nifi/web/client/StandardHttpUriBuilderTest.java
+++ b/nifi-commons/nifi-web-client/src/test/java/org/apache/nifi/web/client/StandardHttpUriBuilderTest.java
@@ -33,7 +33,13 @@ class StandardHttpUriBuilderTest {
 
     private static final String ENCODED_PATH = "/resources/search";
 
+    private static final String ENCODED_PATH_WITH_TRAILING_SEPARATOR = "/resources/search/";
+
     private static final String PATH_WITH_SPACES_ENCODED = "/resources/%20separated%20search";
+
+    private static final String BUCKETS_PATH_SEGMENT = "buckets";
+
+    private static final String FILES_PATH_SEGMENT = "files";
 
     private static final String RESOURCES_PATH_SEGMENT = "resources";
 
@@ -67,6 +73,14 @@ class StandardHttpUriBuilderTest {
 
     private static final URI HTTP_LOCALHOST_PORT_ENCODED_PATH_WITH_SPACES_URI = URI.create(
             String.format("%s://%s:%d%s", HTTP_SCHEME, LOCALHOST, PORT, PATH_WITH_SPACES_ENCODED)
+    );
+
+    private static final URI HTTP_LOCALHOST_PORT_ENCODED_PATH_WITH_SPACES_AND_SEGMENTS_URI = URI.create(
+            String.format("%s://%s:%d%s/%s/%s", HTTP_SCHEME, LOCALHOST, PORT, PATH_WITH_SPACES_ENCODED, BUCKETS_PATH_SEGMENT, FILES_PATH_SEGMENT)
+    );
+
+    private static final URI HTTP_LOCALHOST_PORT_ENCODED_PATH_WITH_TRAILING_SEPARATOR_AND_SEGMENTS_URI = URI.create(
+            String.format("%s://%s:%d%s%s/%s", HTTP_SCHEME, LOCALHOST, PORT, ENCODED_PATH_WITH_TRAILING_SEPARATOR, BUCKETS_PATH_SEGMENT, FILES_PATH_SEGMENT)
     );
 
     private static final URI HTTP_LOCALHOST_RESOURCES_URI = URI.create(
@@ -166,6 +180,36 @@ class StandardHttpUriBuilderTest {
         final URI uri = builder.build();
 
         assertEquals(HTTP_LOCALHOST_PORT_ENCODED_PATH_WITH_SPACES_URI, uri);
+    }
+
+    @Test
+    void testBuildSchemeHostPortEncodedPathWithSpacesAndPathSegments() {
+        final HttpUriBuilder builder = new StandardHttpUriBuilder()
+                .scheme(HTTP_SCHEME)
+                .host(LOCALHOST)
+                .port(PORT)
+                .encodedPath(PATH_WITH_SPACES_ENCODED)
+                .addPathSegment(BUCKETS_PATH_SEGMENT)
+                .addPathSegment(FILES_PATH_SEGMENT);
+
+        final URI uri = builder.build();
+
+        assertEquals(HTTP_LOCALHOST_PORT_ENCODED_PATH_WITH_SPACES_AND_SEGMENTS_URI, uri);
+    }
+
+    @Test
+    void testBuildSchemeHostPortEncodedPathWithTrailingSeparatorAndPathSegments() {
+        final HttpUriBuilder builder = new StandardHttpUriBuilder()
+                .scheme(HTTP_SCHEME)
+                .host(LOCALHOST)
+                .port(PORT)
+                .encodedPath(ENCODED_PATH_WITH_TRAILING_SEPARATOR)
+                .addPathSegment(BUCKETS_PATH_SEGMENT)
+                .addPathSegment(FILES_PATH_SEGMENT);
+
+        final URI uri = builder.build();
+
+        assertEquals(HTTP_LOCALHOST_PORT_ENCODED_PATH_WITH_TRAILING_SEPARATOR_AND_SEGMENTS_URI, uri);
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-13810](https://issues.apache.org/jira/browse/NIFI-13810) Updates the `StandardHttpUriBuilder` in `nifi-web-client` to handle the need for a path segment separator when adding both an encoded path and path segments.

The `encodedPath()` method serves as base path for the URI and may or may not include a trailing forward slash character. When `encodedPath()` is called together with one or more `addPathSegment()` calls, the builder checks for the presence of a trailing forward slash and adds one if needed between the encoded path and the path segments. This update aligns with behavior previously encapsulated in the OkHttp library.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
