### PR TITLE
NIFI-13929: Removed Provenance Repository from the stateless Reposito…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/AbstractRepositoryContext.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/repository/AbstractRepositoryContext.java
@@ -217,23 +217,15 @@ public abstract class AbstractRepositoryContext implements RepositoryContext {
     }
 
     protected String getProvenanceComponentDescription() {
-        switch (connectable.getConnectableType()) {
-            case PROCESSOR:
-                final ProcessorNode procNode = (ProcessorNode) connectable;
-                return procNode.getComponentType();
-            case INPUT_PORT:
-                return "Input Port";
-            case OUTPUT_PORT:
-                return "Output Port";
-            case REMOTE_INPUT_PORT:
-                return ProvenanceEventRecord.REMOTE_INPUT_PORT_TYPE;
-            case REMOTE_OUTPUT_PORT:
-                return ProvenanceEventRecord.REMOTE_OUTPUT_PORT_TYPE;
-            case FUNNEL:
-                return "Funnel";
-            default:
-                throw new AssertionError("Connectable type is " + connectable.getConnectableType());
-        }
+        return switch (connectable.getConnectableType()) {
+            case PROCESSOR -> ((ProcessorNode) connectable).getComponentType();
+            case INPUT_PORT -> "Input Port";
+            case OUTPUT_PORT -> "Output Port";
+            case REMOTE_INPUT_PORT -> ProvenanceEventRecord.REMOTE_INPUT_PORT_TYPE;
+            case REMOTE_OUTPUT_PORT -> ProvenanceEventRecord.REMOTE_OUTPUT_PORT_TYPE;
+            case FUNNEL -> "Funnel";
+            default -> throw new AssertionError("Connectable type is " + connectable.getConnectableType());
+        };
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardStatelessGroupNodeFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardStatelessGroupNodeFactory.java
@@ -56,7 +56,6 @@ import org.apache.nifi.logging.LoggingContext;
 import org.apache.nifi.logging.StandardLoggingContext;
 import org.apache.nifi.parameter.ParameterContextManager;
 import org.apache.nifi.processor.SimpleProcessLogger;
-import org.apache.nifi.provenance.ProvenanceRepository;
 import org.apache.nifi.registry.flow.mapping.ComponentIdLookup;
 import org.apache.nifi.registry.flow.mapping.FlowMappingOptions;
 import org.apache.nifi.registry.flow.mapping.InstantiatedVersionedProcessGroup;
@@ -239,7 +238,7 @@ public class StandardStatelessGroupNodeFactory implements StatelessGroupNodeFact
             .extensionRepository(extensionRepository)
             .flowFileEventRepository(flowFileEventRepository)
             .processScheduler(statelessScheduler)
-            .provenanceRepository((ProvenanceRepository) statelessRepositoryContextFactory.getProvenanceRepository())
+            .provenanceRepository(flowController.getProvenanceRepository())
             .stateManagerProvider(stateManagerProvider)
             .kerberosConfiguration(kerberosConfig)
             .statusTaskInterval(null)

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardStatelessGroupNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/groups/StandardStatelessGroupNode.java
@@ -255,9 +255,9 @@ public class StandardStatelessGroupNode implements StatelessGroupNode {
             writeLock.lock();
             try {
                 if (desiredState == ScheduledState.RUNNING) {
-                    schedulingAgentCallback.trigger();
                     logger.info("{} has been started", this);
                     currentState = ScheduledState.RUNNING;
+                    schedulingAgentCallback.trigger();
                 } else {
                     logger.info("{} completed setup but is no longer scheduled to run; desired state is now {}; will shutdown", this, desiredState);
                     shutdown = true;

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/tasks/TestStatelessFlowTask.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/tasks/TestStatelessFlowTask.java
@@ -89,6 +89,7 @@ public class TestStatelessFlowTask {
     private List<ProvenanceEventRecord> registeredProvenanceEvents;
     private List<ProvenanceEventRecord> statelessProvenanceEvents;
     private Map<String, StandardFlowFileEvent> flowFileEventsByComponentId;
+    private ProvenanceEventRepository statelessProvRepo;
 
     @BeforeEach
     public void setup() throws IOException {
@@ -110,7 +111,7 @@ public class TestStatelessFlowTask {
         rootGroup.addOutputPort(secondOutputPort);
 
         statelessProvenanceEvents = new ArrayList<>();
-        final ProvenanceEventRepository statelessProvRepo = mock(ProvenanceEventRepository.class);
+        statelessProvRepo = mock(ProvenanceEventRepository.class);
         doAnswer(invocation -> statelessProvenanceEvents.size() - 1).when(statelessProvRepo).getMaxEventId();
         doAnswer(invocation -> {
             final long startEventId = invocation.getArgument(0, Long.class);
@@ -123,7 +124,6 @@ public class TestStatelessFlowTask {
         }).when(statelessProvRepo).getEvents(anyLong(), anyInt());
 
         final StatelessDataflow statelessFlow = mock(StatelessDataflow.class);
-        when(statelessFlow.getProvenanceRepository()).thenReturn(statelessProvRepo);
 
         final StatelessGroupNode statelessGroupNode = mock(StatelessGroupNode.class);
         when(statelessGroupNode.getProcessGroup()).thenReturn(rootGroup);
@@ -423,7 +423,7 @@ public class TestStatelessFlowTask {
             statelessProvenanceEvents.add(event);
         }
 
-        task.updateProvenanceRepository(event -> true);
+        task.updateProvenanceRepository(statelessProvRepo, event -> true);
 
         assertEquals(statelessProvenanceEvents, registeredProvenanceEvents);
         for (final ProvenanceEventRecord eventRecord : registeredProvenanceEvents) {
@@ -446,7 +446,7 @@ public class TestStatelessFlowTask {
             statelessProvenanceEvents.add(event);
         }
 
-        task.updateProvenanceRepository(event -> true);
+        task.updateProvenanceRepository(statelessProvRepo, event -> true);
 
         assertEquals(statelessProvenanceEvents, registeredProvenanceEvents);
         for (final ProvenanceEventRecord eventRecord : registeredProvenanceEvents) {

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/DataflowTriggerContext.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/DataflowTriggerContext.java
@@ -17,7 +17,10 @@
 
 package org.apache.nifi.stateless.flow;
 
+import org.apache.nifi.provenance.ProvenanceEventRepository;
+
 public interface DataflowTriggerContext {
+
     /**
      * Provides a mechanism by which the triggering class can abort a dataflow
      * @return <code>true</code> if the dataflow should be aborted, <code>false</code> otherwise
@@ -28,13 +31,22 @@ public interface DataflowTriggerContext {
         return null;
     }
 
+    ProvenanceEventRepository getProvenanceEventRepository();
+
     /**
      * The implicit context that will be used if no other context is provided when triggering a dataflow
      */
     DataflowTriggerContext IMPLICIT_CONTEXT = new DataflowTriggerContext() {
+        private final ProvenanceEventRepository eventRepo = new NopProvenanceEventRepository();
+
         @Override
         public boolean isAbort() {
             return false;
+        }
+
+        @Override
+        public ProvenanceEventRepository getProvenanceEventRepository() {
+            return eventRepo;
         }
     };
 }

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/NopProvenanceEventRepository.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/NopProvenanceEventRepository.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.stateless.flow;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.provenance.ProvenanceEventBuilder;
+import org.apache.nifi.provenance.ProvenanceEventRecord;
+import org.apache.nifi.provenance.ProvenanceEventRepository;
+import org.apache.nifi.provenance.ProvenanceEventType;
+
+import java.util.List;
+import java.util.Map;
+
+public class NopProvenanceEventRepository implements ProvenanceEventRepository {
+    @Override
+    public ProvenanceEventBuilder eventBuilder() {
+        return new EventBuilder();
+    }
+
+    @Override
+    public void registerEvent(final ProvenanceEventRecord event) {
+    }
+
+    @Override
+    public void registerEvents(final Iterable<ProvenanceEventRecord> events) {
+    }
+
+    @Override
+    public List<ProvenanceEventRecord> getEvents(final long minId, final int maxEvents) {
+        return List.of();
+    }
+
+    @Override
+    public Long getMaxEventId() {
+        return 0L;
+    }
+
+    @Override
+    public ProvenanceEventRecord getEvent(final long eventId) {
+        return null;
+    }
+
+    @Override
+    public void close() {
+    }
+
+
+
+    private static class EventBuilder implements ProvenanceEventBuilder {
+
+        @Override
+        public ProvenanceEventBuilder setEventType(final ProvenanceEventType provenanceEventType) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder fromEvent(final ProvenanceEventRecord provenanceEventRecord) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setFlowFileEntryDate(final long l) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setPreviousContentClaim(final String s, final String s1, final String s2, final Long aLong, final long l) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setCurrentContentClaim(final String s, final String s1, final String s2, final Long aLong, final long l) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setSourceQueueIdentifier(final String s) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setAttributes(final Map<String, String> map, final Map<String, String> map1) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setFlowFileUUID(final String s) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setEventTime(final long l) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setEventDuration(final long l) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setLineageStartDate(final long l) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setComponentId(final String s) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setComponentType(final String s) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setSourceSystemFlowFileIdentifier(final String s) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setTransitUri(final String s) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder addParentFlowFile(final FlowFile flowFile) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder removeParentFlowFile(final FlowFile flowFile) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder addChildFlowFile(final FlowFile flowFile) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder addChildFlowFile(final String s) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder removeChildFlowFile(final FlowFile flowFile) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setAlternateIdentifierUri(final String s) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setDetails(final String s) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder setRelationship(final Relationship relationship) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventBuilder fromFlowFile(final FlowFile flowFile) {
+            return this;
+        }
+
+        @Override
+        public ProvenanceEventRecord build() {
+            return new NopProvenanceEventRecord();
+        }
+
+        @Override
+        public List<String> getChildFlowFileIds() {
+            return List.of();
+        }
+
+        @Override
+        public List<String> getParentFlowFileIds() {
+            return List.of();
+        }
+
+        @Override
+        public String getFlowFileId() {
+            return "";
+        }
+
+        @Override
+        public ProvenanceEventBuilder copy() {
+            return this;
+        }
+    }
+
+    private static class NopProvenanceEventRecord implements ProvenanceEventRecord {
+
+        @Override
+        public long getEventId() {
+            return 0;
+        }
+
+        @Override
+        public long getEventTime() {
+            return 0;
+        }
+
+        @Override
+        public long getFlowFileEntryDate() {
+            return 0;
+        }
+
+        @Override
+        public long getLineageStartDate() {
+            return 0;
+        }
+
+        @Override
+        public long getFileSize() {
+            return 0;
+        }
+
+        @Override
+        public Long getPreviousFileSize() {
+            return 0L;
+        }
+
+        @Override
+        public long getEventDuration() {
+            return 0;
+        }
+
+        @Override
+        public ProvenanceEventType getEventType() {
+            return ProvenanceEventType.UNKNOWN;
+        }
+
+        @Override
+        public Map<String, String> getAttributes() {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, String> getPreviousAttributes() {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, String> getUpdatedAttributes() {
+            return Map.of();
+        }
+
+        @Override
+        public String getComponentId() {
+            return "";
+        }
+
+        @Override
+        public String getComponentType() {
+            return "";
+        }
+
+        @Override
+        public String getTransitUri() {
+            return "";
+        }
+
+        @Override
+        public String getSourceSystemFlowFileIdentifier() {
+            return "";
+        }
+
+        @Override
+        public String getFlowFileUuid() {
+            return "";
+        }
+
+        @Override
+        public List<String> getParentUuids() {
+            return List.of();
+        }
+
+        @Override
+        public List<String> getChildUuids() {
+            return List.of();
+        }
+
+        @Override
+        public String getAlternateIdentifierUri() {
+            return "";
+        }
+
+        @Override
+        public String getDetails() {
+            return "";
+        }
+
+        @Override
+        public String getRelationship() {
+            return "";
+        }
+
+        @Override
+        public String getSourceQueueIdentifier() {
+            return "";
+        }
+
+        @Override
+        public String getContentClaimSection() {
+            return "";
+        }
+
+        @Override
+        public String getPreviousContentClaimSection() {
+            return "";
+        }
+
+        @Override
+        public String getContentClaimContainer() {
+            return "";
+        }
+
+        @Override
+        public String getPreviousContentClaimContainer() {
+            return "";
+        }
+
+        @Override
+        public String getContentClaimIdentifier() {
+            return "";
+        }
+
+        @Override
+        public String getPreviousContentClaimIdentifier() {
+            return "";
+        }
+
+        @Override
+        public Long getContentClaimOffset() {
+            return 0L;
+        }
+
+        @Override
+        public Long getPreviousContentClaimOffset() {
+            return 0L;
+        }
+
+        @Override
+        public String getBestEventIdentifier() {
+            return "";
+        }
+    }
+}

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/NopProvenanceEventRepository.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/NopProvenanceEventRepository.java
@@ -27,7 +27,7 @@ import org.apache.nifi.provenance.ProvenanceEventType;
 import java.util.List;
 import java.util.Map;
 
-public class NopProvenanceEventRepository implements ProvenanceEventRepository {
+class NopProvenanceEventRepository implements ProvenanceEventRepository {
     @Override
     public ProvenanceEventBuilder eventBuilder() {
         return new EventBuilder();

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/NopProvenanceEventRepository.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/NopProvenanceEventRepository.java
@@ -27,7 +27,7 @@ import org.apache.nifi.provenance.ProvenanceEventType;
 import java.util.List;
 import java.util.Map;
 
-class NopProvenanceEventRepository implements ProvenanceEventRepository {
+public class NopProvenanceEventRepository implements ProvenanceEventRepository {
     @Override
     public ProvenanceEventBuilder eventBuilder() {
         return new EventBuilder();

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/StatelessDataflow.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/StatelessDataflow.java
@@ -19,7 +19,6 @@ package org.apache.nifi.stateless.flow;
 
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.controller.queue.QueueSize;
-import org.apache.nifi.provenance.ProvenanceEventRepository;
 import org.apache.nifi.reporting.BulletinRepository;
 
 import java.io.InputStream;
@@ -102,11 +101,6 @@ public interface StatelessDataflow {
 
     long getSourceYieldExpiration();
 
-    void resetCounters();
-
-    Map<String, Long> getCounters(boolean includeGlobalContext);
-
     BulletinRepository getBulletinRepository();
 
-    ProvenanceEventRepository getProvenanceRepository();
 }

--- a/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/TriggerResult.java
+++ b/nifi-stateless/nifi-stateless-api/src/main/java/org/apache/nifi/stateless/flow/TriggerResult.java
@@ -18,7 +18,6 @@
 package org.apache.nifi.stateless.flow;
 
 import org.apache.nifi.flowfile.FlowFile;
-import org.apache.nifi.provenance.ProvenanceEventRecord;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -84,9 +83,4 @@ public interface TriggerResult {
      */
     void abort(Throwable cause);
 
-    /**
-     * Returns all Provenance Events that were created during this invocation of the dataflow
-     * @return the list of Provenance events
-     */
-    List<ProvenanceEventRecord> getProvenanceEvents() throws IOException;
 }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/CanceledTriggerResult.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/CanceledTriggerResult.java
@@ -18,7 +18,6 @@
 package org.apache.nifi.stateless.flow;
 
 import org.apache.nifi.flowfile.FlowFile;
-import org.apache.nifi.provenance.ProvenanceEventRecord;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -69,10 +68,5 @@ public class CanceledTriggerResult implements TriggerResult {
 
     @Override
     public void abort(final Throwable cause) {
-    }
-
-    @Override
-    public List<ProvenanceEventRecord> getProvenanceEvents() {
-        return Collections.emptyList();
     }
 }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/ExceptionalTriggerResult.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/ExceptionalTriggerResult.java
@@ -19,7 +19,6 @@ package org.apache.nifi.stateless.flow;
 
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.exception.TerminatedTaskException;
-import org.apache.nifi.provenance.ProvenanceEventRecord;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -79,10 +78,5 @@ public class ExceptionalTriggerResult implements TriggerResult {
         if (cause != null && failureCause != cause) {
             failureCause.addSuppressed(cause);
         }
-    }
-
-    @Override
-    public List<ProvenanceEventRecord> getProvenanceEvents() throws IOException {
-        return Collections.emptyList();
     }
 }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessFlow.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessFlow.java
@@ -65,6 +65,7 @@ import org.apache.nifi.stateless.engine.ProcessContextFactory;
 import org.apache.nifi.stateless.engine.StandardExecutionProgress;
 import org.apache.nifi.stateless.queue.DrainableFlowFileQueue;
 import org.apache.nifi.stateless.repository.RepositoryContextFactory;
+import org.apache.nifi.stateless.repository.StatelessProvenanceRepository;
 import org.apache.nifi.stateless.session.AsynchronousCommitTracker;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.apache.nifi.util.Connectables;
@@ -662,7 +663,7 @@ public class StandardStatelessFlow implements StatelessDataflow {
             throw new IllegalArgumentException("No Input Port exists with name <" + portName + ">. Valid Port names are " + getInputPortNames());
         }
 
-        final RepositoryContext repositoryContext = repositoryContextFactory.createRepositoryContext(inputPort, new NopProvenanceEventRepository());
+        final RepositoryContext repositoryContext = repositoryContextFactory.createRepositoryContext(inputPort, new StatelessProvenanceRepository(10));
         final ProcessSessionFactory sessionFactory = new StandardProcessSessionFactory(repositoryContext, () -> false, new NopPerformanceTracker());
         final ProcessSession session = sessionFactory.createSession();
         try {

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessFlow.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessFlow.java
@@ -31,14 +31,12 @@ import org.apache.nifi.connectable.Port;
 import org.apache.nifi.controller.ComponentNode;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.controller.ControllerService;
-import org.apache.nifi.controller.Counter;
 import org.apache.nifi.controller.ProcessScheduler;
 import org.apache.nifi.controller.ProcessorNode;
 import org.apache.nifi.controller.ReportingTaskNode;
 import org.apache.nifi.controller.queue.FlowFileQueue;
 import org.apache.nifi.controller.queue.QueueSize;
 import org.apache.nifi.controller.repository.ContentRepository;
-import org.apache.nifi.controller.repository.CounterRepository;
 import org.apache.nifi.controller.repository.FlowFileRecord;
 import org.apache.nifi.controller.repository.RepositoryContext;
 import org.apache.nifi.controller.repository.RepositoryRecord;
@@ -59,7 +57,6 @@ import org.apache.nifi.processor.ProcessSessionFactory;
 import org.apache.nifi.processor.Processor;
 import org.apache.nifi.processor.exception.FlowFileAccessException;
 import org.apache.nifi.processor.exception.TerminatedTaskException;
-import org.apache.nifi.provenance.ProvenanceEventRepository;
 import org.apache.nifi.remote.RemoteGroupPort;
 import org.apache.nifi.reporting.BulletinRepository;
 import org.apache.nifi.reporting.ReportingTask;
@@ -514,7 +511,7 @@ public class StandardStatelessFlow implements StatelessDataflow {
             repositoryContextFactory, dataflowDefinition.getFailurePortNames(), tracker, stateManagerProvider, triggerContext, this::purge);
 
         final Future<?> future = runDataflowExecutor.submit(
-            () -> executeDataflow(resultQueue, executionProgress, tracker, triggerContext.getFlowFileSupplier()));
+            () -> executeDataflow(resultQueue, executionProgress, tracker, triggerContext));
 
         final DataflowTrigger trigger = new DataflowTrigger() {
             @Override
@@ -547,7 +544,7 @@ public class StandardStatelessFlow implements StatelessDataflow {
 
 
     private void executeDataflow(final BlockingQueue<TriggerResult> resultQueue, final ExecutionProgress executionProgress, final AsynchronousCommitTracker tracker,
-                                 final FlowFileSupplier flowFileSupplier) {
+                                 final DataflowTriggerContext triggerContext) {
         final long startNanos = System.nanoTime();
         transactionThresholdMeter.reset();
 
@@ -557,7 +554,8 @@ public class StandardStatelessFlow implements StatelessDataflow {
             .processContextFactory(processContextFactory)
             .repositoryContextFactory(repositoryContextFactory)
             .rootConnectables(rootConnectables)
-            .flowFileSupplier(flowFileSupplier)
+            .flowFileSupplier(triggerContext.getFlowFileSupplier())
+            .provenanceEventRepository(triggerContext.getProvenanceEventRepository())
             .inputPorts(inputPorts)
             .transactionThresholdMeter(transactionThresholdMeter)
             .lifecycleStateManager(lifecycleStateManager)
@@ -664,7 +662,7 @@ public class StandardStatelessFlow implements StatelessDataflow {
             throw new IllegalArgumentException("No Input Port exists with name <" + portName + ">. Valid Port names are " + getInputPortNames());
         }
 
-        final RepositoryContext repositoryContext = repositoryContextFactory.createRepositoryContext(inputPort);
+        final RepositoryContext repositoryContext = repositoryContextFactory.createRepositoryContext(inputPort, new NopProvenanceEventRepository());
         final ProcessSessionFactory sessionFactory = new StandardProcessSessionFactory(repositoryContext, () -> false, new NopPerformanceTracker());
         final ProcessSession session = sessionFactory.createSession();
         try {
@@ -817,33 +815,6 @@ public class StandardStatelessFlow implements StatelessDataflow {
         }
 
         return latest;
-    }
-
-    @Override
-    public void resetCounters() {
-        final CounterRepository counterRepo = repositoryContextFactory.getCounterRepository();
-        counterRepo.getCounters().forEach(counter -> counterRepo.resetCounter(counter.getIdentifier()));
-    }
-
-    @Override
-    public Map<String, Long> getCounters(final boolean includeGlobalContext) {
-        final Map<String, Long> counters = new HashMap<>();
-        for (final Counter counter : repositoryContextFactory.getCounterRepository().getCounters()) {
-            // Counter context is either of the format `componentName (componentId)` or `All componentType's` (global context). We only want the
-            // those of the first type - for individual components - unless includeGlobalContext == true
-            final boolean isGlobalContext = !counter.getContext().endsWith(")");
-            if (includeGlobalContext || !isGlobalContext) {
-                final String counterName = isGlobalContext ? counter.getName() : (counter.getName() + " - " + counter.getContext());
-                counters.put(counterName, counter.getValue());
-            }
-        }
-
-        return counters;
-    }
-
-    @Override
-    public ProvenanceEventRepository getProvenanceRepository() {
-        return repositoryContextFactory.getProvenanceRepository();
     }
 
     @Override

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/repository/RepositoryContextFactory.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/repository/RepositoryContextFactory.java
@@ -19,24 +19,19 @@ package org.apache.nifi.stateless.repository;
 
 import org.apache.nifi.connectable.Connectable;
 import org.apache.nifi.controller.repository.ContentRepository;
-import org.apache.nifi.controller.repository.CounterRepository;
 import org.apache.nifi.controller.repository.FlowFileEventRepository;
 import org.apache.nifi.controller.repository.FlowFileRepository;
 import org.apache.nifi.controller.repository.RepositoryContext;
 import org.apache.nifi.provenance.ProvenanceEventRepository;
 
 public interface RepositoryContextFactory {
-    RepositoryContext createRepositoryContext(Connectable connectable);
+    RepositoryContext createRepositoryContext(Connectable connectable, ProvenanceEventRepository provenanceEventRepository);
 
     ContentRepository getContentRepository();
 
     FlowFileRepository getFlowFileRepository();
 
     FlowFileEventRepository getFlowFileEventRepository();
-
-    ProvenanceEventRepository getProvenanceRepository();
-
-    CounterRepository getCounterRepository();
 
     void shutdown();
 }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/repository/StatelessRepositoryContextFactory.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/repository/StatelessRepositoryContextFactory.java
@@ -39,7 +39,6 @@ public class StatelessRepositoryContextFactory implements RepositoryContextFacto
     private final FlowFileRepository flowFileRepository;
     private final FlowFileEventRepository flowFileEventRepository;
     private final CounterRepository counterRepository;
-    private final ProvenanceEventRepository provenanceEventRepository;
     private final StateManagerProvider stateManagerProvider;
 
     public StatelessRepositoryContextFactory(final ContentRepository contentRepository, final FlowFileRepository flowFileRepository, final FlowFileEventRepository flowFileEventRepository,
@@ -48,12 +47,11 @@ public class StatelessRepositoryContextFactory implements RepositoryContextFacto
         this.flowFileRepository = flowFileRepository;
         this.flowFileEventRepository = flowFileEventRepository;
         this.counterRepository = counterRepository;
-        this.provenanceEventRepository = provenanceRepository;
         this.stateManagerProvider = stateManagerProvider;
     }
 
     @Override
-    public RepositoryContext createRepositoryContext(final Connectable connectable) {
+    public RepositoryContext createRepositoryContext(final Connectable connectable, final ProvenanceEventRepository provenanceEventRepository) {
         final StateManager stateManager = stateManagerProvider.getStateManager(connectable.getIdentifier());
         return new StatelessRepositoryContext(connectable, new AtomicLong(0L), contentRepository, flowFileRepository,
             flowFileEventRepository, counterRepository, provenanceEventRepository, stateManager);
@@ -74,16 +72,6 @@ public class StatelessRepositoryContextFactory implements RepositoryContextFacto
     }
 
     @Override
-    public ProvenanceEventRepository getProvenanceRepository() {
-        return provenanceEventRepository;
-    }
-
-    @Override
-    public CounterRepository getCounterRepository() {
-        return counterRepository;
-    }
-
-    @Override
     public void shutdown() {
         contentRepository.shutdown();
 
@@ -97,12 +85,6 @@ public class StatelessRepositoryContextFactory implements RepositoryContextFacto
             flowFileEventRepository.close();
         } catch (final IOException e) {
             logger.warn("Failed to properly shutdown FlowFile Event Repository", e);
-        }
-
-        try {
-            provenanceEventRepository.close();
-        } catch (final IOException e) {
-            logger.warn("Failed to properly shutdown Provenance Repository", e);
         }
     }
 }

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/session/StatelessProcessSessionFactory.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/session/StatelessProcessSessionFactory.java
@@ -20,6 +20,7 @@ package org.apache.nifi.stateless.session;
 import org.apache.nifi.connectable.Connectable;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.ProcessSessionFactory;
+import org.apache.nifi.provenance.ProvenanceEventRepository;
 import org.apache.nifi.stateless.engine.ExecutionProgress;
 import org.apache.nifi.stateless.engine.ProcessContextFactory;
 import org.apache.nifi.stateless.repository.RepositoryContextFactory;
@@ -27,15 +28,18 @@ import org.apache.nifi.stateless.repository.RepositoryContextFactory;
 public class StatelessProcessSessionFactory implements ProcessSessionFactory {
     private final Connectable connectable;
     private final RepositoryContextFactory contextFactory;
+    private final ProvenanceEventRepository provenanceEventRepository;
     private final ProcessContextFactory processContextFactory;
     private final ExecutionProgress executionProgress;
     private final boolean requireSynchronousCommits;
     private final AsynchronousCommitTracker tracker;
 
-    public StatelessProcessSessionFactory(final Connectable connectable, final RepositoryContextFactory contextFactory, final ProcessContextFactory processContextFactory,
+    public StatelessProcessSessionFactory(final Connectable connectable, final RepositoryContextFactory contextFactory,
+                                          final ProvenanceEventRepository provenanceEventRepository, final ProcessContextFactory processContextFactory,
                                           final ExecutionProgress executionProgress, final boolean requireSynchronousCommits, final AsynchronousCommitTracker tracker) {
         this.connectable = connectable;
         this.contextFactory = contextFactory;
+        this.provenanceEventRepository = provenanceEventRepository;
         this.processContextFactory = processContextFactory;
         this.executionProgress = executionProgress;
         this.requireSynchronousCommits = requireSynchronousCommits;
@@ -44,7 +48,8 @@ public class StatelessProcessSessionFactory implements ProcessSessionFactory {
 
     @Override
     public ProcessSession createSession() {
-        final StatelessProcessSession session = new StatelessProcessSession(connectable, contextFactory, processContextFactory, executionProgress, requireSynchronousCommits, tracker);
+        final StatelessProcessSession session = new StatelessProcessSession(connectable, contextFactory, provenanceEventRepository, processContextFactory, executionProgress,
+            requireSynchronousCommits, tracker);
         executionProgress.registerCreatedSession(session);
         return session;
     }

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/stateless/StatelessBasicsIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/stateless/StatelessBasicsIT.java
@@ -87,7 +87,7 @@ public class StatelessBasicsIT extends NiFiSystemIT {
     public void testOrderingIntraSession() throws NiFiClientException, IOException, InterruptedException {
         final int batchSize = 100;
 
-        statelessGroup = getClientUtil().createProcessGroup("Stateless", "root");
+        statelessGroup = getClientUtil().createProcessGroup("testOrderingIntraSession", "root");
         getClientUtil().markStateless(statelessGroup, "1 min");
 
         final ProcessorEntity generate = getClientUtil().createProcessor(GENERATE_FLOWFILE, statelessGroup.getId());
@@ -117,6 +117,7 @@ public class StatelessBasicsIT extends NiFiSystemIT {
 
         getClientUtil().waitForValidProcessor(generate.getId());
         getClientUtil().waitForValidProcessor(router.getId());
+        getClientUtil().waitForValidProcessor(verifyProcessor.getId());
         getClientUtil().startProcessGroupComponents(statelessGroup.getId());
 
         waitForQueueCount(outputToTerminate.getId(), batchSize);


### PR DESCRIPTION
…ryContextFactory and added it to the DataflowTriggerContext. This was necessary because the previous design overlooked the possibility of many threads concurrently running the same dataflow. They all shared the same StatelessProvenanceRepository, but the code was designed as if only a single thread would be using the repository. As a result, the events that were registered with the stateless prov repo were being copied many times into NiFi's underlying provenance repository. This refactoring also led to the discovery of some old Java 8 syntax that could be cleaned up, and it led to the discovery of some methods that were no longer being used and could be cleaned up. Finally, in testing, I found that when a Stateless Group was scheduled, it scheduled the triggering of the stateless group before marking the state as RUNNING; as a result, the second thread could run, determine that the state is STARTING instead of RUNNING, and return without triggering the stateless group. This was addressed by ensuring that we set the state to RUNNING before triggering the stateless group to be triggered.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
