### PR TITLE
NIFI-13724 - Added additional metadata to events (#9239) on 1.x branch

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/EventFactory.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/EventFactory.java
@@ -28,58 +28,59 @@ import org.apache.nifi.registry.hook.EventFieldName;
 import org.apache.nifi.registry.hook.EventType;
 import org.apache.nifi.registry.security.authorization.user.NiFiUserUtils;
 
+import java.util.Objects;
+
 /**
  * Factory to create Events from domain objects.
  */
 public class EventFactory {
 
     public static Event bucketCreated(final Bucket bucket) {
-        return new StandardEvent.Builder()
-                .eventType(EventType.CREATE_BUCKET)
-                .addField(EventFieldName.BUCKET_ID, bucket.getIdentifier())
-                .addField(EventFieldName.USER, NiFiUserUtils.getNiFiUserIdentity())
-                .build();
+        return bucketEvent(bucket, EventType.CREATE_BUCKET);
     }
 
     public static Event bucketUpdated(final Bucket bucket) {
-        return new StandardEvent.Builder()
-                .eventType(EventType.UPDATE_BUCKET)
-                .addField(EventFieldName.BUCKET_ID, bucket.getIdentifier())
-                .addField(EventFieldName.USER, NiFiUserUtils.getNiFiUserIdentity())
-                .build();
+        return bucketEvent(bucket, EventType.UPDATE_BUCKET);
     }
 
     public static Event bucketDeleted(final Bucket bucket) {
+            return bucketEvent(bucket, EventType.DELETE_BUCKET);
+    }
+
+    private static Event bucketEvent(final Bucket bucket, EventType eventType) {
         return new StandardEvent.Builder()
-                .eventType(EventType.DELETE_BUCKET)
+                .eventType(eventType)
                 .addField(EventFieldName.BUCKET_ID, bucket.getIdentifier())
+                .addField(EventFieldName.BUCKET_NAME, bucket.getName())
+                .addField(EventFieldName.BUCKET_DESCRIPTION, Objects.requireNonNullElse(bucket.getDescription(), "")) //Empty string if Null
+                .addField(EventFieldName.CREATED_TIMESTAMP, String.valueOf(bucket.getCreatedTimestamp()))
+                .addField(EventFieldName.ALLOW_PUBLIC_READ, (bucket.isAllowPublicRead() == null) ? "" : String.valueOf(bucket.isAllowPublicRead())) //Empty string if Null
                 .addField(EventFieldName.USER, NiFiUserUtils.getNiFiUserIdentity())
                 .build();
     }
 
     public static Event flowCreated(final VersionedFlow versionedFlow) {
-        return new StandardEvent.Builder()
-                .eventType(EventType.CREATE_FLOW)
-                .addField(EventFieldName.BUCKET_ID, versionedFlow.getBucketIdentifier())
-                .addField(EventFieldName.FLOW_ID, versionedFlow.getIdentifier())
-                .addField(EventFieldName.USER, NiFiUserUtils.getNiFiUserIdentity())
-                .build();
+        return flowEvent(versionedFlow, EventType.CREATE_FLOW);
     }
 
     public static Event flowUpdated(final VersionedFlow versionedFlow) {
-        return new StandardEvent.Builder()
-                .eventType(EventType.UPDATE_FLOW)
-                .addField(EventFieldName.BUCKET_ID, versionedFlow.getBucketIdentifier())
-                .addField(EventFieldName.FLOW_ID, versionedFlow.getIdentifier())
-                .addField(EventFieldName.USER, NiFiUserUtils.getNiFiUserIdentity())
-                .build();
+        return flowEvent(versionedFlow, EventType.UPDATE_FLOW);
     }
 
     public static Event flowDeleted(final VersionedFlow versionedFlow) {
+        return flowEvent(versionedFlow, EventType.DELETE_FLOW);
+    }
+
+    private static Event flowEvent(final VersionedFlow versionedFlow, EventType eventType) {
         return new StandardEvent.Builder()
-                .eventType(EventType.DELETE_FLOW)
+                .eventType(eventType)
                 .addField(EventFieldName.BUCKET_ID, versionedFlow.getBucketIdentifier())
+                .addField(EventFieldName.BUCKET_NAME, Objects.requireNonNullElse(versionedFlow.getBucketName(), "")) //Empty string if Null
                 .addField(EventFieldName.FLOW_ID, versionedFlow.getIdentifier())
+                .addField(EventFieldName.FLOW_NAME, Objects.requireNonNullElse(versionedFlow.getName(), ""))
+                .addField(EventFieldName.FLOW_DESCRIPTION, Objects.requireNonNullElse(versionedFlow.getDescription(), ""))
+                .addField(EventFieldName.CREATED_TIMESTAMP, String.valueOf(versionedFlow.getCreatedTimestamp()))
+                .addField(EventFieldName.MODIFIED_TIMESTAMP, String.valueOf(versionedFlow.getModifiedTimestamp()))
                 .addField(EventFieldName.USER, NiFiUserUtils.getNiFiUserIdentity())
                 .build();
     }
@@ -91,8 +92,11 @@ public class EventFactory {
         return new StandardEvent.Builder()
                 .eventType(EventType.CREATE_FLOW_VERSION)
                 .addField(EventFieldName.BUCKET_ID, versionedFlowSnapshot.getSnapshotMetadata().getBucketIdentifier())
+                .addField(EventFieldName.BUCKET_NAME, (versionedFlowSnapshot.getBucket() == null) ? "" : Objects.requireNonNullElse(versionedFlowSnapshot.getBucket().getName(), ""))
                 .addField(EventFieldName.FLOW_ID, versionedFlowSnapshot.getSnapshotMetadata().getFlowIdentifier())
+                .addField(EventFieldName.FLOW_NAME, (versionedFlowSnapshot.getBucket() == null) ? "" : Objects.requireNonNullElse(versionedFlowSnapshot.getFlow().getName(), ""))
                 .addField(EventFieldName.VERSION, String.valueOf(versionedFlowSnapshot.getSnapshotMetadata().getVersion()))
+                .addField(EventFieldName.MODIFIED_TIMESTAMP, String.valueOf(versionedFlowSnapshot.getSnapshotMetadata().getTimestamp()))
                 .addField(EventFieldName.USER, versionedFlowSnapshot.getSnapshotMetadata().getAuthor())
                 .addField(EventFieldName.COMMENT, versionComments)
                 .build();

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/EventFactory.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/event/EventFactory.java
@@ -28,7 +28,7 @@ import org.apache.nifi.registry.hook.EventFieldName;
 import org.apache.nifi.registry.hook.EventType;
 import org.apache.nifi.registry.security.authorization.user.NiFiUserUtils;
 
-import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Factory to create Events from domain objects.
@@ -52,7 +52,7 @@ public class EventFactory {
                 .eventType(eventType)
                 .addField(EventFieldName.BUCKET_ID, bucket.getIdentifier())
                 .addField(EventFieldName.BUCKET_NAME, bucket.getName())
-                .addField(EventFieldName.BUCKET_DESCRIPTION, Objects.requireNonNullElse(bucket.getDescription(), "")) //Empty string if Null
+                .addField(EventFieldName.BUCKET_DESCRIPTION, Optional.ofNullable(bucket.getDescription()).orElse("")) //Empty string if Null
                 .addField(EventFieldName.CREATED_TIMESTAMP, String.valueOf(bucket.getCreatedTimestamp()))
                 .addField(EventFieldName.ALLOW_PUBLIC_READ, (bucket.isAllowPublicRead() == null) ? "" : String.valueOf(bucket.isAllowPublicRead())) //Empty string if Null
                 .addField(EventFieldName.USER, NiFiUserUtils.getNiFiUserIdentity())
@@ -75,10 +75,10 @@ public class EventFactory {
         return new StandardEvent.Builder()
                 .eventType(eventType)
                 .addField(EventFieldName.BUCKET_ID, versionedFlow.getBucketIdentifier())
-                .addField(EventFieldName.BUCKET_NAME, Objects.requireNonNullElse(versionedFlow.getBucketName(), "")) //Empty string if Null
+                .addField(EventFieldName.BUCKET_NAME, Optional.ofNullable(versionedFlow.getBucketName()).orElse("")) //Empty string if Null
                 .addField(EventFieldName.FLOW_ID, versionedFlow.getIdentifier())
-                .addField(EventFieldName.FLOW_NAME, Objects.requireNonNullElse(versionedFlow.getName(), ""))
-                .addField(EventFieldName.FLOW_DESCRIPTION, Objects.requireNonNullElse(versionedFlow.getDescription(), ""))
+                .addField(EventFieldName.FLOW_NAME, Optional.ofNullable(versionedFlow.getName()).orElse(""))
+                .addField(EventFieldName.FLOW_DESCRIPTION, Optional.ofNullable(versionedFlow.getDescription()).orElse(""))
                 .addField(EventFieldName.CREATED_TIMESTAMP, String.valueOf(versionedFlow.getCreatedTimestamp()))
                 .addField(EventFieldName.MODIFIED_TIMESTAMP, String.valueOf(versionedFlow.getModifiedTimestamp()))
                 .addField(EventFieldName.USER, NiFiUserUtils.getNiFiUserIdentity())
@@ -92,9 +92,9 @@ public class EventFactory {
         return new StandardEvent.Builder()
                 .eventType(EventType.CREATE_FLOW_VERSION)
                 .addField(EventFieldName.BUCKET_ID, versionedFlowSnapshot.getSnapshotMetadata().getBucketIdentifier())
-                .addField(EventFieldName.BUCKET_NAME, (versionedFlowSnapshot.getBucket() == null) ? "" : Objects.requireNonNullElse(versionedFlowSnapshot.getBucket().getName(), ""))
+                .addField(EventFieldName.BUCKET_NAME, (versionedFlowSnapshot.getBucket() == null) ? "" : Optional.ofNullable(versionedFlowSnapshot.getBucket().getName()).orElse(""))
                 .addField(EventFieldName.FLOW_ID, versionedFlowSnapshot.getSnapshotMetadata().getFlowIdentifier())
-                .addField(EventFieldName.FLOW_NAME, (versionedFlowSnapshot.getBucket() == null) ? "" : Objects.requireNonNullElse(versionedFlowSnapshot.getFlow().getName(), ""))
+                .addField(EventFieldName.FLOW_NAME, (versionedFlowSnapshot.getBucket() == null) ? "" : Optional.ofNullable(versionedFlowSnapshot.getFlow().getName()).orElse(""))
                 .addField(EventFieldName.VERSION, String.valueOf(versionedFlowSnapshot.getSnapshotMetadata().getVersion()))
                 .addField(EventFieldName.MODIFIED_TIMESTAMP, String.valueOf(versionedFlowSnapshot.getSnapshotMetadata().getTimestamp()))
                 .addField(EventFieldName.USER, versionedFlowSnapshot.getSnapshotMetadata().getAuthor())

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/event/TestEventService.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/event/TestEventService.java
@@ -53,6 +53,8 @@ public class TestEventService {
     @Test
     public void testPublishConsume() throws InterruptedException {
         final Bucket bucket = new Bucket();
+        bucket.setName("bucket1");
+        bucket.setDescription("bucketDescription");
         bucket.setIdentifier(UUID.randomUUID().toString());
 
         final Event bucketCreatedEvent = EventFactory.bucketCreated(bucket);

--- a/nifi-registry/nifi-registry-core/nifi-registry-provider-api/src/main/java/org/apache/nifi/registry/hook/EventFieldName.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-provider-api/src/main/java/org/apache/nifi/registry/hook/EventFieldName.java
@@ -21,8 +21,15 @@ package org.apache.nifi.registry.hook;
  */
 public enum EventFieldName {
 
+    ALLOW_PUBLIC_READ,
     BUCKET_ID,
+    BUCKET_NAME,
+    BUCKET_DESCRIPTION,
     FLOW_ID,
+    FLOW_NAME,
+    FLOW_DESCRIPTION,
+    CREATED_TIMESTAMP,
+    MODIFIED_TIMESTAMP,
     EXTENSION_BUNDLE_ID,
     VERSION,
     USER,

--- a/nifi-registry/nifi-registry-core/nifi-registry-provider-api/src/main/java/org/apache/nifi/registry/hook/EventType.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-provider-api/src/main/java/org/apache/nifi/registry/hook/EventType.java
@@ -30,15 +30,27 @@ public enum EventType {
 
     CREATE_BUCKET(
             EventFieldName.BUCKET_ID,
+            EventFieldName.BUCKET_NAME,
+            EventFieldName.BUCKET_DESCRIPTION,
+            EventFieldName.CREATED_TIMESTAMP,
+            EventFieldName.ALLOW_PUBLIC_READ,
             EventFieldName.USER),
     CREATE_FLOW(
             EventFieldName.BUCKET_ID,
+            EventFieldName.BUCKET_NAME,
             EventFieldName.FLOW_ID,
+            EventFieldName.FLOW_NAME,
+            EventFieldName.FLOW_DESCRIPTION,
+            EventFieldName.CREATED_TIMESTAMP,
+            EventFieldName.MODIFIED_TIMESTAMP,
             EventFieldName.USER),
     CREATE_FLOW_VERSION(
             EventFieldName.BUCKET_ID,
+            EventFieldName.BUCKET_NAME,
             EventFieldName.FLOW_ID,
+            EventFieldName.FLOW_NAME,
             EventFieldName.VERSION,
+            EventFieldName.MODIFIED_TIMESTAMP,
             EventFieldName.USER,
             EventFieldName.COMMENT),
     CREATE_EXTENSION_BUNDLE(
@@ -55,17 +67,35 @@ public enum EventType {
     REGISTRY_START(),
     UPDATE_BUCKET(
             EventFieldName.BUCKET_ID,
+            EventFieldName.BUCKET_NAME,
+            EventFieldName.BUCKET_DESCRIPTION,
+            EventFieldName.CREATED_TIMESTAMP,
+            EventFieldName.ALLOW_PUBLIC_READ,
             EventFieldName.USER),
     UPDATE_FLOW(
             EventFieldName.BUCKET_ID,
+            EventFieldName.BUCKET_NAME,
             EventFieldName.FLOW_ID,
+            EventFieldName.FLOW_NAME,
+            EventFieldName.FLOW_DESCRIPTION,
+            EventFieldName.CREATED_TIMESTAMP,
+            EventFieldName.MODIFIED_TIMESTAMP,
             EventFieldName.USER),
     DELETE_BUCKET(
             EventFieldName.BUCKET_ID,
+            EventFieldName.BUCKET_NAME,
+            EventFieldName.BUCKET_DESCRIPTION,
+            EventFieldName.CREATED_TIMESTAMP,
+            EventFieldName.ALLOW_PUBLIC_READ,
             EventFieldName.USER),
     DELETE_FLOW(
             EventFieldName.BUCKET_ID,
+            EventFieldName.BUCKET_NAME,
             EventFieldName.FLOW_ID,
+            EventFieldName.FLOW_NAME,
+            EventFieldName.FLOW_DESCRIPTION,
+            EventFieldName.CREATED_TIMESTAMP,
+            EventFieldName.MODIFIED_TIMESTAMP,
             EventFieldName.USER),
     DELETE_EXTENSION_BUNDLE(
             EventFieldName.BUCKET_ID,


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13724](https://issues.apache.org/jira/browse/NIFI-13724)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X ] Pull Request based on current revision of the `main` branch
- [X ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ X] Build completed using `mvn clean install -P contrib-check`
  - [ X] JDK 21

### Licensing

- [ n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ X] Documentation formatting appears as expected in rendered files