### PR TITLE
NIFI-13904 - Fix CLI commands to set/remove parameter context inheritance

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/FetchParams.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/FetchParams.java
@@ -23,11 +23,13 @@ import org.apache.nifi.toolkit.cli.api.CommandException;
 import org.apache.nifi.toolkit.cli.api.Context;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClient;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.ParamContextClient;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.ParamProviderClient;
 import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
 import org.apache.nifi.toolkit.cli.impl.result.nifi.ParamProviderResult;
 import org.apache.nifi.toolkit.cli.impl.util.JacksonUtils;
+import org.apache.nifi.web.api.entity.ParameterContextsEntity;
 import org.apache.nifi.web.api.entity.ParameterProviderApplyParametersRequestEntity;
 import org.apache.nifi.web.api.entity.ParameterProviderEntity;
 import org.apache.nifi.web.api.entity.ParameterProviderParameterApplicationEntity;
@@ -81,6 +83,8 @@ public class FetchParams extends AbstractNiFiCommand<ParamProviderResult> {
             parameterApplicationEntity = objectMapper.readValue(parameterApplicationJson, ParameterProviderParameterApplicationEntity.class);
         }
         final ParamProviderClient paramProviderClient = client.getParamProviderClient();
+        final ParamContextClient paramContextClient = client.getParamContextClient();
+        final ParameterContextsEntity paramContextEntity = paramContextClient.getParamContexts();
         final ParameterProviderEntity existingParameterProvider = paramProviderClient.getParamProvider(paramProviderId);
 
         final ParameterProviderParameterFetchEntity fetchEntity = new ParameterProviderParameterFetchEntity();
@@ -92,7 +96,7 @@ public class FetchParams extends AbstractNiFiCommand<ParamProviderResult> {
             applyParametersAndWait(paramProviderClient, fetchedParameterProvider, parameterApplicationEntity, sensitiveParamPattern);
         }
 
