### PR TITLE
NIFI-13843 - use record.isDropUnknownFields() to honor JSON Writer Schema

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/RecordReader.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/RecordReader.java
@@ -47,7 +47,7 @@ public interface RecordReader extends Closeable {
      * @throws SchemaValidationException if a Record contains a field that violates the schema and cannot be coerced into the appropriate field type.
      */
     default Record nextRecord() throws IOException, MalformedRecordException {
-        return nextRecord(true, false);
+        return nextRecord(true, true);
     }
 
     /**

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/MapRecord.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/MapRecord.java
@@ -558,10 +558,6 @@ public class MapRecord implements Record {
     private Optional<RecordField> setValueAndGetField(final String fieldName, final Object value) {
         final Optional<RecordField> field = getSchema().getField(fieldName);
         if (field.isEmpty()) {
-            if (dropUnknownFields) {
-                return field;
-            }
-
             updateValue(fieldName, value);
             return field;
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -625,6 +625,7 @@
                         <exclude>src/test/resources/TestConvertRecord/input/person_bad_enum.json</exclude>
                         <exclude>src/test/resources/TestConvertRecord/input/person_long_id.json</exclude>
                         <exclude>src/test/resources/TestConvertRecord/input/person.json</exclude>
+                        <exclude>src/test/resources/TestConvertRecord/input/person_dropfield.json</exclude>
                         <exclude>src/test/resources/TestConvertRecord/schema/person_with_union_enum_string.avsc</exclude>
                         <exclude>src/test/resources/TestConvertRecord/schema/person.avsc</exclude>
                         <exclude>src/test/resources/TestCountText/jabberwocky.txt</exclude>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestConvertRecord/input/person_dropfield.json
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/resources/TestConvertRecord/input/person_dropfield.json
@@ -1,0 +1,9 @@
+[ {
+  "id" : 485,
+  "name" : {
+    "last" : "Doe",
+    "first" : "John"
+  },
+  "status" : "ACTIVE",
+  "fieldThatShouldBeRemoved": "Test"
+} ]


### PR DESCRIPTION
# Summary

[NIFI-13843](https://issues.apache.org/jira/browse/NIFI-13843)

Consider the following use case:

- GFF Processor, generating a JSON with 3 fields: `a`, `b`, and `c`
- ConvertRecord with JSON Reader / JSON Writer
  - Both reader and writer are configured with a schema only specifying fields `a` and `b`

The expected result is a JSON that only contains fields `a` and `b`.

We're following the below path in the code:

- `AbstractRecordProcessor` (L131)
````java
Record firstRecord = reader.nextRecord(); 
````

In this case, the default method for `nextRecord()` is defined in `RecordReader` (L50)

````java
default Record nextRecord() throws IOException, MalformedRecordException {
    return nextRecord(true, false);
} 
````

where we are NOT dropping the unknown fields (Java doc needs some fixing here as it is saying the opposite)

We get to 

````java
writer.write(firstRecord); 
````

which gets us to

- `WriteJsonResult` (L206)

Here, we do a check

````java
isUseSerializeForm(record, writeSchema) 
````

which currently returns true when it should not. Because of this we write the serialised form which ignores the writer schema.

In this method `isUseSerializeForm()`, we do check

````java
record.getSchema().equals(writeSchema) 
````

But at this point `record.getSchema()` returns the schema defined in the reader which is equal to the one defined in the writer - even though the record has additional fields compared to the defined schema.

The suggested fix is to also add a check on

````java
record.isDropUnknownFields() 
````

If `dropUnknownFields` is `false`, then we do not use the serialised form.

**While this approach does solve the problem, I suspect that it may have a performance impact given the default on nextRecord() which currently keeps the unknown fields.**

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
