### PR TITLE
NIFI-13335 1.x Added ability for the XMLRecordReader to handle where an array of data has different types.

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
@@ -245,6 +245,7 @@
 
                         <exclude>src/test/resources/text/testschema</exclude>
 
+                        <exclude>src/test/resources/xml/dataWithArrayOfDifferentTypes.xml</exclude>
                         <exclude>src/test/resources/xml/field_with_sub-element.xml</exclude>
                         <exclude>src/test/resources/xml/people.xml</exclude>
                         <exclude>src/test/resources/xml/people2.xml</exclude>

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/XMLRecordReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/XMLRecordReader.java
@@ -547,6 +547,7 @@ public class XMLRecordReader implements RecordReader {
             case BOOLEAN:
             case BYTE:
             case CHAR:
+            case CHOICE:
             case DECIMAL:
             case DOUBLE:
             case FLOAT:

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLReader.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLReader.java
@@ -46,11 +46,18 @@ public class TestXMLReader {
     private final String EVALUATE_IS_ARRAY = "xml.stream.is.array";
 
     private TestRunner setup(Map<PropertyDescriptor, String> xmlReaderProperties) throws InitializationException {
+        return setup(xmlReaderProperties, null);
+    }
+
+    private TestRunner setup(Map<PropertyDescriptor, String> xmlReaderProperties, String recordFieldNameToGetAsString) throws InitializationException {
         TestRunner runner = TestRunners.newTestRunner(TestXMLReaderProcessor.class);
         XMLReader reader = new XMLReader();
 
         runner.addControllerService("xml_reader", reader);
         runner.setProperty(TestXMLReaderProcessor.XML_READER, "xml_reader");
+        if (recordFieldNameToGetAsString != null) {
+            runner.setProperty(TestXMLReaderProcessor.RECORD_FIELD_TO_GET_AS_STRING, recordFieldNameToGetAsString);
+        }
 
         for (Map.Entry<PropertyDescriptor, String> entry : xmlReaderProperties.entrySet()) {
             runner.setProperty(reader, entry.getKey(), entry.getValue());
@@ -296,6 +303,25 @@ public class TestXMLReader {
 
         MockFlowFile out = runner.getFlowFilesForRelationship(TestXMLReaderProcessor.SUCCESS).get(0);
         String actualContent = out.getContent();
+        assertEquals(expectedContent, actualContent);
+    }
+
+    @Test
+    void testInferSchemaWhereNameValuesHasMixedTypes() throws Exception {
+        final Map<PropertyDescriptor, String> xmlReaderProperties = new HashMap<>();
+        xmlReaderProperties.put(SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaInferenceUtil.INFER_SCHEMA.getValue());
+        xmlReaderProperties.put(XMLReader.RECORD_FORMAT, XMLReader.RECORD_SINGLE.getValue());
+        xmlReaderProperties.put(XMLReader.PARSE_XML_ATTRIBUTES, "true");
+        xmlReaderProperties.put(XMLReader.CONTENT_FIELD_NAME, "Value");
+        TestRunner runner = setup(xmlReaderProperties, "Data");
+
+        final InputStream is = new FileInputStream("src/test/resources/xml/dataWithArrayOfDifferentTypes.xml");
+        runner.enqueue(is);
+        runner.run();
+
+        final MockFlowFile out = runner.getFlowFilesForRelationship(TestXMLReaderProcessor.SUCCESS).get(0);
+        final String expectedContent = "[MapRecord[{Name=Param1, Value=String1}], MapRecord[{Name=Param2, Value=2}], MapRecord[{Name=Param3, Value=String3}]]";
+        final String actualContent = out.getContent();
         assertEquals(expectedContent, actualContent);
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLReaderProcessor.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/xml/TestXMLReaderProcessor.java
@@ -24,6 +24,7 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
 import org.apache.nifi.serialization.record.Record;
@@ -31,6 +32,7 @@ import org.apache.nifi.util.StringUtils;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -44,12 +46,20 @@ public class TestXMLReaderProcessor extends AbstractProcessor {
             .required(true)
             .build();
 
+    static final PropertyDescriptor RECORD_FIELD_TO_GET_AS_STRING = new PropertyDescriptor.Builder()
+            .name("record_field_to_get_as_string")
+            .description("record_field_to_get_as_string")
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .required(false)
+            .build();
+
     public static final Relationship SUCCESS = new Relationship.Builder().name("success").description("success").build();
 
     @Override
     public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
         FlowFile flowFile = session.get();
         final RecordReaderFactory readerFactory = context.getProperty(XML_READER).asControllerService(RecordReaderFactory.class);
+        final String recordFieldAsString = context.getProperty(RECORD_FIELD_TO_GET_AS_STRING).getValue();
 
         final List<String> records = new ArrayList<>();
 
@@ -57,7 +67,11 @@ public class TestXMLReaderProcessor extends AbstractProcessor {
              final RecordReader reader = readerFactory.createRecordReader(flowFile, in, getLogger())) {
             Record record;
             while ((record = reader.nextRecord()) != null) {
-                records.add(record.toString());
+                if (recordFieldAsString == null) {
+                    records.add(record.toString());
+                } else {
+                    records.add(record.getAsString(recordFieldAsString));
+                }
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -69,7 +83,7 @@ public class TestXMLReaderProcessor extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return new ArrayList<PropertyDescriptor>() {{ add(XML_READER); }};
+        return Arrays.asList(XML_READER, RECORD_FIELD_TO_GET_AS_STRING);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/xml/dataWithArrayOfDifferentTypes.xml
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/xml/dataWithArrayOfDifferentTypes.xml
@@ -1,0 +1,5 @@
+<UserData>
+    <Data Name="Param1">String1</Data>
+    <Data Name="Param2">2</Data>
+    <Data Name="Param3">String3</Data>
+</UserData>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13335](https://issues.apache.org/jira/browse/NIFI-13335)

This is a backport of the fix made in #9356

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK  ~21~ 8

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
