### PR TITLE
NIFI-13900 Fix Jetty Servlet Mapping Log Warnings

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/JettyServer.java
@@ -115,6 +115,7 @@ import org.eclipse.jetty.deploy.App;
 import org.eclipse.jetty.deploy.AppProvider;
 import org.eclipse.jetty.deploy.DeploymentManager;
 import org.eclipse.jetty.ee10.servlet.FilterMapping;
+import org.eclipse.jetty.ee10.servlet.ResourceServlet;
 import org.eclipse.jetty.ee10.servlet.ServletHandler;
 import org.eclipse.jetty.ee10.webapp.MetaInfConfiguration;
 import org.eclipse.jetty.rewrite.handler.RedirectPatternRule;
@@ -126,7 +127,6 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.ee10.servlet.DefaultServlet;
 import org.eclipse.jetty.ee10.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
@@ -316,6 +316,7 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
 
         // add a rewrite error handler for the ui to handle 404
         final RewriteHandler uiErrorHandler = new RewriteHandler();
+        uiErrorHandler.setServer(server);
         final RedirectPatternRule redirectToUi = new RedirectPatternRule("/*", "/nifi/#/404");
         uiErrorHandler.addRule(redirectToUi);
         webUiContext.setErrorHandler(uiErrorHandler);
@@ -707,13 +708,13 @@ public class JettyServer implements NiFiServer, ExtensionUiLoader {
         try {
             final File docsDir = getDocsDir();
 
-            final ServletHolder docs = new ServletHolder("docs", DefaultServlet.class);
+            final ServletHolder docs = new ServletHolder("docs", ResourceServlet.class);
             final Path htmlBaseResource = docsDir.toPath().resolve("html");
             docs.setInitParameter("baseResource", htmlBaseResource.toString());
             docs.setInitParameter("dirAllowed", "false");
             webAppContext.addServlet(docs, "/html/*");
 
-            final ServletHolder restApi = new ServletHolder("rest-api", DefaultServlet.class);
+            final ServletHolder restApi = new ServletHolder("rest-api", ResourceServlet.class);
             final File webApiDocsDir = getWebApiDocsDir();
             restApi.setInitParameter("baseResource", webApiDocsDir.getPath());
             restApi.setInitParameter("dirAllowed", "false");


### PR DESCRIPTION
# Summary

[NIFI-13900](https://issues.apache.org/jira/browse/NIFI-13900) Resolves log warning messages from Jetty server related to missing configuration and non-preferred servlet selection for hosting documentation resources.

With these changes, the warning messages are no longer logged.

```
WARN [main] o.eclipse.jetty.server.Handler$Abstract No Server set for oejrh.RewriteHandler@17a644eb{STARTING}
WARN [NiFi Web Server-144] o.e.jetty.ee10.servlet.DefaultServlet Incorrect mapping for DefaultServlet at /html/*. Use ResourceServlet
```

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
