### PR TITLE
NIFI-13950 - NiFi CLI - add commands to list branch, bucket, flows, versions through NiFi API

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
@@ -47,6 +47,7 @@ public enum CommandOption {
     FLOW_NAME("fn", "flowName", "A flow name", true),
     FLOW_DESC("fd", "flowDesc", "A flow description", true),
     FLOW_VERSION("fv", "flowVersion", "A version of a flow", true),
+    FLOW_BRANCH("fb", "flowBranch", "A branch for the flow", true),
 
     FLOW_VERSION_1("fv1", "flowVersion1", "A version of a flow", true),
     FLOW_VERSION_2("fv2", "flowVersion2", "A version of a flow", true),

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
@@ -106,6 +106,10 @@ import org.apache.nifi.toolkit.cli.impl.command.nifi.policies.UpdateAccessPolicy
 import org.apache.nifi.toolkit.cli.impl.command.nifi.processors.ChangeVersionProcessor;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.CreateRegistryClient;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.GetRegistryClientId;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.ListBranches;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.ListBuckets;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.ListFlowVersions;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.ListFlows;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.ListRegistryClients;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.registry.UpdateRegistryClient;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.reporting.DeleteReportingTask;
@@ -145,6 +149,10 @@ public class NiFiCommandGroup extends AbstractCommandGroup {
         commands.add(new CreateRegistryClient());
         commands.add(new UpdateRegistryClient());
         commands.add(new GetRegistryClientId());
+        commands.add(new ListBranches());
+        commands.add(new ListBuckets());
+        commands.add(new ListFlows());
+        commands.add(new ListFlowVersions());
         commands.add(new PGImport());
         commands.add(new PGConnect());
         commands.add(new PGStart());

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/ListBranches.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/ListBranches.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.command.nifi.registry;
+
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.nifi.toolkit.cli.api.Context;
+import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
+import org.apache.nifi.toolkit.cli.impl.result.nifi.RegistryBranchesResult;
+import org.apache.nifi.toolkit.client.NiFiClient;
+import org.apache.nifi.toolkit.client.NiFiClientException;
+import org.apache.nifi.web.api.entity.FlowRegistryBranchesEntity;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Lists the branches seen by the specified registry client.
+ */
+public class ListBranches extends AbstractNiFiCommand<RegistryBranchesResult> {
+
+    public ListBranches() {
+        super("list-branches", RegistryBranchesResult.class);
+    }
+
+    @Override
+    protected void doInitialize(Context context) {
+        super.doInitialize(context);
+        addOption(CommandOption.REGISTRY_CLIENT_ID.createOption());
+    }
+
+    @Override
+    public String getDescription() {
+        return "Returns the list of branches seen by the specified registry client.";
+    }
+
+    @Override
+    public RegistryBranchesResult doExecute(final NiFiClient client, final Properties properties)
+            throws NiFiClientException, IOException, MissingOptionException {
+        final String regClientId = getRequiredArg(properties, CommandOption.REGISTRY_CLIENT_ID);
+        final FlowRegistryBranchesEntity branches = client.getFlowClient().getFlowRegistryBranches(regClientId);
+        return new RegistryBranchesResult(getResultType(properties), branches);
+    }
+
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/ListBuckets.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/ListBuckets.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.command.nifi.registry;
+
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.nifi.toolkit.cli.api.Context;
+import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
+import org.apache.nifi.toolkit.cli.impl.result.nifi.RegistryBucketsResult;
+import org.apache.nifi.toolkit.client.NiFiClient;
+import org.apache.nifi.toolkit.client.NiFiClientException;
+import org.apache.nifi.web.api.entity.FlowRegistryBucketsEntity;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Lists buckets for a given branch seen by a given registry client
+ */
+public class ListBuckets extends AbstractNiFiCommand<RegistryBucketsResult> {
+
+    public ListBuckets() {
+        super("list-buckets", RegistryBucketsResult.class);
+    }
+
+    @Override
+    protected void doInitialize(Context context) {
+        super.doInitialize(context);
+        addOption(CommandOption.REGISTRY_CLIENT_ID.createOption());
+        addOption(CommandOption.FLOW_BRANCH.createOption());
+    }
+
+    @Override
+    public String getDescription() {
+        return "Returns the list of branches seen by the specified registry client.";
+    }
+
+    @Override
+    public RegistryBucketsResult doExecute(final NiFiClient client, final Properties properties)
+            throws NiFiClientException, IOException, MissingOptionException {
+        final String regClientId = getRequiredArg(properties, CommandOption.REGISTRY_CLIENT_ID);
+        final String branchName = getRequiredArg(properties, CommandOption.FLOW_BRANCH);
+        final FlowRegistryBucketsEntity buckets = client.getFlowClient().getFlowRegistryBuckets(regClientId, branchName);
+        return new RegistryBucketsResult(getResultType(properties), buckets);
+    }
+
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/ListFlowVersions.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/ListFlowVersions.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.command.nifi.registry;
+
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.nifi.toolkit.cli.api.Context;
+import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
+import org.apache.nifi.toolkit.cli.impl.result.nifi.RegistryFlowVersionsResult;
+import org.apache.nifi.toolkit.client.NiFiClient;
+import org.apache.nifi.toolkit.client.NiFiClientException;
+import org.apache.nifi.web.api.entity.VersionedFlowSnapshotMetadataSetEntity;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Lists flow versions for a given flow in a given branch and bucket seen by a
+ * given registry client
+ */
+public class ListFlowVersions extends AbstractNiFiCommand<RegistryFlowVersionsResult> {
+
+    public ListFlowVersions() {
+        super("list-flow-versions", RegistryFlowVersionsResult.class);
+    }
+
+    @Override
+    protected void doInitialize(Context context) {
+        super.doInitialize(context);
+        addOption(CommandOption.REGISTRY_CLIENT_ID.createOption());
+        addOption(CommandOption.FLOW_BRANCH.createOption());
+        addOption(CommandOption.BUCKET_ID.createOption());
+        addOption(CommandOption.FLOW_ID.createOption());
+    }
+
+    @Override
+    public String getDescription() {
+        return "Returns the list of flow versions for a given flow in a given branch and bucket seen by the specified registry client.";
+    }
+
+    @Override
+    public RegistryFlowVersionsResult doExecute(final NiFiClient client, final Properties properties)
+            throws NiFiClientException, IOException, MissingOptionException {
+        final String regClientId = getRequiredArg(properties, CommandOption.REGISTRY_CLIENT_ID);
+        final String branchName = getRequiredArg(properties, CommandOption.FLOW_BRANCH);
+        final String bucketId = getRequiredArg(properties, CommandOption.BUCKET_ID);
+        final String flowId = getRequiredArg(properties, CommandOption.FLOW_ID);
+        final VersionedFlowSnapshotMetadataSetEntity flowVersions = client.getFlowClient().getVersions(regClientId, bucketId, flowId, branchName);
+        return new RegistryFlowVersionsResult(getResultType(properties), flowVersions);
+    }
+
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/ListFlows.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/ListFlows.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.command.nifi.registry;
+
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.nifi.toolkit.cli.api.Context;
+import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
+import org.apache.nifi.toolkit.cli.impl.result.nifi.RegistryFlowsResult;
+import org.apache.nifi.toolkit.client.NiFiClient;
+import org.apache.nifi.toolkit.client.NiFiClientException;
+import org.apache.nifi.web.api.entity.VersionedFlowsEntity;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Lists flows for a given branch and bucket seen by a given registry client
+ */
+public class ListFlows extends AbstractNiFiCommand<RegistryFlowsResult> {
+
+    public ListFlows() {
+        super("list-flows", RegistryFlowsResult.class);
+    }
+
+    @Override
+    protected void doInitialize(Context context) {
+        super.doInitialize(context);
+        addOption(CommandOption.REGISTRY_CLIENT_ID.createOption());
+        addOption(CommandOption.FLOW_BRANCH.createOption());
+        addOption(CommandOption.BUCKET_ID.createOption());
+    }
+
+    @Override
+    public String getDescription() {
+        return "Returns the list of flows in a given branch and bucket seen by the specified registry client.";
+    }
+
+    @Override
+    public RegistryFlowsResult doExecute(final NiFiClient client, final Properties properties)
+            throws NiFiClientException, IOException, MissingOptionException {
+        final String regClientId = getRequiredArg(properties, CommandOption.REGISTRY_CLIENT_ID);
+        final String branchName = getRequiredArg(properties, CommandOption.FLOW_BRANCH);
+        final String bucketId = getRequiredArg(properties, CommandOption.BUCKET_ID);
+        final VersionedFlowsEntity flows = client.getFlowClient().getFlowRegistryFlows(regClientId, branchName, bucketId);
+        return new RegistryFlowsResult(getResultType(properties), flows);
+    }
+
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/RegistryBranchesResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/RegistryBranchesResult.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.result.nifi;
+
+import org.apache.nifi.toolkit.cli.api.ResultType;
+import org.apache.nifi.toolkit.cli.impl.result.AbstractWritableResult;
+import org.apache.nifi.toolkit.cli.impl.result.writer.DynamicTableWriter;
+import org.apache.nifi.toolkit.cli.impl.result.writer.Table;
+import org.apache.nifi.toolkit.cli.impl.result.writer.TableWriter;
+import org.apache.nifi.web.api.dto.FlowRegistryBranchDTO;
+import org.apache.nifi.web.api.entity.FlowRegistryBranchEntity;
+import org.apache.nifi.web.api.entity.FlowRegistryBranchesEntity;
+
+import java.io.PrintStream;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Result for a FlowRegistryBranchesEntity.
+ */
+public class RegistryBranchesResult extends AbstractWritableResult<FlowRegistryBranchesEntity> {
+
+    final FlowRegistryBranchesEntity branchesEntity;
+
+    public RegistryBranchesResult(final ResultType resultType, final FlowRegistryBranchesEntity branchesEntity) {
+        super(resultType);
+        this.branchesEntity = Objects.requireNonNull(branchesEntity);
+    }
+
+    @Override
+    public FlowRegistryBranchesEntity getResult() {
+        return this.branchesEntity;
+    }
+
+    @Override
+    protected void writeSimpleResult(final PrintStream output) {
+        final Set<FlowRegistryBranchEntity> branches = branchesEntity.getBranches();
+        if (branches == null || branches.isEmpty()) {
+            return;
+        }
+
+        final List<FlowRegistryBranchDTO> branchesDTO = branches.stream()
+            .map(b -> b.getBranch())
+            .sorted(Comparator.comparing(FlowRegistryBranchDTO::getName))
+            .toList();
+
+        final Table table = new Table.Builder()
+                .column("#", 3, 3, false)
+                .column("Name", 20, 36, true)
+                .build();
+
+        for (int i = 0; i < branchesDTO.size(); i++) {
+            FlowRegistryBranchDTO branch = branchesDTO.get(i);
+            table.addRow("" + (i + 1), branch.getName());
+        }
+
+        final TableWriter tableWriter = new DynamicTableWriter();
+        tableWriter.write(table, output);
+    }
+
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/RegistryBucketsResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/RegistryBucketsResult.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.result.nifi;
+
+import org.apache.nifi.toolkit.cli.api.ResultType;
+import org.apache.nifi.toolkit.cli.impl.result.AbstractWritableResult;
+import org.apache.nifi.toolkit.cli.impl.result.writer.DynamicTableWriter;
+import org.apache.nifi.toolkit.cli.impl.result.writer.Table;
+import org.apache.nifi.toolkit.cli.impl.result.writer.TableWriter;
+import org.apache.nifi.web.api.dto.FlowRegistryBucketDTO;
+import org.apache.nifi.web.api.entity.FlowRegistryBucketEntity;
+import org.apache.nifi.web.api.entity.FlowRegistryBucketsEntity;
+
+import java.io.PrintStream;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Result for a FlowRegistryBucketsEntity.
+ */
+public class RegistryBucketsResult extends AbstractWritableResult<FlowRegistryBucketsEntity> {
+
+    final FlowRegistryBucketsEntity bucketsEntity;
+
+    public RegistryBucketsResult(final ResultType resultType, final FlowRegistryBucketsEntity bucketsEntity) {
+        super(resultType);
+        this.bucketsEntity = Objects.requireNonNull(bucketsEntity);
+    }
+
+    @Override
+    public FlowRegistryBucketsEntity getResult() {
+        return this.bucketsEntity;
+    }
+
+    @Override
+    protected void writeSimpleResult(final PrintStream output) {
+        final Set<FlowRegistryBucketEntity> buckets = bucketsEntity.getBuckets();
+        if (buckets == null || buckets.isEmpty()) {
+            return;
+        }
+
+        final List<FlowRegistryBucketDTO> bucketsDTO = buckets.stream()
+            .map(b -> b.getBucket())
+            .sorted(Comparator.comparing(FlowRegistryBucketDTO::getName))
+            .toList();
+
+        final Table table = new Table.Builder()
+                .column("#", 3, 3, false)
+                .column("Name", 20, 36, true)
+                .column("Id", 36, 36, false)
+                .column("Description", 11, 40, true)
+                .build();
+
+        for (int i = 0; i < bucketsDTO.size(); i++) {
+            FlowRegistryBucketDTO bucket = bucketsDTO.get(i);
+            table.addRow("" + (i + 1), bucket.getName(), bucket.getId(), bucket.getDescription() == null ? "" : bucket.getDescription());
+        }
+
+        final TableWriter tableWriter = new DynamicTableWriter();
+        tableWriter.write(table, output);
+    }
+
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/RegistryFlowVersionsResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/RegistryFlowVersionsResult.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.result.nifi;
+
+import org.apache.nifi.registry.flow.RegisteredFlowSnapshotMetadata;
+import org.apache.nifi.toolkit.cli.api.ResultType;
+import org.apache.nifi.toolkit.cli.impl.result.AbstractWritableResult;
+import org.apache.nifi.toolkit.cli.impl.result.writer.DynamicTableWriter;
+import org.apache.nifi.toolkit.cli.impl.result.writer.Table;
+import org.apache.nifi.toolkit.cli.impl.result.writer.TableWriter;
+import org.apache.nifi.web.api.entity.VersionedFlowSnapshotMetadataEntity;
+import org.apache.nifi.web.api.entity.VersionedFlowSnapshotMetadataSetEntity;
+
+import java.io.PrintStream;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Result for a VersionedFlowSnapshotMetadataSetEntity.
+ */
+public class RegistryFlowVersionsResult extends AbstractWritableResult<VersionedFlowSnapshotMetadataSetEntity> {
+
+    final VersionedFlowSnapshotMetadataSetEntity flowVersionsEntity;
+
+    public RegistryFlowVersionsResult(final ResultType resultType, final VersionedFlowSnapshotMetadataSetEntity flowVersionsEntity) {
+        super(resultType);
+        this.flowVersionsEntity = Objects.requireNonNull(flowVersionsEntity);
+    }
+
+    @Override
+    public VersionedFlowSnapshotMetadataSetEntity getResult() {
+        return this.flowVersionsEntity;
+    }
+
+    @Override
+    protected void writeSimpleResult(final PrintStream output) {
+        final Set<VersionedFlowSnapshotMetadataEntity> flowVersions = flowVersionsEntity.getVersionedFlowSnapshotMetadataSet();
+        if (flowVersions == null || flowVersions.isEmpty()) {
+            return;
+        }
+
+        final List<RegisteredFlowSnapshotMetadata> flowVersionsMetadata = flowVersions.stream()
+            .map(fv -> fv.getVersionedFlowSnapshotMetadata())
+            .sorted(Comparator.comparingLong(RegisteredFlowSnapshotMetadata::getTimestamp))
+            .toList();
+
+        // date length, with locale specifics
+        final String datePattern = "%1$ta, %<tb %<td %<tY %<tR %<tZ";
+        final int dateLength = String.format(datePattern, new Date()).length();
+
+        final Table table = new Table.Builder()
+                .column("#", 3, 3, false)
+                .column("Version ID", 3, 50, false)
+                .column("Date", dateLength, dateLength + 10, false)
+                .column("Author", 20, 100, true)
+                .column("Message", 8, 100, true)
+                .build();
+
+        for (int i = 0; i < flowVersionsMetadata.size(); i++) {
+            RegisteredFlowSnapshotMetadata vfs = flowVersionsMetadata.get(i);
+            table.addRow(
+                    "" + (i + 1),
+                    vfs.getVersion(),
+                    String.format(datePattern, new Date(vfs.getTimestamp())),
+                    vfs.getAuthor() == null ? "" : vfs.getAuthor(),
+                    vfs.getComments() == null ? "" : vfs.getComments()
+            );
+        }
+
+        final TableWriter tableWriter = new DynamicTableWriter();
+        tableWriter.write(table, output);
+    }
+
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/RegistryFlowsResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/RegistryFlowsResult.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.result.nifi;
+
+import org.apache.nifi.toolkit.cli.api.ResultType;
+import org.apache.nifi.toolkit.cli.impl.result.AbstractWritableResult;
+import org.apache.nifi.toolkit.cli.impl.result.writer.DynamicTableWriter;
+import org.apache.nifi.toolkit.cli.impl.result.writer.Table;
+import org.apache.nifi.toolkit.cli.impl.result.writer.TableWriter;
+import org.apache.nifi.web.api.dto.VersionedFlowDTO;
+import org.apache.nifi.web.api.entity.VersionedFlowEntity;
+import org.apache.nifi.web.api.entity.VersionedFlowsEntity;
+
+import java.io.PrintStream;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Result for a VersionedFlowsEntity.
+ */
+public class RegistryFlowsResult extends AbstractWritableResult<VersionedFlowsEntity> {
+
+    final VersionedFlowsEntity flowsEntity;
+
+    public RegistryFlowsResult(final ResultType resultType, final VersionedFlowsEntity flowsEntity) {
+        super(resultType);
+        this.flowsEntity = Objects.requireNonNull(flowsEntity);
+    }
+
+    @Override
+    public VersionedFlowsEntity getResult() {
+        return this.flowsEntity;
+    }
+
+    @Override
+    protected void writeSimpleResult(final PrintStream output) {
+        final Set<VersionedFlowEntity> flows = flowsEntity.getVersionedFlows();
+        if (flows == null || flows.isEmpty()) {
+            return;
+        }
+
+        final List<VersionedFlowDTO> flowsDTO = flows.stream()
+            .map(f -> f.getVersionedFlow())
+            .sorted(Comparator.comparing(VersionedFlowDTO::getFlowName))
+            .toList();
+
+        final Table table = new Table.Builder()
+                .column("#", 3, 3, false)
+                .column("Name", 20, 36, true)
+                .column("Id", 36, 36, false)
+                .column("Description", 11, 40, true)
+                .build();
+
+        for (int i = 0; i < flowsDTO.size(); i++) {
+            VersionedFlowDTO flow = flowsDTO.get(i);
+            table.addRow("" + (i + 1), flow.getFlowName(), flow.getFlowId(), flow.getDescription() == null ? "" : flow.getDescription());
+        }
+
+        final TableWriter tableWriter = new DynamicTableWriter();
+        tableWriter.write(table, output);
+    }
+
+}

--- a/nifi-toolkit/nifi-toolkit-client/src/main/java/org/apache/nifi/toolkit/client/FlowClient.java
+++ b/nifi-toolkit/nifi-toolkit-client/src/main/java/org/apache/nifi/toolkit/client/FlowClient.java
@@ -23,6 +23,8 @@ import org.apache.nifi.web.api.entity.ConnectionStatusEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceTypesEntity;
 import org.apache.nifi.web.api.entity.ControllerServicesEntity;
 import org.apache.nifi.web.api.entity.CurrentUserEntity;
+import org.apache.nifi.web.api.entity.FlowRegistryBranchesEntity;
+import org.apache.nifi.web.api.entity.FlowRegistryBucketsEntity;
 import org.apache.nifi.web.api.entity.ParameterProvidersEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupFlowEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupStatusEntity;
@@ -31,6 +33,7 @@ import org.apache.nifi.web.api.entity.ReportingTaskTypesEntity;
 import org.apache.nifi.web.api.entity.ReportingTasksEntity;
 import org.apache.nifi.web.api.entity.ScheduleComponentsEntity;
 import org.apache.nifi.web.api.entity.VersionedFlowSnapshotMetadataSetEntity;
+import org.apache.nifi.web.api.entity.VersionedFlowsEntity;
 
 import java.io.IOException;
 
@@ -90,6 +93,18 @@ public interface FlowClient {
      * @return the set of snapshot metadata entities
      */
     VersionedFlowSnapshotMetadataSetEntity getVersions(String registryId, String bucketId, String flowId)
+            throws NiFiClientException, IOException;
+
+    /**
+     * Gets the possible versions for the given flow in the given bucket/branch in the given registry.
+     *
+     * @param registryId the id of the registry client
+     * @param bucketId the bucket id
+     * @param flowId the flow id
+     * @param branch the branch name
+     * @return the set of snapshot metadata entities
+     */
+    VersionedFlowSnapshotMetadataSetEntity getVersions(String registryId, String bucketId, String flowId, String branch)
             throws NiFiClientException, IOException;
 
     /**
@@ -190,4 +205,28 @@ public interface FlowClient {
      * @return the reporting task types
      */
     ReportingTaskTypesEntity getReportingTaskTypes() throws NiFiClientException, IOException;
+
+    /**
+     * Returns the list of branches for the specified registry client ID
+     * @param registryClientId Registry Client ID
+     * @return list of branches
+     */
+    FlowRegistryBranchesEntity getFlowRegistryBranches(String registryClientId) throws NiFiClientException, IOException;
+
+    /**
+     * Returns the list of buckets in a given branch for the specified registry client ID
+     * @param registryClientId Registry Client ID
+     * @param branch Name of the branch
+     * @return list of buckets
+     */
+    FlowRegistryBucketsEntity getFlowRegistryBuckets(String registryClientId, String branch) throws NiFiClientException, IOException;
+
+    /**
+     * Returns the list of flows in a given branch and bucket for the specified registry client ID
+     * @param registryClientId Registry Client ID
+     * @param branch Name of the branch
+     * @param bucket ID of the bucket
+     * @return list of flows
+     */
+    VersionedFlowsEntity getFlowRegistryFlows(String registryClientId, String branch, String bucket) throws NiFiClientException, IOException;
 }


### PR DESCRIPTION
# Summary

[NIFI-13950](https://issues.apache.org/jira/browse/NIFI-13950) - NiFi CLI - add commands to list branch, bucket, flows, versions through NiFi for Registry Clients

Currently, the CLI only provides access to branches / buckets / flows and versions via the use of `cli.sh registry ...` which only works when using the NiFi Registry.

Now that Registry Client is an extension point and that we have additional implementations, we should provide CLI commands to provide read-only access through a given registry client for listing branches / buckets / flows and versions. This will help users when they want to import a given flow with `cli.sh nifi pg-import ...`. In particular when it relates to versions because, when using a GitHub Registry Client, the version is a commit ID and it might not always be easy to retrieve / provide.

````
./bin/cli.sh nifi list-branches -p nifi-cli.properties -rcid dd0aa635-0192-1000-2ee5-eb1ccc20d5c3

#   Name
-   ----
1   dev
2   main
````

````
./bin/cli.sh nifi list-buckets -p nifi-cli.properties -rcid dd0aa635-0192-1000-2ee5-eb1ccc20d5c3 -fb main

#   Name      Id        Description
-   -------   -------   -----------
1   bucket1   bucket1
````

````
./bin/cli.sh nifi list-flows -p nifi-cli.properties -rcid dd0aa635-0192-1000-2ee5-eb1ccc20d5c3 -fb main -b bucket1

#   Name   Id     Description
-   ----   ----   -----------
1   test   test
````

````
./bin/cli.sh nifi list-flow-versions -p nifi-cli.properties -rcid dd0aa635-0192-1000-2ee5-eb1ccc20d5c3 -fb main -b bucket1 -f test

#   Version ID                                 Date                           Author       Message
-   ----------------------------------------   ----------------------------   ----------   -------------------------
1   3a15c8efa2b39adcfddb14611d1b5f14de122db0   Tue, Sept 10 2024 22:29 CEST   pvillard31   test
2   f9a09d02c5f20198a1d33567bcc53364e58d1eb9   Tue, Sept 10 2024 22:56 CEST   pvillard31   added processor
3   6ae0a1f83b32db1f788ef5020cc40d4413a61aaf   Thu, Sept 12 2024 14:21 CEST   pvillard31   Saving Flow Snapshot test
4   5f70b6f374a8013270e3ae3ab36f25d9576dacfc   Mon, Sept 16 2024 16:15 CEST   pvillard31   Saving Flow Snapshot test
5   7b3c17203e1563bb1759f7c540ac85247b4e7f17   Tue, Sept 17 2024 13:17 CEST   pvillard31   Saving Flow Snapshot test
6   7cfed33af8e6670cdf86424f632ed9bee4d9415f   Tue, Sept 17 2024 14:48 CEST   pvillard31   Saving Flow Snapshot test
7   a4b25e6c23ee6de53fdd54d6d2dae09af2292ff6   Fri, Sept 27 2024 11:25 CEST   pvillard31   Saving Flow Snapshot test
8   871acd74da8e997d4025ba8209e36ba170917f7e   Thu, Oct 03 2024 15:42 CEST    pvillard31   Saving Flow Snapshot test
````


# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
