### PR TITLE
NIFI-13886 Upgrade Spring from 6.1.13 to 6.1.14 and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <ant.version>1.10.15</ant.version>
-        <org.apache.sshd.version>2.13.2</org.apache.sshd.version>
+        <org.apache.sshd.version>2.14.0</org.apache.sshd.version>
         <mime4j.version>0.8.11</mime4j.version>
     </properties>
 

--- a/nifi-commons/nifi-metrics/pom.xml
+++ b/nifi-commons/nifi-metrics/pom.xml
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jvm</artifactId>
-            <version>4.2.27</version>
+            <version>4.2.28</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>4.2.27</version>
+            <version>4.2.28</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-commons/pom.xml
+++ b/nifi-commons/pom.xml
@@ -71,7 +71,7 @@
     </modules>
     <properties>
         <gcp.sdk.version>26.38.0</gcp.sdk.version>
-        <guava.version>33.2.1-jre</guava.version>
+        <guava.version>33.3.1-jre</guava.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bom/pom.xml
+++ b/nifi-extension-bom/pom.xml
@@ -189,19 +189,19 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.7</version>
+                <version>9.7.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-commons</artifactId>
-                <version>9.7</version>
+                <version>9.7.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-tree</artifactId>
-                <version>9.7</version>
+                <version>9.7.1</version>
                 <scope>provided</scope>
             </dependency>
             <!-- Jetty EE10 Apache JSP and deps -->
@@ -214,13 +214,13 @@
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>apache-jsp</artifactId>
-                <version>10.1.16</version>
+                <version>10.1.31</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>apache-el</artifactId>
-                <version>10.1.16</version>
+                <version>10.1.31</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.2.1-jre</version>
+                <version>33.3.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -55,7 +55,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.2.1-jre</version>
+                <version>33.3.1-jre</version>
             </dependency>
             <!-- Override Apache Qpid Proton J for Azure EventHubs to resolve PROTON-2347 -->
             <dependency>

--- a/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.2.1-jre</version>
+            <version>33.3.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.2.1-jre</version>
+                <version>33.3.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <gremlin.version>3.7.2</gremlin.version>
         <janusgraph.version>1.0.0</janusgraph.version>
-        <guava.version>33.2.1-jre</guava.version>
+        <guava.version>33.3.1-jre</guava.version>
         <amqp-client.version>5.22.0</amqp-client.version>
     </properties>
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.2.1-jre</version>
+            <version>33.3.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-hadoop-libraries-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-hadoop-libraries-bundle/pom.xml
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.2.1-jre</version>
+                <version>33.3.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
@@ -160,7 +160,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.2.1-jre</version>
+                <version>33.3.1-jre</version>
             </dependency>
             <!-- Override Groovy from hive-exec -->
             <dependency>

--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
@@ -40,7 +40,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.2.1-jre</version>
+                <version>33.3.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.2.1-jre</version>
+            <version>33.3.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/pom.xml
@@ -37,7 +37,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.2.1-jre</version>
+                <version>33.3.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-sql-reporting-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-sql-reporting-bundle/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>nifi-sql-reporting-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <guava.version>33.2.1-jre</guava.version>
+        <guava.version>33.3.1-jre</guava.version>
     </properties>
     <modules>
         <module>nifi-sql-reporting-tasks</module>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.2.1-jre</version>
+            <version>33.3.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-common</artifactId>
-            <version>2.13.2</version>
+            <version>2.14.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -405,7 +405,7 @@
         <dependency>
             <groupId>net.datafaker</groupId>
             <artifactId>datafaker</artifactId>
-            <version>2.3.1</version>
+            <version>2.4.0</version>
             <exclusions>
                 <!-- Exclude snakeyaml with android qualifier -->
                 <exclusion>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/faker/FakerUtils.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/faker/FakerUtils.java
