### PR TITLE
NIFI-12061: add SECRET_NAME parameter to avoid listing all secrets

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
@@ -74,31 +74,27 @@ import java.util.regex.Pattern;
 public class AwsSecretsManagerParameterProvider extends AbstractParameterProvider implements VerifiableParameterProvider {
     enum ListingStrategy implements DescribedValue {
         Enumeration(
-                "Enumeration",
                 "Enumerate secret names",
                 "Provides a set of secret names to fetch, separated by a comma delimiter ','. " +
                         "This strategy requires the GetSecretValue permission only."
         ),
         Pattern(
-                "Pattern",
                 "Use regular expression",
                 "Provides a regular expression to match keys of attributes to filter for. " +
                         "This strategy requires both ListSecrets and GetSecretValue permissions."
         );
 
-        private final String value;
         private final String displayName;
         private final String description;
 
-        ListingStrategy(final String value, final String displayName, final String description) {
+        ListingStrategy(final String displayName, final String description) {
             this.displayName = displayName;
-            this.value = value;
             this.description = description;
         }
 
         @Override
         public String getValue() {
-            return this.value;
+            return name();
         }
 
         @Override

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
@@ -97,7 +97,7 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
     public static final PropertyDescriptor SECRET_NAMES = new PropertyDescriptor.Builder()
             .name("secret-names")
             .displayName("Secret Names")
-            .description("Comma-separated list of secret names to fetch. This parameter is ignored if the Secret Listing Strategy parameter is set to 'Pattern'.")
+            .description("Comma-separated list of secret names to fetch.")
             .dependsOn(SECRET_LISTING_STRATEGY, ENUMERATED_STRATEGY)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
@@ -39,7 +39,6 @@ import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.parameter.AbstractParameterProvider;

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
@@ -98,7 +98,8 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
             .name("secret-names")
             .displayName("Secret Names")
             .description("Comma-separated list of secret names to fetch.")
-            .dependsOn(SECRET_LISTING_STRATEGY, ENUMERATED_STRATEGY)
+            .dependsOn(SECRET_LISTING_STRATEGY, ListingStrategy.ENUMERATION)
+            .required(true)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
     /**

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
@@ -88,8 +88,7 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
             .name("secret-name-pattern")
             .displayName("Secret Name Pattern")
             .description("A Regular Expression matching on Secret Name that identifies Secrets whose parameters should be fetched. " +
-                    "Any secrets whose names do not match this pattern will not be fetched. " +
-                    "This parameter is ignored if Secret Listing Strategy parameter is set to 'Enumerated'.")
+                    "Any secrets whose names do not match this pattern will not be fetched.")
             .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
             .dependsOn(SECRET_LISTING_STRATEGY, PATTERN_STRATEGY)
             .defaultValue(".*")

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
@@ -108,12 +108,9 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
     public static final PropertyDescriptor SECRET_LISTING_STRATEGY = new PropertyDescriptor.Builder()
             .name("secret-listing-strategy")
             .displayName("Secret Listing Strategy")
-            .description("Strategy to use when listing secrets. 'Pattern' strategy uses Secret Name Pattern property and fetches  " +
-                    "all secrets whose names match the pattern. 'Pattern' strategy requires ListSecrets and GetSecretValue permissions. "+
-                    "'Enumerated' strategy uses 'Secret Names' property and fetches all secrets in the list. " +
-                    "'Enumerated' strategy requires only GetSecretValue permission.")
+            .description("Strategy to use when listing secrets.")
             .required(true)
-            .allowableValues(PATTERN_STRATEGY, ENUMERATED_STRATEGY)
+            .allowableValues(ListingStrategy.class)
             .defaultValue(PATTERN_STRATEGY)
             .build();
 
@@ -123,7 +120,8 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
             .description("A Regular Expression matching on Secret Name that identifies Secrets whose parameters should be fetched. " +
                     "Any secrets whose names do not match this pattern will not be fetched.")
             .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
-            .dependsOn(SECRET_LISTING_STRATEGY, PATTERN_STRATEGY)
+            .dependsOn(SECRET_LISTING_STRATEGY, ListingStrategy.PATTERN)
+            .required(true)
             .defaultValue(".*")
             .build();
 

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
@@ -70,8 +70,41 @@ import java.util.regex.Pattern;
 @CapabilityDescription("Fetches parameters from AWS SecretsManager.  Each secret becomes a Parameter group, which can map to a Parameter Context, with " +
         "key/value pairs in the secret mapping to Parameters in the group.")
 public class AwsSecretsManagerParameterProvider extends AbstractParameterProvider implements VerifiableParameterProvider {
-    public static final String ENUMERATED_STRATEGY = "Enumerated";
-    public static final String PATTERN_STRATEGY = "Pattern";
+    enum ListingStrategy implements DescribedValue {
+        ENUMERATION(
+                "Enumerate secret names",
+                "Provides a set of secret names to fetch, separated by a comma delimiter ','. " +
+                        "This strategy requires the GetSecretValue permission only."
+        ),
+        PATTERN(
+                "Use regular expression",
+                "Provides a regular expression to match keys of attributes to filter for. " +
+                        "This strategy requires both ListSecrets and GetSecretValue permissions."
+        );
+
+        private final String value;
+        private final String description;
+
+        ListingStrategy(final String value, final String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String getValue() {
+            return this.value;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return this.value;
+        }
+
+        @Override
+        public String getDescription() {
+            return this.description;
+        }
+    }
     public static final PropertyDescriptor SECRET_LISTING_STRATEGY = new PropertyDescriptor.Builder()
             .name("secret-listing-strategy")
             .displayName("Secret Listing Strategy")

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/test/java/org/apache/nifi/parameter/aws/TestAwsSecretsManagerParameterProvider.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/test/java/org/apache/nifi/parameter/aws/TestAwsSecretsManagerParameterProvider.java
@@ -91,29 +91,40 @@ public class TestAwsSecretsManagerParameterProvider {
     @Test
     public void testFetchParametersWithNoSecrets() throws InitializationException {
         final List<ParameterGroup> expectedGroups = Collections.singletonList(new ParameterGroup("MySecret", Collections.emptyList()));
-        runProviderTest(mockSecretsManager(expectedGroups), 0, null, ConfigVerificationResult.Outcome.SUCCESSFUL);
+        runProviderTest(mockSecretsManager(expectedGroups), 0, ConfigVerificationResult.Outcome.SUCCESSFUL,
+                AwsSecretsManagerParameterProvider.PATTERN_STRATEGY, null);
     }
 
     @Test
     public void testFetchParameters() throws InitializationException {
-        runProviderTest(mockSecretsManager(mockParameterGroups), 8, null, ConfigVerificationResult.Outcome.SUCCESSFUL);
+        runProviderTest(mockSecretsManager(mockParameterGroups), 8, ConfigVerificationResult.Outcome.SUCCESSFUL,
+                AwsSecretsManagerParameterProvider.PATTERN_STRATEGY, null);
     }
 
     @Test
     public void testFetchSpecificSecret() throws InitializationException {
-        runProviderTest(mockSecretsManagerNoList(mockParameterGroups, "MySecret"), 6, "MySecret", ConfigVerificationResult.Outcome.SUCCESSFUL);
+        runProviderTest(mockSecretsManagerNoList(mockParameterGroups, "MySecret"), 6, ConfigVerificationResult.Outcome.SUCCESSFUL,
+                AwsSecretsManagerParameterProvider.ENUMERATED_STRATEGY, "MySecret");
+    }
+
+    @Test
+    public void testFetchTwoSecrets() throws InitializationException {
+        runProviderTest(mockSecretsManagerNoList(mockParameterGroups, "MySecret,OtherSecret"), 8, ConfigVerificationResult.Outcome.SUCCESSFUL,
+                AwsSecretsManagerParameterProvider.ENUMERATED_STRATEGY, "MySecret,OtherSecret");
     }
 
     @Test
     public void testFetchNonExistentSecret() throws InitializationException {
         when(defaultSecretsManager.getSecretValue(argThat(matchesGetSecretValueRequest("MySecretDoesNotExist")))).thenThrow(new ResourceNotFoundException("Fake exception"));
-        runProviderTest(defaultSecretsManager, 0, "MySecretDoesNotExist", ConfigVerificationResult.Outcome.FAILED);
+        runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
+                AwsSecretsManagerParameterProvider.ENUMERATED_STRATEGY, "BadSecret");
     }
 
     @Test
     public void testFetchParametersListFailure() throws InitializationException {
         when(defaultSecretsManager.listSecrets(any())).thenThrow(new AWSSecretsManagerException("Fake exception"));
-        runProviderTest(defaultSecretsManager, 0, null, ConfigVerificationResult.Outcome.FAILED);
+        runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
+                AwsSecretsManagerParameterProvider.PATTERN_STRATEGY, null);
     }
 
     @Test
@@ -123,30 +134,33 @@ public class TestAwsSecretsManagerParameterProvider {
         when(listSecretsResult.getSecretList()).thenReturn(secretList);
         when(defaultSecretsManager.listSecrets(argThat(ListSecretsRequestMatcher.hasToken(null)))).thenReturn(listSecretsResult);
         when(defaultSecretsManager.getSecretValue(argThat(matchesGetSecretValueRequest("MySecret")))).thenThrow(new AWSSecretsManagerException("Fake exception"));
-        runProviderTest(defaultSecretsManager, 0, null, ConfigVerificationResult.Outcome.FAILED);
+        runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
+                AwsSecretsManagerParameterProvider.PATTERN_STRATEGY, null);
     }
 
     private AwsSecretsManagerParameterProvider getParameterProvider() {
         return spy(new AwsSecretsManagerParameterProvider());
     }
 
-    private AWSSecretsManager mockSecretsManagerNoList(final List<ParameterGroup> mockParameterGroups, final String secretName) {
+    private AWSSecretsManager mockSecretsManagerNoList(final List<ParameterGroup> mockParameterGroups, final String secretNames) {
         final AWSSecretsManager secretsManager = mock(AWSSecretsManager.class);
 
         mockParameterGroups.forEach(group -> {
             final String groupName = group.getGroupName();
-            if(groupName.equalsIgnoreCase(secretName)) {
-                final Map<String, String> keyValues = group.getParameters().stream().collect(Collectors.toMap(
-                        param -> param.getDescriptor().getName(),
-                        Parameter::getValue));
-                final String secretString;
-                try {
-                    secretString = objectMapper.writeValueAsString(keyValues);
-                    final GetSecretValueResult result = new GetSecretValueResult().withName(groupName).withSecretString(secretString);
-                    when(secretsManager.getSecretValue(argThat(matchesGetSecretValueRequest(groupName))))
-                            .thenReturn(result);
-                } catch (final JsonProcessingException e) {
-                    throw new IllegalStateException(e);
+            for(String secretName : Arrays.asList(secretNames.split(","))) {
+                if(groupName.equalsIgnoreCase(secretName)) {
+                    final Map<String, String> keyValues = group.getParameters().stream().collect(Collectors.toMap(
+                            param -> param.getDescriptor().getName(),
+                            Parameter::getValue));
+                    final String secretString;
+                    try {
+                        secretString = objectMapper.writeValueAsString(keyValues);
+                        final GetSecretValueResult result = new GetSecretValueResult().withName(groupName).withSecretString(secretString);
+                        when(secretsManager.getSecretValue(argThat(matchesGetSecretValueRequest(groupName))))
+                                .thenReturn(result);
+                    } catch (final JsonProcessingException e) {
+                        throw new IllegalStateException(e);
+                    }
                 }
             }
         });
@@ -188,8 +202,10 @@ public class TestAwsSecretsManagerParameterProvider {
     }
 
     private List<ParameterGroup> runProviderTest(final AWSSecretsManager secretsManager,
-                                                 final int expectedCount, final String secretName,
-                                                 final ConfigVerificationResult.Outcome expectedOutcome) throws InitializationException {
+                                                 final int expectedCount,
+                                                 final ConfigVerificationResult.Outcome expectedOutcome,
+                                                 final String listingStrategy,
+                                                 final String namePattern) throws InitializationException {
 
         final AwsSecretsManagerParameterProvider parameterProvider = getParameterProvider();
         doReturn(secretsManager).when(parameterProvider).configureClient(any());
@@ -197,8 +213,11 @@ public class TestAwsSecretsManagerParameterProvider {
                 new MockComponentLog("providerId", parameterProvider));
         parameterProvider.initialize(initContext);
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
-        if(secretName != null) {
-            properties.put(AwsSecretsManagerParameterProvider.SECRET_NAME, secretName);
+        if(listingStrategy != null) {
+            properties.put(AwsSecretsManagerParameterProvider.SECRET_LISTING_STRATEGY, listingStrategy);
+        }
+        if(namePattern != null) {
+            properties.put(AwsSecretsManagerParameterProvider.SECRET_NAME_PATTERN, namePattern);
         }
         final MockConfigurationContext mockConfigurationContext = new MockConfigurationContext(properties, null);
 

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/test/java/org/apache/nifi/parameter/aws/TestAwsSecretsManagerParameterProvider.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/test/java/org/apache/nifi/parameter/aws/TestAwsSecretsManagerParameterProvider.java
@@ -92,39 +92,39 @@ public class TestAwsSecretsManagerParameterProvider {
     public void testFetchParametersWithNoSecrets() throws InitializationException {
         final List<ParameterGroup> expectedGroups = Collections.singletonList(new ParameterGroup("MySecret", Collections.emptyList()));
         runProviderTest(mockSecretsManager(expectedGroups), 0, ConfigVerificationResult.Outcome.SUCCESSFUL,
-                AwsSecretsManagerParameterProvider.PATTERN_STRATEGY, null);
+                "Pattern", null);
     }
 
     @Test
     public void testFetchParameters() throws InitializationException {
         runProviderTest(mockSecretsManager(mockParameterGroups), 8, ConfigVerificationResult.Outcome.SUCCESSFUL,
-                AwsSecretsManagerParameterProvider.PATTERN_STRATEGY, null);
+                "Pattern", null);
     }
 
     @Test
     public void testFetchSpecificSecret() throws InitializationException {
         runProviderTest(mockSecretsManagerNoList(mockParameterGroups, "MySecret"), 6, ConfigVerificationResult.Outcome.SUCCESSFUL,
-                AwsSecretsManagerParameterProvider.ENUMERATED_STRATEGY, "MySecret");
+                "Enumeration", "MySecret");
     }
 
     @Test
     public void testFetchTwoSecrets() throws InitializationException {
         runProviderTest(mockSecretsManagerNoList(mockParameterGroups, "MySecret,OtherSecret"), 8, ConfigVerificationResult.Outcome.SUCCESSFUL,
-                AwsSecretsManagerParameterProvider.ENUMERATED_STRATEGY, "MySecret,OtherSecret");
+                "Enumeration", "MySecret,OtherSecret");
     }
 
     @Test
     public void testFetchNonExistentSecret() throws InitializationException {
         when(defaultSecretsManager.getSecretValue(argThat(matchesGetSecretValueRequest("MySecretDoesNotExist")))).thenThrow(new ResourceNotFoundException("Fake exception"));
         runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
-                AwsSecretsManagerParameterProvider.ENUMERATED_STRATEGY, "BadSecret");
+                "Enumeration", "BadSecret");
     }
 
     @Test
     public void testFetchParametersListFailure() throws InitializationException {
         when(defaultSecretsManager.listSecrets(any())).thenThrow(new AWSSecretsManagerException("Fake exception"));
         runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
-                AwsSecretsManagerParameterProvider.PATTERN_STRATEGY, null);
+                "Pattern", null);
     }
 
     @Test
@@ -135,7 +135,7 @@ public class TestAwsSecretsManagerParameterProvider {
         when(defaultSecretsManager.listSecrets(argThat(ListSecretsRequestMatcher.hasToken(null)))).thenReturn(listSecretsResult);
         when(defaultSecretsManager.getSecretValue(argThat(matchesGetSecretValueRequest("MySecret")))).thenThrow(new AWSSecretsManagerException("Fake exception"));
         runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
-                AwsSecretsManagerParameterProvider.PATTERN_STRATEGY, null);
+                "Pattern", null);
     }
 
     private AwsSecretsManagerParameterProvider getParameterProvider() {

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/test/java/org/apache/nifi/parameter/aws/TestAwsSecretsManagerParameterProvider.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/test/java/org/apache/nifi/parameter/aws/TestAwsSecretsManagerParameterProvider.java
@@ -205,7 +205,7 @@ public class TestAwsSecretsManagerParameterProvider {
                                                  final int expectedCount,
                                                  final ConfigVerificationResult.Outcome expectedOutcome,
                                                  final String listingStrategy,
-                                                 final String namePattern) throws InitializationException {
+                                                 final String secretNames) throws InitializationException {
 
         final AwsSecretsManagerParameterProvider parameterProvider = getParameterProvider();
         doReturn(secretsManager).when(parameterProvider).configureClient(any());
@@ -216,8 +216,8 @@ public class TestAwsSecretsManagerParameterProvider {
         if(listingStrategy != null) {
             properties.put(AwsSecretsManagerParameterProvider.SECRET_LISTING_STRATEGY, listingStrategy);
         }
-        if(namePattern != null) {
-            properties.put(AwsSecretsManagerParameterProvider.SECRET_NAME_PATTERN, namePattern);
+        if(secretNames != null) {
+            properties.put(AwsSecretsManagerParameterProvider.SECRET_NAMES, secretNames);
         }
         final MockConfigurationContext mockConfigurationContext = new MockConfigurationContext(properties, null);
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12061](https://issues.apache.org/jira/browse/NIFI-12061)
Add `Secret Name` parameter to `AwsSecretsManagerParameterProvider` to allow the provider to work without `ListSecrets` permission. Original behavior where the provider lists all secrets and matches them to `Secret Name Pattern` is preserved by leaving `Secret Name` parameter undefined. The new behavior will skip listing secrets and ignore `Secret Name Pattern` only if `Secret Name` is provided.  I made this change in [Anetac's Nifi fork](https://github.com/Eng-Anetac/nifi) months ago and we are using it in production.

Related PR to main branch: https://github.com/apache/nifi/pull/9483
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-12061`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-12061`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `support/nifi-1.x` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 1.8
  - [x] JDK 11
  - [x] JDK 17

### Licensing


- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
