### PR TITLE
NIFI-13941 Fix Maximum Length for DNS Certificate SAN from Proxy Hosts

### DIFF
--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/property/SecurityApplicationPropertyHandler.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/property/SecurityApplicationPropertyHandler.java
@@ -78,7 +78,8 @@ public class SecurityApplicationPropertyHandler implements ApplicationPropertyHa
 
     private static final String PROPERTY_SEPARATOR = "=";
 
-    private static final Pattern HOST_PORT_PATTERN = Pattern.compile("^([\\w-.]{1,63}):?\\d{0,5}$");
+    // Maximum address length based on RFC 1035 Section 2.3.4
+    private static final Pattern HOST_PORT_PATTERN = Pattern.compile("^([\\w-.]{1,254}):?\\d{0,5}$");
 
     private static final int HOST_GROUP = 1;
 

--- a/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/property/SecurityApplicationPropertyHandler.java
+++ b/nifi-bootstrap/src/main/java/org/apache/nifi/bootstrap/property/SecurityApplicationPropertyHandler.java
@@ -308,6 +308,8 @@ public class SecurityApplicationPropertyHandler implements ApplicationPropertyHa
                 if (hostPortMatcher.matches()) {
                     final String host = hostPortMatcher.group(HOST_GROUP);
                     hosts.add(host);
+                } else {
+                    logger.warn("Invalid host [{}] configured for [{}] in nifi.properties", hostPortGroup, SecurityProperty.WEB_PROXY_HOST.getName());
                 }
             }
         }

--- a/nifi-bootstrap/src/test/java/org/apache/nifi/bootstrap/property/SecurityApplicationPropertyHandlerTest.java
+++ b/nifi-bootstrap/src/test/java/org/apache/nifi/bootstrap/property/SecurityApplicationPropertyHandlerTest.java
@@ -61,7 +61,7 @@ class SecurityApplicationPropertyHandlerTest {
 
     private static final int DNS_NAME_TYPE = 2;
 
-    private static final String FIRST_PROXY_HOST = "nifi.apache.org";
+    private static final String FIRST_PROXY_HOST = "maximum.domain.subject.alternative.name.length.greater.than.sixty.four.characters.nifi.apache.org";
 
     private static final int FIRST_PROXY_HOST_PORT = 443;
 


### PR DESCRIPTION
# Summary

[NIFI-13941](https://issues.apache.org/jira/browse/NIFI-13941) Corrects DNS Subject Alternative Name handling for generated certificates derived from the `nifi.web.proxy.host` property. Recent changes reduced the maximum length to 64 characters, instead of the 255 allowed according to [RFC 1035 Section 2.3.4](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4). The adjusted regular expression and unit test verify names longer than 64 characters are allowed.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
