### PR TITLE
NIFI-13819 Provided a row number and sheet name if ExcelReader throw exception when it fails to convert a value.

### DIFF
--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
@@ -76,14 +76,20 @@ public class ExcelRecordReader implements RecordReader {
 
     @Override
     public Record nextRecord(boolean coerceTypes, boolean dropUnknownFields) throws MalformedRecordException {
+        Row currentRow = null;
         try {
             if (rowIterator.hasNext()) {
-                Row currentRow = rowIterator.next();
+                currentRow = rowIterator.next();
                 Map<String, Object> currentRowValues = getCurrentRowValues(currentRow, coerceTypes, dropUnknownFields);
                 return new MapRecord(schema, currentRowValues);
             }
         } catch (Exception e) {
-            throw new MalformedRecordException("Read next Record from Excel XLSX failed", e);
+            String exceptionMessage = "Read next Record from Excel XLSX failed";
+            if (currentRow != null) {
+                exceptionMessage = String.format("%s on row %s in sheet %s",
+                        exceptionMessage, currentRow.getRowNum(), currentRow.getSheet().getSheetName());
+            }
+            throw new MalformedRecordException(exceptionMessage, e);
         }
         return null;
     }

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelRecordReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelRecordReader.java
@@ -285,6 +285,26 @@ public class TestExcelRecordReader {
     }
 
     @Test
+    void testWhereCellValueDoesNotMatchSchemaType()  {
+        RecordSchema schema = new SimpleRecordSchema(Arrays.asList(new RecordField("first", RecordFieldType.STRING.getDataType()),
+                new RecordField("second", RecordFieldType.FLOAT.getDataType())));
+        List<String> requiredSheets = Collections.singletonList("TestSheetA");
+        ExcelRecordReaderConfiguration configuration = new ExcelRecordReaderConfiguration.Builder()
+                .withSchema(schema)
+                .withFirstRow(2)
+                .withRequiredSheets(requiredSheets)
+                .build();
+
+        final MalformedRecordException mre = assertThrows(MalformedRecordException.class, () ->  {
+            ExcelRecordReader recordReader = new ExcelRecordReader(configuration, getInputStream(MULTI_SHEET_FILE), logger);
+            getRecords(recordReader, true, false);
+        });
+
+        assertInstanceOf(NumberFormatException.class, mre.getCause());
+        assertTrue(mre.getMessage().contains("on row") && mre.getMessage().contains("in sheet"));
+    }
+
+    @Test
     void testPasswordProtected() throws Exception {
         RecordSchema schema = getPasswordProtectedSchema();
         ExcelRecordReaderConfiguration configuration = new ExcelRecordReaderConfiguration.Builder()


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13819](https://issues.apache.org/jira/browse/NIFI-13819)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
