### PR TITLE
NIFI-13892 Suppress JVM Logging for Lucene Vectorization

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/logback.xml
@@ -226,6 +226,11 @@
     <!-- Suppress non-error messages from JetBrains Xodus FileDataWriter related to FileChannel -->
     <logger name="jetbrains.exodus.io.FileDataWriter" level="WARN" />
 
+    <!-- Suppress warnings from Lucene Vectorization Provider related to JDK incubator features -->
+    <logger name="org.apache.lucene.internal.vectorization.VectorizationProvider" level="ERROR" />
+    <!-- Suppress information from Lucene Memory Segment Provider related to native access configuration -->
+    <logger name="org.apache.lucene.store.MemorySegmentIndexInputProvider" level="WARN" />
+
     <!-- These log messages would normally go to the USER_FILE log, but they belong in the APP_FILE -->
     <logger name="org.apache.nifi.web.security.requests" level="INFO" additivity="false">
         <appender-ref ref="APP_FILE"/>


### PR DESCRIPTION
# Summary

[NIFI-13892](https://issues.apache.org/jira/browse/NIFI-13892) Suppressing logging for Lucene Vectorization and Memory Segment classes to avoid exposing unnecessary implementation details in the default Logback configuration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
