### PR TITLE
NIFI-13891 Update Documentation for Bootstrap Network Address

### DIFF
--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-server/src/main/java/org/apache/nifi/minifi/StandardMiNiFiServer.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-server/src/main/java/org/apache/nifi/minifi/StandardMiNiFiServer.java
@@ -42,6 +42,7 @@ public class StandardMiNiFiServer extends HeadlessNiFiServer implements MiNiFiSe
 
     private static final Logger logger = LoggerFactory.getLogger(StandardMiNiFiServer.class);
     private static final String BOOTSTRAP_PORT_PROPERTY = "nifi.bootstrap.listen.port";
+    private static final String LISTENER_BOOTSTRAP_PORT = "nifi.listener.bootstrap.port";
 
     private BootstrapListener bootstrapListener;
     private C2NifiClientService c2NifiClientService;
@@ -131,7 +132,11 @@ public class StandardMiNiFiServer extends HeadlessNiFiServer implements MiNiFiSe
 
                 bootstrapListener = new BootstrapListener(this, port);
                 NiFiProperties niFiProperties = getNiFiProperties();
-                bootstrapListener.start(niFiProperties.getDefaultListenerBootstrapPort());
+
+                // Default to 0 for random ephemeral port number
+                final String listenerBootstrapPortProperty = niFiProperties.getProperty(LISTENER_BOOTSTRAP_PORT, "0");
+                final int listenerBootstrapPort = Integer.parseInt(listenerBootstrapPortProperty);
+                bootstrapListener.start(listenerBootstrapPort);
             } catch (IOException e) {
                 throw new UncheckedIOException("Failed to start MiNiFi because of Bootstrap listener initialization error", e);
             } catch (NumberFormatException e) {

--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -84,7 +84,6 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String PROCESSOR_SCHEDULING_TIMEOUT = "nifi.processor.scheduling.timeout";
     public static final String BACKPRESSURE_COUNT = "nifi.queue.backpressure.count";
     public static final String BACKPRESSURE_SIZE = "nifi.queue.backpressure.size";
-    public static final String LISTENER_BOOTSTRAP_PORT = "nifi.listener.bootstrap.port";
     public static final String UPLOAD_WORKING_DIRECTORY = "nifi.upload.working.directory";
 
     // content repository properties
@@ -389,7 +388,6 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String DEFAULT_SECURITY_USER_SAML_HTTP_CLIENT_READ_TIMEOUT = "30 secs";
     private static final String DEFAULT_SECURITY_USER_JWS_KEY_ROTATION_PERIOD = "PT1H";
     public static final String DEFAULT_WEB_SHOULD_SEND_SERVER_VERSION = "true";
-    public static final int DEFAULT_LISTENER_BOOTSTRAP_PORT = 0;
     public static final Boolean DEFAULT_FLOW_REGISTRY_CHECK_FOR_RULE_VIOLATIONS_BEFORE_COMMIT = false;
     public static final String DEFAULT_UPLOAD_WORKING_DIR = "./work/uploads";
 
@@ -1651,10 +1649,6 @@ public class NiFiProperties extends ApplicationProperties {
 
     public String getDefaultBackPressureDataSizeThreshold() {
         return getProperty(BACKPRESSURE_SIZE, DEFAULT_BACKPRESSURE_SIZE);
-    }
-
-    public int getDefaultListenerBootstrapPort() {
-        return getIntegerProperty(LISTENER_BOOTSTRAP_PORT, DEFAULT_LISTENER_BOOTSTRAP_PORT);
     }
 
     /**

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -104,8 +104,6 @@ The following table lists the default ports used by NiFi and the corresponding p
 |Remote Input Socket Port*        | `nifi.remote.input.socket.port`       | `10443`
 |Cluster Node Protocol Port*      | `nifi.cluster.node.protocol.port`     | `11443`
 |Cluster Node Load Balancing Port | `nifi.cluster.node.load.balance.port` | `6342`
-|Web HTTP Forwarding Port         | `nifi.web.http.port.forwarding`       | _none_
-|Listener Bootstrap Port          | `nifi.listener.bootstrap.port`        | _random ephemeral_
 |==================================================================================================================================================
 
 NOTE: The ports marked with an asterisk (*) have property values that are blank by default in _nifi.properties_.
@@ -2837,11 +2835,7 @@ if the service is still running, the Bootstrap will `kill` the process, or termi
 |`java.arg.N`|Any number of JVM arguments can be passed to the NiFi JVM when the process is started. These arguments are defined by adding properties to _bootstrap.conf_ that
 begin with `java.arg.`. The rest of the property name is not relevant, other than to differentiate property names, and will be ignored. The default includes
 properties for minimum and maximum Java Heap size, the garbage collector to use, Java IO temporary directory, etc.
-|`nifi.diagnostics.on.shutdown.enabled`|(true or false) This property decides whether to run NiFi diagnostics before shutting down. The default value is `false`.
-|`nifi.diagnostics.on.shutdown.verbose`|(true or false) This property decides whether to run NiFi diagnostics in verbose mode. The default value is `false`.
-|`nifi.diagnostics.on.shutdown.directory`|This property specifies the location of the NiFi diagnostics directory. The default value is `./diagnostics`.
-|`nifi.diagnostics.on.shutdown.max.filecount`|This property specifies the maximum permitted number of diagnostic files. If the limit is exceeded, the oldest files are deleted. The default value is `10`.
-|`nifi.diagnostics.on.shutdown.max.directory.size`|This property specifies the maximum permitted size of the diagnostics directory. If the limit is exceeded, the oldest files are deleted. The default value is `10 MB`.
+|`management.server.address`|HTTP URL on which NiFi listens for management requests. Defaults to `http://127.0.0.1:52020` when not specified.
 |====
 
 [[proxy_configuration]]
@@ -3705,15 +3699,6 @@ These properties pertain to various security features in NiFi. Many of these pro
 |`nifi.security.ocsp.responder.certificate`|This is the location of the OCSP responder certificate if one is being used. It is blank by default.
 |====
 
-=== Bootstrap Properties
-
-These properties pertain to the connection NiFi uses to receive communications from NiFi Bootstrap.
-
-|====
-|*Property*|*Description*
-|`nifi.listener.bootstrap.port`|This property defines the port used to listen for communications from NiFi Bootstrap. If this property is missing, empty, or `0`, a random ephemeral port is used.
-|====
-
 === Identity Mapping Properties
 
 These properties can be utilized to normalize user identities.  When implemented, identities authenticated by different identity providers (certificates, LDAP, Kerberos) are treated the same internally in NiFi.  As a result, duplicate users are avoided and user-specific configurations such as authorizations only need to be setup once per user.
@@ -4286,11 +4271,14 @@ The `--verbose` flag may be provided as an option before the filename, which may
 
 NiFi can be configured to automatically execute the diagnostics command in the event of a shutdown. The feature is disabled by default and can be enabled with the `nifi.diagnostics.on.shutdown.enabled` property in the `nifi.properties` configuration file. It is also possible to configure where the files should be stored and how many files should be kept using the below properties:
 
-```
-nifi.diagnostics.on.shutdown.directory=./diagnostics
-nifi.diagnostics.on.shutdown.max.filecount=10
-nifi.diagnostics.on.shutdown.max.directory.size=10 MB
-```
+|====
+|*Property*|*Description*
+|`nifi.diagnostics.on.shutdown.enabled`|(true or false) This property decides whether to run NiFi diagnostics before shutting down. The default value is `false`.
+|`nifi.diagnostics.on.shutdown.verbose`|(true or false) This property decides whether to run NiFi diagnostics in verbose mode. The default value is `false`.
+|`nifi.diagnostics.on.shutdown.directory`|This property specifies the location of the NiFi diagnostics directory. The default value is `./diagnostics`.
+|`nifi.diagnostics.on.shutdown.max.filecount`|This property specifies the maximum permitted number of diagnostic files. If the limit is exceeded, the oldest files are deleted. The default value is `10`.
+|`nifi.diagnostics.on.shutdown.max.directory.size`|This property specifies the maximum permitted size of the diagnostics directory. If the limit is exceeded, the oldest files are deleted. The default value is `10 MB`.
+|====
 
 In the case of a lengthy diagnostic, NiFi may terminate before the command execution ends. In this case, the `graceful.shutdown.seconds` property should be set to a higher value in the `bootstrap.conf` configuration file.
 

--- a/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -163,9 +163,6 @@
         <nifi.security.ocsp.responder.url />
         <nifi.security.ocsp.responder.certificate />
 
-        <!-- nifi.properties: listener bootstrap -->
-        <nifi.listener.bootstrap.port>0</nifi.listener.bootstrap.port>
-
         <!-- nifi.properties: openid connect -->
         <nifi.security.user.oidc.discovery.url />
         <nifi.security.user.oidc.connect.timeout>5 secs</nifi.security.user.oidc.connect.timeout>

--- a/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -252,11 +252,6 @@ nifi.security.user.saml.http.client.read.timeout=${nifi.security.user.saml.http.
 # nifi.security.group.mapping.value.anygroup=$1
 # nifi.security.group.mapping.transform.anygroup=LOWER
 
-# Listener Bootstrap properties #
-# This property defines the port used to listen for communications from NiFi Bootstrap. If this property
-# is missing, empty, or 0, a random ephemeral port is used.
-nifi.listener.bootstrap.port=${nifi.listener.bootstrap.port}
-
 # cluster common properties (all nodes must have same values) #
 nifi.cluster.protocol.heartbeat.interval=${nifi.cluster.protocol.heartbeat.interval}
 nifi.cluster.protocol.heartbeat.missable.max=${nifi.cluster.protocol.heartbeat.missable.max}


### PR DESCRIPTION
# Summary

[NIFI-13891](https://issues.apache.org/jira/browse/NIFI-13891) Updates the documentation and default `nifi.properties` files to reflect the refactored Bootstrap Management Server configuration.

- Removed unused `nifi.listener.bootstrap.port` property from `nifi.properties`
- Added documentation for `management.server.address` property in `bootstrap.conf`
- Corrected location of `nifi.diagnostics.on.shutdown property` documentation
- Added localized handling to bootstrap port property in `StandardMiNiFiServer`

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
