### PR TITLE
[NIFI-13869] - Enhance QuerySalesforceObject Processor to Support Querying Deleted Records

### DIFF
--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/rest/SalesforceRestClient.java
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/rest/SalesforceRestClient.java
@@ -57,6 +57,14 @@ public class SalesforceRestClient {
         return executeRequest(request);
     }
 
+    public InputStream queryAll(String query) {
+        HttpUrl httpUrl = HttpUrl.get(getUrl("/queryAll")).newBuilder()
+                .addQueryParameter("q", query)
+                .build();
+        Request request = buildGetRequest(httpUrl.toString());
+        return executeRequest(request);
+    }
+
     public InputStream getNextRecords(String nextRecordsUrl) {
         HttpUrl httpUrl = HttpUrl.get(configuration.getInstanceUrl() + nextRecordsUrl).newBuilder().build();
         Request request = buildGetRequest(httpUrl.toString());


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13869](https://issues.apache.org/jira/browse/NIFI-13869)

Enhance the `QuerySalesforceObject` processor to support querying deleted records (soft-deletes) from Salesforce. This enhancement introduces a new boolean property `Include Deleted Records` that allows users to include deleted records in their queries. When enabled, the processor automatically includes the `IsDeleted` field in the SELECT clause and utilizes the `queryAll` Salesforce API endpoint to retrieve both active and deleted records. This functionality is essential for scenarios requiring audit trails, compliance tracking, and monitoring record deletions.

**Key Changes:**
- **New Property Added:**
  - `Include Deleted Records` (Boolean): Enables the inclusion of deleted records in Salesforce queries.
  
- **Query Modification:**
  - When `Include Deleted Records` is set to `true`, the `IsDeleted` field is added to the SELECT statement if not already present.
  - The processor switches from using the `/query` endpoint to the `/queryAll` endpoint to fetch both active and deleted records.
  
- **SalesforceRestClient Updates:**
  - Added a new method `queryAll(String query)` to support the `/queryAll` API endpoint.
  
- **Backward Compatibility:**
  - The default behavior remains unchanged (`Include Deleted Records` is `false`), ensuring existing workflows are not disrupted unless explicitly enabled.
  
- **State Management:**
  - Updated state reset logic to account for changes in the `Include Deleted Records` property, ensuring consistent behavior upon property modifications.
  
- **Documentation:**
  - Updated processor annotations and descriptions to reflect the new functionality and guide users on utilizing the `Include Deleted Records` property.

This enhancement allows users to effectively track and manage deleted records within their Salesforce integrations, aligning with audit and compliance requirements without affecting existing data retrieval processes.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-13869) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-13869`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-13869`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
- [x] Processor annotations and descriptions updated to include new property and functionality
- [x] User-facing documentation (if applicable) updated to guide on using `Include Deleted Records`

### Testing

- [ ] Unit tests added to cover new functionality
- [ ] All existing tests pass successfully
- [x] Backward compatibility confirmed by ensuring default behavior excludes deleted records

### Code Review

- [x] Code adheres to Apache NiFi coding standards and guidelines
- [x] Code reviewed for readability, maintainability, and performance considerations
- [ ] No warnings or errors reported by static analysis tools

