### PR TITLE
NIFI-13881 Upgrade JUnit from 5.10.4 to 5.11.2 along with Plugins

### DIFF
--- a/nifi-extension-bundles/nifi-cipher-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-cipher-bundle/pom.xml
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>com.exceptionfactory.jagged</groupId>
                 <artifactId>jagged-bom</artifactId>
-                <version>0.4.0</version>
+                <version>1.0.0</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecordTest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecordTest.java
@@ -46,7 +46,6 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.sql.SQLNonTransientConnectionException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.time.LocalDateTime;
@@ -93,10 +92,10 @@ public class QueryDatabaseTableRecordTest {
     }
 
     @AfterAll
-    public static void cleanUpAfterClass() throws Exception {
+    public static void cleanUpAfterClass() {
         try {
             DriverManager.getConnection("jdbc:derby:" + DB_LOCATION + ";shutdown=true");
-        } catch (SQLNonTransientConnectionException e) {
+        } catch (Exception e) {
             // Do nothing, this is what happens at Derby shutdown
         }
         // remove previous test database, if any

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableTest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/QueryDatabaseTableTest.java
@@ -51,7 +51,6 @@ import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.sql.SQLNonTransientConnectionException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.time.LocalDateTime;
@@ -97,10 +96,10 @@ public class QueryDatabaseTableTest {
     }
 
     @AfterAll
-    public static void cleanUpAfterClass() throws Exception {
+    public static void cleanUpAfterClass() {
         try {
             DriverManager.getConnection("jdbc:derby:" + DB_LOCATION + ";shutdown=true");
-        } catch (SQLNonTransientConnectionException e) {
+        } catch (Exception e) {
             // Do nothing, this is what happens at Derby shutdown
         }
         // remove previous test database, if any

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>32</version>
+        <version>33</version>
         <relativePath />
     </parent>
     <groupId>org.apache.nifi</groupId>
@@ -141,7 +141,7 @@
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
         <json.smart.version>2.5.0</json.smart.version>
         <groovy.version>4.0.23</groovy.version>
-        <surefire.version>3.2.5</surefire.version>
+        <surefire.version>3.5.1</surefire.version>
         <hadoop.version>3.4.0</hadoop.version>
         <ozone.version>1.2.1</ozone.version>
         <gcs.version>2.1.5</gcs.version>
@@ -149,7 +149,7 @@
         <jersey.bom.version>3.1.8</jersey.bom.version>
         <log4j2.version>2.24.1</log4j2.version>
         <logback.version>1.5.8</logback.version>
-        <mockito.version>5.14.1</mockito.version>
+        <mockito.version>5.14.2</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.3</snakeyaml.version>
         <netty.4.version>4.1.114.Final</netty.4.version>
@@ -306,7 +306,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.4</version>
+                <version>5.11.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -568,7 +568,7 @@
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-commons</artifactId>
-                <version>1.10.4</version>
+                <version>1.11.2</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -666,7 +666,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -715,7 +715,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.antlr</groupId>
@@ -725,12 +725,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.5.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>10.16.0</version>
+                            <version>10.18.2</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -741,7 +741,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.16.2</version>
+                    <version>2.17.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.rat</groupId>
@@ -755,12 +755,12 @@
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.13</version>
+                    <version>1.7.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.patrodyne.jvnet</groupId>
                     <artifactId>hisrc-higherjaxb40-maven-plugin</artifactId>
-                    <version>2.2.0</version>
+                    <version>2.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
@@ -770,17 +770,17 @@
                 <plugin>
                     <groupId>io.swagger.core.v3</groupId>
                     <artifactId>swagger-maven-plugin-jakarta</artifactId>
-                    <version>2.2.23</version>
+                    <version>2.2.25</version>
                 </plugin>
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>3.0.55</version>
+                    <version>3.0.63</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.4.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -1087,7 +1087,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>10.0.3</version>
+                        <version>10.0.4</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>


### PR DESCRIPTION
# Summary

[NIFI-13881](https://issues.apache.org/jira/browse/NIFI-13881) Upgrades JUnit dependencies from 5.10.4 to [5.11.2](https://junit.org/junit5/docs/5.11.2/release-notes/#release-notes-5.11.2) along with current Maven Plugins.

Upgrades include moving from Jagged 0.4.0 to [1.0.0](https://github.com/exceptionfactory/jagged/releases/tag/1.0.0) which does not contain any functional changes, but indicates a stable version.

Version upgrades include the following:

- Upgraded Apache Parent from 32 to 33
- Upgraded Surefire Plugin from 3.2.5 to 3.5.1
- Upgraded Mockito from 5.14.1 to 5.14.2
- Upgraded JUnit Platform from 1.10.4 to 1.11.2
- Upgraded Exec Maven Plugin from 3.2.0 o 3.4.1
- Upgraded Buildnumber Maven Plugin from 3.2.0
- Upgraded Maven Checkstyle Plugin from 3.3.1 to 3.5.0
- Upgraded Checkstyle from 10.16.0 to 10.18.2
- Upgraded Versions Maven Plugin from 2.16.2 to 2.17.1
- Upgraded Nexus Staging Plugin from 1.6.13 to 1.7.00
- Upgraded JAXB Maven Plugin from 2.2.0 to 2.2.1
- Upgraded Swagger Maven Plugin from 2.2.23 to 2.2.25
- Upgraded Swagger Codegen Plugin from 3.0.55 to 3.0.63
- Upgraded Maven JAR Plugin from 3.4.1 to 3.4.2
- Upgraded Dependency Check Plugin from 10.0.3 to 10.0.4
- Upgraded Jagged BOM from 0.4.0 to 1.0.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
