### PR TITLE
NIFI-12304 added ListenHTTP FlowFileV3 unpack behavior UseCase

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
@@ -23,6 +23,7 @@ import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.documentation.UseCase;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.annotation.notification.OnPrimaryNodeStateChange;
@@ -88,6 +89,20 @@ import java.util.regex.Pattern;
         + "For details see the documentation of the \"Listening Port for health check requests\" property."
         + "A Record Reader and Record Writer property can be enabled on the processor to process incoming requests as records. "
         + "Record processing is not allowed for multipart requests and request in FlowFileV3 format (minifi).")
+@UseCase(
+        description = "Unpack FlowFileV3 content received in a POST",
+        keywords = {"flowfile", "flowfilev3", "unpack"},
+        notes = """
+        POST requests with "Content-Type: application/flowfile-v3" will have their payload interpreted as FlowFileV3 format
+        and will be automatically unpacked. This will output the original FlowFile(s) from within the FlowFileV3 format and
+        will not require a separate UnpackContent processor.
+        """,
+        configuration = """
+        This feature of ListenHTTP is always on, no configuration required.
+
+        The MergeContent and PackageFlowFile processors can generate FlowFileV3 formatted data.
+        """
+)
 public class ListenHTTP extends AbstractSessionFactoryProcessor {
     private static final String MATCH_ALL = ".*";
 


### PR DESCRIPTION
# Summary

[NIFI-12304](https://issues.apache.org/jira/browse/NIFI-12304)
Added ListenHTTP FlowFileV3 unpack behavior UseCase to its documentation

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
