### PR TITLE
NIFI-13898 Upgrade Lucene from 9.12.0 to 10.0.0

### DIFF
--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/QueryTask.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/QueryTask.java
@@ -179,7 +179,7 @@ public class QueryTask implements Runnable {
 
     private Tuple<List<ProvenanceEventRecord>, Long> readDocuments(final TopDocs topDocs, final StoredFields storedFields) {
         // If no topDocs is supplied, just provide a Tuple that has no records and a hit count of 0.
-        if (topDocs == null || topDocs.totalHits.value == 0) {
+        if (topDocs == null || topDocs.totalHits.value() == 0) {
             return new Tuple<>(Collections.<ProvenanceEventRecord> emptyList(), 0L);
         }
 
@@ -210,7 +210,7 @@ public class QueryTask implements Runnable {
         final long fetchEventNanos = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - endConvert);
         logger.debug("Fetching {} events from Event Store took {} ms ({} events actually fetched)", eventIds.size(), fetchEventNanos, events.size());
 
-        final long totalHits = topDocs.totalHits.value;
+        final long totalHits = topDocs.totalHits.value();
         return new Tuple<>(events, totalHits);
     }
 

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/lucene/TestSimpleIndexManager.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/test/java/org/apache/nifi/provenance/lucene/TestSimpleIndexManager.java
@@ -97,7 +97,7 @@ public class TestSimpleIndexManager {
 
             final EventIndexSearcher searcher = mgr.borrowIndexSearcher(dir);
             final TopDocs topDocs = searcher.getIndexSearcher().search(new MatchAllDocsQuery(), 2);
-            assertEquals(2, topDocs.totalHits.value);
+            assertEquals(2, topDocs.totalHits.value());
             mgr.returnIndexSearcher(searcher);
         } finally {
             FileUtils.deleteFile(dir, true);

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/pom.xml
@@ -27,7 +27,7 @@
         <module>nifi-provenance-repository-nar</module>
     </modules>
     <properties>
-        <lucene.version>9.12.0</lucene.version>
+        <lucene.version>10.0.0</lucene.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
# Summary

[NIFI-13898](https://issues.apache.org/jira/browse/NIFI-13898) Upgrades Apache Lucene dependencies for the Provenance Repository from 9.12.0 to [10.0.0](https://lucene.apache.org/core/10_0_0/changes/Changes.html).

Minor adjustments include changing the value accessor for the Lucene `TotalHits` as described in Lucene Issue https://github.com/apache/lucene/pull/13762.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
