### PR TITLE
NIFI-13890 - fix referencing components for quoted parameters

### DIFF
--- a/nifi-commons/nifi-parameter/src/main/java/org/apache/nifi/parameter/AbstractParameterParser.java
+++ b/nifi-commons/nifi-parameter/src/main/java/org/apache/nifi/parameter/AbstractParameterParser.java
@@ -45,7 +45,19 @@ public abstract class AbstractParameterParser implements ParameterParser {
         final ParameterToken token;
         if (sequentialStartTags % 2 == 1) {
             final String parameterName = input.substring(startCharIndex + sequentialStartTags + 1, endCharIndex);
-            token = new StandardParameterReference(parameterName, startOffset, endCharIndex, referenceText);
+            if (parameterName.contains("'")) {
+                if (parameterName.startsWith("'") && parameterName.endsWith("'")) {
+                    final String parameterNameWithoutQuotes = parameterName.substring(1, parameterName.length() - 1);
+                    if (parameterNameWithoutQuotes.contains("'")) {
+                        return null;
+                    }
+                    token = new StandardParameterReference(parameterNameWithoutQuotes, startOffset, endCharIndex, referenceText);
+                } else {
+                    return null;
+                }
+            } else {
+                token = new StandardParameterReference(parameterName, startOffset, endCharIndex, referenceText);
+            }
         } else {
             token = new EscapedParameterReference(startOffset, endCharIndex, referenceText);
         }

--- a/nifi-commons/nifi-parameter/src/test/java/org/apache/nifi/parameter/TestExpressionLanguageAgnosticParameterParser.java
+++ b/nifi-commons/nifi-parameter/src/test/java/org/apache/nifi/parameter/TestExpressionLanguageAgnosticParameterParser.java
@@ -164,8 +164,10 @@ public class TestExpressionLanguageAgnosticParameterParser {
     @Test
     public void testNonReferences() {
         final ParameterParser parameterParser = new ExpressionLanguageAgnosticParameterParser();
+        final String[] badReferences = new String[] {"#foo", "Some text #{blah foo", "#foo}", "#}foo{",
+                "#{'fo'o}", "#{'My'Param'}", "#f{oo}", "#", "##", "###", "####", "#####", "#{", "##{", "###{"};
 
-        for (final String input : new String[] {"#foo", "Some text #{blah foo", "#foo}", "#}foo{", "#f{oo}", "#", "##", "###", "####", "#####", "#{", "##{", "###{"}) {
+        for (final String input : badReferences) {
             assertEquals(0, parameterParser.parseTokens(input).toList().size());
         }
     }
@@ -180,7 +182,7 @@ public class TestExpressionLanguageAgnosticParameterParser {
     @Test
     public void testReferenceInsideAndOutsideExpressionLanguage() {
         final ParameterParser parameterParser = new ExpressionLanguageAgnosticParameterParser();
-        final List<ParameterToken> tokens = parameterParser.parseTokens("#{hello}${#{hello}:toUpper()}#{hello}").toList();
+        final List<ParameterToken> tokens = parameterParser.parseTokens("#{hello}${#{'hello'}:toUpper()}#{hello}").toList();
         assertEquals(3, tokens.size());
 
         for (final ParameterToken token : tokens) {
@@ -206,12 +208,12 @@ public class TestExpressionLanguageAgnosticParameterParser {
     @Test
     public void testMultipleReferencesSameExpression() {
         final ParameterParser parameterParser = new ExpressionLanguageAgnosticParameterParser();
-        final List<ParameterToken> tokens = parameterParser.parseTokens("${#{hello}:append(#{there})}").toList();
+        final List<ParameterToken> tokens = parameterParser.parseTokens("${#{'my parameter'}:append(#{there})}").toList();
         assertEquals(2, tokens.size());
 
         final ParameterToken firstToken = tokens.get(0);
         assertTrue(firstToken.isParameterReference());
-        assertEquals("hello", ((ParameterReference) firstToken).getParameterName());
+        assertEquals("my parameter", ((ParameterReference) firstToken).getParameterName());
 
         final ParameterToken secondToken = tokens.get(1);
         assertTrue(secondToken.isParameterReference());


### PR DESCRIPTION
# Summary

[NIFI-13890](https://issues.apache.org/jira/browse/NIFI-13890) - No referencing component for quoted parameter

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
