### PR TITLE
NIFI-13404: recreate s3Object before returning input stream

### DIFF
--- a/minifi/minifi-c2/minifi-c2-cache/minifi-c2-cache-s3/src/main/java/org/apache/nifi/minifi/c2/cache/s3/S3WritableConfiguration.java
+++ b/minifi/minifi-c2/minifi-c2-cache/minifi-c2-cache-s3/src/main/java/org/apache/nifi/minifi/c2/cache/s3/S3WritableConfiguration.java
@@ -29,10 +29,10 @@ import org.apache.nifi.minifi.c2.api.ConfigurationProviderException;
 import org.apache.nifi.minifi.c2.api.cache.WriteableConfiguration;
 
 public class S3WritableConfiguration implements WriteableConfiguration {
-
   private final AmazonS3 s3;
-  private final S3Object s3Object;
   private final String version;
+  private final String bucketName;
+  private final String objectKey;
 
   /**
    * Creates a new S3 writable configuration.
@@ -43,7 +43,8 @@ public class S3WritableConfiguration implements WriteableConfiguration {
   public S3WritableConfiguration(AmazonS3 s3, S3ObjectSummary s3ObjectSummary, String version) {
 
     this.s3 = s3;
-    this.s3Object = s3.getObject(s3ObjectSummary.getBucketName(), s3ObjectSummary.getKey());
+    this.bucketName = s3ObjectSummary.getBucketName();
+    this.objectKey = s3ObjectSummary.getKey();
     this.version = version;
 
   }
@@ -55,9 +56,9 @@ public class S3WritableConfiguration implements WriteableConfiguration {
    * @param version The version of the configuration.
    */
   public S3WritableConfiguration(AmazonS3 s3, S3Object s3Object, String version) {
-
     this.s3 = s3;
-    this.s3Object = s3Object;
+    this.bucketName = s3Object.getBucketName();
+    this.objectKey = s3Object.getKey();
     this.version = version;
 
   }
@@ -69,32 +70,34 @@ public class S3WritableConfiguration implements WriteableConfiguration {
 
   @Override
   public boolean exists() {
-    return s3.doesObjectExist(s3Object.getBucketName(), s3Object.getKey());
+    return s3.doesObjectExist(bucketName, objectKey);
   }
 
   @Override
   public OutputStream getOutputStream() throws ConfigurationProviderException {
+    S3Object s3Object = s3.getObject(bucketName, objectKey);
     return new S3OutputStream(s3Object.getBucketName(), s3Object.getKey(), s3);
   }
 
   @Override
   public InputStream getInputStream() throws ConfigurationProviderException {
+    S3Object s3Object = s3.getObject(bucketName, objectKey);
     return s3Object.getObjectContent();
   }
 
   @Override
   public URL getURL() throws ConfigurationProviderException {
-    return s3.getUrl(s3Object.getBucketName(), s3Object.getKey());
+    return s3.getUrl(bucketName, objectKey);
   }
 
   @Override
   public String getName() {
-    return s3Object.getKey();
+    return objectKey;
   }
 
   @Override
   public String toString() {
-    return "FileSystemWritableConfiguration{objectKey=" + s3Object.getKey()
+    return "FileSystemWritableConfiguration{objectKey=" + objectKey
       + ", version='" + version + "'}";
   }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13404](https://issues.apache.org/jira/browse/NIFI-13404)

Previous implementation had a problem where once I/O streams in `S3Object` instance are closed, they would not be reopened. The solution is to re-instantiate `S3Object` when I/O streams are requested before returning references to the streams. In order to do that, this change also removes the reference to `S3Object` as a class member and adds `bucketName` and `objectKey` class members. 

I made this change in [Anetac's Nifi fork](https://github.com/Eng-Anetac/nifi) months ago and we are using it in production.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `support/nifi-1.x` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
