### PR TITLE
NIFI-10002 Validate Directory Path in ListFile

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -506,7 +506,12 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
 
     private List<FileInfo> performListing(final ProcessContext context, final Long minTimestamp, final ListingMode listingMode, final boolean applyFilters)
             throws IOException {
-        final Path basePath = new File(getPath(context)).toPath();
+        final String evaluatedPath = getPath(context);
+        if (evaluatedPath == null || evaluatedPath.isBlank()) {
+            throw new IOException("Blank Directory is not valid: review configured expression for Directory property");
+        }
+
+        final Path basePath = new File(evaluatedPath).toPath();
         final Boolean recurse = context.getProperty(RECURSE).asBoolean();
         final Map<Path, BasicFileAttributes> lastModifiedMap = new HashMap<>();
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListFile.java
@@ -27,6 +27,8 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.util.list.AbstractListProcessor;
 import org.apache.nifi.processor.util.list.ListProcessorTestWatcher;
 import org.apache.nifi.processor.util.file.transfer.FileInfo;
+import org.apache.nifi.util.LogMessage;
+import org.apache.nifi.util.MockComponentLog;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -159,6 +161,20 @@ public class TestListFile {
         assertEquals("/dir/test1", processor.getPath(context));
         runner.setProperty(ListFile.DIRECTORY, "${literal(\"/DIR/TEST2\"):toLower()}");
         assertEquals("/dir/test2", processor.getPath(context));
+    }
+
+    @Test
+    public void testPerformListingBlankDirectoryFailed() throws Exception {
+        runner.setProperty(ListFile.DIRECTORY, "${literal('')}");
+        runNext();
+        runner.assertTransferCount(ListFile.REL_SUCCESS, 0);
+
+        final MockComponentLog logger = runner.getLogger();
+        final List<LogMessage> errorMessages = logger.getErrorMessages();
+        assertFalse(errorMessages.isEmpty());
+
+        final LogMessage firstLogMessage = errorMessages.getFirst();
+        assertTrue(firstLogMessage.getMsg().contains("Blank"));
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-10002](https://issues.apache.org/jira/browse/NIFI-10002) Adds validation to the evaluated Directory path when performing a listing in the `ListFile` Processor. The validation checks for `null` or a blank string and throws an `IOException` when found.

An empty string is valid constructor argument for `java.io.File` but should never be valid for the `ListFile` Processor as it defaults to the current process working directory. The exception message indicates that the configured expression value for the `Directory` property should be checked. The `Directory` property supports environment variables or other expression language functions, so checking the evaluated expression before listing is necessary to avoid unexpected listing of the current working directory.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
