### PR TITLE
NIFI-13790: Report SEND provenance event in PublishKafka

### DIFF
--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/PublishKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/PublishKafka.java
@@ -485,6 +485,9 @@ public class PublishKafka extends AbstractProcessor implements KafkaPublishCompo
 
             final Relationship relationship = flowFileResult.getExceptions().isEmpty() ? REL_SUCCESS : REL_FAILURE;
             session.transfer(flowFile, relationship);
+            final int numTopics = flowFileResult.getSentPerTopic().keySet().size();
+            final String topicList = String.join(",", flowFileResult.getSentPerTopic().keySet().toArray(new String[numTopics]));
+            session.getProvenanceReporter().send(flowFile, "kafka://" + topicList);
         }
     }
 


### PR DESCRIPTION
# Summary

[NIFI-13790](https://issues.apache.org/jira/browse/NIFI-13790) This PR reports a SEND event for each FlowFile successfully published and transferred to success. I was hesitant to add a `getTransitUri()` method to the KafkaConnectionService API but I certainly can in order to give a more informative URI, and could add other methods if need be to generate an informative description for the provenance event. I could also wrap the new code in a `try-catch` catching and logging an error versus rolling back / failing because the FlowFiles will have already been transferred.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
