### PR TITLE
NIFI-13798: Update Airtable docs with PATs due to API Keys deprecatio…

### DIFF
--- a/nifi-nar-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/main/java/org/apache/nifi/processors/airtable/QueryAirtableTable.java
+++ b/nifi-nar-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/main/java/org/apache/nifi/processors/airtable/QueryAirtableTable.java
@@ -108,10 +108,11 @@ public class QueryAirtableTable extends AbstractProcessor {
             .required(true)
             .build();
 
-    static final PropertyDescriptor API_KEY = new PropertyDescriptor.Builder()
+    // API Keys are deprecated, Airtable now provides Personal Access Tokens instead.
+    static final PropertyDescriptor PAT = new PropertyDescriptor.Builder()
             .name("api-key")
-            .displayName("API Key")
-            .description("The REST API key to use in queries. Should be generated on Airtable's account page.")
+            .displayName("Personal Access Token")
+            .description("The Personal Access Token (PAT) to use in queries. Should be generated on Airtable's account page.")
             .required(true)
             .sensitive(true)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
@@ -195,7 +196,7 @@ public class QueryAirtableTable extends AbstractProcessor {
 
     private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
             API_URL,
-            API_KEY,
+            PAT,
             BASE_ID,
             TABLE_ID,
             FIELDS,
@@ -225,11 +226,11 @@ public class QueryAirtableTable extends AbstractProcessor {
     @OnScheduled
     public void onScheduled(final ProcessContext context) {
         final String apiUrl = context.getProperty(API_URL).evaluateAttributeExpressions().getValue();
-        final String apiKey = context.getProperty(API_KEY).getValue();
+        final String pat = context.getProperty(PAT).getValue();
         final String baseId = context.getProperty(BASE_ID).evaluateAttributeExpressions().getValue();
         final String tableId = context.getProperty(TABLE_ID).evaluateAttributeExpressions().getValue();
         final WebClientServiceProvider webClientServiceProvider = context.getProperty(WEB_CLIENT_SERVICE_PROVIDER).asControllerService(WebClientServiceProvider.class);
-        airtableRestService = new AirtableRestService(webClientServiceProvider, apiUrl, apiKey, baseId, tableId);
+        airtableRestService = new AirtableRestService(webClientServiceProvider, apiUrl, pat, baseId, tableId);
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/main/java/org/apache/nifi/processors/airtable/service/AirtableRestService.java
+++ b/nifi-nar-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/main/java/org/apache/nifi/processors/airtable/service/AirtableRestService.java
@@ -40,18 +40,18 @@ public class AirtableRestService {
 
     private final WebClientServiceProvider webClientServiceProvider;
     private final String apiUrl;
-    private final String apiKey;
+    private final String pat;
     private final String baseId;
     private final String tableId;
 
     public AirtableRestService(final WebClientServiceProvider webClientServiceProvider,
             final String apiUrl,
-            final String apiKey,
+            final String pat,
             final String baseId,
             final String tableId) {
         this.webClientServiceProvider = webClientServiceProvider;
         this.apiUrl = apiUrl;
-        this.apiKey = apiKey;
+        this.pat = pat;
         this.baseId = baseId;
         this.tableId = tableId;
     }
@@ -61,7 +61,7 @@ public class AirtableRestService {
         try (final HttpResponseEntity response = webClientServiceProvider.getWebClientService()
                 .get()
                 .uri(uri)
-                .header("Authorization", "Bearer " + apiKey)
+                .header("Authorization", "Bearer " + pat)
                 .retrieve()) {
 
             final InputStream bodyInputStream = response.body();

--- a/nifi-nar-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/main/resources/docs/org.apache.nifi.processors.airtable.QueryAirtableTable/additionalDetails.html
+++ b/nifi-nar-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/main/resources/docs/org.apache.nifi.processors.airtable.QueryAirtableTable/additionalDetails.html
@@ -41,9 +41,11 @@ td {text-align: left}
     It can also split large record sets to multiple FlowFiles just like a database processor.
 </p>
 
-<h3>API Key</h3>
+<h3>Personal Access Token</h3>
 <p>
-    Airtable REST API calls requires an API Key that needs to be passed in a request. An Airtable account is required to generate an API Key.
+    Please note that API Keys were deprecated, Airtable now provides Personal Access Tokens (PATs) instead.
+    Airtable REST API calls requires a PAT (Personal Access Token) that needs to be passed in a request. An Airtable account
+    is required to generate the PAT.
 </p>
 
 <h3>API rate limit</h3>
@@ -56,7 +58,7 @@ td {text-align: left}
 
 <h3>Metadata API</h3>
 <p>
-    Currently the Metadata API of Airtable is unstable, and we don't provide a way to use it.
+    Currently, the Metadata API of Airtable is unstable, and we don't provide a way to use it.
     Until it becomes stable you can set up a ConvertRecord or MergeRecord processor with a JsonTreeReader to read the content and convert it into a Record with schema.
 </p>
 </body>

--- a/nifi-nar-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/test/java/org/apache/nifi/processors/airtable/TestAirtableRestService.java
+++ b/nifi-nar-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/test/java/org/apache/nifi/processors/airtable/TestAirtableRestService.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.airtable;
+
+import org.apache.nifi.processors.airtable.service.AirtableRestService;
+import org.apache.nifi.web.client.provider.api.WebClientServiceProvider;
+import org.apache.nifi.web.client.provider.service.StandardWebClientServiceProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestAirtableRestService {
+
+    private static final String API_URL_WITHOUT_SLASH = "https://api.airtable.com/v0";
+    private static final String API_URL_WITH_SLASH = "https://api.airtable.com/v0/";
+    private static final String PAT = "pat";
+    private static final String BASE_ID = "base-id";
+    private static final String TABLE_ID = "table-id";
+    private static final String EXPECTED_URL = String.format("%s/%s/%s", API_URL_WITHOUT_SLASH, BASE_ID, TABLE_ID);
+
+    private final WebClientServiceProvider webClientServiceProvider = new StandardWebClientServiceProvider();
+
+    @Test
+    void testApiUrlEndsWithoutSlash() {
+        AirtableRestService serviceWithoutSlash = new AirtableRestService(webClientServiceProvider, API_URL_WITHOUT_SLASH, PAT, BASE_ID, TABLE_ID);
+        String apiUrlWithSlash = serviceWithoutSlash.createUriBuilder().build().toString();
+        assertEquals(EXPECTED_URL, apiUrlWithSlash);
+    }
+
+    @Test
+    void testApiUrlEndsWithSlash() {
+        AirtableRestService serviceWithSlash = new AirtableRestService(webClientServiceProvider, API_URL_WITH_SLASH, PAT, BASE_ID, TABLE_ID);
+        String apiUrlWithSlash = serviceWithSlash.createUriBuilder().build().toString();
+        assertEquals(EXPECTED_URL, apiUrlWithSlash);
+    }
+}
+
+

--- a/nifi-nar-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/test/java/org/apache/nifi/processors/airtable/TestQueryAirtableTable.java
+++ b/nifi-nar-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/test/java/org/apache/nifi/processors/airtable/TestQueryAirtableTable.java
@@ -61,7 +61,7 @@ public class TestQueryAirtableTable {
         runner.addControllerService("webClientService", webClientServiceProvider);
         runner.enableControllerService(webClientServiceProvider);
 
-        runner.setProperty(QueryAirtableTable.API_KEY, "???");
+        runner.setProperty(QueryAirtableTable.PAT, "???");
         runner.setProperty(QueryAirtableTable.BASE_ID, "baseid");
         runner.setProperty(QueryAirtableTable.TABLE_ID, "tableid");
         runner.setProperty(QueryAirtableTable.WEB_CLIENT_SERVICE_PROVIDER, webClientServiceProvider.getIdentifier());


### PR DESCRIPTION
…n (nifi 1.x)

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13798](https://issues.apache.org/jira/browse/NIFI-13798)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
