### PR TITLE
NIFI-13544 Add property to set the size of the threadpool of pubsub p…

### DIFF
--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PubSubAttributes.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PubSubAttributes.java
@@ -50,4 +50,7 @@ public class PubSubAttributes {
             + " delivered to subscribers in the order in which they are received by the"
             + " Pub/Sub system. All 'PubsubMessage's published in a given 'PublishRequest'"
             + " must specify the same 'ordering_key' value.";
+
+    public static final String EXECUTOR_THREADS_NUMBER_ATTRIBUTE = "gcp.pubsub.executor.threads";
+    public static final String EXECUTOR_THREADS_NUMBER_DESCRIPTION = "Number of thrads used by the pubsub executor.";
 }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/ThreadCountValidator.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/ThreadCountValidator.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.gcp.pubsub;
+
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.processor.util.StandardValidators;
+import java.util.Optional;
+
+public class ThreadCountValidator implements Validator {
+
+    @Override
+    public ValidationResult validate(String subject, String input, ValidationContext context) {
+        if (input == null || input.isEmpty() || "auto".equalsIgnoreCase(input)) {
+            return new ValidationResult.Builder().subject(subject).input(input).valid(true).build();
+        }
+        // Use existing integer validator for the integer check
+        return StandardValidators.POSITIVE_INTEGER_VALIDATOR.validate(subject, input, context);
+    }
+
+    public static Optional<Integer> parse(String input) {
+        if (input == null || input.isEmpty() || "auto".equalsIgnoreCase(input)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Integer.parseInt(input));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
…ublish

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13544](https://issues.apache.org/jira/browse/NIFI-13544)

The PR adds a setting to the PublishGCPPubSub processor limiting the number of threads to be used by the processor. By default (if empty) use the default behaviour of having (5 * Number of CPU) threads per processor.

# Tracking 

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [X] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [X] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
