### PR TITLE
[NIFI-13925] update codemirror cursor and matching brackets

### DIFF
--- a/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_app.scss
@@ -605,7 +605,7 @@
 
     /* overriding 3rd party styles */
 
-    *:not([class^='mat-']):not([class^='mdc-']):not([class^='resizable-triangle']) {
+    *:not([class^='mat-']):not([class^='mdc-']):not([class^='resizable-triangle']):not([class^='CodeMirror-cursor']) {
         // Tailwind sets a default that doesn't shift with light and dark themes
         border-color: $border-color;
     }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_codemirror-theme.scss
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/assets/styles/_codemirror-theme.scss
@@ -45,6 +45,7 @@
         neutral,
         map.get(map.get($config, neutral), lighter)
     );
+    $primary-contrast: map.get(map.get($config, primary), contrast);
     $neutral-contrast: map.get(map.get($config, neutral), contrast);
     $border-color: mat.get-theme-color($material-theme, neutral-variant, map.get($config, neutral-variant));
     $selected-color: $material-theme-tertiary-palette-variant;
@@ -213,10 +214,8 @@
 
     .cm-s-nifi .CodeMirror-matchingbracket {
         text-decoration: underline;
-        color: $neutral-contrast !important;
+        color: $primary-contrast !important;
         background-color: $material-theme-neutral-palette-default;
-        opacity: 0.5;
-        filter: alpha(opacity=50);
     }
 
     .cm-s-nifi .CodeMirror-nonmatchingbracket {


### PR DESCRIPTION
Prior to this PR:
<img width="391" alt="Screenshot 2024-10-23 at 3 43 16 PM" src="https://github.com/user-attachments/assets/0e355f97-e34e-461e-9c0a-5a4276fe7c25">
<img width="400" alt="Screenshot 2024-10-23 at 3 43 32 PM" src="https://github.com/user-attachments/assets/3cd0a4e8-2b1a-42da-aebe-22ec655e9adf">

After updates included with this PR:
<img width="399" alt="Screenshot 2024-10-23 at 3 44 01 PM" src="https://github.com/user-attachments/assets/d6ca74c1-862e-413b-9a57-2da635258bc9">
<img width="403" alt="Screenshot 2024-10-23 at 3 44 12 PM" src="https://github.com/user-attachments/assets/5d022f35-b12c-49ec-b93d-bbf97fc0622a">
<img width="402" alt="Screenshot 2024-10-23 at 3 44 19 PM" src="https://github.com/user-attachments/assets/aae3ec6a-b721-4133-9bb0-2be856037394">
<img width="399" alt="Screenshot 2024-10-23 at 3 44 32 PM" src="https://github.com/user-attachments/assets/4ac0dc8c-5723-47df-a0a5-68e61a2abdbb">

