### PR TITLE
NIFI-13744 Correct Excel Reader Cell Type Inferencing

### DIFF
--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/CellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/CellFieldTypeReader.java
@@ -29,17 +29,17 @@ interface CellFieldTypeReader {
     /**
      * Infer Cell Field Type and update Map of Field Type information
      *
-     * @param cell Spreadsheet Cell required
-     * @param fieldName Cell field name for tracking in Field Types
-     * @param fieldTypes Map of Field Name to Field Type Inference information
+     * @param cell Spreadsheet Cell can be null
+     * @param fieldName Cell field name for tracking in Field Types required
+     * @param fieldTypes Map of Field Name to Field Type Inference information required
      */
     void inferCellFieldType(Cell cell, String fieldName, Map<String, FieldTypeInference> fieldTypes);
 
     /**
      * Get Record Data Type from Spreadsheet Cell
      *
-     * @param cell Spreadsheet Cell
-     * @return Record Data Type
+     * @param cell Spreadsheet Cell can be null
+     * @return Record Data Type or null
      */
     DataType getCellDataType(Cell cell);
 }

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/CellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/CellFieldTypeReader.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.excel;
+
+import org.apache.nifi.schema.inference.FieldTypeInference;
+import org.apache.nifi.serialization.record.DataType;
+import org.apache.poi.ss.usermodel.Cell;
+
+import java.util.Map;
+
+/**
+ * Shared abstraction for determining Record Field Data Type from Spreadsheet Cell Types
+ */
+interface CellFieldTypeReader {
+    /**
+     * Infer Cell Field Type and update Map of Field Type information
+     *
+     * @param cell Spreadsheet Cell required
+     * @param fieldName Cell field name for tracking in Field Types
+     * @param fieldTypes Map of Field Name to Field Type Inference information
+     */
+    void inferCellFieldType(Cell cell, String fieldName, Map<String, FieldTypeInference> fieldTypes);
+
+    /**
+     * Get Record Data Type from Spreadsheet Cell
+     *
+     * @param cell Spreadsheet Cell
+     * @return Record Data Type
+     */
+    DataType getCellDataType(Cell cell);
+}

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelHeaderSchemaStrategy.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelHeaderSchemaStrategy.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelHeaderSchemaStrategy.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelHeaderSchemaStrategy.java
@@ -55,11 +55,11 @@ public class ExcelHeaderSchemaStrategy implements SchemaAccessStrategy {
     private final CellFieldTypeReader cellFieldTypeReader;
     private final DataFormatter dataFormatter;
 
-    public ExcelHeaderSchemaStrategy(PropertyContext context, ComponentLog logger, TimeValueInference timeValueInference, Locale locale) {
+    public ExcelHeaderSchemaStrategy(PropertyContext context, ComponentLog logger, TimeValueInference timeValueInference) {
         this.context = context;
         this.logger = logger;
         this.cellFieldTypeReader = new StandardCellFieldTypeReader(timeValueInference);
-        this.dataFormatter = locale == null ? new DataFormatter() : new DataFormatter(locale);
+        this.dataFormatter = new DataFormatter();
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelReader.java
@@ -158,7 +158,7 @@ public class ExcelReader extends SchemaRegistryService implements RecordReaderFa
     @Override
     protected SchemaAccessStrategy getSchemaAccessStrategy(final String allowableValue, final SchemaRegistry schemaRegistry, final PropertyContext context) {
         if (allowableValue.equalsIgnoreCase(ExcelHeaderSchemaStrategy.USE_STARTING_ROW.getValue())) {
-            return new ExcelHeaderSchemaStrategy(context, getLogger(), new TimeValueInference(dateFormat, timeFormat, timestampFormat), null);
+            return new ExcelHeaderSchemaStrategy(context, getLogger(), new TimeValueInference(dateFormat, timeFormat, timestampFormat));
         } else if (SchemaInferenceUtil.INFER_SCHEMA.getValue().equals(allowableValue)) {
             final RecordSourceFactory<Row> sourceFactory = (variables, in) -> new ExcelRecordSource(in, context, variables, getLogger());
             final SchemaInferenceEngine<Row> inference = new ExcelSchemaInference(new TimeValueInference(dateFormat, timeFormat, timestampFormat));

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
@@ -26,6 +26,7 @@ import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.util.DataTypeUtils;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.Row;
 
@@ -133,15 +134,32 @@ public class ExcelRecordReader implements RecordReader {
         return currentRowValues;
     }
 
-    private static Object getCellValue(Cell cell) {
-        if (cell != null) {
-            return switch (cell.getCellType()) {
-                case _NONE, BLANK, ERROR, FORMULA, STRING -> cell.getStringCellValue();
+    private static Object getCellValue(final Cell cell) {
+        final Object cellValue;
+
+        if (cell == null) {
+            cellValue = null;
+        } else {
+            final CellType cellType = cell.getCellType();
+            cellValue = switch (cellType) {
+                case _NONE, BLANK, ERROR, STRING -> cell.getStringCellValue();
                 case NUMERIC -> DateUtil.isCellDateFormatted(cell) ? cell.getDateCellValue() : cell.getNumericCellValue();
                 case BOOLEAN -> cell.getBooleanCellValue();
+                case FORMULA -> getFormulaCellValue(cell);
             };
         }
-        return null;
+
+        return cellValue;
+    }
+
+    private static Object getFormulaCellValue(final Cell cell) {
+        final CellType formulaResultType = cell.getCachedFormulaResultType();
+        return switch (formulaResultType) {
+            case BOOLEAN -> cell.getBooleanCellValue();
+            case STRING -> cell.getStringCellValue();
+            case NUMERIC -> DateUtil.isCellDateFormatted(cell) ? cell.getDateCellValue() : cell.getNumericCellValue();
+            default -> null;
+        };
     }
 
     private Object convert(final Object value, final DataType dataType, final String fieldName) {

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelRecordReader.java
@@ -156,7 +156,7 @@ public class ExcelRecordReader implements RecordReader {
         final CellType formulaResultType = cell.getCachedFormulaResultType();
         return switch (formulaResultType) {
             case BOOLEAN -> cell.getBooleanCellValue();
-            case STRING -> cell.getStringCellValue();
+            case STRING, ERROR -> cell.getStringCellValue();
             case NUMERIC -> DateUtil.isCellDateFormatted(cell) ? cell.getDateCellValue() : cell.getNumericCellValue();
             default -> null;
         };

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.excel;
+
+import org.apache.nifi.schema.inference.FieldTypeInference;
+import org.apache.nifi.schema.inference.TimeValueInference;
+import org.apache.nifi.serialization.record.DataType;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.DateUtil;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Standard implementation of Cell Field Type Reader uses Cell Type and Cell Value information with inference based on Timestamp formats
+ */
+class StandardCellFieldTypeReader implements CellFieldTypeReader {
+    private final TimeValueInference timeValueInference;
+
+    StandardCellFieldTypeReader(final TimeValueInference timeValueInference) {
+        this.timeValueInference = Objects.requireNonNull(timeValueInference, "Time Value Inference required");
+    }
+
+    /**
+     * Infer Cell Field Type and append possible Data Types to mapped Field Type Inference information
+     *
+     * @param cell Spreadsheet Cell required
+     * @param fieldName Cell field name for tracking in Field Types
+     * @param fieldTypes Map of Field Name to Field Type Inference information
+     */
+    @Override
+    public void inferCellFieldType(final Cell cell, final String fieldName, final Map<String, FieldTypeInference> fieldTypes) {
+        Objects.requireNonNull(cell, "Cell required");
+        Objects.requireNonNull(fieldName, "Field Name required");
+        Objects.requireNonNull(fieldTypes, "Field Types required");
+
+        final FieldTypeInference fieldTypeInference = fieldTypes.computeIfAbsent(fieldName, key -> new FieldTypeInference());
+        final DataType dataType = getCellDataType(cell);
+        fieldTypeInference.addPossibleDataType(dataType);
+    }
+
+    /**
+     * Get Record Data Type from Spreadsheet Cell Type and additional resolution of NUMERIC and STRING types
+     *
+     * @param cell Spreadsheet Cell required
+     * @return Record Data Type
+     */
+    @Override
+    public DataType getCellDataType(final Cell cell) {
+        Objects.requireNonNull(cell, "Cell required");
+
+        final CellType cellType = cell.getCellType();
+
+        final DataType dataType;
+
+        if (CellType.NUMERIC == cellType) {
+            // Date Formatting check limited to NUMERIC Cell Types
+            if (DateUtil.isCellDateFormatted(cell)) {
+                // Default to TIMESTAMP for date formatted values using standard Date Time Pattern
+                dataType = RecordFieldType.TIMESTAMP.getDataType();
+            } else {
+                final double numericCellValue = cell.getNumericCellValue();
+                final long roundedCellValue = (long) numericCellValue;
+                if (roundedCellValue == numericCellValue) {
+                    dataType = RecordFieldType.LONG.getDataType();
+                } else {
+                    // Default to DOUBLE for NUMERIC values following cell.getNumericCellValue()
+                    dataType = RecordFieldType.DOUBLE.getDataType();
+                }
+            }
+        } else if (CellType.BOOLEAN == cellType) {
+            dataType = RecordFieldType.BOOLEAN.getDataType();
+        } else if (CellType.STRING == cellType) {
+            final String cellValue = cell.getRichStringCellValue().getString();
+            // Attempt Time Value inference for STRING cell values
+            final Optional<DataType> timeDataType = timeValueInference.getDataType(cellValue);
+            dataType = timeDataType.orElse(RecordFieldType.STRING.getDataType());
+        } else if (CellType.FORMULA == cellType) {
+            dataType = RecordFieldType.STRING.getDataType();
+        } else {
+            // Default to null for known and unknown Cell Types: BLANK, ERROR
+            dataType = null;
+        }
+
+        return dataType;
+    }
+}

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
@@ -79,8 +79,7 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
         if (CellType.NUMERIC == cellType) {
             // Date Formatting check limited to NUMERIC Cell Types
             if (DateUtil.isCellDateFormatted(cell)) {
-                // Default to TIMESTAMP for date formatted values using standard Date Time Pattern
-                dataType = RecordFieldType.TIMESTAMP.getDataType();
+                dataType = getDateTimeDataType(cell);
             } else {
                 final double numericCellValue = cell.getNumericCellValue();
                 final long roundedCellValue = (long) numericCellValue;
@@ -103,6 +102,24 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
         } else {
             // Default to null for known and unknown Cell Types
             dataType = null;
+        }
+
+        return dataType;
+    }
+
+    private DataType getDateTimeDataType(final Cell cell) {
+        final DataType dataType;
+
+        final double numericCellValue = cell.getNumericCellValue();
+        final long roundedCellValue = (long) numericCellValue;
+        if (roundedCellValue == numericCellValue) {
+            // Numbers without decimal fractions indicate Dates without Times
+            dataType = RecordFieldType.DATE.getDataType();
+        } else if (numericCellValue < 1) {
+            // Decimal fractions indicate Times without Dates
+            dataType = RecordFieldType.TIME.getDataType();
+        } else {
+            dataType = RecordFieldType.TIMESTAMP.getDataType();
         }
 
         return dataType;

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
@@ -78,13 +78,11 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
 
         if (CellType.NUMERIC == cellType) {
             // Date Formatting check limited to NUMERIC Cell Types
+            final double numericCellValue = cell.getNumericCellValue();
             if (DateUtil.isCellDateFormatted(cell)) {
-                final double numericCellValue = cell.getNumericCellValue();
                 dataType = getDateTimeDataType(numericCellValue);
             } else {
-                final double numericCellValue = cell.getNumericCellValue();
-                final long roundedCellValue = (long) numericCellValue;
-                if (roundedCellValue == numericCellValue) {
+                if (isWholeNumber(numericCellValue)) {
                     dataType = RecordFieldType.LONG.getDataType();
                 } else {
                     // Default to DOUBLE for NUMERIC values following cell.getNumericCellValue()
@@ -111,8 +109,7 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
     private DataType getDateTimeDataType(final double numericCellValue) {
         final DataType dataType;
 
-        final long roundedCellValue = (long) numericCellValue;
-        if (roundedCellValue == numericCellValue) {
+        if (isWholeNumber(numericCellValue)) {
             // Numbers without decimal fractions indicate Dates without Times
             dataType = RecordFieldType.DATE.getDataType();
         } else if (numericCellValue < 1) {
@@ -148,5 +145,10 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
         }
 
         return dataType;
+    }
+
+    private boolean isWholeNumber(final double numericCellValue) {
+        final long roundedCellValue = (long) numericCellValue;
+        return roundedCellValue == numericCellValue;
     }
 }

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
@@ -88,7 +88,7 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
         } else if (CellType.BOOLEAN == cellType) {
             dataType = RecordFieldType.BOOLEAN.getDataType();
         } else if (CellType.STRING == cellType) {
-            final String cellValue = cell.getRichStringCellValue().getString();
+            final String cellValue = cell.getStringCellValue();
             // Attempt Time Value inference for STRING cell values
             final Optional<DataType> timeDataType = timeValueInference.getDataType(cellValue);
             dataType = timeDataType.orElse(RecordFieldType.STRING.getDataType());

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
@@ -34,6 +34,11 @@ import java.util.Optional;
 class StandardCellFieldTypeReader implements CellFieldTypeReader {
     private final TimeValueInference timeValueInference;
 
+    /**
+     * Standard Cell Field Type Reader constructor with Time Value Inference for handling STRING Cell Types that may contain values with Timestamps
+     *
+     * @param timeValueInference Time Value Inference required for STRING Cell Type evaluation
+     */
     StandardCellFieldTypeReader(final TimeValueInference timeValueInference) {
         this.timeValueInference = Objects.requireNonNull(timeValueInference, "Time Value Inference required");
     }
@@ -41,13 +46,12 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
     /**
      * Infer Cell Field Type and append possible Data Types to mapped Field Type Inference information
      *
-     * @param cell Spreadsheet Cell required
-     * @param fieldName Cell field name for tracking in Field Types
-     * @param fieldTypes Map of Field Name to Field Type Inference information
+     * @param cell Spreadsheet Cell can be null
+     * @param fieldName Cell field name for tracking in Field Types required
+     * @param fieldTypes Map of Field Name to Field Type Inference information required
      */
     @Override
     public void inferCellFieldType(final Cell cell, final String fieldName, final Map<String, FieldTypeInference> fieldTypes) {
-        Objects.requireNonNull(cell, "Cell required");
         Objects.requireNonNull(fieldName, "Field Name required");
         Objects.requireNonNull(fieldTypes, "Field Types required");
 
@@ -59,12 +63,14 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
     /**
      * Get Record Data Type from Spreadsheet Cell Type and additional resolution of NUMERIC and STRING types
      *
-     * @param cell Spreadsheet Cell required
-     * @return Record Data Type
+     * @param cell Spreadsheet Cell can be null
+     * @return Record Data Type or null
      */
     @Override
     public DataType getCellDataType(final Cell cell) {
-        Objects.requireNonNull(cell, "Cell required");
+        if (cell == null) {
+            return null;
+        }
 
         final CellType cellType = cell.getCellType();
 
@@ -95,7 +101,7 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
         } else if (CellType.FORMULA == cellType) {
             dataType = getFormulaResultDataType(cell);
         } else {
-            // Default to null for known and unknown Cell Types: BLANK, ERROR
+            // Default to null for known and unknown Cell Types such as ERROR
             dataType = null;
         }
 

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
@@ -79,7 +79,8 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
         if (CellType.NUMERIC == cellType) {
             // Date Formatting check limited to NUMERIC Cell Types
             if (DateUtil.isCellDateFormatted(cell)) {
-                dataType = getDateTimeDataType(cell);
+                final double numericCellValue = cell.getNumericCellValue();
+                dataType = getDateTimeDataType(numericCellValue);
             } else {
                 final double numericCellValue = cell.getNumericCellValue();
                 final long roundedCellValue = (long) numericCellValue;
@@ -107,10 +108,9 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
         return dataType;
     }
 
-    private DataType getDateTimeDataType(final Cell cell) {
+    private DataType getDateTimeDataType(final double numericCellValue) {
         final DataType dataType;
 
-        final double numericCellValue = cell.getNumericCellValue();
         final long roundedCellValue = (long) numericCellValue;
         if (roundedCellValue == numericCellValue) {
             // Numbers without decimal fractions indicate Dates without Times
@@ -136,8 +136,8 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
         } else if (CellType.NUMERIC == formulaResultType) {
             // Date Formatting check limited to NUMERIC Cell Types without Conditional Formatting Evaluator
             if (DateUtil.isCellDateFormatted(cell)) {
-                // Default to TIMESTAMP for date formatted values using standard Date Time Pattern
-                dataType = RecordFieldType.TIMESTAMP.getDataType();
+                final double numericCellValue = cell.getNumericCellValue();
+                dataType = getDateTimeDataType(numericCellValue);
             } else {
                 // Default to DOUBLE for NUMERIC values following cell.getNumericCellValue()
                 dataType = RecordFieldType.DOUBLE.getDataType();

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/StandardCellFieldTypeReader.java
@@ -101,7 +101,7 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
         } else if (CellType.FORMULA == cellType) {
             dataType = getFormulaResultDataType(cell);
         } else {
-            // Default to null for known and unknown Cell Types such as ERROR
+            // Default to null for known and unknown Cell Types
             dataType = null;
         }
 
@@ -126,7 +126,7 @@ class StandardCellFieldTypeReader implements CellFieldTypeReader {
                 dataType = RecordFieldType.DOUBLE.getDataType();
             }
         } else {
-            // Default to null for known and unknown Formula Result Cell Types: BLANK, ERROR
+            // Default to null for known and unknown Formula Result Cell Types
             dataType = null;
         }
 

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelHeaderSchemaStrategy.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelHeaderSchemaStrategy.java
@@ -57,7 +57,7 @@ public class TestExcelHeaderSchemaStrategy {
         final ByteArrayOutputStream outputStream = getSingleSheetWorkbook(data);
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         final ConfigurationContext context = new MockConfigurationContext(properties, null, null);
-        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, null, null);
+        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE, null);
 
         try (final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
             SchemaNotFoundException schemaNotFoundException = assertThrows(SchemaNotFoundException.class, () -> schemaStrategy.getSchema(null, inputStream, null));
@@ -101,7 +101,6 @@ public class TestExcelHeaderSchemaStrategy {
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         final ConfigurationContext context = new MockConfigurationContext(properties, null, null);
         final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE, null);
-        assertTrue(data.length - 1 < ExcelHeaderSchemaStrategy.NUM_ROWS_TO_DETERMINE_TYPES);
 
         try (final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
             assertDoesNotThrow(() -> schemaStrategy.getSchema(null, inputStream, null));
@@ -129,7 +128,6 @@ public class TestExcelHeaderSchemaStrategy {
         Object[][] data = {{"ID", "First", "Middle"}, {1, "One", "O"}, {2, "Two", "T"}, {3, "Three", "T"},
                 {4, "Four", "F"}, {5, "Five", "F"}, {6, "Six", "S"}, {7, "Seven", "S"}, {8, "Eight", "E"},
                 {9, "Nine", "N"}, {10, "Ten", "T"}, {11, "Eleven", "E"}};
-        assertTrue(data.length - 1 > ExcelHeaderSchemaStrategy.NUM_ROWS_TO_DETERMINE_TYPES);
 
         final ByteArrayOutputStream outputStream = getSingleSheetWorkbook(data);
         final Map<PropertyDescriptor, String> properties = new HashMap<>();

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelHeaderSchemaStrategy.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelHeaderSchemaStrategy.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(MockitoExtension.class)
 public class TestExcelHeaderSchemaStrategy {
     private static final TimeValueInference TIME_VALUE_INFERENCE = new TimeValueInference("MM/dd/yyyy", "HH:mm:ss.SSS", "yyyy/MM/dd/ HH:mm");
+
     @Mock
     ComponentLog logger;
 
@@ -57,7 +58,7 @@ public class TestExcelHeaderSchemaStrategy {
         final ByteArrayOutputStream outputStream = getSingleSheetWorkbook(data);
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         final ConfigurationContext context = new MockConfigurationContext(properties, null, null);
-        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE, null);
+        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE);
 
         try (final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
             SchemaNotFoundException schemaNotFoundException = assertThrows(SchemaNotFoundException.class, () -> schemaStrategy.getSchema(null, inputStream, null));
@@ -71,7 +72,7 @@ public class TestExcelHeaderSchemaStrategy {
         final ByteArrayOutputStream outputStream = getSingleSheetWorkbook(data);
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         final ConfigurationContext context = new MockConfigurationContext(properties, null, null);
-        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE, null);
+        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE);
 
         try (final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
             RecordSchema schema = schemaStrategy.getSchema(null, inputStream, null);
@@ -86,7 +87,7 @@ public class TestExcelHeaderSchemaStrategy {
         final ByteArrayOutputStream outputStream = getSingleSheetWorkbook(data);
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         final ConfigurationContext context = new MockConfigurationContext(properties, null, null);
-        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE, null);
+        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE);
 
         try (final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
             SchemaNotFoundException schemaNotFoundException = assertThrows(SchemaNotFoundException.class, () -> schemaStrategy.getSchema(null, inputStream, null));
@@ -100,7 +101,7 @@ public class TestExcelHeaderSchemaStrategy {
         final ByteArrayOutputStream outputStream = getSingleSheetWorkbook(data);
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         final ConfigurationContext context = new MockConfigurationContext(properties, null, null);
-        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE, null);
+        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE);
 
         try (final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
             assertDoesNotThrow(() -> schemaStrategy.getSchema(null, inputStream, null));
@@ -116,7 +117,7 @@ public class TestExcelHeaderSchemaStrategy {
         final ByteArrayOutputStream outputStream = getSingleSheetWorkbook(data);
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         final ConfigurationContext context = new MockConfigurationContext(properties, null, null);
-        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE, null);
+        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE);
 
         try (final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
             assertDoesNotThrow(() -> schemaStrategy.getSchema(null, inputStream, null));
@@ -132,7 +133,7 @@ public class TestExcelHeaderSchemaStrategy {
         final ByteArrayOutputStream outputStream = getSingleSheetWorkbook(data);
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         final ConfigurationContext context = new MockConfigurationContext(properties, null, null);
-        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE, null);
+        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE);
 
         try (final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
             assertDoesNotThrow(() -> schemaStrategy.getSchema(null, inputStream, null));
@@ -145,7 +146,7 @@ public class TestExcelHeaderSchemaStrategy {
         final ByteArrayOutputStream outputStream = getSingleSheetWorkbook(data);
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
         final ConfigurationContext context = new MockConfigurationContext(properties, null, null);
-        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE, null);
+        final ExcelHeaderSchemaStrategy schemaStrategy = new ExcelHeaderSchemaStrategy(context, logger, TIME_VALUE_INFERENCE);
 
         try (final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
             SchemaNotFoundException schemaNotFoundException = assertThrows(SchemaNotFoundException.class, () -> schemaStrategy.getSchema(null, inputStream, null));

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelSchemaInference.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelSchemaInference.java
@@ -19,25 +19,20 @@ package org.apache.nifi.excel;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Stream;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.schema.inference.InferSchemaAccessStrategy;
 import org.apache.nifi.schema.inference.TimeValueInference;
+import org.apache.nifi.serialization.record.DataType;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.util.MockConfigurationContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -50,44 +45,13 @@ public class TestExcelSchemaInference {
     private static final String EXPECTED_SECOND_FIELD_NAME = ExcelUtils.FIELD_NAME_PREFIX + "1";
     private static final String EXPECTED_THIRD_FIELD_NAME = ExcelUtils.FIELD_NAME_PREFIX + "2";
     private static final String EXPECTED_FOURTH_FIELD_NAME = ExcelUtils.FIELD_NAME_PREFIX + "3";
+
+    private static final String SIMPLE_FORMATTING_PATH = "/excel/simpleDataFormatting.xlsx";
+
     private final TimeValueInference timestampInference = new TimeValueInference("MM/dd/yyyy", "HH:mm:ss.SSS", "yyyy/MM/dd/ HH:mm");
 
     @Mock
     ComponentLog logger;
-
-    @ParameterizedTest
-    @MethodSource("getLocales")
-    public void testInferenceAgainstDifferentLocales(Locale locale) throws IOException {
-        final Map<PropertyDescriptor, String> properties = new HashMap<>();
-        new ExcelReader().getSupportedPropertyDescriptors().forEach(prop -> properties.put(prop, prop.getDefaultValue()));
-        final PropertyContext context = new MockConfigurationContext(properties, null, null);
-
-        try (final InputStream inputStream = getResourceStream("/excel/numbers.xlsx")) {
-            final InferSchemaAccessStrategy<?> accessStrategy = new InferSchemaAccessStrategy<>(
-                    (variables, content) -> new ExcelRecordSource(content, context, variables, logger),
-                    new ExcelSchemaInference(timestampInference, locale), logger);
-            final RecordSchema schema = accessStrategy.getSchema(null, inputStream, null);
-            final List<String> fieldNames = schema.getFieldNames();
-            assertEquals(Collections.singletonList(EXPECTED_FIRST_FIELD_NAME), fieldNames);
-
-            if (Locale.FRENCH.equals(locale)) {
-                assertEquals(RecordFieldType.STRING, schema.getDataType(EXPECTED_FIRST_FIELD_NAME).get().getFieldType());
-            } else {
-                assertEquals(RecordFieldType.CHOICE.getChoiceDataType(RecordFieldType.FLOAT.getDataType(), RecordFieldType.STRING.getDataType()),
-                        schema.getDataType(EXPECTED_FIRST_FIELD_NAME).get());
-            }
-        }
-    }
-
-    private static Stream<Arguments> getLocales() {
-        Locale hindi = Locale.of("hin");
-        return Stream.of(
-                Arguments.of(Locale.ENGLISH),
-                Arguments.of(hindi),
-                Arguments.of(Locale.JAPANESE),
-                Arguments.of(Locale.FRENCH)
-        );
-    }
 
     @Test
     public void testInferenceIncludesAllRecords() throws IOException {
@@ -96,23 +60,39 @@ public class TestExcelSchemaInference {
         final PropertyContext context = new MockConfigurationContext(properties, null, null);
 
         final RecordSchema schema;
-        try (final InputStream inputStream = getResourceStream("/excel/simpleDataFormatting.xlsx")) {
+        try (final InputStream inputStream = getResourceStream()) {
             final InferSchemaAccessStrategy<?> accessStrategy = new InferSchemaAccessStrategy<>(
                     (variables, content) -> new ExcelRecordSource(content, context, variables, logger),
                     new ExcelSchemaInference(timestampInference), Mockito.mock(ComponentLog.class));
             schema = accessStrategy.getSchema(null, inputStream, null);
         }
 
-        final List<String> fieldNames = schema.getFieldNames();
-        assertEquals(Arrays.asList(EXPECTED_FIRST_FIELD_NAME, EXPECTED_SECOND_FIELD_NAME,
-                EXPECTED_THIRD_FIELD_NAME, EXPECTED_FOURTH_FIELD_NAME), fieldNames);
-        assertEquals(RecordFieldType.CHOICE.getChoiceDataType(RecordFieldType.INT.getDataType(),
-                RecordFieldType.STRING.getDataType()), schema.getDataType(EXPECTED_FIRST_FIELD_NAME).get());
-        assertEquals(RecordFieldType.CHOICE.getChoiceDataType(RecordFieldType.TIMESTAMP.getDataType("yyyy/MM/dd/ HH:mm"), RecordFieldType.STRING.getDataType()),
-                schema.getDataType(EXPECTED_SECOND_FIELD_NAME).get());
-        assertEquals(RecordFieldType.STRING, schema.getDataType(EXPECTED_THIRD_FIELD_NAME).get().getFieldType());
-        assertEquals(RecordFieldType.CHOICE.getChoiceDataType(RecordFieldType.BOOLEAN.getDataType(),
-                RecordFieldType.STRING.getDataType()), schema.getDataType(EXPECTED_FOURTH_FIELD_NAME).get());
+        assertFieldNamesFound(schema);
+        assertFieldDataTypeEquals(schema, EXPECTED_FIRST_FIELD_NAME,
+                RecordFieldType.CHOICE.getChoiceDataType(
+                        RecordFieldType.LONG.getDataType(),
+                        RecordFieldType.STRING.getDataType()
+                )
+        );
+        assertFieldDataTypeEquals(schema, EXPECTED_SECOND_FIELD_NAME,
+                RecordFieldType.CHOICE.getChoiceDataType(
+                        // Assert Timestamp Data Type with standard Date and Time Pattern
+                        RecordFieldType.TIMESTAMP.getDataType(),
+                        RecordFieldType.STRING.getDataType()
+                )
+        );
+        assertFieldDataTypeEquals(schema, EXPECTED_THIRD_FIELD_NAME,
+                RecordFieldType.CHOICE.getChoiceDataType(
+                        RecordFieldType.DOUBLE.getDataType(),
+                        RecordFieldType.STRING.getDataType()
+                )
+        );
+        assertFieldDataTypeEquals(schema, EXPECTED_FOURTH_FIELD_NAME,
+                RecordFieldType.CHOICE.getChoiceDataType(
+                        RecordFieldType.BOOLEAN.getDataType(),
+                        RecordFieldType.STRING.getDataType()
+                )
+        );
     }
 
     @Test
@@ -127,28 +107,44 @@ public class TestExcelSchemaInference {
         attributes.put("rows.to.skip", "2");
 
         final RecordSchema schema;
-        try (final InputStream inputStream = getResourceStream("/excel/simpleDataFormatting.xlsx")) {
+        try (final InputStream inputStream = getResourceStream()) {
             final InferSchemaAccessStrategy<?> accessStrategy = new InferSchemaAccessStrategy<>(
                     (variables, content) -> new ExcelRecordSource(content, context, variables, logger),
                     new ExcelSchemaInference(timestampInference), Mockito.mock(ComponentLog.class));
             schema = accessStrategy.getSchema(attributes, inputStream, null);
         }
 
-        final List<String> fieldNames = schema.getFieldNames();
-        assertEquals(Arrays.asList(EXPECTED_FIRST_FIELD_NAME, EXPECTED_SECOND_FIELD_NAME,
-                EXPECTED_THIRD_FIELD_NAME, EXPECTED_FOURTH_FIELD_NAME), fieldNames);
-        assertEquals(RecordFieldType.INT.getDataType(), schema.getDataType(EXPECTED_FIRST_FIELD_NAME).get());
-        assertEquals(RecordFieldType.CHOICE.getChoiceDataType(RecordFieldType.TIMESTAMP.getDataType("yyyy/MM/dd/ HH:mm"), RecordFieldType.STRING.getDataType()),
-                schema.getDataType(EXPECTED_SECOND_FIELD_NAME).get());
-        assertEquals(RecordFieldType.STRING, schema.getDataType(EXPECTED_THIRD_FIELD_NAME).get().getFieldType());
-        assertEquals(RecordFieldType.BOOLEAN.getDataType(), schema.getDataType(EXPECTED_FOURTH_FIELD_NAME).get());
+        assertFieldNamesFound(schema);
+
+        assertFieldDataTypeEquals(schema, EXPECTED_FIRST_FIELD_NAME, RecordFieldType.LONG.getDataType());
+        assertFieldDataTypeEquals(schema, EXPECTED_SECOND_FIELD_NAME, RecordFieldType.TIMESTAMP.getDataType());
+        assertFieldDataTypeEquals(schema, EXPECTED_THIRD_FIELD_NAME, RecordFieldType.DOUBLE.getDataType());
+        assertFieldDataTypeEquals(schema, EXPECTED_FOURTH_FIELD_NAME, RecordFieldType.BOOLEAN.getDataType());
     }
 
-    private InputStream getResourceStream(final String relativePath) {
-        final InputStream resourceStream = getClass().getResourceAsStream(relativePath);
+    private InputStream getResourceStream() {
+        final InputStream resourceStream = getClass().getResourceAsStream(SIMPLE_FORMATTING_PATH);
         if (resourceStream == null) {
-            throw new IllegalStateException(String.format("Resource [%s] not found", relativePath));
+            throw new IllegalStateException(String.format("Resource [%s] not found", SIMPLE_FORMATTING_PATH));
         }
         return resourceStream;
+    }
+
+    private void assertFieldDataTypeEquals(final RecordSchema schema, final String fieldName, final DataType expectedDataType) {
+        final DataType fieldDataType = schema.getDataType(fieldName).orElse(null);
+        assertEquals(expectedDataType, fieldDataType);
+    }
+
+    private void assertFieldNamesFound(final RecordSchema schema) {
+        final List<String> fieldNames = schema.getFieldNames();
+        assertEquals(
+                Arrays.asList(
+                        EXPECTED_FIRST_FIELD_NAME,
+                        EXPECTED_SECOND_FIELD_NAME,
+                        EXPECTED_THIRD_FIELD_NAME,
+                        EXPECTED_FOURTH_FIELD_NAME
+                ),
+                fieldNames
+        );
     }
 }

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
@@ -130,16 +130,18 @@ class TestStandardCellFieldTypeReader {
     }
 
     @Test
+    void testGetCellDataTypeFormulaNumericDate() {
+        assertFormulaNumericDateTimeDataTypeFound(NUMERIC_DATE, RecordFieldType.DATE.getDataType());
+    }
+
+    @Test
+    void testGetCellDataTypeFormulaNumericTime() {
+        assertFormulaNumericDateTimeDataTypeFound(NUMERIC_TIME, RecordFieldType.TIME.getDataType());
+    }
+
+    @Test
     void testGetCellDataTypeFormulaNumericTimestamp() {
-        when(cell.getCellType()).thenReturn(CellType.FORMULA);
-        when(cell.getCachedFormulaResultType()).thenReturn(CellType.NUMERIC);
-        when(cell.getCellStyle()).thenReturn(cellStyle);
-        // Set Data Format to internal Date Format for Data Type detection in DateUtil.isCellDateFormatted
-        when(cellStyle.getDataFormat()).thenReturn(EXCEL_INTERNAL_DATE_FORMAT);
-
-        final DataType dataType = reader.getCellDataType(cell);
-
-        assertEquals(RecordFieldType.TIMESTAMP.getDataType(), dataType);
+        assertFormulaNumericDateTimeDataTypeFound(NUMERIC_TIMESTAMP, RecordFieldType.TIMESTAMP.getDataType());
     }
 
     @Test
@@ -230,6 +232,19 @@ class TestStandardCellFieldTypeReader {
 
     private void assertNumericDateTimeDataTypeFound(final double numericCellValue, final DataType expectedDataType) {
         when(cell.getCellType()).thenReturn(CellType.NUMERIC);
+        when(cell.getNumericCellValue()).thenReturn(numericCellValue);
+        when(cell.getCellStyle()).thenReturn(cellStyle);
+        // Set Data Format to internal Date Format for Data Type detection in DateUtil.isCellDateFormatted
+        when(cellStyle.getDataFormat()).thenReturn(EXCEL_INTERNAL_DATE_FORMAT);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(expectedDataType, dataType);
+    }
+
+    private void assertFormulaNumericDateTimeDataTypeFound(final double numericCellValue, final DataType expectedDataType) {
+        when(cell.getCellType()).thenReturn(CellType.FORMULA);
+        when(cell.getCachedFormulaResultType()).thenReturn(CellType.NUMERIC);
         when(cell.getNumericCellValue()).thenReturn(numericCellValue);
         when(cell.getCellStyle()).thenReturn(cellStyle);
         // Set Data Format to internal Date Format for Data Type detection in DateUtil.isCellDateFormatted

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.excel;
+
+import org.apache.nifi.schema.inference.FieldTypeInference;
+import org.apache.nifi.schema.inference.TimeValueInference;
+import org.apache.nifi.serialization.record.DataType;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.RichTextString;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestStandardCellFieldTypeReader {
+
+    private static final String TIMESTAMP_FORMATTED = "2020-01-01 12:00:00";
+
+    private static final double NUMERIC_DOUBLE = 123.45;
+
+    private static final Long NUMERIC_LONG = Long.MAX_VALUE;
+
+    private static final Long NUMERIC_TIMESTAMP = 45678L;
+
+    private static final short EXCEL_INTERNAL_DATE_FORMAT = 14;
+
+    private static final String FIELD_NAME = "FirstField";
+
+    @Mock
+    private Cell cell;
+
+    @Mock
+    private CellStyle cellStyle;
+
+    @Mock
+    private RichTextString richTextString;
+
+    @Mock
+    private TimeValueInference timeValueInference;
+
+    private StandardCellFieldTypeReader reader;
+
+    @BeforeEach
+    void setReader() {
+        reader = new StandardCellFieldTypeReader(timeValueInference);
+    }
+
+    @Test
+    void testGetCellDataTypeBlank() {
+        when(cell.getCellType()).thenReturn(CellType.BLANK);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertNull(dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeError() {
+        when(cell.getCellType()).thenReturn(CellType.ERROR);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertNull(dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeFormula() {
+        when(cell.getCellType()).thenReturn(CellType.FORMULA);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(RecordFieldType.STRING.getDataType(), dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeBoolean() {
+        when(cell.getCellType()).thenReturn(CellType.BOOLEAN);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(RecordFieldType.BOOLEAN.getDataType(), dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeString() {
+        when(cell.getCellType()).thenReturn(CellType.STRING);
+        when(cell.getRichStringCellValue()).thenReturn(richTextString);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(RecordFieldType.STRING.getDataType(), dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeStringTimestamp() {
+        final DataType timestampDataType = RecordFieldType.TIMESTAMP.getDataType();
+
+        when(cell.getCellType()).thenReturn(CellType.STRING);
+        when(cell.getRichStringCellValue()).thenReturn(richTextString);
+        when(richTextString.getString()).thenReturn(TIMESTAMP_FORMATTED);
+        when(timeValueInference.getDataType(eq(TIMESTAMP_FORMATTED))).thenReturn(Optional.of(timestampDataType));
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(timestampDataType, dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeNumericDouble() {
+        when(cell.getCellType()).thenReturn(CellType.NUMERIC);
+        when(cell.getNumericCellValue()).thenReturn(NUMERIC_DOUBLE);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(RecordFieldType.DOUBLE.getDataType(), dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeNumericLong() {
+        when(cell.getCellType()).thenReturn(CellType.NUMERIC);
+        when(cell.getNumericCellValue()).thenReturn(NUMERIC_LONG.doubleValue());
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(RecordFieldType.LONG.getDataType(), dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeNumericTimestamp() {
+        when(cell.getCellType()).thenReturn(CellType.NUMERIC);
+        when(cell.getNumericCellValue()).thenReturn(NUMERIC_TIMESTAMP.doubleValue());
+        when(cell.getCellStyle()).thenReturn(cellStyle);
+        // Set Data Format to internal Date Format for Data Type detection in DateUtil.isCellDateFormatted
+        when(cellStyle.getDataFormat()).thenReturn(EXCEL_INTERNAL_DATE_FORMAT);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(RecordFieldType.TIMESTAMP.getDataType(), dataType);
+    }
+
+    @Test
+    void testInferCellFieldType() {
+        final Map<String, FieldTypeInference> fieldTypes = new HashMap<>();
+
+        reader.inferCellFieldType(cell, FIELD_NAME, fieldTypes);
+
+        final FieldTypeInference fieldTypeInference = fieldTypes.get(FIELD_NAME);
+        assertNotNull(fieldTypeInference);
+    }
+}

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
@@ -23,7 +23,6 @@ import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.CellType;
-import org.apache.poi.ss.usermodel.RichTextString;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,9 +59,6 @@ class TestStandardCellFieldTypeReader {
 
     @Mock
     private CellStyle cellStyle;
-
-    @Mock
-    private RichTextString richTextString;
 
     @Mock
     private TimeValueInference timeValueInference;
@@ -113,7 +109,6 @@ class TestStandardCellFieldTypeReader {
     @Test
     void testGetCellDataTypeString() {
         when(cell.getCellType()).thenReturn(CellType.STRING);
-        when(cell.getRichStringCellValue()).thenReturn(richTextString);
 
         final DataType dataType = reader.getCellDataType(cell);
 
@@ -125,8 +120,7 @@ class TestStandardCellFieldTypeReader {
         final DataType timestampDataType = RecordFieldType.TIMESTAMP.getDataType();
 
         when(cell.getCellType()).thenReturn(CellType.STRING);
-        when(cell.getRichStringCellValue()).thenReturn(richTextString);
-        when(richTextString.getString()).thenReturn(TIMESTAMP_FORMATTED);
+        when(cell.getStringCellValue()).thenReturn(TIMESTAMP_FORMATTED);
         when(timeValueInference.getDataType(eq(TIMESTAMP_FORMATTED))).thenReturn(Optional.of(timestampDataType));
 
         final DataType dataType = reader.getCellDataType(cell);

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
@@ -89,12 +89,56 @@ class TestStandardCellFieldTypeReader {
     }
 
     @Test
-    void testGetCellDataTypeFormula() {
+    void testGetCellDataTypeFormulaBoolean() {
         when(cell.getCellType()).thenReturn(CellType.FORMULA);
+        when(cell.getCachedFormulaResultType()).thenReturn(CellType.BOOLEAN);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(RecordFieldType.BOOLEAN.getDataType(), dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeFormulaString() {
+        when(cell.getCellType()).thenReturn(CellType.FORMULA);
+        when(cell.getCachedFormulaResultType()).thenReturn(CellType.STRING);
 
         final DataType dataType = reader.getCellDataType(cell);
 
         assertEquals(RecordFieldType.STRING.getDataType(), dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeFormulaNumericDouble() {
+        when(cell.getCellType()).thenReturn(CellType.FORMULA);
+        when(cell.getCachedFormulaResultType()).thenReturn(CellType.NUMERIC);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(RecordFieldType.DOUBLE.getDataType(), dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeFormulaNumericTimestamp() {
+        when(cell.getCellType()).thenReturn(CellType.FORMULA);
+        when(cell.getCachedFormulaResultType()).thenReturn(CellType.NUMERIC);
+        when(cell.getCellStyle()).thenReturn(cellStyle);
+        // Set Data Format to internal Date Format for Data Type detection in DateUtil.isCellDateFormatted
+        when(cellStyle.getDataFormat()).thenReturn(EXCEL_INTERNAL_DATE_FORMAT);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(RecordFieldType.TIMESTAMP.getDataType(), dataType);
+    }
+
+    @Test
+    void testGetCellDataTypeFormulaError() {
+        when(cell.getCellType()).thenReturn(CellType.FORMULA);
+        when(cell.getCachedFormulaResultType()).thenReturn(CellType.ERROR);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertNull(dataType);
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
@@ -48,7 +48,11 @@ class TestStandardCellFieldTypeReader {
 
     private static final Long NUMERIC_LONG = Long.MAX_VALUE;
 
-    private static final Long NUMERIC_TIMESTAMP = 45678L;
+    private static final double NUMERIC_TIMESTAMP = 40909.417;
+
+    private static final double NUMERIC_DATE = 40909;
+
+    private static final double NUMERIC_TIME = 0.417;
 
     private static final short EXCEL_INTERNAL_DATE_FORMAT = 14;
 
@@ -200,16 +204,18 @@ class TestStandardCellFieldTypeReader {
     }
 
     @Test
+    void testGetCellDataTypeNumericDate() {
+        assertNumericDateTimeDataTypeFound(NUMERIC_DATE, RecordFieldType.DATE.getDataType());
+    }
+
+    @Test
+    void testGetCellDataTypeNumericTime() {
+        assertNumericDateTimeDataTypeFound(NUMERIC_TIME, RecordFieldType.TIME.getDataType());
+    }
+
+    @Test
     void testGetCellDataTypeNumericTimestamp() {
-        when(cell.getCellType()).thenReturn(CellType.NUMERIC);
-        when(cell.getNumericCellValue()).thenReturn(NUMERIC_TIMESTAMP.doubleValue());
-        when(cell.getCellStyle()).thenReturn(cellStyle);
-        // Set Data Format to internal Date Format for Data Type detection in DateUtil.isCellDateFormatted
-        when(cellStyle.getDataFormat()).thenReturn(EXCEL_INTERNAL_DATE_FORMAT);
-
-        final DataType dataType = reader.getCellDataType(cell);
-
-        assertEquals(RecordFieldType.TIMESTAMP.getDataType(), dataType);
+        assertNumericDateTimeDataTypeFound(NUMERIC_TIMESTAMP, RecordFieldType.TIMESTAMP.getDataType());
     }
 
     @Test
@@ -220,5 +226,17 @@ class TestStandardCellFieldTypeReader {
 
         final FieldTypeInference fieldTypeInference = fieldTypes.get(FIELD_NAME);
         assertNotNull(fieldTypeInference);
+    }
+
+    private void assertNumericDateTimeDataTypeFound(final double numericCellValue, final DataType expectedDataType) {
+        when(cell.getCellType()).thenReturn(CellType.NUMERIC);
+        when(cell.getNumericCellValue()).thenReturn(numericCellValue);
+        when(cell.getCellStyle()).thenReturn(cellStyle);
+        // Set Data Format to internal Date Format for Data Type detection in DateUtil.isCellDateFormatted
+        when(cellStyle.getDataFormat()).thenReturn(EXCEL_INTERNAL_DATE_FORMAT);
+
+        final DataType dataType = reader.getCellDataType(cell);
+
+        assertEquals(expectedDataType, dataType);
     }
 }

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestStandardCellFieldTypeReader.java
@@ -71,6 +71,13 @@ class TestStandardCellFieldTypeReader {
     }
 
     @Test
+    void testGetCellDataTypeNullCell() {
+        final DataType dataType = reader.getCellDataType(null);
+
+        assertNull(dataType);
+    }
+
+    @Test
     void testGetCellDataTypeBlank() {
         when(cell.getCellType()).thenReturn(CellType.BLANK);
 


### PR DESCRIPTION
# Summary

[NIFI-13744](https://issues.apache.org/jira/browse/NIFI-13744) Corrects Excel Reader type inferencing with Record Data Type detection based on spreadsheet cell properties.

The `CellType` provides the general shape of the value, but requires additional evaluation of `NUMERIC` and `STRING` types to determine whether the field could representation a timestamp, based on Cell Style.

The new `CellFieldTypeReader` replaces existing use of the `SchemaInferenceUtil`, which is limited to `String` input values, requiring value formatting. The standard implementation avoids cell value formatting in most cases, instead relying type detection. The POI library can return timestamp values in several forms, including `java.util.Date` and `java.time.LocalDateTime`, but it does not differentiate between values that contain only dates or only times. For these scenarios, using a defined schema for the Excel Reader provides better resolution.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
