### PR TITLE
NIFI-13942 Improve failure message for uploaded NARs that fail to ins…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/nar/NarManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/nar/NarManager.java
@@ -55,7 +55,15 @@ public interface NarManager {
      * @param coordinate the coordinate of the NAR
      * @param narState the new state
      */
-    void updateState(BundleCoordinate coordinate, NarState narState, String failureMessage);
+    void updateState(BundleCoordinate coordinate, NarState narState);
+
+    /**
+     * Updates the state of the NAR with the given coordinate to be in a failed state for the given exception that caused the failure.
+     *
+     * @param coordinate the coordinate of the NAR
+     * @param failure the exception that caused the failure
+     */
+    void updateFailed(BundleCoordinate coordinate, Throwable failure);
 
     /**
      * @return all NARs contained in the NAR Manager

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/nar/NarNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/nar/NarNode.java
@@ -85,8 +85,9 @@ public class NarNode {
         return failureMessage;
     }
 
-    public void setFailureMessage(final String failureMessage) {
-        this.failureMessage = failureMessage;
+    public void setFailure(final Throwable failure) {
+        this.state = NarState.FAILED;
+        this.failureMessage = "%s - %s".formatted(failure.getClass().getSimpleName(), failure.getMessage());
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/nar/NarInstallTask.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/nar/NarInstallTask.java
@@ -117,19 +117,18 @@ public class NarInstallTask implements Runnable {
                         installed = true;
                     } catch (final Throwable t) {
                         LOGGER.error("Failed to install NAR [{}]", coordinate, t);
-                        narNode.setState(NarState.FAILED);
-                        narNode.setFailureMessage(t.getMessage());
+                        narNode.setFailure(t);
                     }
                 } else {
                     try {
                         verifyExtensionDefinitions(loadedCoordinate);
-                        narManager.updateState(loadedCoordinate, NarState.INSTALLED, null);
+                        narManager.updateState(loadedCoordinate, NarState.INSTALLED);
                         installed = true;
                     } catch (final NarNotFoundException e) {
                         LOGGER.warn("NAR [{}] was loaded, but no longer exists in the NAR Manager", loadedCoordinate);
                     } catch (final Throwable t) {
                         LOGGER.error("Failed to install NAR [{}]", coordinate, t);
-                        narManager.updateState(loadedCoordinate, NarState.FAILED, t.getMessage());
+                        narManager.updateFailed(loadedCoordinate, t);
                     }
                 }
 
@@ -152,7 +151,7 @@ public class NarInstallTask implements Runnable {
                     narNode.setState(NarState.MISSING_DEPENDENCY);
                 } else {
                     try {
-                        narManager.updateState(skippedCoordinate, NarState.MISSING_DEPENDENCY, null);
+                        narManager.updateState(skippedCoordinate, NarState.MISSING_DEPENDENCY);
                     } catch (final NarNotFoundException e) {
                         LOGGER.warn("NAR [{}] was skipped, but no longer exists in the NAR Manager", skippedCoordinate);
                     }
@@ -167,8 +166,7 @@ public class NarInstallTask implements Runnable {
 
         } catch (final Throwable t) {
             LOGGER.error("Failed to install NAR [{}]", coordinate, t);
-            narNode.setState(NarState.FAILED);
-            narNode.setFailureMessage(t.getMessage());
+            narNode.setFailure(t);
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/nar/StandardNarManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/nar/StandardNarManager.java
@@ -141,13 +141,21 @@ public class StandardNarManager implements NarManager, InitializingBean, Closeab
     }
 
     @Override
-    public synchronized void updateState(final BundleCoordinate coordinate, final NarState narState, final String failureMessage) {
+    public synchronized void updateState(final BundleCoordinate coordinate, final NarState narState) {
         final NarNode narNode = narNodesById.values().stream()
                 .filter(n -> n.getManifest().getCoordinate().equals(coordinate))
                 .findFirst()
                 .orElseThrow(() -> new NarNotFoundException(coordinate));
         narNode.setState(narState);
-        narNode.setFailureMessage(failureMessage);
+    }
+
+    @Override
+    public void updateFailed(final BundleCoordinate coordinate, final Throwable failure) {
+        final NarNode narNode = narNodesById.values().stream()
+                .filter(n -> n.getManifest().getCoordinate().equals(coordinate))
+                .findFirst()
+                .orElseThrow(() -> new NarNotFoundException(coordinate));
+        narNode.setFailure(failure);
     }
 
     @Override


### PR DESCRIPTION
…tall

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13942](https://issues.apache.org/jira/browse/NIFI-13942)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
