### PR TITLE
NIFI-13868: add `pg-delete` command to Nifi Toolkit

### DIFF
--- a/nifi-docs/src/main/asciidoc/toolkit-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/toolkit-guide.adoc
@@ -100,6 +100,7 @@ The following are available commands:
  nifi pg-get-param-context
  nifi pg-set-param-context
  nifi pg-replace
+ nifi pg-delete
  nifi get-services
  nifi get-service
  nifi create-service
@@ -309,15 +310,15 @@ Typing "nifi " and then a tab will show the sub-commands for NiFi:
  create-reg-client       get-nodes               merge-param-context     pg-start
  create-reporting-task   get-param-context       offload-node            pg-status
  create-service          get-policy              pg-change-version       pg-stop
- create-user             get-reg-client-id       pg-create-service       set-param
- create-user-group       get-reporting-task      pg-disable-services     start-reporting-tasks
- current-user            get-reporting-tasks     pg-enable-services      stop-reporting-tasks
- delete-node             get-root-id             pg-get-all-versions     update-policy
- delete-param            get-service             pg-get-param-context    update-reg-client
- delete-param-context    get-services            pg-get-services         update-user-group
- disable-services        import-param-context    pg-get-vars             upload-template
- disconnect-node         list-param-contexts     pg-get-version          delete-reporting-task
- download-template       list-reg-clients        pg-import
+ create-user             get-reg-client-id       pg-create-service       pg-delete
+ create-user-group       get-reporting-task      pg-disable-services     set-param
+ current-user            get-reporting-tasks     pg-enable-services      start-reporting-tasks
+ delete-node             get-root-id             pg-get-all-versions     stop-reporting-tasks
+ delete-param            get-service             pg-get-param-context    update-policy
+ delete-param-context    get-services            pg-get-services         update-reg-client
+ disable-services        import-param-context    pg-get-vars             update-user-group
+ disconnect-node         list-param-contexts     pg-get-version          upload-template
+ download-template       list-reg-clients        pg-import               delete-reporting-task
 
 Arguments that represent a path to a file, such as `-p` or when setting a properties file in the session, will auto-complete the path being typed:
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProcessGroupClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProcessGroupClient.java
@@ -75,4 +75,6 @@ public interface ProcessGroupClient {
         throws NiFiClientException, IOException;
 
     FlowComparisonEntity getLocalModifications(String processGroupId) throws NiFiClientException, IOException;
+
+    void deleteProcessGroup(ProcessGroupEntity entity) throws NiFiClientException, IOException;
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProcessGroupClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProcessGroupClient.java
@@ -76,5 +76,5 @@ public interface ProcessGroupClient {
 
     FlowComparisonEntity getLocalModifications(String processGroupId) throws NiFiClientException, IOException;
 
-    void deleteProcessGroup(ProcessGroupEntity entity) throws NiFiClientException, IOException;
+    ProcessGroupEntity deleteProcessGroup(ProcessGroupEntity entity) throws NiFiClientException, IOException;
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyProcessGroupClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyProcessGroupClient.java
@@ -357,17 +357,16 @@ public class JerseyProcessGroupClient extends AbstractJerseyClient implements Pr
     }
 
     @Override
-    public void deleteProcessGroup(ProcessGroupEntity entity) throws NiFiClientException, IOException {
+    public ProcessGroupEntity deleteProcessGroup(ProcessGroupEntity entity) throws NiFiClientException, IOException {
         if (entity == null) {
             throw new IllegalArgumentException("Process group entity cannot be null");
         }
-        executeAction("Error deleting process group", () -> {
+        return executeAction("Error deleting process group", () -> {
             final WebTarget target = processGroupsTarget
                     .path("{id}")
                     .queryParam("version", entity.getRevision().getVersion())
                     .resolveTemplate("id", entity.getId());
-            getRequestBuilder(target).delete();
-            return null;
+            return getRequestBuilder(target).delete(ProcessGroupEntity.class);
         });
     }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyProcessGroupClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyProcessGroupClient.java
@@ -356,4 +356,18 @@ public class JerseyProcessGroupClient extends AbstractJerseyClient implements Pr
         });
     }
 
+    @Override
+    public void deleteProcessGroup(ProcessGroupEntity entity) throws NiFiClientException, IOException {
+        if (entity == null) {
+            throw new IllegalArgumentException("Process group entity cannot be null");
+        }
+        executeAction("Error deleting process group", () -> {
+            final WebTarget target = processGroupsTarget
+                    .path("{id}")
+                    .queryParam("version", entity.getRevision().getVersion())
+                    .resolveTemplate("id", entity.getId());
+            getRequestBuilder(target).delete();
+            return null;
+        });
+    }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
@@ -66,6 +66,7 @@ import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGChangeVersion;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGConnect;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGCreate;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGCreateControllerService;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGDelete;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGDisableControllerServices;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGEnableControllerServices;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGGetAllVersions;
@@ -150,6 +151,7 @@ public class NiFiCommandGroup extends AbstractCommandGroup {
         commands.add(new PGGetParamContext());
         commands.add(new PGSetParamContext());
         commands.add(new PGReplace());
+        commands.add(new PGDelete());
         commands.add(new GetControllerServices());
         commands.add(new GetControllerService());
         commands.add(new CreateControllerService());

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.command.nifi.pg;
+
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.nifi.toolkit.cli.api.Context;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClient;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.ProcessGroupClient;
+import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
+import org.apache.nifi.toolkit.cli.impl.result.VoidResult;
+import org.apache.nifi.web.api.entity.ProcessGroupEntity;
+
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Command to delete a process group.
+ */
+public class PGDelete extends AbstractNiFiCommand<VoidResult> {
+
+        public PGDelete() {
+            super("pg-delete", VoidResult.class);
+        }
+
+        @Override
+        public String getDescription() {
+            return "Deletes the given process group.";
+        }
+
+        @Override
+        protected void doInitialize(final Context context) {
+            addOption(CommandOption.PG_ID.createOption());
+        }
+
+        @Override
+        public VoidResult doExecute(final NiFiClient client, final Properties properties)
+                throws NiFiClientException, IOException, MissingOptionException {
+
+            final String pgId = getRequiredArg(properties, CommandOption.PG_ID);
+
+            final ProcessGroupClient pgClient = client.getProcessGroupClient();
+            final ProcessGroupEntity pgEntity = pgClient.getProcessGroup(pgId);
+            if(pgEntity == null) {
+                throw new NiFiClientException("Process group with id " + pgId + " not found.");
+            }
+            pgClient.deleteProcessGroup(pgEntity);
+
+            return new VoidResult();
+        }
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
@@ -23,7 +23,7 @@ import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.ProcessGroupClient;
 import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
-import org.apache.nifi.toolkit.cli.impl.result.VoidResult;
+import org.apache.nifi.toolkit.cli.impl.result.StringResult;
 import org.apache.nifi.web.api.entity.ProcessGroupEntity;
 
 
@@ -33,10 +33,10 @@ import java.util.Properties;
 /**
  * Command to delete a process group.
  */
-public class PGDelete extends AbstractNiFiCommand<VoidResult> {
+public class PGDelete extends AbstractNiFiCommand<StringResult> {
 
         public PGDelete() {
-            super("pg-delete", VoidResult.class);
+            super("pg-delete", StringResult.class);
         }
 
         @Override
@@ -50,7 +50,7 @@ public class PGDelete extends AbstractNiFiCommand<VoidResult> {
         }
 
         @Override
-        public VoidResult doExecute(final NiFiClient client, final Properties properties)
+        public StringResult doExecute(final NiFiClient client, final Properties properties)
                 throws NiFiClientException, IOException, MissingOptionException {
 
             final String pgId = getRequiredArg(properties, CommandOption.PG_ID);
@@ -61,7 +61,6 @@ public class PGDelete extends AbstractNiFiCommand<VoidResult> {
                 throw new NiFiClientException("Process group with id " + pgId + " not found.");
             }
             pgClient.deleteProcessGroup(pgEntity);
-
-            return new VoidResult();
+            return new StringResult(pgId, isInteractive());
         }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
@@ -57,7 +57,7 @@ public class PGDelete extends AbstractNiFiCommand<VoidResult> {
 
             final ProcessGroupClient pgClient = client.getProcessGroupClient();
             final ProcessGroupEntity pgEntity = pgClient.getProcessGroup(pgId);
-            if(pgEntity == null) {
+            if (pgEntity == null) {
                 throw new NiFiClientException("Process group with id " + pgId + " not found.");
             }
             pgClient.deleteProcessGroup(pgEntity);

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
@@ -34,32 +34,32 @@ import java.util.Properties;
  */
 public class PGDelete extends AbstractNiFiCommand<StringResult> {
 
-        public PGDelete() {
-            super("pg-delete", StringResult.class);
+    public PGDelete() {
+        super("pg-delete", StringResult.class);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Deletes the given process group. Deleting a process group requires, stopping all Processors, disabling all Controller Services, and emptying all Queues.";
+    }
+
+    @Override
+    protected void doInitialize(final Context context) {
+        addOption(CommandOption.PG_ID.createOption());
+    }
+
+    @Override
+    public StringResult doExecute(final NiFiClient client, final Properties properties)
+            throws NiFiClientException, IOException, MissingOptionException {
+
+        final String pgId = getRequiredArg(properties, CommandOption.PG_ID);
+
+        final ProcessGroupClient pgClient = client.getProcessGroupClient();
+        final ProcessGroupEntity pgEntity = pgClient.getProcessGroup(pgId);
+        if (pgEntity == null) {
+            throw new NiFiClientException("Process group with id " + pgId + " not found.");
         }
-
-        @Override
-        public String getDescription() {
-            return "Deletes the given process group. Deleting a process group requires, stopping all Processors, disabling all Controller Services, and emptying all Queues.";
-        }
-
-        @Override
-        protected void doInitialize(final Context context) {
-            addOption(CommandOption.PG_ID.createOption());
-        }
-
-        @Override
-        public StringResult doExecute(final NiFiClient client, final Properties properties)
-                throws NiFiClientException, IOException, MissingOptionException {
-
-            final String pgId = getRequiredArg(properties, CommandOption.PG_ID);
-
-            final ProcessGroupClient pgClient = client.getProcessGroupClient();
-            final ProcessGroupEntity pgEntity = pgClient.getProcessGroup(pgId);
-            if (pgEntity == null) {
-                throw new NiFiClientException("Process group with id " + pgId + " not found.");
-            }
-            pgClient.deleteProcessGroup(pgEntity);
-            return new StringResult(pgId, isInteractive());
-        }
+        pgClient.deleteProcessGroup(pgEntity);
+        return new StringResult(pgId, isInteractive());
+    }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
@@ -26,7 +26,6 @@ import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
 import org.apache.nifi.toolkit.cli.impl.result.StringResult;
 import org.apache.nifi.web.api.entity.ProcessGroupEntity;
 
-
 import java.io.IOException;
 import java.util.Properties;
 
@@ -41,7 +40,7 @@ public class PGDelete extends AbstractNiFiCommand<StringResult> {
 
         @Override
         public String getDescription() {
-            return "Deletes the given process group.";
+            return "Deletes the given process group. Deleting a process group requires, stopping all Processors, disabling all Controller Services, and emptying all Queues.";
         }
 
         @Override


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13868](https://issues.apache.org/jira/browse/NIFI-13868)

Adding `pg-delete` command to Nifi Toolkit. The command works the same way as deleting a process group via UI. If there are messages in PG queue, deletion will fail. I ported this change from [Anetac's Nifi fork](https://github.com/Eng-Anetac/nifi) where I made it a while ago. We have been using this feature in production at Anetac for months now.

PR with the same feature for `main` branch: https://github.com/apache/nifi/pull/9388
The change for support/nifi-1.x branch is larger than for main, because the support branch does not have changes for NIFI-12898

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `support/nifi-1.x` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing


- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
