### PR TITLE
[NIFI-13917] update sidenav font color to match applicaiton font color

### DIFF
--- a/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
@@ -746,6 +746,10 @@
             letter-spacing: normal;
             line-height: normal;
         }
+
+        .mat-drawer {
+            color: var(--mat-app-text-color);
+        }
     }
 
     .mat-expansion-panel {


### PR DESCRIPTION
Previously:
<img width="388" alt="Screenshot 2024-10-23 at 12 20 50 PM" src="https://github.com/user-attachments/assets/756a8b65-c34f-4557-9b29-85320e6de0fb">


With this change applied:
<img width="398" alt="Screenshot 2024-10-23 at 12 20 18 PM" src="https://github.com/user-attachments/assets/251faf9e-6d96-4c1c-a457-dfda3ec0d310">

Now the font color of the PG name matches the operation palette.