### PR TITLE
NIFI-13674 Added merge.reason attribute for MergeRecord.

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeRecord.java
@@ -96,7 +96,7 @@ import java.util.stream.Collectors;
     @WritesAttribute(attribute = "merge.bin.age", description = "The age of the bin, in milliseconds, when it was merged and output. Effectively "
         + "this is the greatest amount of time that any FlowFile in this bundle remained waiting in this processor before it was output"),
     @WritesAttribute(attribute = "merge.uuid", description = "UUID of the merged FlowFile that will be added to the original FlowFiles attributes"),
-    @WritesAttribute(attribute = MergeRecord.REASON_FOR_MERGING, description = "This processor allows for several thresholds to be configured for merging FlowFiles. "
+    @WritesAttribute(attribute = MergeRecord.MERGE_COMPLETION_REASON, description = "This processor allows for several thresholds to be configured for merging FlowFiles. "
         + " This attribute indicates which of the Thresholds resulted in the FlowFiles being merged. For an explanation of each of the possible values "
         + " and their meanings, see the Processor's Usage / documentation and see the 'Additional Details' page."),
     @WritesAttribute(attribute = "<Attributes from Record Writer>", description = "Any Attribute that the configured Record Writer returns will be added to the FlowFile.")
@@ -174,7 +174,7 @@ public class MergeRecord extends AbstractSessionFactoryProcessor {
     public static final String MERGE_COUNT_ATTRIBUTE = "merge.count";
     public static final String MERGE_BIN_AGE_ATTRIBUTE = "merge.bin.age";
     public static final String MERGE_UUID_ATTRIBUTE = "merge.uuid";
-    public static final String REASON_FOR_MERGING = "merge.reason";
+    public static final String MERGE_COMPLETION_REASON = "merge.completion.reason";
 
     public static final AllowableValue MERGE_STRATEGY_BIN_PACK = new AllowableValue(
         "Bin-Packing Algorithm",

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeRecord.java
@@ -96,6 +96,9 @@ import java.util.stream.Collectors;
     @WritesAttribute(attribute = "merge.bin.age", description = "The age of the bin, in milliseconds, when it was merged and output. Effectively "
         + "this is the greatest amount of time that any FlowFile in this bundle remained waiting in this processor before it was output"),
     @WritesAttribute(attribute = "merge.uuid", description = "UUID of the merged FlowFile that will be added to the original FlowFiles attributes"),
+    @WritesAttribute(attribute = MergeRecord.REASON_FOR_MERGING, description = "This processor allows for several thresholds to be configured for merging FlowFiles. "
+        + " This attribute indicates which of the Thresholds resulted in the FlowFiles being merged. For an explanation of each of the possible values "
+        + " and their meanings, see the Processor's Usage / documentation and see the 'Additional Details' page."),
     @WritesAttribute(attribute = "<Attributes from Record Writer>", description = "Any Attribute that the configured Record Writer returns will be added to the FlowFile.")
 })
 @SeeAlso({MergeContent.class, SplitRecord.class, PartitionRecord.class})
@@ -171,6 +174,7 @@ public class MergeRecord extends AbstractSessionFactoryProcessor {
     public static final String MERGE_COUNT_ATTRIBUTE = "merge.count";
     public static final String MERGE_BIN_AGE_ATTRIBUTE = "merge.bin.age";
     public static final String MERGE_UUID_ATTRIBUTE = "merge.uuid";
+    public static final String REASON_FOR_MERGING = "merge.reason";
 
     public static final AllowableValue MERGE_STRATEGY_BIN_PACK = new AllowableValue(
         "Bin-Packing Algorithm",

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBin.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBin.java
@@ -398,6 +398,7 @@ public class RecordBin {
             attributes.put(CoreAttributes.MIME_TYPE.key(), recordWriter.getMimeType());
             attributes.put(MergeRecord.MERGE_COUNT_ATTRIBUTE, Integer.toString(flowFiles.size()));
             attributes.put(MergeRecord.MERGE_BIN_AGE_ATTRIBUTE, Long.toString(getBinAge()));
+            attributes.put(MergeRecord.REASON_FOR_MERGING, completionReason);
 
             merged = session.putAllAttributes(merged, attributes);
             flowFiles.forEach(ff -> session.putAttribute(ff, MergeRecord.MERGE_UUID_ATTRIBUTE, merged.getAttribute(CoreAttributes.UUID.key())));

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBin.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/merge/RecordBin.java
@@ -398,7 +398,7 @@ public class RecordBin {
             attributes.put(CoreAttributes.MIME_TYPE.key(), recordWriter.getMimeType());
             attributes.put(MergeRecord.MERGE_COUNT_ATTRIBUTE, Integer.toString(flowFiles.size()));
             attributes.put(MergeRecord.MERGE_BIN_AGE_ATTRIBUTE, Long.toString(getBinAge()));
-            attributes.put(MergeRecord.REASON_FOR_MERGING, completionReason);
+            attributes.put(MergeRecord.MERGE_COMPLETION_REASON, completionReason);
 
             merged = session.putAllAttributes(merged, attributes);
             flowFiles.forEach(ff -> session.putAttribute(ff, MergeRecord.MERGE_UUID_ATTRIBUTE, merged.getAttribute(CoreAttributes.UUID.key())));

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestMergeRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestMergeRecord.java
@@ -79,6 +79,7 @@ public class TestMergeRecord {
 
         runner.getFlowFilesForRelationship(MergeRecord.REL_ORIGINAL).forEach(
             ff -> assertEquals(mff.getAttribute(CoreAttributes.UUID.key()), ff.getAttribute(MergeRecord.MERGE_UUID_ATTRIBUTE)));
+        mff.assertAttributeEquals(MergeRecord.REASON_FOR_MERGING, "Bin is full");
     }
 
     @Test
@@ -96,6 +97,7 @@ public class TestMergeRecord {
 
         runner.getFlowFilesForRelationship(MergeRecord.REL_ORIGINAL).forEach(
                 ff -> assertEquals(mff.getAttribute(CoreAttributes.UUID.key()), ff.getAttribute(MergeRecord.MERGE_UUID_ATTRIBUTE)));
+        mff.assertAttributeEquals(MergeRecord.REASON_FOR_MERGING, "Bin is full enough");
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestMergeRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestMergeRecord.java
@@ -79,7 +79,7 @@ public class TestMergeRecord {
 
         runner.getFlowFilesForRelationship(MergeRecord.REL_ORIGINAL).forEach(
             ff -> assertEquals(mff.getAttribute(CoreAttributes.UUID.key()), ff.getAttribute(MergeRecord.MERGE_UUID_ATTRIBUTE)));
-        mff.assertAttributeEquals(MergeRecord.REASON_FOR_MERGING, "Bin is full");
+        mff.assertAttributeEquals(MergeRecord.MERGE_COMPLETION_REASON, "Bin is full");
     }
 
     @Test
@@ -97,7 +97,7 @@ public class TestMergeRecord {
 
         runner.getFlowFilesForRelationship(MergeRecord.REL_ORIGINAL).forEach(
                 ff -> assertEquals(mff.getAttribute(CoreAttributes.UUID.key()), ff.getAttribute(MergeRecord.MERGE_UUID_ATTRIBUTE)));
-        mff.assertAttributeEquals(MergeRecord.REASON_FOR_MERGING, "Bin is full enough");
+        mff.assertAttributeEquals(MergeRecord.MERGE_COMPLETION_REASON, "Bin is full enough");
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13674](https://issues.apache.org/jira/browse/NIFI-13674)

I copied the description of the `WritesAttribute`  annotation from `MergeContent` `merge.reason`. Please confirm whether that is okay.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
