### PR TITLE
NIFI-13944: Upgrade Redis to 5.2.0

### DIFF
--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -2560,6 +2560,7 @@ The following binary components are provided to the 'Public Domain'.  See projec
 
     (Public Domain) XZ for Java (org.tukaani:xz:jar:1.5 - http://tukaani.org/xz/java.html
     (Public Domain) AOP Alliance 1.0 (http://aopalliance.sourceforge.net/)
+    (Public Domain) JSON (org.json:json:jar:20240303)
 
 The following binary components are provided under the Creative Commons Zero license version 1.0.  See project link for details.
 

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/pom.xml
@@ -54,10 +54,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-        </dependency>
-        <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>${jedis.version}</version>

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-nar/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,209 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+APACHE NIFI SUBCOMPONENTS:
+
+The Apache NiFi project contains subcomponents with separate copyright
+notices and license terms. Your use of the source code for the these
+subcomponents is subject to the terms and conditions of the following
+licenses.

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-nar/src/main/resources/META-INF/LICENSE
@@ -207,3 +207,32 @@ The Apache NiFi project contains subcomponents with separate copyright
 notices and license terms. Your use of the source code for the these
 subcomponents is subject to the terms and conditions of the following
 licenses.
+
+  The binary distribution of this product bundles 'Antlr 3' which is available
+  under a "3-clause BSD" license.  For details see http://www.antlr3.org/license.html
+
+    Copyright (c) 2013 Terence Parr
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+    Neither the name of the author nor the names of its contributors may be used
+    to endorse or promote products derived from this software without specific
+    prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+    THE POSSIBILITY OF SUCH DAMAGE.

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-nar/src/main/resources/META-INF/NOTICE
@@ -8,25 +8,77 @@ The Apache Software Foundation (http://www.apache.org/).
 Apache Software License v2
 ******************
 
-  (ASLv2) Jackson JSON processor
+  (ASLv2) Apache Commons Pool
     The following NOTICE information applies:
-      # Jackson JSON processor
+      Apache Commons Pool
+      Copyright 1999-2009 The Apache Software Foundation.
 
-      Jackson is a high-performance, Free/Open Source JSON processing library.
-      It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-      been in development since 2007.
-      It is currently developed by a community of developers, as well as supported
-      commercially by FasterXML.com.
+  (ASLv2) Open JSON
+    The following NOTICE information applies:
+      Android JSON library
+      Copyright (C) 2010 The Android Open Source Project
 
-      ## Licensing
+      This product includes software developed by
+      The Android Open Source Project
 
-      Jackson core and extension components may licensed under different licenses.
-      To find the details that apply to this artifact see the accompanying LICENSE file.
-      For more information, including possible other licensing options, contact
-      FasterXML.com (http://fasterxml.com).
+  (ASLv2) Spring Framework
+      The following NOTICE information applies:
+        Spring Framework 5
+        Copyright (c) 2002-2021 Pivotal, Inc.
 
-      ## Credits
+  (ASLv2) Micrometer
+    The following NOTICE information applies:
+      Micrometer
 
-      A list of contributors may be found from CREDITS file, which is included
-      in some artifacts (usually source distributions); but is always available
-      from the source code management (SCM) system project uses.
+      Copyright (c) 2017-Present VMware, Inc. All Rights Reserved.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         https://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+      -------------------------------------------------------------------------------
+
+      This product contains a modified portion of 'io.netty.util.internal.logging',
+      in the Netty/Common library distributed by The Netty Project:
+
+        * Copyright 2013 The Netty Project
+        * License: Apache License v2.0
+        * Homepage: https://netty.io
+
+      This product contains a modified portion of 'StringUtils.isBlank()',
+      in the Commons Lang library distributed by The Apache Software Foundation:
+
+        * Copyright 2001-2019 The Apache Software Foundation
+        * License: Apache License v2.0
+        * Homepage: https://commons.apache.org/proper/commons-lang/
+
+      This product contains a modified portion of 'JsonUtf8Writer',
+      in the Moshi library distributed by Square, Inc:
+
+        * Copyright 2010 Google Inc.
+        * License: Apache License v2.0
+        * Homepage: https://github.com/square/moshi
+
+      This product contains a modified portion of the 'org.springframework.lang'
+      package in the Spring Framework library, distributed by VMware, Inc:
+
+        * Copyright 2002-2019 the original author or authors.
+        * License: Apache License v2.0
+        * Homepage: https://spring.io/projects/spring-framework
+
+************************
+Eclipse Distribution License 1.0
+************************
+
+The following binary components are provided under the Eclipse Distribution License 1.0.
+
+    (EDL 1.0) Jakarta Activation API (jakarta.activation:jakarta.activation-api:jar:1.2.2)
+    (EDL 1.0) Jakarta XML Binding API (jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3)

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-nar/src/main/resources/META-INF/NOTICE
@@ -13,72 +13,7 @@ Apache Software License v2
       Apache Commons Pool
       Copyright 1999-2009 The Apache Software Foundation.
 
-  (ASLv2) Open JSON
-    The following NOTICE information applies:
-      Android JSON library
-      Copyright (C) 2010 The Android Open Source Project
-
-      This product includes software developed by
-      The Android Open Source Project
-
   (ASLv2) Spring Framework
       The following NOTICE information applies:
         Spring Framework 5
         Copyright (c) 2002-2021 Pivotal, Inc.
-
-  (ASLv2) Micrometer
-    The following NOTICE information applies:
-      Micrometer
-
-      Copyright (c) 2017-Present VMware, Inc. All Rights Reserved.
-
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-
-         https://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-
-      -------------------------------------------------------------------------------
-
-      This product contains a modified portion of 'io.netty.util.internal.logging',
-      in the Netty/Common library distributed by The Netty Project:
-
-        * Copyright 2013 The Netty Project
-        * License: Apache License v2.0
-        * Homepage: https://netty.io
-
-      This product contains a modified portion of 'StringUtils.isBlank()',
-      in the Commons Lang library distributed by The Apache Software Foundation:
-
-        * Copyright 2001-2019 The Apache Software Foundation
-        * License: Apache License v2.0
-        * Homepage: https://commons.apache.org/proper/commons-lang/
-
-      This product contains a modified portion of 'JsonUtf8Writer',
-      in the Moshi library distributed by Square, Inc:
-
-        * Copyright 2010 Google Inc.
-        * License: Apache License v2.0
-        * Homepage: https://github.com/square/moshi
-
-      This product contains a modified portion of the 'org.springframework.lang'
-      package in the Spring Framework library, distributed by VMware, Inc:
-
-        * Copyright 2002-2019 the original author or authors.
-        * License: Apache License v2.0
-        * Homepage: https://spring.io/projects/spring-framework
-
-************************
-Eclipse Distribution License 1.0
-************************
-
-The following binary components are provided under the Eclipse Distribution License 1.0.
-
-    (EDL 1.0) Jakarta Activation API (jakarta.activation:jakarta.activation-api:jar:1.2.2)
-    (EDL 1.0) Jakarta XML Binding API (jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3)

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-nar/src/main/resources/META-INF/NOTICE
@@ -4,16 +4,3 @@ Copyright 2014-2024 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
-******************
-Apache Software License v2
-******************
-
-  (ASLv2) Apache Commons Pool
-    The following NOTICE information applies:
-      Apache Commons Pool
-      Copyright 1999-2009 The Apache Software Foundation.
-
-  (ASLv2) Spring Framework
-      The following NOTICE information applies:
-        Spring Framework 5
-        Copyright (c) 2002-2021 Pivotal, Inc.

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/src/main/resources/META-INF/NOTICE
@@ -15,9 +15,13 @@ The following binary components are provided under the Apache Software License v
         Apache Commons Pool
         Copyright 1999-2009 The Apache Software Foundation.
 
+    (ASLv2) Google GSON
+      The following NOTICE information applies:
+        Copyright 2008 Google Inc.
+
     (ASLv2) Spring Framework
         The following NOTICE information applies:
-          Spring Framework 5
+          Spring Framework 6
           Copyright (c) 2002-2021 Pivotal, Inc.
 
     (ASLv2) Micrometer
@@ -68,22 +72,13 @@ The following binary components are provided under the Apache Software License v
             * License: Apache License v2.0
             * Homepage: https://spring.io/projects/spring-framework
 
-
-  (ASLv2) Open JSON
-      The following NOTICE information applies:
-        Android JSON library
-        Copyright (C) 2010 The Android Open Source Project
-
-        This product includes software developed by
-        The Android Open Source Project
-
 ************************
 The MIT License
 ************************
 
 The following binary components are provided under the MIT License.  See project link for details.
 
-  (MIT License) Jedis (redis.clients:jedis:2.9.0 - https://github.com/xetorthio/jedis)
+  (MIT License) Jedis (redis.clients:jedis:5.2.0 - https://github.com/redis/jedis)
 
 ************************
 Eclipse Distribution License 1.0
@@ -91,7 +86,13 @@ Eclipse Distribution License 1.0
 
 The following binary components are provided under the Eclipse Distribution License 1.0.
 
-    (EDL 1.0) Jakarta Activation API (jakarta.activation:jakarta.activation-api:jar:1.2.2)
-    (EDL 1.0) Jakarta XML Binding API (jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3)
+    (EDL 1.0) Jakarta Activation API (jakarta.activation:jakarta.activation-api:jar:2.1.3)
+    (EDL 1.0) Jakarta XML Binding API (jakarta.xml.bind:jakarta.xml.bind-api:jar:4.0.2)
 
+*****************
+Public Domain
+*****************
 
+The following binary components are provided to the 'Public Domain'.
+
+    (Public Domain) JSON (org.json:json:jar:20240303)

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-service-api-nar/src/main/resources/META-INF/NOTICE
@@ -20,6 +20,62 @@ The following binary components are provided under the Apache Software License v
           Spring Framework 5
           Copyright (c) 2002-2021 Pivotal, Inc.
 
+    (ASLv2) Micrometer
+        The following NOTICE information applies:
+          Micrometer
+
+          Copyright (c) 2017-Present VMware, Inc. All Rights Reserved.
+
+          Licensed under the Apache License, Version 2.0 (the "License");
+          you may not use this file except in compliance with the License.
+          You may obtain a copy of the License at
+
+             https://www.apache.org/licenses/LICENSE-2.0
+
+          Unless required by applicable law or agreed to in writing, software
+          distributed under the License is distributed on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          See the License for the specific language governing permissions and
+          limitations under the License.
+
+          -------------------------------------------------------------------------------
+
+          This product contains a modified portion of 'io.netty.util.internal.logging',
+          in the Netty/Common library distributed by The Netty Project:
+
+            * Copyright 2013 The Netty Project
+            * License: Apache License v2.0
+            * Homepage: https://netty.io
+
+          This product contains a modified portion of 'StringUtils.isBlank()',
+          in the Commons Lang library distributed by The Apache Software Foundation:
+
+            * Copyright 2001-2019 The Apache Software Foundation
+            * License: Apache License v2.0
+            * Homepage: https://commons.apache.org/proper/commons-lang/
+
+          This product contains a modified portion of 'JsonUtf8Writer',
+          in the Moshi library distributed by Square, Inc:
+
+            * Copyright 2010 Google Inc.
+            * License: Apache License v2.0
+            * Homepage: https://github.com/square/moshi
+
+          This product contains a modified portion of the 'org.springframework.lang'
+          package in the Spring Framework library, distributed by VMware, Inc:
+
+            * Copyright 2002-2019 the original author or authors.
+            * License: Apache License v2.0
+            * Homepage: https://spring.io/projects/spring-framework
+
+
+  (ASLv2) Open JSON
+      The following NOTICE information applies:
+        Android JSON library
+        Copyright (C) 2010 The Android Open Source Project
+
+        This product includes software developed by
+        The Android Open Source Project
 
 ************************
 The MIT License
@@ -28,4 +84,14 @@ The MIT License
 The following binary components are provided under the MIT License.  See project link for details.
 
   (MIT License) Jedis (redis.clients:jedis:2.9.0 - https://github.com/xetorthio/jedis)
+
+************************
+Eclipse Distribution License 1.0
+************************
+
+The following binary components are provided under the Eclipse Distribution License 1.0.
+
+    (EDL 1.0) Jakarta Activation API (jakarta.activation:jakarta.activation-api:jar:1.2.2)
+    (EDL 1.0) Jakarta XML Binding API (jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3)
+
 

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-service-api/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-service-api/pom.xml
@@ -35,12 +35,6 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>${jedis.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.json</groupId>
-                    <artifactId>json</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-service-api/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-service-api/pom.xml
@@ -35,6 +35,12 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>${jedis.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.json</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/nifi-extension-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/pom.xml
@@ -25,8 +25,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring.data.redis.version>2.7.18</spring.data.redis.version>
-        <jedis.version>3.10.0</jedis.version>
+        <spring.data.redis.version>3.3.5</spring.data.redis.version>
+        <jedis.version>5.2.0</jedis.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -853,7 +853,7 @@
                                         <!-- JUnit 5 is the preferred test framework -->
                                         <exclude>org.testng:testng</exclude>
                                         <!-- Cat-X Deps -->
-                                        <exclude>org.json:json:*:*:compile</exclude>
+                                        <exclude>org.json:json:[,20240303]:compile</exclude>
                                         <exclude>c3p0:c3p0:*:*:compile</exclude>
                                         <!-- Versions of JSR305 before 3.0.1 are not allowed https://github.com/findbugsproject/findbugs/issues/128 -->
                                         <exclude>com.google.code.findbugs:jsr305:[,3.0.0]:compile</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -853,7 +853,7 @@
                                         <!-- JUnit 5 is the preferred test framework -->
                                         <exclude>org.testng:testng</exclude>
                                         <!-- Cat-X Deps -->
-                                        <exclude>org.json:json:[,20240303]:compile</exclude>
+                                        <exclude>org.json:json:(,20240303):compile</exclude>
                                         <exclude>c3p0:c3p0:*:*:compile</exclude>
                                         <!-- Versions of JSR305 before 3.0.1 are not allowed https://github.com/findbugsproject/findbugs/issues/128 -->
                                         <exclude>com.google.code.findbugs:jsr305:[,3.0.0]:compile</exclude>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13944](https://issues.apache.org/jira/browse/NIFI-13944) This PR upgrades the Redis library to 5.2.0 along with the corresponding Spring Redis version, and excludes the banned org.json:json dependency in favor of Ted Dunning's version.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