@@ -58,7 +58,7 @@ public class FakerUtils {
     private static final String PACKAGE_PREFIX = "net.datafaker.providers";
 
     public static AllowableValue[] createFakerPropertyList() {
-        final List<EnFile> fakerFiles = EnFile.getFiles();
+        final List<EnFile> fakerFiles = EnFile.getFiles().toList();
         final Map<String, Class<?>> possibleFakerTypeMap = new HashMap<>(fakerFiles.size());
         for (EnFile fakerFile : fakerFiles) {
             String className = normalizeClassName(fakerFile.getFile().substring(0, fakerFile.getFile().indexOf('.')));
@@ -125,13 +125,13 @@ public class FakerUtils {
 
         // Handle DateAndTime methods not discovered by programmatically getting methods from the Faker objects
         if (FT_FUTURE_DATE.getValue().equals(type)) {
-            return faker.date().future(RANDOM_DATE_DAYS, TimeUnit.DAYS);
+            return faker.timeAndDate().future(RANDOM_DATE_DAYS, TimeUnit.DAYS);
         }
         if (FT_PAST_DATE.getValue().equals(type)) {
-            return faker.date().past(RANDOM_DATE_DAYS, TimeUnit.DAYS);
+            return faker.timeAndDate().past(RANDOM_DATE_DAYS, TimeUnit.DAYS);
         }
         if (FT_BIRTHDAY.getValue().equals(type)) {
-            return faker.date().birthday();
+            return faker.timeAndDate().birthday();
         }
 
         // Handle Crypto methods not discovered by programmatically getting methods from the Faker objects

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -34,7 +34,7 @@
         <module>nifi-standard-content-viewer-nar</module>
     </modules>
     <properties>
-        <org.apache.sshd.version>2.13.2</org.apache.sshd.version>
+        <org.apache.sshd.version>2.14.0</org.apache.sshd.version>
         <tika.version>2.9.2</tika.version>
     </properties>
     <dependencyManagement>
@@ -169,7 +169,7 @@
             <dependency>
                 <groupId>com.github.wnameless.json</groupId>
                 <artifactId>json-flattener</artifactId>
-                <version>0.16.6</version>
+                <version>0.17.0</version>
             </dependency>
             <dependency>
                 <groupId>io.krakens</groupId>
@@ -221,7 +221,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.2.1-jre</version>
+                <version>33.3.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.networknt</groupId>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-hbase_2-client-service-bundle/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.2.1-jre</version>
+                <version>33.3.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
@@ -121,13 +121,13 @@
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
-                <version>3.47.0</version>
+                <version>3.48.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
-                <version>2.28.0</version>
+                <version>2.33.0</version>
                 <scope>provided</scope>
             </dependency>
             <!-- OkHttp -->

--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -25,7 +25,7 @@
     <description>NiFi: Framework Bundle</description>
     <properties>
         <curator.version>5.7.1</curator.version>
-        <guava.version>33.2.1-jre</guava.version>
+        <guava.version>33.3.1-jre</guava.version>
         <tika.version>2.9.2</tika.version>
         <org.opensaml.version>4.3.2</org.opensaml.version>
     </properties>
@@ -317,7 +317,7 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
-                <version>4.2.27</version>
+                <version>4.2.28</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -114,7 +114,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.2.1-jre</version>
+                <version>33.3.1-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -40,7 +40,7 @@
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.0.0.202409031743-r</jgit.version>
-        <org.apache.sshd.version>2.13.2</org.apache.sshd.version>
+        <org.apache.sshd.version>2.14.0</org.apache.sshd.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <guava.version>33.2.1-jre</guava.version>
+        <guava.version>33.3.1-jre</guava.version>
         <jline.version>3.27.0</jline.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,15 +102,15 @@
         <docker.jre.image.name>bellsoft/liberica-openjre-debian</docker.jre.image.name>
         <docker.image.tag>21</docker.image.tag>
         <node.version>v22.1.0</node.version>
-        <frontend.mvn.plugin.version>1.15.0</frontend.mvn.plugin.version>
+        <frontend.mvn.plugin.version>1.15.1</frontend.mvn.plugin.version>
         <nifi.nar.maven.plugin.version>2.1.0</nifi.nar.maven.plugin.version>
         <nifi-api.version>2.0.0</nifi-api.version>
         <project.build.outputTimestamp>1706227889</project.build.outputTimestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
-        <com.amazonaws.version>1.12.772</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.28.13</software.amazon.awssdk.version>
+        <com.amazonaws.version>1.12.774</com.amazonaws.version>
+        <software.amazon.awssdk.version>2.28.24</software.amazon.awssdk.version>
         <gson.version>2.11.0</gson.version>
         <io.fabric8.kubernetes.client.version>6.13.4</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.0.21</kotlin.version>
@@ -139,24 +139,24 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
-        <json.smart.version>2.5.0</json.smart.version>
+        <json.smart.version>2.5.1</json.smart.version>
         <groovy.version>4.0.23</groovy.version>
         <surefire.version>3.5.1</surefire.version>
         <hadoop.version>3.4.0</hadoop.version>
         <ozone.version>1.2.1</ozone.version>
         <gcs.version>2.1.5</gcs.version>
         <aspectj.version>1.9.22.1</aspectj.version>
-        <jersey.bom.version>3.1.8</jersey.bom.version>
+        <jersey.bom.version>3.1.9</jersey.bom.version>
         <log4j2.version>2.24.1</log4j2.version>
-        <logback.version>1.5.8</logback.version>
+        <logback.version>1.5.11</logback.version>
         <mockito.version>5.14.2</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.3</snakeyaml.version>
         <netty.4.version>4.1.114.Final</netty.4.version>
-        <servlet-api.version>6.0.0</servlet-api.version>
-        <spring.version>6.1.13</spring.version>
+        <servlet-api.version>6.1.0</servlet-api.version>
+        <spring.version>6.1.14</spring.version>
         <spring.security.version>6.3.3</spring.security.version>
-        <swagger.annotations.version>2.2.24</swagger.annotations.version>
+        <swagger.annotations.version>2.2.25</swagger.annotations.version>
         <h2.version>2.3.232</h2.version>
         <zookeeper.version>3.9.2</zookeeper.version>
         <caffeine.version>3.1.8</caffeine.version>


### PR DESCRIPTION
# Summary

[NIFI-13886](https://issues.apache.org/jira/browse/NIFI-13886) Upgrades Spring Framework dependencies from 6.1.13 to [6.1.14](https://github.com/spring-projects/spring-framework/releases/tag/v6.1.14) and also includes incremental upgrades for common dependencies:

- Upgraded Apache MINA SSHD from 2.13.2 to [2.14.0](https://github.com/apache/mina-sshd/releases/tag/sshd-2.14.0)
- Upgraded Dropwizard Metrics from 4.2.27 to [4.2.28](https://github.com/dropwizard/metrics/releases/tag/v4.2.28)
- Upgraded Guava from 33.2.1 to [33.3.1](https://github.com/google/guava/releases/tag/v33.3.1)
- Upgraded ASM from 9.7 to [9.7.1](https://asm.ow2.io/versions.html)
- Upgraded Apache JSP from 10.1.16 to 10.1.31
- Upgraded Apache EL from 10.1.16 to 10.1.31
- Upgraded Data Faker from 2.3.1 to [2.4.0](https://www.datafaker.net/releases/2.4.0/)
- Upgraded JSON Flattener from 0.16.6 to [0.17.0](https://github.com/wnameless/json-flattener/blob/master/release-notes#L140)
- Upgraded Check Qual from 3.47.0 to 3.48.1
- Upgraded error-prone-annotations from 2.28.0 to 2.33.0
- Upgraded frontend-maven-plugin from 1.15.0 to [1.15.1](https://github.com/eirslett/frontend-maven-plugin/blob/master/CHANGELOG.md#1151)
- Upgraded AWS SDK from 1.12.772 to 1.2.774
- Upgraded AWS SDK from 2.28.13 to 2.28.24
- Upgraded JSON Smart from 2.5.0 to [2.5.1](https://github.com/netplex/json-smart-v2/releases/tag/2.5.1)
- Upgraded Jersey from 3.1.8 to [3.1.9](https://github.com/eclipse-ee4j/jersey/releases/tag/3.1.9)
- Upgraded Logback from 1.5.8 to [1.5.11](https://logback.qos.ch/news.html#1.5.11)
- Upgraded Servlet API from 6.0.0 to [6.1.0](https://jakarta.ee/zh/specifications/servlet/6.1/)
- Upgraded Swagger Annotations from 2.2.24 to 2.2.25

The Data Faker 2.4.0 version required minor adjustments to remove references to the deprecated DateAndTime class in favor of TimeAndDate.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
