### PR TITLE
NIFI-13875 Upgrade Calcite from 1.37.0 to 1.38.0

### DIFF
--- a/nifi-commons/nifi-calcite-utils/pom.xml
+++ b/nifi-commons/nifi-calcite-utils/pom.xml
@@ -52,12 +52,12 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-linq4j</artifactId>
-            <version>1.37.0</version>
+            <version>1.38.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.37.0</version>
+            <version>1.38.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/nifi-extension-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/pom.xml
+++ b/nifi-extension-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.37.0</version>
+            <version>1.38.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestQueryRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestQueryRecord.java
@@ -307,7 +307,7 @@ public class TestQueryRecord {
         final Record output = written.get(0);
         assertEquals("John Doe", output.getValue("name"));
         assertEquals("Software Engineer", output.getValue("title"));
-        assertEquals(BigDecimal.valueOf(90.5D), output.getValue("height_total"));
+        assertEquals(new BigDecimal("90.500000000"), output.getValue("height_total"));
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -185,7 +185,7 @@
             <dependency>
                 <groupId>org.apache.calcite</groupId>
                 <artifactId>calcite-core</artifactId>
-                <version>1.37.0</version>
+                <version>1.38.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>log4j</groupId>

--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -24,7 +24,7 @@
     <packaging>pom</packaging>
     <description>NiFi: Framework Bundle</description>
     <properties>
-        <curator.version>5.7.0</curator.version>
+        <curator.version>5.7.1</curator.version>
         <guava.version>33.2.1-jre</guava.version>
         <tika.version>2.9.2</tika.version>
         <org.opensaml.version>4.3.2</org.opensaml.version>


### PR DESCRIPTION
# Summary

[NIFI-13875](https://issues.apache.org/jira/browse/NIFI-13875) Upgrades Calcite from 1.37.0 to 1.38.0 and includes a minor adjustment to `TestQueryRecord` to account for [decimal precision handling changes](https://calcite.apache.org/docs/history.html#breaking-1-38-0) in Calcite 1.38.0.

Curator [5.7.1](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12314425&version=12355135) includes minimal changes from version 5.7.0.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
