### PR TITLE
NIFI-13927 - Use synchronized lists in PublishGCPubSub

### DIFF
--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PublishGCPubSub.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PublishGCPubSub.java
@@ -321,8 +321,8 @@ public class PublishGCPubSub extends AbstractGCPubSubWithProxyProcessor {
 
         for (final FlowFile flowFile : flowFileBatch) {
             final List<ApiFuture<String>> futures = new ArrayList<>();
-            final List<String> successes = new ArrayList<>();
-            final List<Throwable> failures = new ArrayList<>();
+            final List<String> successes = Collections.synchronizedList(new ArrayList<>());
+            final List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
 
             if (flowFile.getSize() > maxMessageSize) {
                 final String message = String.format("FlowFile size %d exceeds MAX_MESSAGE_SIZE", flowFile.getSize());
@@ -368,8 +368,8 @@ public class PublishGCPubSub extends AbstractGCPubSubWithProxyProcessor {
 
         for (final FlowFile flowFile : flowFileBatch) {
             final List<ApiFuture<String>> futures = new ArrayList<>();
-            final List<String> successes = new ArrayList<>();
-            final List<Throwable> failures = new ArrayList<>();
+            final List<String> successes = Collections.synchronizedList(new ArrayList<>());
+            final List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
 
             final Map<String, String> attributes = flowFile.getAttributes();
             try (final RecordReader reader = readerFactory.createRecordReader(


### PR DESCRIPTION
# Summary

[NIFI-13927](https://issues.apache.org/jira/browse/NIFI-13927) - PublishGCPPubSub processor stop working and is stucked when using Record Oriented mode

See #9445 for more details

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