-        return new ParamProviderResult(getResultType(properties), fetchedParameterProvider);
+        return new ParamProviderResult(getResultType(properties), fetchedParameterProvider, paramContextEntity);
     }
 
     private void applyParametersAndWait(final ParamProviderClient paramProviderClient, final ParameterProviderEntity fetchedParameterProvider,

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/GetParamProvider.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/GetParamProvider.java
@@ -21,10 +21,12 @@ import org.apache.nifi.toolkit.cli.api.CommandException;
 import org.apache.nifi.toolkit.cli.api.Context;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClient;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.ParamContextClient;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.ParamProviderClient;
 import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
 import org.apache.nifi.toolkit.cli.impl.result.nifi.ParamProviderResult;
+import org.apache.nifi.web.api.entity.ParameterContextsEntity;
 import org.apache.nifi.web.api.entity.ParameterProviderEntity;
 
 import java.io.IOException;
@@ -51,7 +53,9 @@ public class GetParamProvider extends AbstractNiFiCommand<ParamProviderResult> {
             throws NiFiClientException, IOException, MissingOptionException, CommandException {
         final String paramProviderId = getRequiredArg(properties, CommandOption.PARAM_PROVIDER_ID);
         final ParamProviderClient paramProviderClient = client.getParamProviderClient();
+        final ParamContextClient paramContextClient = client.getParamContextClient();
+        final ParameterContextsEntity paramContextEntity = paramContextClient.getParamContexts();
         final ParameterProviderEntity parameterProvider = paramProviderClient.getParamProvider(paramProviderId);
-        return new ParamProviderResult(getResultType(properties), parameterProvider);
+        return new ParamProviderResult(getResultType(properties), parameterProvider, paramContextEntity);
     }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/RemoveInheritedParamContexts.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/RemoveInheritedParamContexts.java
@@ -69,6 +69,14 @@ public class RemoveInheritedParamContexts extends AbstractUpdateParamContextComm
         parameterContextDTO.setId(existingParameterContextEntity.getId());
         parameterContextDTO.setParameters(existingParameterContextEntity.getComponent().getParameters());
 
+        // we need to explicitly set null for the sensitive parameters as we are getting **** for the values
+        // on the client side. This is the only way for the server side to know that the values are not changed
+        // during the update parameter context request
+        parameterContextDTO.getParameters()
+            .stream()
+            .filter(t -> t.getParameter().getSensitive().booleanValue())
+            .forEach(t -> t.getParameter().setValue(null));
+
         final ParameterContextEntity updatedParameterContextEntity = new ParameterContextEntity();
         updatedParameterContextEntity.setId(paramContextId);
         updatedParameterContextEntity.setComponent(parameterContextDTO);

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/SetInheritedParamContexts.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/SetInheritedParamContexts.java
@@ -87,6 +87,14 @@ public class SetInheritedParamContexts extends AbstractUpdateParamContextCommand
         parameterContextDTO.setId(existingParameterContextEntity.getId());
         parameterContextDTO.setParameters(existingParameterContextEntity.getComponent().getParameters());
 
+        // we need to explicitly set null for the sensitive parameters as we are getting **** for the values
+        // on the client side. This is the only way for the server side to know that the values are not changed
+        // during the update parameter context request
+        parameterContextDTO.getParameters()
+            .stream()
+            .filter(t -> t.getParameter().getSensitive().booleanValue())
+            .forEach(t -> t.getParameter().setValue(null));
+
         final ParameterContextEntity updatedParameterContextEntity = new ParameterContextEntity();
         updatedParameterContextEntity.setId(paramContextId);
         updatedParameterContextEntity.setComponent(parameterContextDTO);

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/ParamProviderResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/ParamProviderResult.java
@@ -22,6 +22,7 @@ import org.apache.nifi.toolkit.cli.impl.result.writer.DynamicTableWriter;
 import org.apache.nifi.toolkit.cli.impl.result.writer.Table;
 import org.apache.nifi.toolkit.cli.impl.result.writer.TableWriter;
 import org.apache.nifi.web.api.dto.ParameterProviderDTO;
+import org.apache.nifi.web.api.entity.ParameterContextsEntity;
 import org.apache.nifi.web.api.entity.ParameterGroupConfigurationEntity;
 import org.apache.nifi.web.api.entity.ParameterProviderEntity;
 
@@ -35,10 +36,13 @@ import java.util.List;
 public class ParamProviderResult extends AbstractWritableResult<ParameterProviderEntity> {
 
     private final ParameterProviderEntity parameterProvider;
+    private final ParameterContextsEntity parameterContexts;
 
-    public ParamProviderResult(final ResultType resultType, final ParameterProviderEntity parameterProvider) {
+    public ParamProviderResult(final ResultType resultType, final ParameterProviderEntity parameterProvider,
+            final ParameterContextsEntity paramContextEntity) {
         super(resultType);
         this.parameterProvider = parameterProvider;
+        this.parameterContexts = paramContextEntity;
     }
 
     @Override
@@ -59,6 +63,7 @@ public class ParamProviderResult extends AbstractWritableResult<ParameterProvide
         }
         final Table fetchedParametersTable = new Table.Builder()
                 .column("Parameter Group", 20, 60, false)
+                .column("Parameter Context Id", 36, 36, false)
                 .column("Parameter Context Name", 20, 60, false)
                 .column("Fetched Parameter Name", 20, 60, false)
                 .build();
@@ -67,6 +72,7 @@ public class ParamProviderResult extends AbstractWritableResult<ParameterProvide
                 group.getParameterSensitivities().keySet().stream().sorted()
                         .forEach(param -> fetchedParametersTable.addRow(new String[] {
                                 group.getGroupName(),
+                                getParameterContextId(group.getParameterContextName()),
                                 group.getParameterContextName(),
                                 param
                         }));
@@ -81,6 +87,16 @@ public class ParamProviderResult extends AbstractWritableResult<ParameterProvide
         if (!fetchedParametersTable.getRows().isEmpty()) {
             tableWriter.write(fetchedParametersTable, output);
         }
+    }
+
+    private String getParameterContextId(final String name) {
+        return parameterContexts.getParameterContexts()
+                .stream()
+                .filter(t -> t.getComponent().getName().equals(name))
+                .findFirst()
+                .get()
+                .getComponent()
+                .getId();
     }
 
     @Override


### PR DESCRIPTION
# Summary

[NIFI-13904](https://issues.apache.org/jira/browse/NIFI-13904) - Linking Parameter Contexts using NiFi Toolkit causes sensitive parameters to become invalid

The current implementation of the CLI for setting / removing the parameter context inheritance is broken when the parameter context to update contains sensitive parameters. The reason is that, currently, the update parameter request is adding all of the parameter entities in the request. However, when we retrieve sensitive parameters, we never really retrieve the sensitive values on the client side, we only get `*****` strings. Because of this, the current update request is actually updating the values of the sensitive parameters to this  `*****` value and this is what makes referencing components invalid. The update request needs to be updated so that the value of the sensitive parameters is explicitly set to `null` so that the backend knows that the sensitive parameters are not changed by this update request.

This pull request also slightly improves the display output of parameters retrieved via a parameter provider. I'm happy to put this into a separate PR if we think this is better. While reproducing the issue, I noticed that the command to fetch parameters from a parameter provider is not giving information about the created parameter contexts so this additional information can be useful and removes the need for listing parameter contexts.

Example:

````
./bin/cli.sh nifi fetch-params -p nifi-cli.properties -ppid b56a9960-0192-1000-b4f7-33908ea4027f --sensitiveParamPattern ".*ensitive.*" --applyParameters

Property Name                 Property Value
---------------------------   ------------------------------------------------------
parameter-group-directories   /Users/pierre/dev/nifi_use_cases/NIFI-13904/parameters
parameter-value-byte-limit    256 B
parameter-value-encoding      plaintext


Parameter Group   Parameter Context Id                   Parameter Context Name   Fetched Parameter Name
---------------   ------------------------------------   ----------------------   ----------------------
parameters        b56e3ce7-0192-1000-65fd-1ce89d329bbe   parameters               myParameter
parameters        b56e3ce7-0192-1000-65fd-1ce89d329bbe   parameters               mySensitiveParameter
````

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
