### PR TITLE
[NIFI-13920] fix draggable icon color while dragging

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/new-canvas-item/_new-canvas-item.component-theme.scss
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/new-canvas-item/_new-canvas-item.component-theme.scss
@@ -59,7 +59,7 @@
 
             &.cdk-drag-dragging {
                 color: $material-theme-secondary-palette-default;
-                mix-blend-mode: hard-light; // Make sure the dragged icon is always visible
+                mix-blend-mode: difference; // Make sure the dragged icon is always visible
             }
         }
 


### PR DESCRIPTION
Restore dragging icon color:

![Kapture 2024-10-22 at 17 56 43](https://github.com/user-attachments/assets/28c7cf80-6363-43df-b5ec-a4d795da2c43)
