### PR TITLE
NIFI-13860 Avoid Throwing Exceptions for Failures in IPLookupService

### DIFF
--- a/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/maxmind/IPLookupService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/maxmind/IPLookupService.java
@@ -72,7 +72,7 @@ import java.util.stream.Stream;
 public class IPLookupService extends AbstractControllerService implements RecordLookupService {
 
     private volatile String databaseFile = null;
-    private static final String IP_KEY = "ip";
+    static final String IP_KEY = "ip";
     private static final Set<String> REQUIRED_KEYS = Stream.of(IP_KEY).collect(Collectors.toSet());
 
     private volatile DatabaseReader databaseReader = null;
@@ -260,7 +260,7 @@ public class IPLookupService extends AbstractControllerService implements Record
         if (getProperty(LOOKUP_CITY).asBoolean()) {
             final CityResponse cityResponse;
             try {
-                cityResponse = databaseReader.city(inetAddress);
+                cityResponse = databaseReader.tryCity(inetAddress).orElse(null);
             } catch (final InvalidDatabaseException idbe) {
                 throw idbe;
             } catch (final Exception e) {
@@ -276,7 +276,7 @@ public class IPLookupService extends AbstractControllerService implements Record
         if (getProperty(LOOKUP_ISP).asBoolean()) {
             final IspResponse ispResponse;
             try {
-                ispResponse = databaseReader.isp(inetAddress);
+                ispResponse = databaseReader.tryIsp(inetAddress).orElse(null);
             } catch (final InvalidDatabaseException idbe) {
                 throw idbe;
             } catch (final Exception e) {
@@ -292,7 +292,7 @@ public class IPLookupService extends AbstractControllerService implements Record
         if (getProperty(LOOKUP_DOMAIN).asBoolean()) {
             final DomainResponse domainResponse;
             try {
-                domainResponse = databaseReader.domain(inetAddress);
+                domainResponse = databaseReader.tryDomain(inetAddress).orElse(null);
             } catch (final InvalidDatabaseException idbe) {
                 throw idbe;
             } catch (final Exception e) {
@@ -308,7 +308,7 @@ public class IPLookupService extends AbstractControllerService implements Record
         if (getProperty(LOOKUP_CONNECTION_TYPE).asBoolean()) {
             final ConnectionTypeResponse connectionTypeResponse;
             try {
-                connectionTypeResponse = databaseReader.connectionType(inetAddress);
+                connectionTypeResponse = databaseReader.tryConnectionType(inetAddress).orElse(null);
             } catch (final InvalidDatabaseException idbe) {
                 throw idbe;
             } catch (final Exception e) {
@@ -329,7 +329,7 @@ public class IPLookupService extends AbstractControllerService implements Record
         if (getProperty(LOOKUP_ANONYMOUS_IP_INFO).asBoolean()) {
             final AnonymousIpResponse anonymousIpResponse;
             try {
-                anonymousIpResponse = databaseReader.anonymousIp(inetAddress);
+                anonymousIpResponse = databaseReader.tryAnonymousIp(inetAddress).orElse(null);
             } catch (final InvalidDatabaseException idbe) {
                 throw idbe;
             } catch (final Exception e) {
@@ -383,7 +383,7 @@ public class IPLookupService extends AbstractControllerService implements Record
 
     private void loadDatabase(final File dbFile, final String dbFileChecksum) throws IOException {
         final StopWatch stopWatch = new StopWatch(true);
-        final DatabaseReader reader = new DatabaseReader.Builder(dbFile).build();
+        final DatabaseReader reader = createDatabaseReader(dbFile);
         stopWatch.stop();
         getLogger().info("Completed loading of Maxmind Database.  Elapsed time was {} milliseconds.", stopWatch.getDuration(TimeUnit.MILLISECONDS));
         databaseReader = reader;
@@ -479,5 +479,9 @@ public class IPLookupService extends AbstractControllerService implements Record
 
         final Record containerRecord = new MapRecord(ContainerSchema.CONTAINER_SCHEMA, values);
         return containerRecord;
+    }
+
+    DatabaseReader createDatabaseReader(File dbFile) throws IOException {
+        return new DatabaseReader.Builder(dbFile).build();
     }
 }

--- a/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/maxmind/TestIPLookupService.java
+++ b/nifi-nar-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/test/java/org/apache/nifi/lookup/maxmind/TestIPLookupService.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.lookup.maxmind;
+
+import com.maxmind.geoip2.DatabaseReader;
+import org.apache.nifi.lookup.TestProcessor;
+import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestIPLookupService {
+    private static final String TEST_SUBJECT_ID = "testSubject";
+
+    private static final String SOME_VALID_IP = "0.0.0.0";
+
+    @TempDir
+    static Path tempDir;
+    static Path tempDummyMmdbFile;
+
+    private TestRunner runner;
+    private IPLookupService testSubject;
+
+    private DatabaseReader mockDatabaseReader;
+
+    @BeforeAll
+    public static void init() throws IOException {
+        tempDummyMmdbFile = Files.createFile(tempDir.resolve("dummy.mmdb"));
+    }
+
+    @BeforeEach
+    public void setUp() {
+        runner = TestRunners.newTestRunner(TestProcessor.class);
+        testSubject = new IPLookupService() {
+            @NotNull
+            @Override
+            DatabaseReader createDatabaseReader(File dbFile) throws IOException {
+                return mockDatabaseReader;
+            }
+        };
+
+        mockDatabaseReader = mock(DatabaseReader.class);
+    }
+
+    @Test
+    void testLookupDefaultNoResult() throws Exception {
+        // GIVEN
+        runner.addControllerService(TEST_SUBJECT_ID, testSubject);
+        runner.setProperty(testSubject, IPLookupService.GEO_DATABASE_FILE, tempDummyMmdbFile.toString());
+        runner.enableControllerService(testSubject);
+        runner.assertValid(testSubject);
+
+        when(mockDatabaseReader.tryCity(any(InetAddress.class))).thenReturn(Optional.empty());
+
+        // WHEN
+        final Optional<Record> lookupResult = testSubject.lookup(Collections.singletonMap(IPLookupService.IP_KEY, SOME_VALID_IP));
+
+        // THEN
+        verify(mockDatabaseReader).tryCity(any(InetAddress.class));
+
+        assertEquals(Optional.empty(), lookupResult);
+    }
+
+    @Test
+    void testLookupCityNoResult() throws Exception {
+        // GIVEN
+        runner.addControllerService(TEST_SUBJECT_ID, testSubject);
+        runner.setProperty(testSubject, IPLookupService.GEO_DATABASE_FILE, tempDummyMmdbFile.toString());
+        runner.setProperty(testSubject, IPLookupService.LOOKUP_CITY, "true");
+        runner.enableControllerService(testSubject);
+        runner.assertValid(testSubject);
+
+        when(mockDatabaseReader.tryCity(any(InetAddress.class))).thenReturn(Optional.empty());
+
+        // WHEN
+        final Optional<Record> lookupResult = testSubject.lookup(Collections.singletonMap(IPLookupService.IP_KEY, SOME_VALID_IP));
+
+        // THEN
+        verify(mockDatabaseReader).tryCity(any(InetAddress.class));
+
+        assertEquals(Optional.empty(), lookupResult);
+    }
+
+    @Test
+    void testLookupISPNoResult() throws Exception {
+        // GIVEN
+        runner.addControllerService(TEST_SUBJECT_ID, testSubject);
+        runner.setProperty(testSubject, IPLookupService.GEO_DATABASE_FILE, tempDummyMmdbFile.toString());
+        runner.setProperty(testSubject, IPLookupService.LOOKUP_CITY, "false");
+        runner.setProperty(testSubject, IPLookupService.LOOKUP_ISP, "true");
+        runner.enableControllerService(testSubject);
+        runner.assertValid(testSubject);
+
+        when(mockDatabaseReader.tryIsp(any(InetAddress.class))).thenReturn(Optional.empty());
+
+        // WHEN
+        final Optional<Record> lookupResult = testSubject.lookup(Collections.singletonMap(IPLookupService.IP_KEY, SOME_VALID_IP));
+
+        // THEN
+        verify(mockDatabaseReader).tryIsp(any(InetAddress.class));
+
+        assertEquals(Optional.empty(), lookupResult);
+    }
+
+    @Test
+    void testLookupDomainNoResult() throws Exception {
+        // GIVEN
+        runner.addControllerService(TEST_SUBJECT_ID, testSubject);
+        runner.setProperty(testSubject, IPLookupService.GEO_DATABASE_FILE, tempDummyMmdbFile.toString());
+        runner.setProperty(testSubject, IPLookupService.LOOKUP_CITY, "false");
+        runner.setProperty(testSubject, IPLookupService.LOOKUP_DOMAIN, "true");
+        runner.enableControllerService(testSubject);
+        runner.assertValid(testSubject);
+
+        when(mockDatabaseReader.tryDomain(any(InetAddress.class))).thenReturn(Optional.empty());
+
+        // WHEN
+        final Optional<Record> lookupResult = testSubject.lookup(Collections.singletonMap(IPLookupService.IP_KEY, SOME_VALID_IP));
+
+        // THEN
+        verify(mockDatabaseReader).tryDomain(any(InetAddress.class));
+
+        assertEquals(Optional.empty(), lookupResult);
+    }
+
+    @Test
+    void testLookupConnectionTypeNoResult() throws Exception {
+        // GIVEN
+        runner.addControllerService(TEST_SUBJECT_ID, testSubject);
+        runner.setProperty(testSubject, IPLookupService.GEO_DATABASE_FILE, tempDummyMmdbFile.toString());
+        runner.setProperty(testSubject, IPLookupService.LOOKUP_CITY, "false");
+        runner.setProperty(testSubject, IPLookupService.LOOKUP_CONNECTION_TYPE, "true");
+        runner.enableControllerService(testSubject);
+        runner.assertValid(testSubject);
+
+        when(mockDatabaseReader.tryConnectionType(any(InetAddress.class))).thenReturn(Optional.empty());
+
+        // WHEN
+        final Optional<Record> lookupResult = testSubject.lookup(Collections.singletonMap(IPLookupService.IP_KEY, SOME_VALID_IP));
+
+        // THEN
+        verify(mockDatabaseReader).tryConnectionType(any(InetAddress.class));
+
+        assertEquals(Optional.empty(), lookupResult);
+    }
+
+    @Test
+    void testLookupAnonymousIpNoResult() throws Exception {
+        // GIVEN
+        runner.addControllerService(TEST_SUBJECT_ID, testSubject);
+        runner.setProperty(testSubject, IPLookupService.GEO_DATABASE_FILE, tempDummyMmdbFile.toString());
+        runner.setProperty(testSubject, IPLookupService.LOOKUP_CITY, "false");
+        runner.setProperty(testSubject, IPLookupService.LOOKUP_ANONYMOUS_IP_INFO, "true");
+        runner.enableControllerService(testSubject);
+        runner.assertValid(testSubject);
+
+        when(mockDatabaseReader.tryAnonymousIp(any(InetAddress.class))).thenReturn(Optional.empty());
+
+        // WHEN
+        final Optional<Record> lookupResult = testSubject.lookup(Collections.singletonMap(IPLookupService.IP_KEY, SOME_VALID_IP));
+
+        // THEN
+        verify(mockDatabaseReader).tryAnonymousIp(any(InetAddress.class));
+
+        assertEquals(Optional.empty(), lookupResult);
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13860](https://issues.apache.org/jira/browse/NIFI-13860)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
