### PR TITLE
NIFI-13496 Fix SNMP Integration Test Failures

### DIFF
--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/factory/core/SNMPManagerFactory.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/factory/core/SNMPManagerFactory.java
@@ -23,14 +23,19 @@ import org.snmp4j.smi.UdpAddress;
 import org.snmp4j.transport.DefaultUdpTransportMapping;
 
 import java.io.IOException;
+import java.net.InetAddress;
 
 public class SNMPManagerFactory {
+
+    private static final String ALL_ADDRESSES = "0.0.0.0";
 
     public Snmp createSnmpManagerInstance(final SNMPConfiguration configuration) {
         final int port = configuration.getManagerPort();
         final Snmp snmpManager;
         try {
-            final DefaultUdpTransportMapping transportMapping = new DefaultUdpTransportMapping(new UdpAddress(port));
+            final InetAddress listenAddress = InetAddress.getByName(ALL_ADDRESSES);
+            final UdpAddress udpAddress = new UdpAddress(listenAddress, port);
+            final DefaultUdpTransportMapping transportMapping = new DefaultUdpTransportMapping(udpAddress);
             snmpManager = new Snmp(transportMapping);
             snmpManager.listen();
         } catch (IOException e) {

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/helper/configurations/SNMPV3ConfigurationFactory.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/helper/configurations/SNMPV3ConfigurationFactory.java
@@ -24,7 +24,7 @@ public class SNMPV3ConfigurationFactory implements SNMPConfigurationFactory {
     // V3 security (users are set in test agents)
     public static final String SECURITY_LEVEL = "authPriv";
     public static final String SECURITY_NAME = "SHAAES128";
-    public static final String AUTH_PROTOCOL = "SHA";
+    public static final String AUTH_PROTOCOL = "HMAC384SHA512";
     public static final String AUTH_PASSPHRASE = "SHAAES128AuthPassphrase";
     public static final String PRIV_PROTOCOL = "AES128";
     public static final String PRIV_PASSPHRASE = "SHAAES128PrivPassphrase";

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/testagents/TestSNMPV3Agent.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/testagents/TestSNMPV3Agent.java
@@ -21,10 +21,8 @@ import org.snmp4j.agent.mo.snmp.StorageType;
 import org.snmp4j.agent.mo.snmp.VacmMIB;
 import org.snmp4j.agent.security.MutableVACM;
 import org.snmp4j.mp.MPv3;
-import org.snmp4j.security.AuthMD5;
-import org.snmp4j.security.AuthSHA;
+import org.snmp4j.security.AuthHMAC384SHA512;
 import org.snmp4j.security.PrivAES128;
-import org.snmp4j.security.PrivDES;
 import org.snmp4j.security.SecurityLevel;
 import org.snmp4j.security.SecurityModel;
 import org.snmp4j.security.USM;
@@ -44,30 +42,12 @@ public class TestSNMPV3Agent extends TestAgent {
 
     @Override
     protected void addUsmUser(final USM usm) {
-        UsmUser user = new UsmUser(new OctetString("SHA"),
-                AuthSHA.ID,
-                new OctetString("SHAAuthPassword"),
-                null,
-                null);
-        usm.addUser(user.getSecurityName(), usm.getLocalEngineID(), user);
-        user = new UsmUser(new OctetString("SHADES"),
-                AuthSHA.ID,
-                new OctetString("SHADESAuthPassword"),
-                PrivDES.ID,
-                new OctetString("SHADESPrivPassword"));
-        usm.addUser(user.getSecurityName(), usm.getLocalEngineID(), user);
-        user = new UsmUser(new OctetString("MD5DES"),
-                AuthMD5.ID,
-                new OctetString("MD5DESAuthPassword"),
-                PrivDES.ID,
-                new OctetString("MD5DESPrivPassword"));
-        usm.addUser(user.getSecurityName(), usm.getLocalEngineID(), user);
-        user = new UsmUser(new OctetString("SHAAES128"),
-                AuthSHA.ID,
+        UsmUser user = new UsmUser(new OctetString("HMAC384SHA512"),
+                AuthHMAC384SHA512.ID,
                 new OctetString("SHAAES128AuthPassword"),
                 PrivAES128.ID,
                 new OctetString("SHAAES128PrivPassword"));
-        usm.addUser(user.getSecurityName(), usm.getLocalEngineID(), user);
+        usm.addUser(user);
     }
 
     @Override


### PR DESCRIPTION
# Summary

[NIFI-13946](https://issues.apache.org/jira/browse/NIFI-13946) Fixes SNMP integration tests that failed following upgrades from SNMP4J version 2 to [version 3](https://www.snmp4j.org/CHANGES.txt).

Changes include setting `0.0.0.0` as the listen address for `ListenTrapSNMP`, aligning with existing behavior. Additional changes include removing SHA and MD5 protocols from the integration test class for SNMP Version 3.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
