### PR TITLE
NIFI-13933 Upgrade Spring Security to 6.3.4 and other dependencies

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -113,6 +113,12 @@
                 <artifactId>apache-mime4j-core</artifactId>
                 <version>${mime4j.version}</version>
             </dependency>
+            <!-- Override protobuf-java from amazon-kinesis-client -->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.25.5</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/nifi-commons/nifi-calcite-utils/pom.xml
+++ b/nifi-commons/nifi-calcite-utils/pom.xml
@@ -65,6 +65,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Override protobuf-java from calcite-core -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.25.5</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/nifi-dependency-check-maven/suppressions.xml
+++ b/nifi-dependency-check-maven/suppressions.xml
@@ -20,16 +20,6 @@
         <cpe regex="true">^cpe:.*$</cpe>
     </suppress>
     <suppress>
-        <notes>CVE-2017-10355 does not apply to Xerces 2.12.2</notes>
-        <packageUrl regex="true">^pkg:maven/xerces/xercesImpl@.*$</packageUrl>
-        <cve>CVE-2017-10355</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2007-6465 applies to Ganglia Server not Ganglia client libraries</notes>
-        <packageUrl regex="true">^pkg:maven/com\.yammer\.metrics/metrics\-ganglia@.*$</packageUrl>
-        <cve>CVE-2007-6465</cve>
-    </suppress>
-    <suppress>
         <notes>Elasticsearch Server vulnerabilities do not apply to elasticsearch-rest-client</notes>
         <packageUrl regex="true">^pkg:maven/org\.elasticsearch\.client/elasticsearch\-.*?\-client@.*$</packageUrl>
         <cpe regex="true">^cpe:/a:elastic.*$</cpe>
@@ -43,11 +33,6 @@
         <notes>CVE-2022-30187 applies to Azure Blob not the EventHubs Checkpoint Store Blob library</notes>
         <packageUrl regex="true">^pkg:maven/com\.azure/azure\-messaging\-eventhubs\-checkpointstore\-blob@.*$</packageUrl>
         <cve>CVE-2022-30187</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2010-1151 applies to mod_auth_shadow in Apache HTTP Server not the FTP server library</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.ftpserver/.*$</packageUrl>
-        <cve>CVE-2010-1151</cve>
     </suppress>
     <suppress>
         <notes>CVE-2018-14335 applies to H2 running with a web server console enabled</notes>
@@ -70,16 +55,6 @@
         <cpe>cpe:/a:grpc:grpc</cpe>
     </suppress>
     <suppress>
-        <notes>CVE-2020-9040 applies to Couchbase Server not the client library</notes>
-        <packageUrl regex="true">^pkg:maven/com\.couchbase\.client/core\-io@.*$</packageUrl>
-        <vulnerabilityName>CVE-2020-9040</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes>CVE-2022-41881 applies to HA Proxy components in Netty which are not used in Couchbase or other components</notes>
-        <packageUrl regex="true">^pkg:maven/io\.netty/.*$</packageUrl>
-        <cve>CVE-2022-41881</cve>
-    </suppress>
-    <suppress>
         <notes>CVE-2021-34538 applies to Apache Hive server not the Storage API library</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.hive/hive\-storage\-api@.*$</packageUrl>
         <cve>CVE-2021-34538</cve>
@@ -93,16 +68,6 @@
         <notes>The Jackson maintainers dispute the applicability of CVE-2023-35116 based on cyclic nature of reported concern</notes>
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
         <vulnerabilityName>CVE-2023-35116</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes>CVE-2023-25194 applies to Kafka Connect workers not client libraries</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka.*?@.*$</packageUrl>
-        <cve>CVE-2023-25194</cve>
-    </suppress>
-    <suppress>
-        <notes>CVE-2023-34462 applies to Netty servers using SniHandler not Netty 4.1 shaded for Couchbase and HBase 2</notes>
-        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*$</packageUrl>
-        <cve>CVE-2023-34462</cve>
     </suppress>
     <suppress>
         <notes>The Square Wire framework is not the same as the Wire secure communication application</notes>
@@ -190,11 +155,6 @@
         <cve>CVE-2020-13949</cve>
     </suppress>
     <suppress>
-        <notes>CVE-2023-44487 applies to netty-codec-http2 as a Server</notes>
-        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*$</packageUrl>
-        <cve>CVE-2023-44487</cve>
-    </suppress>
-    <suppress>
         <notes>Parquet MR vulnerabilities do not apply to other Parquet libraries</notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.parquet/parquet\-(?!mr).*$</packageUrl>
         <cpe>cpe:/a:apache:parquet-mr</cpe>
@@ -235,11 +195,6 @@
         <cve>CVE-2020-7656</cve>
     </suppress>
     <suppress>
-        <notes>jQuery vulnerability warning for historical versions</notes>
-        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
-        <vulnerabilityName>jQuery 1.x and 2.x are End-of-Life and no longer receiving security updates</vulnerabilityName>
-    </suppress>
-    <suppress>
         <notes>CVE-2023-44487 references gRPC for Go</notes>
         <packageUrl regex="true">^pkg:maven/io\.grpc/grpc.*$</packageUrl>
         <cve>CVE-2023-44487</cve>
@@ -255,13 +210,8 @@
         <cve>CVE-2020-8908</cve>
     </suppress>
     <suppress>
