### PR TITLE
NIFI-13868: add pg-delete command to Nifi Toolkit

### DIFF
--- a/nifi-docs/src/main/asciidoc/toolkit-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/toolkit-guide.adoc
@@ -91,6 +91,7 @@ The following are available commands:
  nifi pg-set-param-context
  nifi pg-replace
  nifi pg-export
+ nifi pg-delete
  nifi get-services
  nifi get-service
  nifi create-service
@@ -312,18 +313,19 @@ For example, typing tab at an empty prompt should display possible commands for 
 Typing "nifi " and then a tab will show the sub-commands for NiFi:
 
  #> nifi
- change-version-processor          delete-flow-analysis-rule         export-reporting-task             get-policy                        list-user-groups                  pg-export                         pg-stop-version-control
- cluster-summary                   delete-node                       export-reporting-tasks            get-reg-client-id                 list-users                        pg-get-all-versions               remove-inherited-param-contexts
+ change-version-processor          delete-flow-analysis-rule         export-reporting-task             get-policy                        list-user-groups                  pg-export                         pg-delete
+ cluster-summary                   delete-node                       export-reporting-tasks            get-reg-client-id                 list-users                        pg-get-all-versions               pg-stop-version-control
  connect-node                      delete-param                      fetch-params                      get-reporting-task                logout-access-token               pg-get-param-context              set-inherited-param-contexts
