### PR TITLE
NIFI-13955 - Filter out .directories in Git Registry clients

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -83,6 +84,15 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
             .required(false)
             .build();
 
+    public static final PropertyDescriptor DIRECTORY_FILTER_EXCLUDE = new PropertyDescriptor.Builder()
+            .name("Directory Filter Exclusion")
+            .description("Directories whose names match the given regular expression will be ignored "
+                    + "when listing buckets.")
+            .defaultValue("[.].*")
+            .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
+            .required(true)
+            .build();
+
     static final String DEFAULT_BUCKET_NAME = "default";
     static final String DEFAULT_BUCKET_KEEP_FILE_PATH = DEFAULT_BUCKET_NAME + "/.keep";
     static final String DEFAULT_BUCKET_KEEP_FILE_CONTENT = "Do Not Delete";
@@ -98,6 +108,7 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
 
     private volatile FlowSnapshotSerializer flowSnapshotSerializer;
     private volatile GitRepositoryClient repositoryClient;
+    private volatile Pattern directoryExclusionPattern;
     private final AtomicBoolean clientInitialized = new AtomicBoolean(false);
 
     private volatile List<PropertyDescriptor> propertyDescriptors;
@@ -109,6 +120,7 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
         final List<PropertyDescriptor> combinedPropertyDescriptors = new ArrayList<>(createPropertyDescriptors());
         combinedPropertyDescriptors.add(REPOSITORY_BRANCH);
         combinedPropertyDescriptors.add(REPOSITORY_PATH);
+        combinedPropertyDescriptors.add(DIRECTORY_FILTER_EXCLUDE);
         propertyDescriptors = Collections.unmodifiableList(combinedPropertyDescriptors);
 
         flowSnapshotSerializer = createFlowSnapshotSerializer();
@@ -174,7 +186,7 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
         verifyReadPermissions(repositoryClient);
 
         final Set<FlowRegistryBucket> buckets = repositoryClient.getTopLevelDirectoryNames(branch).stream()
-                .filter(bucketName -> !bucketName.startsWith("."))
+                .filter(bucketName -> !directoryExclusionPattern.matcher(bucketName).matches())
                 .map(bucketName -> createFlowRegistryBucket(repositoryClient, bucketName))
                 .collect(Collectors.toSet());
 
@@ -569,6 +581,7 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
             repositoryClient = createRepositoryClient(context);
             clientInitialized.set(true);
             initializeDefaultBucket(context);
+            directoryExclusionPattern = Pattern.compile(context.getProperty(DIRECTORY_FILTER_EXCLUDE).getValue());
         }
         return repositoryClient;
     }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
@@ -174,6 +174,7 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
         verifyReadPermissions(repositoryClient);
 
         final Set<FlowRegistryBucket> buckets = repositoryClient.getTopLevelDirectoryNames(branch).stream()
+                .filter(bucketName -> !bucketName.startsWith("."))
                 .map(bucketName -> createFlowRegistryBucket(repositoryClient, bucketName))
                 .collect(Collectors.toSet());
 

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/test/java/org/apache/nifi/github/GitHubFlowRegistryClientTest.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/test/java/org/apache/nifi/github/GitHubFlowRegistryClientTest.java
@@ -52,6 +52,7 @@ public class GitHubFlowRegistryClientTest {
 
     static final String DEFAULT_REPO_PATH = "some-path";
     static final String DEFAULT_REPO_BRANCH = "some-branch";
+    static final String DEFAULT_FILTER = "[.].*";
 
     private GitHubRepositoryClient repositoryClient;
     private FlowSnapshotSerializer flowSnapshotSerializer;
@@ -74,7 +75,14 @@ public class GitHubFlowRegistryClientTest {
 
         when(repositoryClient.hasReadPermission()).thenReturn(true);
         when(repositoryClient.hasWritePermission()).thenReturn(true);
-        when(repositoryClient.getTopLevelDirectoryNames(anyString())).thenReturn(Set.of("existing-bucket"));
+        when(repositoryClient.getTopLevelDirectoryNames(anyString())).thenReturn(Set.of("existing-bucket", ".github"));
+    }
+
+    @Test
+    public void testDirExclusion() throws IOException, FlowRegistryException {
+        setupClientConfigurationContextWithDefaults();
+        final Set<FlowRegistryBucket> buckets = flowRegistryClient.getBuckets(clientConfigurationContext, DEFAULT_REPO_BRANCH);
+        assertEquals(buckets.stream().filter(b -> b.getName().equals(".github")).count(), 0);
     }
 
     @Test
@@ -169,6 +177,9 @@ public class GitHubFlowRegistryClientTest {
 
         final PropertyValue branchPropertyValue = createMockPropertyValue(branch);
         when(clientConfigurationContext.getProperty(GitHubFlowRegistryClient.REPOSITORY_BRANCH)).thenReturn(branchPropertyValue);
+
+        final PropertyValue filterPropertyValue = createMockPropertyValue(DEFAULT_FILTER);
+        when(clientConfigurationContext.getProperty(GitHubFlowRegistryClient.DIRECTORY_FILTER_EXCLUDE)).thenReturn(filterPropertyValue);
     }
 
     private void setupClientConfigurationContextWithDefaults() {


### PR DESCRIPTION
# Summary

[NIFI-13955](https://issues.apache.org/jira/browse/NIFI-13955) - Filter out .directories in Git Registry clients

If a Git Registry Client (GitHub/GitLab) is configured without a repo path (looking at the root of the repo), we should filter out directories with names starting with a dot (as we may have directories like `.github`), otherwise they will be showing as potential buckets.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
