### PR TITLE
NIFI-13579 Improve Timestamp Zone Offset Formatting and Parsing

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
@@ -92,7 +92,7 @@ class ObjectLocalDateTimeFieldConverter implements FieldConverter<Object, LocalD
         if (resolved instanceof ZonedDateTime zonedDateTime) {
             // Convert Instant to LocalDateTime using system default zone offset to incorporate adjusted hours and minutes
             final Instant instant = zonedDateTime.toInstant();
-            parsed = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+            parsed = ofInstant(instant);
         } else if (resolved instanceof LocalDateTime localDateTime) {
             parsed = localDateTime;
         } else {

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverter.java
@@ -26,16 +26,12 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Convert Object to String using instanceof evaluation and optional format pattern for DateTimeFormatter
  */
 class ObjectStringFieldConverter implements FieldConverter<Object, String> {
-    private static final Map<String, DateTimeFormatter> FORMATTERS = new ConcurrentHashMap<>();
-
     /**
      * Convert Object field to String using optional format supported in DateTimeFormatter
      *
@@ -59,7 +55,10 @@ class ObjectStringFieldConverter implements FieldConverter<Object, String> {
             }
             final DateTimeFormatter formatter = DateTimeFormatterRegistry.getDateTimeFormatter(pattern.get());
             final LocalDateTime localDateTime = timestamp.toLocalDateTime();
-            return formatter.format(localDateTime);
+
+            // Convert LocalDateTime to ZonedDateTime using system default zone to support offsets in Date Time Formatter
+            final ZonedDateTime dateTime = ZonedDateTime.of(localDateTime, ZoneId.systemDefault());
+            return formatter.format(dateTime);
         }
         if (field instanceof java.util.Date date) {
             if (pattern.isEmpty()) {

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverterTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.serialization.record.field;
+
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.zone.ZoneRules;
+import java.util.Date;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ObjectStringFieldConverterTest {
+    private static final ObjectStringFieldConverter CONVERTER = new ObjectStringFieldConverter();
+
+    private static final String DEFAULT_PATTERN = RecordFieldType.TIMESTAMP.getDefaultFormat();
+
+    private static final String FIELD_NAME = Timestamp.class.getSimpleName();
+
+    private static final String DATE_TIME_DEFAULT = "2000-01-01 12:00:00";
+
+    private static final String DATE_TIME_NANOSECONDS_PATTERN = "yyyy-MM-dd HH:mm:ss.SSSSSSSSS";
+
+    private static final String DATE_TIME_NANOSECONDS = "2000-01-01 12:00:00.123456789";
+
+    private static final String DATE_TIME_ZONE_OFFSET_PATTERN = "yyyy-MM-dd HH:mm:ssZZZZZ";
+
+    @Test
+    void testConvertFieldNull() {
+        final String string = CONVERTER.convertField(null, Optional.of(DEFAULT_PATTERN), FIELD_NAME);
+        assertNull(string);
+    }
+
+    @Test
+    void testConvertFieldTimestampDefaultPattern() {
+        final Timestamp timestamp = Timestamp.valueOf(DATE_TIME_DEFAULT);
+
+        final String string = CONVERTER.convertField(timestamp, Optional.of(DEFAULT_PATTERN), FIELD_NAME);
+
+        assertEquals(DATE_TIME_DEFAULT, string);
+    }
+
+    @Test
+    void testConvertFieldTimestampNanoseconds() {
+        final Timestamp timestamp = Timestamp.valueOf(DATE_TIME_NANOSECONDS);
+
+        final String string = CONVERTER.convertField(timestamp, Optional.of(DATE_TIME_NANOSECONDS_PATTERN), FIELD_NAME);
+
+        assertEquals(DATE_TIME_NANOSECONDS, string);
+    }
+
+    @Test
+    void testConvertFieldTimestampEmptyPattern() {
+        final Timestamp timestamp = Timestamp.valueOf(DATE_TIME_DEFAULT);
+
+        final String string = CONVERTER.convertField(timestamp, Optional.empty(), FIELD_NAME);
+
+        final String expected = Long.toString(timestamp.getTime());
+        assertEquals(expected, string);
+    }
+
+    @Test
+    void testConvertFieldTimestampZoneOffsetPattern() {
+        final Timestamp timestamp = Timestamp.valueOf(DATE_TIME_DEFAULT);
+
+        final String string = CONVERTER.convertField(timestamp, Optional.of(DATE_TIME_ZONE_OFFSET_PATTERN), FIELD_NAME);
+
+        final String dateTimeZoneOffsetExpected = getDateTimeZoneOffset();
+        assertEquals(dateTimeZoneOffsetExpected, string);
+    }
+
+    @Test
+    void testConvertFieldDateDefaultPattern() {
+        final Date date = new Date(Timestamp.valueOf(DATE_TIME_DEFAULT).getTime());
+
+        final String string = CONVERTER.convertField(date, Optional.of(DEFAULT_PATTERN), FIELD_NAME);
+
+        assertEquals(DATE_TIME_DEFAULT, string);
+    }
+
+    @Test
+    void testConvertFieldDateEmptyPattern() {
+        final Date date = new Date(Timestamp.valueOf(DATE_TIME_DEFAULT).getTime());
+
+        final String string = CONVERTER.convertField(date, Optional.empty(), FIELD_NAME);
+
+        final String expected = Long.toString(date.getTime());
+        assertEquals(expected, string);
+    }
+
+    @Test
+    void testConvertFieldDateZoneOffsetPattern() {
+        final Timestamp inputTimestamp = Timestamp.valueOf(DATE_TIME_DEFAULT);
+        final long inputTime = inputTimestamp.getTime();
+        final Date date = new Date(inputTime);
+
+        final String string = CONVERTER.convertField(date, Optional.of(DATE_TIME_ZONE_OFFSET_PATTERN), FIELD_NAME);
+
+        final String dateTimeZoneOffsetExpected = getDateTimeZoneOffset();
+        assertEquals(dateTimeZoneOffsetExpected, string);
+    }
+
+    private String getDateTimeZoneOffset() {
+        final Timestamp inputTimestamp = Timestamp.valueOf(DATE_TIME_DEFAULT);
+        final LocalDateTime inputLocalDateTime = inputTimestamp.toLocalDateTime();
+
+        final ZoneId systemDefaultZoneId = ZoneOffset.systemDefault();
+        final ZoneRules zoneRules = systemDefaultZoneId.getRules();
+        final ZoneOffset inputZoneOffset = zoneRules.getOffset(inputLocalDateTime);
+        final String inputZoneOffsetId = inputZoneOffset.getId();
+
+        // Get Date Time with Zone Offset from current system configuration
+        return DATE_TIME_DEFAULT + inputZoneOffsetId;
+    }
+}

--- a/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
@@ -69,7 +69,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -512,8 +514,8 @@ public class TestIcebergRecordConverter {
         values.put("binary", "hello".getBytes());
         values.put("date", "2017-04-04");
         values.put("time", "14:20:33.000");
-        values.put("timestamp", "2017-04-04 14:20:33.789-0500");
-        values.put("timestampTz", "2017-04-04 14:20:33.789-0500");
+        values.put("timestamp", Timestamp.valueOf(LOCAL_DATE_TIME));
+        values.put("timestampTz", Timestamp.valueOf(LOCAL_DATE_TIME));
         values.put("uuid", "0000-00-00-00-000000");
         values.put("choice", "10");
 
@@ -764,7 +766,8 @@ public class TestIcebergRecordConverter {
         assertEquals(results.size(), 1);
         GenericRecord resultRecord = results.getFirst();
 
-        OffsetDateTime offsetDateTime = OffsetDateTime.of(LOCAL_DATE_TIME, ZoneOffset.ofHours(-5));
+        final ZonedDateTime zonedDateTime = ZonedDateTime.of(LOCAL_DATE_TIME, ZoneId.systemDefault());
+        OffsetDateTime offsetDateTime = zonedDateTime.toOffsetDateTime();
 
         assertEquals("123", resultRecord.get(0, String.class));
         assertEquals(Integer.valueOf(8), resultRecord.get(1, Integer.class));


### PR DESCRIPTION
# Summary

[NIFI-13579](https://issues.apache.org/jira/browse/NIFI-13579) Improves timestamp formatting and parsing for Record Readers and Record Writers as it relates to zone offset handling.

Following significant changes to move from `java.util.Date` to `java.time` classes for earlier 2.0.0 milestone releases, zone offset handling no longer worked in ways similar to earlier versions. When reading a timestamp string with a zone offset, `LocalDateTime.parse()` would ignore the zone offset and only consider the local date and time components. When writing a timestamp as a string, the converter would throw an exception due to the `LocalDateTime` object not having a value for offset seconds.

The current set of changes adjusts Field Converter behavior to address these issues. When converting from a string to a timestamp, the parsing makes use of the [DateTimeFormatter.parseBest()](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#parseBest(java.lang.CharSequence,java.time.temporal.TemporalQuery...)) method to first try parsing with `ZonedDateTime` to handle zone offsets, and then parsing with `LocalDateTime`.

When converting from a Timestamp or `LocalDateTime` to a string, the conversion creates a `ZonedDateTime` from a `LocalDateTime` using the system default zone offset, avoiding unexpected zone offset conversion.

Changes include new unit tests for these scenarios, as well as a new test for the `ValidateRecord` Processor with CSV Reader and Writer, exercising both sides of the conversion. These test methods get the current zone offset value from the JVM to ensure that tests work as expected regardless of the system timezone.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