- create-flow-analysis-rule         delete-param-context              get-access-token                  get-reporting-tasks               merge-param-context               pg-get-services                   set-param
- create-param-context              delete-param-provider             get-access-token-spnego           get-root-id                       offload-node                      pg-get-version                    set-param-provider-property
- create-param-provider             delete-reporting-task             get-controller-configuration      get-service                       pg-change-all-versions            pg-import                         start-reporting-tasks
- create-reg-client                 disable-flow-analysis-rules       get-flow-analysis-rule            get-services                      pg-change-version                 pg-list                           stop-reporting-tasks
- create-reporting-task             disable-services                  get-flow-analysis-rules           import-param-context              pg-connect                        pg-replace                        update-controller-configuration
- create-service                    disconnect-node                   get-node                          import-reporting-tasks            pg-create                         pg-set-param-context              update-policy
- create-user                       enable-flow-analysis-rules        get-nodes                         list-param-contexts               pg-create-service                 pg-start                          update-reg-client
- create-user-group                 enable-services                   get-param-context                 list-param-providers              pg-disable-services               pg-status                         update-user-group
- current-user                      export-param-context              get-param-provider                list-reg-clients                  pg-enable-services                pg-stop
+ create-flow-analysis-rule         delete-param-context              get-access-token                  get-reporting-tasks               merge-param-context               pg-get-services                   remove-inherited-param-contexts
+ create-param-context              delete-param-provider             get-access-token-spnego           get-root-id                       offload-node                      pg-get-version                    set-param
+ create-param-provider             delete-reporting-task             get-controller-configuration      get-service                       pg-change-all-versions            pg-import                         set-param-provider-property
+ create-reg-client                 disable-flow-analysis-rules       get-flow-analysis-rule            get-services                      pg-change-version                 pg-list                           start-reporting-tasks
+ create-reporting-task             disable-services                  get-flow-analysis-rules           import-param-context              pg-connect                        pg-replace                        stop-reporting-tasks
+ create-service                    disconnect-node                   get-node                          import-reporting-tasks            pg-create                         pg-set-param-context              update-controller-configuration
+ create-user                       enable-flow-analysis-rules        get-nodes                         list-param-contexts               pg-create-service                 pg-start                          update-policy
+ create-user-group                 enable-services                   get-param-context                 list-param-providers              pg-disable-services               pg-status                         update-reg-client
+ current-user                      export-param-context              get-param-provider                list-reg-clients                  pg-enable-services                pg-stop                           update-user-group
+
 
 Arguments that represent a path to a file, such as `-p` or when setting a properties file in the session, will auto-complete the path being typed:
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
@@ -84,6 +84,7 @@ import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGChangeVersion;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGConnect;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGCreate;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGCreateControllerService;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGDelete;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGDisableControllerServices;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGEmptyQueues;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGEnableControllerServices;
@@ -165,6 +166,7 @@ public class NiFiCommandGroup extends AbstractCommandGroup {
         commands.add(new PGReplace());
         commands.add(new PGExport());
         commands.add(new PGEmptyQueues());
+        commands.add(new PGDelete());
         commands.add(new GetControllerServices());
         commands.add(new GetControllerService());
         commands.add(new CreateControllerService());

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
@@ -34,32 +34,32 @@ import java.util.Properties;
  */
 public class PGDelete extends AbstractNiFiCommand<StringResult> {
 
-        public PGDelete() {
-            super("pg-delete", StringResult.class);
+    public PGDelete() {
+        super("pg-delete", StringResult.class);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Deletes the given process group. Deleting a process group requires, stopping all Processors, disabling all Controller Services, and emptying all Queues.";
+    }
+
+    @Override
+    protected void doInitialize(final Context context) {
+        addOption(CommandOption.PG_ID.createOption());
+    }
+
+    @Override
+    public StringResult doExecute(final NiFiClient client, final Properties properties)
+            throws NiFiClientException, IOException, MissingOptionException {
+
+        final String pgId = getRequiredArg(properties, CommandOption.PG_ID);
+
+        final ProcessGroupClient pgClient = client.getProcessGroupClient();
+        final ProcessGroupEntity pgEntity = pgClient.getProcessGroup(pgId);
+        if (pgEntity == null) {
+            throw new NiFiClientException("Process group with id " + pgId + " not found.");
         }
-
-        @Override
-        public String getDescription() {
-            return "Deletes the given process group. Deleting a process group requires, stopping all Processors, disabling all Controller Services, and emptying all Queues.";
-        }
-
-        @Override
-        protected void doInitialize(final Context context) {
-            addOption(CommandOption.PG_ID.createOption());
-        }
-
-        @Override
-        public StringResult doExecute(final NiFiClient client, final Properties properties)
-                throws NiFiClientException, IOException, MissingOptionException {
-
-            final String pgId = getRequiredArg(properties, CommandOption.PG_ID);
-
-            final ProcessGroupClient pgClient = client.getProcessGroupClient();
-            final ProcessGroupEntity pgEntity = pgClient.getProcessGroup(pgId);
-            if (pgEntity == null) {
-                throw new NiFiClientException("Process group with id " + pgId + " not found.");
-            }
-            pgClient.deleteProcessGroup(pgEntity);
-            return new StringResult(pgId, isInteractive());
-        }
+        pgClient.deleteProcessGroup(pgEntity);
+        return new StringResult(pgId, isInteractive());
+    }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.command.nifi.pg;
+
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.nifi.toolkit.cli.api.Context;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClient;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.ProcessGroupClient;
+import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
+import org.apache.nifi.toolkit.cli.impl.result.StringResult;
+import org.apache.nifi.web.api.entity.ProcessGroupEntity;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Command to delete a process group.
+ */
+public class PGDelete extends AbstractNiFiCommand<StringResult> {
+
+        public PGDelete() {
+            super("pg-delete", StringResult.class);
+        }
+
+        @Override
+        public String getDescription() {
+            return "Deletes the given process group. Deleting a process group requires, stopping all Processors, disabling all Controller Services, and emptying all Queues.";
+        }
+
+        @Override
+        protected void doInitialize(final Context context) {
+            addOption(CommandOption.PG_ID.createOption());
+        }
+
+        @Override
+        public StringResult doExecute(final NiFiClient client, final Properties properties)
+                throws NiFiClientException, IOException, MissingOptionException {
+
+            final String pgId = getRequiredArg(properties, CommandOption.PG_ID);
+
+            final ProcessGroupClient pgClient = client.getProcessGroupClient();
+            final ProcessGroupEntity pgEntity = pgClient.getProcessGroup(pgId);
+            if (pgEntity == null) {
+                throw new NiFiClientException("Process group with id " + pgId + " not found.");
+            }
+            pgClient.deleteProcessGroup(pgEntity);
+            return new StringResult(pgId, isInteractive());
+        }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13868](https://issues.apache.org/jira/browse/NIFI-13868)

Adding `pg-delete` command to Nifi Toolkit. The command works the same way as deleting a process group via UI. If there are messages in PG queue, deletion will fail. I ported this change from [Anetac's Nifi fork](https://github.com/Eng-Anetac/nifi) where I made it a while ago. We have been using this feature in production at Anetac for months now.

The code change to `main` branch is smaller than the one to support/nifi-1.x branch, because @markap14 has already added some of the functionality under NIFI-12898

Related PR for support/nifi-1.x branch: https://github.com/apache/nifi/pull/9387

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing


- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
