### PR TITLE
NIFI-13924 - Fix NiFi CLI delete-param command

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/DeleteParam.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/params/DeleteParam.java
@@ -83,6 +83,7 @@ public class DeleteParam extends AbstractUpdateParamContextCommand<VoidResult> {
         parameterDTO.setValue(null);
         parameterDTO.setDescription(null);
         parameterDTO.setSensitive(null);
+        parameterDTO.setReferencedAssets(null);
 
         final ParameterEntity parameterEntity = new ParameterEntity();
         parameterEntity.setParameter(parameterDTO);


### PR DESCRIPTION
# Summary

[NIFI-13924](https://issues.apache.org/jira/browse/NIFI-13924) - NiFi CLI - delete-param has no effect

While doing some testing for [NIFI-13904](https://issues.apache.org/jira/browse/NIFI-13904), I noticed that the delete-param CLI command has no effect. After some digging, this is due to [NIFI-12898](https://issues.apache.org/jira/browse/NIFI-12898) and the addition of asset support. In the CLI, the referenced asset needs to set to null to let the backend know that this is a deletion request.

See: https://github.com/apache/nifi/blame/main/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardParameterContextDAO.java#L209

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