-        <notes>CVE-2023-36052 applies to Azure CLI not Azure Java libraries</notes>
-        <packageUrl regex="true">^pkg:maven/com\.azure/.*$</packageUrl>
-        <cve>CVE-2023-36052</cve>
-    </suppress>
-    <suppress>
         <notes>Findings for Apache Hadoop do not apply to the shaded Protobuf library</notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop\.thirdparty/hadoop\-shaded\-protobuf_3_21@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop\.thirdparty/hadoop\-shaded\-protobuf_3_25@.*$</packageUrl>
         <cpe>cpe:/a:apache:hadoop</cpe>
     </suppress>
     <suppress>
@@ -273,5 +223,31 @@
         <notes>CVE-2024-23082 applies to threetenbp 1.6.8 and earlier not 1.6.9</notes>
         <packageUrl regex="true">^pkg:maven/org\.threeten/threetenbp@.*$</packageUrl>
         <vulnerabilityName>CVE-2024-23082</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2023-7272 applies to Eclipse Parrson not javax.json</notes>
+        <packageUrl regex="true">^pkg:maven/org\.glassfish/javax\.json@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-7272</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>CVE-2024-43591 applies to Azure CLI not azure-core-amqp</notes>
+        <packageUrl regex="true">^pkg:maven/com\.azure/.*$</packageUrl>
+        <cpe>cpe:/a:microsoft:azure_cli</cpe>
+        <cve>CVE-2024-43591</cve>
+    </suppress>
+    <suppress>
+        <notes>jquery is not used although bundled in Hadoop avro-ipc libraries</notes>
+        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
+        <vulnerabilityName>jquery issue: 162</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes>Google OpenTelemetry shared-resourcemapping versions do not align with base OpenTelemetry versions leading to false positives</notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.cloud\.opentelemetry/.*$</packageUrl>
+        <cpe>cpe:/a:opentelemetry:opentelemetry</cpe>
+    </suppress>
+    <suppress>
+        <notes>CVE-2024-35255 is resolved in msal4j 1.15.1 and the CPE for other languages does not apply</notes>
+        <cve>CVE-2024-35255</cve>
+        <cpe>cpe:/a:microsoft:authentication_library:*:*:*:*:*:.net:*:*</cpe>
     </suppress>
 </suppressions>

--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -66,6 +66,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- Override protobuf-java from amazon-kinesis-client -->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.25.5</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/AbstractGCSTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/storage/AbstractGCSTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.reset;
 @ExtendWith(MockitoExtension.class)
 public abstract class AbstractGCSTest {
     private static final String PROJECT_ID = System.getProperty("test.gcp.project.id", "nifi-test-gcp-project");
-    private static final String DEFAULT_STORAGE_URL = "https://storage.googleapis.com";
+    private static final String DEFAULT_STORAGE_URL = "https://storage.googleapis.com/";
     private static final Integer RETRIES = 9;
 
     static final String BUCKET = RemoteStorageHelper.generateBucketName();

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.47.0</google.libraries.version>
+        <google.libraries.version>26.49.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>1.13.1</version>
+            <version>1.14.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.xerial.snappy</groupId>

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -63,6 +63,13 @@
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>9.1.0</version>
+            <exclusions>
+                <!-- Exclude unused protobuf-java -->
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <json.smart.version>2.5.1</json.smart.version>
         <groovy.version>4.0.23</groovy.version>
         <surefire.version>3.5.1</surefire.version>
-        <hadoop.version>3.4.0</hadoop.version>
+        <hadoop.version>3.4.1</hadoop.version>
         <ozone.version>1.2.1</ozone.version>
         <gcs.version>2.1.5</gcs.version>
         <aspectj.version>1.9.22.1</aspectj.version>
@@ -155,7 +155,7 @@
         <netty.4.version>4.1.114.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.version>6.1.14</spring.version>
-        <spring.security.version>6.3.3</spring.security.version>
+        <spring.security.version>6.3.4</spring.security.version>
         <swagger.annotations.version>2.2.25</swagger.annotations.version>
         <h2.version>2.3.232</h2.version>
         <zookeeper.version>3.9.2</zookeeper.version>
@@ -163,6 +163,7 @@
         <hapi.version>2.5.1</hapi.version>
         <commons.dbcp2.version>2.12.0</commons.dbcp2.version>
         <prometheus.version>0.16.0</prometheus.version>
+        <velocity-engine-core.version>2.4.1</velocity-engine-core.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -558,6 +559,12 @@
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper-jute</artifactId>
                 <version>${zookeeper.version}</version>
+            </dependency>
+            <!-- Override velocity-engine-core 2.3 for framework and Hadoop dependencies -->
+            <dependency>
+                <groupId>org.apache.velocity</groupId>
+                <artifactId>velocity-engine-core</artifactId>
+                <version>${velocity-engine-core.version}</version>
             </dependency>
             <!-- Managed JUnit 4 version for transitive dependencies such as OkHttp MockWebServer -->
             <dependency>


### PR DESCRIPTION
# Summary

[NIFI-13933](https://issues.apache.org/jira/browse/NIFI-13933) Upgrades Spring Security from 6.3.3 to [6.3.4](https://github.com/spring-projects/spring-security/releases/tag/6.3.4) mitigating an associated vulnerability for WebFlux classes that NiFi does not use.

Additional incremental upgrades include the following:

- Upgraded Hadoop from 3.4.0 to 3.4.1
- Upgraded Velocity Engine Core from 2.3.0 to 2.4.1
- Upgraded Parquet Avro from 1.13.1 to 1.14.3
- Upgraded Google Libraries from 26.47.0 to 26.49.0
- Set protobuf-java to 3.25.5 for calcite-core and amazon-kinesis-client libraries

Changes also include removing unnecessary suppressions and adding new false positive suppressions to the Dependency Check Plugin configuration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
