### PR TITLE
NIFI-13888 Increase Timeout to 15 seconds in TestEventIndexTask

### DIFF
--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/index/lucene/TestEventIndexTask.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/index/lucene/TestEventIndexTask.java
@@ -44,7 +44,7 @@ public class TestEventIndexTask {
 
     @Test
     public void testIndexWriterCommittedWhenAppropriate() {
-        assertTimeout(Duration.ofSeconds(5), this::runIndexWriteCommittedWhenAppropriate);
+        assertTimeout(Duration.ofSeconds(15), this::runIndexWriteCommittedWhenAppropriate);
     }
 
     private void runIndexWriteCommittedWhenAppropriate() throws InterruptedException, IOException {


### PR DESCRIPTION
# Summary

[NIFI-13888](https://issues.apache.org/jira/browse/NIFI-13888) The `TestEventIndexTask` test method `testIndexWriterCommittedWhenAppropriate` is unstable when running multi-thread builds due to resource contention. Increasing the timeout from 5 to 15 seconds should provide greater build stability.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
