### PR TITLE
NIFI-13865: Enable the JVM to record a heap dump when an OOM error occurs

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
@@ -58,3 +58,5 @@ java.arg.securityAuthUseSubjectCredsOnly=-Djavax.security.auth.useSubjectCredsOn
 #            org.apache.jasper.servlet.JasperLoader,org.jvnet.hk2.internal.DelegatingClassLoader,org.apache.nifi.nar.NarClassLoader
 # End of Java Agent config for native library loading.
 
+java.arg.heapDumpPath=-XX:HeapDumpPath=./work
+java.arg.heapDumpOnOutOfMemory=-XX:+HeapDumpOnOutOfMemoryError

--- a/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/bootstrap.conf
@@ -58,5 +58,8 @@ java.arg.securityAuthUseSubjectCredsOnly=-Djavax.security.auth.useSubjectCredsOn
 #            org.apache.jasper.servlet.JasperLoader,org.jvnet.hk2.internal.DelegatingClassLoader,org.apache.nifi.nar.NarClassLoader
 # End of Java Agent config for native library loading.
 
-java.arg.heapDumpPath=-XX:HeapDumpPath=./work
-java.arg.heapDumpOnOutOfMemory=-XX:+HeapDumpOnOutOfMemoryError
+# The following commands will allow NiFi to produce a heap dump if an OutOfMemoryError(OOME) occurs while NiFi is running.
+# Note that since the data in memory is not encrypted, sensitive values may be available in the heap dump, this should be
+# considered before enabling the following arguments
+#java.arg.heapDumpPath=-XX:HeapDumpPath=./work
+#java.arg.heapDumpOnOutOfMemory=-XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
# Summary

[NIFI-13865](https://issues.apache.org/jira/browse/NIFI-13865). This PR adds the following arguments to bootstrap.conf for the NiFi JVM to enable taking a heap dump when an OutOfMemoryError occurs. I'm not sure about the feasibility of unit/integration testing

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
