### PR TITLE
NIFI-13495 Exclude FindBugs Annotations and Hibernate Annotations

### DIFF
--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/nifi-opentelemetry-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/nifi-opentelemetry-processors/pom.xml
@@ -65,6 +65,10 @@
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java-util</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
@@ -272,7 +272,7 @@
                     <artifactId>hibernate-entitymanager</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.hibernate</groupId>
+                    <groupId>org.hibernate.orm</groupId>
                     <artifactId>hibernate-core</artifactId>
                 </exclusion>
             </exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -855,6 +855,14 @@
                                         <!-- Cat-X Deps -->
                                         <exclude>org.json:json:*:*:compile</exclude>
                                         <exclude>c3p0:c3p0:*:*:compile</exclude>
+                                        <!-- FindBugs Annotations is LGPL-2 -->
+                                        <exclude>com.google.code.findbugs:annotations:*</exclude>
+                                        <!-- Hibernate Commons Annotations is LGPL-2.1 before version 7.0.0 -->
+                                        <exclude>org.hibernate.common:hibernate-commons-annotations:[,7.0.0]</exclude>
+                                        <!-- Hibernate Core is LGPL-2.1 -->
+                                        <exclude>org.hibernate.orm:hibernate-core:*</exclude>
+                                        <!-- Hibernate Entity Manager is LGPL-2.1 -->
+                                        <exclude>org.hibernate:hibernate-entitymanager:*</exclude>
                                         <!-- Versions of JSR305 before 3.0.1 are not allowed https://github.com/findbugsproject/findbugs/issues/128 -->
                                         <exclude>com.google.code.findbugs:jsr305:[,3.0.0]:compile</exclude>
                                         <!-- SLF4J routing to Log4j 1.2 is a runtime implementation that conflicts with Logback -->


### PR DESCRIPTION
# Summary

[NIFI-13495](https://issues.apache.org/jira/browse/NIFI-13495) Excludes FindBugs Annotations and Hibernate Annotations dependencies due to LGPL 2 licensing conflicts. Annotation libraries are not required at runtime and cannot be included in distributed components.

Additional changes include adding these dependencies to the list of banned dependencies to avoid future inclusion.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
