### PR TITLE
NIFI-13827: support for the reply-to fuctionality and honor attached file mime type

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
@@ -470,8 +470,12 @@ public class PutEmail extends AbstractProcessor {
                 final MimeBodyPart mimeFile = new MimeBodyPart();
                 session.read(flowFile, stream -> {
                     try {
-                        final String mimeType = flowFile.getAttribute("mime.type");
-                        mimeFile.setDataHandler(new DataHandler(new ByteArrayDataSource(stream, (mimeType == null || mimeType.isEmpty()) ? "application/octet-stream" : mimeType)));
+                        final String mimeTypeAttribute = flowFile.getAttribute("mime.type");
+                        String mimeType = "application/octet-stream";
+                        if(mimeTypeAttribute != null && !mimeTypeAttribute.isEmpty()) {
+                            mimeType = mimeTypeAttribute;
+                        }
+                        mimeFile.setDataHandler(new DataHandler(new ByteArrayDataSource(stream, mimeType)));
                     } catch (final Exception e) {
                         throw new IOException(e);
                     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
@@ -472,7 +472,7 @@ public class PutEmail extends AbstractProcessor {
                     try {
                         final String mimeTypeAttribute = flowFile.getAttribute("mime.type");
                         String mimeType = "application/octet-stream";
-                        if(mimeTypeAttribute != null && !mimeTypeAttribute.isEmpty()) {
+                        if (mimeTypeAttribute != null && !mimeTypeAttribute.isEmpty()) {
                             mimeType = mimeTypeAttribute;
                         }
                         mimeFile.setDataHandler(new DataHandler(new ByteArrayDataSource(stream, mimeType)));

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
@@ -237,6 +237,15 @@ public class PutEmail extends AbstractProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
+    public static final PropertyDescriptor REPLY_TO = new PropertyDescriptor.Builder()
+        .name("Reply-To")
+        .description("The recipients that will receive the reply instead of the from (see RFC2822 §3.6.2)."
+            + "This feature is useful, for example, when the email is sent by a no-reply account. This field is optional."
+            + "Comma separated sequence of addresses following RFC822 syntax.")
+        .required(false)
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .build();
     public static final PropertyDescriptor SUBJECT = new PropertyDescriptor.Builder()
             .name("Subject")
             .description("The email subject")
@@ -304,6 +313,7 @@ public class PutEmail extends AbstractProcessor {
             TO,
             CC,
             BCC,
+            REPLY_TO,
             SUBJECT,
             MESSAGE,
             CONTENT_AS_MESSAGE,
@@ -422,6 +432,7 @@ public class PutEmail extends AbstractProcessor {
             message.setRecipients(RecipientType.TO, toInetAddresses(context, flowFile, TO));
             message.setRecipients(RecipientType.CC, toInetAddresses(context, flowFile, CC));
             message.setRecipients(RecipientType.BCC, toInetAddresses(context, flowFile, BCC));
+            message.setReplyTo(toInetAddresses(context, flowFile, REPLY_TO));
 
             if (attributeNamePattern != null) {
                 for (final Map.Entry<String, String> entry : flowFile.getAttributes().entrySet()) {
@@ -459,7 +470,8 @@ public class PutEmail extends AbstractProcessor {
                 final MimeBodyPart mimeFile = new MimeBodyPart();
                 session.read(flowFile, stream -> {
                     try {
-                        mimeFile.setDataHandler(new DataHandler(new ByteArrayDataSource(stream, "application/octet-stream")));
+                        final String mimeType = flowFile.getAttribute("mime.type");
+                        mimeFile.setDataHandler(new DataHandler(new ByteArrayDataSource(stream, (mimeType == null || mimeType.isEmpty()) ? "application/octet-stream" : mimeType)));
                     } catch (final Exception e) {
                         throw new IOException(e);
                     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
@@ -185,6 +185,7 @@ public class TestPutEmail {
         runner.setProperty(PutEmail.TO, "${to}");
         runner.setProperty(PutEmail.BCC, "${bcc}");
         runner.setProperty(PutEmail.CC, "${cc}");
+        runner.setProperty(PutEmail.REPLY_TO, "${reply-to}");
         runner.setProperty(PutEmail.ATTRIBUTE_NAME_REGEX, "Precedence.*");
         runner.setProperty(PutEmail.INPUT_CHARACTER_SET, StandardCharsets.UTF_8.name());
 
@@ -194,6 +195,7 @@ public class TestPutEmail {
         attributes.put("to", "to@apache.org");
         attributes.put("bcc", "bcc@apache.org");
         attributes.put("cc", "cc@apache.org");
+        attributes.put("reply-to", "replytome@apache.org");
         attributes.put("Precedence", "bulk");
         attributes.put("PrecedenceEncodeDecodeTest", "búlk");
         runner.enqueue("Some Text".getBytes(), attributes);
@@ -215,6 +217,8 @@ public class TestPutEmail {
         assertEquals("bcc@apache.org", message.getRecipients(RecipientType.BCC)[0].toString());
         assertEquals(1, message.getRecipients(RecipientType.CC).length);
         assertEquals("cc@apache.org", message.getRecipients(RecipientType.CC)[0].toString());
+        assertEquals(1, message.getReplyTo().length);
+        assertEquals("replytome@apache.org", message.getReplyTo()[0].toString());
         assertEquals("bulk", MimeUtility.decodeText(message.getHeader("Precedence")[0]));
         assertEquals("búlk", MimeUtility.decodeText(message.getHeader("PrecedenceEncodeDecodeTest")[0]));
     }
@@ -267,6 +271,7 @@ public class TestPutEmail {
 
         Map<String, String> attributes = new HashMap<>();
         attributes.put(CoreAttributes.FILENAME.key(), "test한的ほу́.pdf");
+        attributes.put(CoreAttributes.MIME_TYPE.key(), "application/pdf");
         runner.enqueue("Some text".getBytes(), attributes);
 
         runner.run();
@@ -290,7 +295,9 @@ public class TestPutEmail {
         final BodyPart attachPart = multipart.getBodyPart(1);
         final InputStream attachIs = attachPart.getDataHandler().getInputStream();
         final String text = IOUtils.toString(attachIs, StandardCharsets.UTF_8);
+        final String mimeType = attachPart.getDataHandler().getContentType();
         assertEquals("test한的ほу́.pdf", MimeUtility.decodeText(attachPart.getFileName()));
+        assertEquals("application/pdf", mimeType);
         assertEquals("Some text", text);
 
         assertNull(message.getRecipients(RecipientType.BCC));


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13827](https://issues.apache.org/jira/browse/NIFI-13827)

This commit introduces: one new property descriptor for setting the reply-to address; checks and sets the file mime for the attached file. In case the mime type is null, the standard `application/octect-stream` is used.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [X] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [X] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
