### PR TITLE
NIFI-13882 Upgrade Kotlin from 1.9.25 to 2.0.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <software.amazon.awssdk.version>2.28.13</software.amazon.awssdk.version>
         <gson.version>2.11.0</gson.version>
         <io.fabric8.kubernetes.client.version>6.13.4</io.fabric8.kubernetes.client.version>
-        <kotlin.version>1.9.25</kotlin.version>
+        <kotlin.version>2.0.21</kotlin.version>
         <okhttp.version>4.12.0</okhttp.version>
         <okio.version>3.9.1</okio.version>
         <org.apache.commons.cli.version>1.9.0</org.apache.commons.cli.version>


### PR DESCRIPTION
# Summary

[NIFI-13882](https://issues.apache.org/jira/browse/NIFI-13882) Upgrades Kotlin standard libraries from 1.9.25 to [2.0.21](https://github.com/JetBrains/kotlin/releases/tag/v2.0.21) in support the the OkHttp library and JetBrains Xodus.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
