### PR TITLE
NIFI-13951: Add warn policy to dropdown selection

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/flow-analysis-rules/edit-flow-analysis-rule/edit-flow-analysis-rule.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/flow-analysis-rules/edit-flow-analysis-rule/edit-flow-analysis-rule.component.spec.ts
@@ -16,6 +16,8 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 
 import { EditFlowAnalysisRule } from './edit-flow-analysis-rule.component';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
@@ -26,10 +28,12 @@ import { ClusterConnectionService } from '../../../../../service/cluster-connect
 import 'codemirror/addon/hint/show-hint';
 import { MockComponent } from 'ng-mocks';
 import { ContextErrorBanner } from '../../../../../ui/common/context-error-banner/context-error-banner.component';
+import { HarnessLoader } from '@angular/cdk/testing';
 
 describe('EditFlowAnalysisRule', () => {
     let component: EditFlowAnalysisRule;
     let fixture: ComponentFixture<EditFlowAnalysisRule>;
+    let loader: HarnessLoader;
 
     const data: EditFlowAnalysisRuleDialogRequest = {
         id: 'd5142be7-018c-1000-7105-2b1163fe0355',
@@ -110,10 +114,21 @@ describe('EditFlowAnalysisRule', () => {
         });
         fixture = TestBed.createComponent(EditFlowAnalysisRule);
         component = fixture.componentInstance;
+        loader = TestbedHarnessEnvironment.loader(fixture);
         fixture.detectChanges();
     });
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    describe('Settings Tab', () => {
+        it('should default to selecting enforcementPolicy value passed in as data', () => {
+            loader.getAllHarnesses(MatSelectHarness).then((selectHarnesses) => {
+                selectHarnesses[0].getValueText().then((option) => {
+                    expect(option).toBe('Enforce');
+                });
+            });
+        });
     });
 });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/flow-analysis-rules/edit-flow-analysis-rule/edit-flow-analysis-rule.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/settings/ui/flow-analysis-rules/edit-flow-analysis-rule/edit-flow-analysis-rule.component.ts
@@ -92,6 +92,11 @@ export class EditFlowAnalysisRule extends TabbedDialog {
             text: 'Enforce',
             value: 'ENFORCE',
             description: 'Treat violations of this rule as errors the correction of which is mandatory.'
+        },
+        {
+            text: 'Warn',
+            value: 'WARN',
+            description: 'Treat violations of this rule as warnings the correction of which is optional.'
         }
     ];
 
@@ -121,7 +126,10 @@ export class EditFlowAnalysisRule extends TabbedDialog {
         this.editFlowAnalysisRuleForm = this.formBuilder.group({
             name: new FormControl(request.flowAnalysisRule.component.name, Validators.required),
             state: new FormControl(request.flowAnalysisRule.component.state === 'STOPPED', Validators.required),
-            enforcementPolicy: new FormControl('ENFORCE', Validators.required),
+            enforcementPolicy: new FormControl(
+                request.flowAnalysisRule.component.enforcementPolicy,
+                Validators.required
+            ),
             properties: new FormControl({ value: properties, disabled: this.readonly }),
             comments: new FormControl(request.flowAnalysisRule.component.comments)
         });


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13951](https://issues.apache.org/jira/browse/NIFI-13951)

In addition to adding the missing Warn policy level as an option to the enforcement policy select, the default selection is no longer hard coded as `Enforce` but instead reads the value returned from the backend.

cc @pvillard31 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
