### PR TITLE
NIFI-13819 1.x Provided row number and sheet name if ExcelReader throws exception when it fails to convert a value and removed the "public" key word from each unit test.

### DIFF
--- a/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
+++ b/nifi-nar-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
@@ -86,14 +86,20 @@ public class ExcelRecordReader implements RecordReader {
 
     @Override
     public Record nextRecord(boolean coerceTypes, boolean dropUnknownFields) throws MalformedRecordException {
+        Row currentRow = null;
         try {
             if (rowIterator.hasNext()) {
-                Row currentRow = rowIterator.next();
+                currentRow = rowIterator.next();
                 Map<String, Object> currentRowValues = getCurrentRowValues(currentRow, coerceTypes, dropUnknownFields);
                 return new MapRecord(schema, currentRowValues);
             }
         } catch (Exception e) {
-            throw new MalformedRecordException("Read next Record from Excel XLSX failed", e);
+            String exceptionMessage = "Read next Record from Excel XLSX failed";
+            if (currentRow != null) {
+                exceptionMessage = String.format("%s on row %s in sheet %s",
+                        exceptionMessage, currentRow.getRowNum(), currentRow.getSheet().getSheetName());
+            }
+            throw new MalformedRecordException(exceptionMessage, e);
         }
         return null;
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13819](https://issues.apache.org/jira/browse/NIFI-13819)

This is a back port of #9327 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK  ~21~ 8

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
