### PR TITLE
NIFI-12061: allow using AWS Secrets Manager without ListSecrets permi…

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
@@ -39,6 +39,7 @@ import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.ConfigVerificationResult;
+import org.apache.nifi.components.DescribedValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.logging.ComponentLog;
@@ -50,13 +51,16 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderService;
 import org.apache.nifi.ssl.SSLContextService;
 
+import javax.net.ssl.SSLContext;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import javax.net.ssl.SSLContext;
 
 /**
  * Reads secrets from AWS Secrets Manager to provide parameter values.  Secrets must be created similar to the following AWS cli command: <br/><br/>
@@ -68,6 +72,53 @@ import javax.net.ssl.SSLContext;
 @CapabilityDescription("Fetches parameters from AWS SecretsManager.  Each secret becomes a Parameter group, which can map to a Parameter Context, with " +
         "key/value pairs in the secret mapping to Parameters in the group.")
 public class AwsSecretsManagerParameterProvider extends AbstractParameterProvider implements VerifiableParameterProvider {
+    enum ListingStrategy implements DescribedValue {
+        Enumeration(
+                "Enumeration",
+                "Enumerate secret names",
+                "Provides a set of secret names to fetch, separated by a comma delimiter ','. " +
+                        "This strategy requires the GetSecretValue permission only."
+        ),
+        Pattern(
+                "Pattern",
+                "Use regular expression",
+                "Provides a regular expression to match keys of attributes to filter for. " +
+                        "This strategy requires both ListSecrets and GetSecretValue permissions."
+        );
+
+        private final String value;
+        private final String displayName;
+        private final String description;
+
+        ListingStrategy(final String value, final String displayName, final String description) {
+            this.displayName = displayName;
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String getValue() {
+            return this.value;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return this.displayName;
+        }
+
+        @Override
+        public String getDescription() {
+            return this.description;
+        }
+    }
+    public static final PropertyDescriptor SECRET_LISTING_STRATEGY = new PropertyDescriptor.Builder()
+            .name("secret-listing-strategy")
+            .displayName("Secret Listing Strategy")
+            .description("Strategy to use when listing secrets.")
+            .required(true)
+            .allowableValues(ListingStrategy.class)
+            .defaultValue(ListingStrategy.Pattern.getValue())
+            .build();
 
     public static final PropertyDescriptor SECRET_NAME_PATTERN = new PropertyDescriptor.Builder()
             .name("secret-name-pattern")
@@ -75,8 +126,18 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
             .description("A Regular Expression matching on Secret Name that identifies Secrets whose parameters should be fetched. " +
                     "Any secrets whose names do not match this pattern will not be fetched.")
             .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
+            .dependsOn(SECRET_LISTING_STRATEGY, ListingStrategy.Pattern)
             .required(true)
             .defaultValue(".*")
+            .build();
+
+    public static final PropertyDescriptor SECRET_NAMES = new PropertyDescriptor.Builder()
+            .name("secret-names")
+            .displayName("Secret Names")
+            .description("Comma-separated list of secret names to fetch.")
+            .dependsOn(SECRET_LISTING_STRATEGY, ListingStrategy.Enumeration)
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
     /**
      * AWS credentials provider service
@@ -117,13 +178,15 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
 
     private static final String DEFAULT_USER_AGENT = "NiFi";
     private static final Protocol DEFAULT_PROTOCOL = Protocol.HTTPS;
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+            SECRET_LISTING_STRATEGY,
             SECRET_NAME_PATTERN,
+            SECRET_NAMES,
             REGION,
             AWS_CREDENTIALS_PROVIDER_SERVICE,
             TIMEOUT,
             SSL_CONTEXT_SERVICE
-    );
+    ));
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -137,21 +200,40 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
         AWSSecretsManager secretsManager = this.configureClient(context);
 
         final List<ParameterGroup> groups = new ArrayList<>();
-        ListSecretsRequest listSecretsRequest = new ListSecretsRequest();
-        ListSecretsResult listSecretsResult = secretsManager.listSecrets(listSecretsRequest);
-        while (!listSecretsResult.getSecretList().isEmpty()) {
-            for (final SecretListEntry entry : listSecretsResult.getSecretList()) {
-                groups.addAll(fetchSecret(secretsManager, context, entry.getName()));
-            }
-            final String nextToken = listSecretsResult.getNextToken();
-            if (nextToken == null) {
-                break;
-            }
 
-            listSecretsRequest.setNextToken(nextToken);
-            listSecretsResult = secretsManager.listSecrets(listSecretsRequest);
+        // Fetch either by pattern or by enumerated list. See description of SECRET_LISTING_STRATEGY for more details.
+        final String listingStrategy = context.getProperty(SECRET_LISTING_STRATEGY).getValue();
+        final ListingStrategy linstingStrategyType = ListingStrategy.valueOf(listingStrategy);
+        Set<String> secretsToFetch = new java.util.HashSet<>();
+        if (linstingStrategyType == ListingStrategy.Enumeration) {
+            String secretNames = context.getProperty(SECRET_NAMES).getValue();
+            secretsToFetch = new java.util.HashSet<>(Arrays.asList(secretNames.split(",")));
+        } else {
+            final Pattern secretNamePattern = Pattern.compile(context.getProperty(SECRET_NAME_PATTERN).getValue());
+            ListSecretsRequest listSecretsRequest = new ListSecretsRequest();
+            ListSecretsResult listSecretsResult = secretsManager.listSecrets(listSecretsRequest);
+            while (!listSecretsResult.getSecretList().isEmpty()) {
+                for (final SecretListEntry entry : listSecretsResult.getSecretList()) {
+                    String secretName = entry.getName();
+                    if (!secretNamePattern.matcher(secretName).matches()) {
+                        getLogger().debug("Secret [{}] does not match the secret name pattern {}", secretName, secretNamePattern);
+                        continue;
+                    }
+                    secretsToFetch.add(secretName);
+                }
+                final String nextToken = listSecretsResult.getNextToken();
+                if (nextToken == null) {
+                    break;
+                }
+                listSecretsRequest.setNextToken(nextToken);
+                listSecretsResult = secretsManager.listSecrets(listSecretsRequest);
+            }
         }
-
+        if (secretsToFetch.size() > 0) {
+            for (String secretName : secretsToFetch) {
+                groups.addAll(fetchSecret(secretsManager, secretName));
+            }
+        }
         return groups;
     }
 
@@ -182,18 +264,13 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
         return results;
     }
 
-    private List<ParameterGroup> fetchSecret(final AWSSecretsManager secretsManager, final ConfigurationContext context, final String secretName) {
+    private List<ParameterGroup> fetchSecret(final AWSSecretsManager secretsManager, final String secretName) {
         final List<ParameterGroup> groups = new ArrayList<>();
-        final Pattern secretNamePattern = Pattern.compile(context.getProperty(SECRET_NAME_PATTERN).getValue());
 
         final List<Parameter> parameters = new ArrayList<>();
 
-        if (!secretNamePattern.matcher(secretName).matches()) {
-            getLogger().debug("Secret [{}] does not match the secret name pattern {}", secretName, secretNamePattern);
-            return groups;
-        }
-
         final GetSecretValueRequest getSecretValueRequest = new GetSecretValueRequest().withSecretId(secretName);
+
         try {
             final GetSecretValueResult getSecretValueResult = secretsManager.getSecretValue(getSecretValueRequest);
 
@@ -232,10 +309,10 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
 
     private Parameter createParameter(final String parameterName, final String parameterValue) {
         return new Parameter.Builder()
-            .name(parameterName)
-            .value(parameterValue)
-            .provided(true)
-            .build();
+                .name(parameterName)
+                .value(parameterValue)
+                .provided(true)
+                .build();
     }
 
     protected ClientConfiguration createConfiguration(final ConfigurationContext context) {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
@@ -54,7 +54,6 @@ import org.apache.nifi.ssl.SSLContextService;
 import javax.net.ssl.SSLContext;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/test/java/org/apache/nifi/parameter/aws/TestAwsSecretsManagerParameterProvider.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/test/java/org/apache/nifi/parameter/aws/TestAwsSecretsManagerParameterProvider.java
@@ -22,6 +22,7 @@ import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.amazonaws.services.secretsmanager.model.ListSecretsRequest;
 import com.amazonaws.services.secretsmanager.model.ListSecretsResult;
+import com.amazonaws.services.secretsmanager.model.ResourceNotFoundException;
 import com.amazonaws.services.secretsmanager.model.SecretListEntry;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -89,18 +90,40 @@ public class TestAwsSecretsManagerParameterProvider {
     @Test
     public void testFetchParametersWithNoSecrets() throws InitializationException {
         final List<ParameterGroup> expectedGroups = Collections.singletonList(new ParameterGroup("MySecret", Collections.emptyList()));
-        runProviderTest(mockSecretsManager(expectedGroups), 0, ConfigVerificationResult.Outcome.SUCCESSFUL);
+        runProviderTest(mockSecretsManager(expectedGroups), 0, ConfigVerificationResult.Outcome.SUCCESSFUL,
+                "Pattern", null);
     }
 
     @Test
     public void testFetchParameters() throws InitializationException {
-        runProviderTest(mockSecretsManager(mockParameterGroups), 8, ConfigVerificationResult.Outcome.SUCCESSFUL);
+        runProviderTest(mockSecretsManager(mockParameterGroups), 8, ConfigVerificationResult.Outcome.SUCCESSFUL,
+                "Pattern", null);
+    }
+
+    @Test
+    public void testFetchSpecificSecret() throws InitializationException {
+        runProviderTest(mockSecretsManagerNoList(mockParameterGroups, "MySecret"), 6, ConfigVerificationResult.Outcome.SUCCESSFUL,
+                "Enumeration", "MySecret");
+    }
+
+    @Test
+    public void testFetchTwoSecrets() throws InitializationException {
+        runProviderTest(mockSecretsManagerNoList(mockParameterGroups, "MySecret,OtherSecret"), 8, ConfigVerificationResult.Outcome.SUCCESSFUL,
+                "Enumeration", "MySecret,OtherSecret");
+    }
+
+    @Test
+    public void testFetchNonExistentSecret() throws InitializationException {
+        when(defaultSecretsManager.getSecretValue(argThat(matchesGetSecretValueRequest("MySecretDoesNotExist")))).thenThrow(new ResourceNotFoundException("Fake exception"));
+        runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
+                "Enumeration", "BadSecret");
     }
 
     @Test
     public void testFetchParametersListFailure() throws InitializationException {
         when(defaultSecretsManager.listSecrets(any())).thenThrow(new AWSSecretsManagerException("Fake exception"));
-        runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED);
+        runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
+                "Pattern", null);
     }
 
     @Test
@@ -110,13 +133,38 @@ public class TestAwsSecretsManagerParameterProvider {
         when(listSecretsResult.getSecretList()).thenReturn(secretList);
         when(defaultSecretsManager.listSecrets(argThat(ListSecretsRequestMatcher.hasToken(null)))).thenReturn(listSecretsResult);
         when(defaultSecretsManager.getSecretValue(argThat(matchesGetSecretValueRequest("MySecret")))).thenThrow(new AWSSecretsManagerException("Fake exception"));
-        runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED);
+        runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
+                "Pattern", null);
     }
 
     private AwsSecretsManagerParameterProvider getParameterProvider() {
         return spy(new AwsSecretsManagerParameterProvider());
     }
 
+    private AWSSecretsManager mockSecretsManagerNoList(final List<ParameterGroup> mockParameterGroups, final String secretNames) {
+        final AWSSecretsManager secretsManager = mock(AWSSecretsManager.class);
+
+        mockParameterGroups.forEach(group -> {
+            final String groupName = group.getGroupName();
+            for (String secretName : Arrays.asList(secretNames.split(","))) {
+                if (groupName.equalsIgnoreCase(secretName)) {
+                    final Map<String, String> keyValues = group.getParameters().stream().collect(Collectors.toMap(
+                            param -> param.getDescriptor().getName(),
+                            Parameter::getValue));
+                    final String secretString;
+                    try {
+                        secretString = objectMapper.writeValueAsString(keyValues);
+                        final GetSecretValueResult result = new GetSecretValueResult().withName(groupName).withSecretString(secretString);
+                        when(secretsManager.getSecretValue(argThat(matchesGetSecretValueRequest(groupName))))
+                                .thenReturn(result);
+                    } catch (final JsonProcessingException e) {
+                        throw new IllegalStateException(e);
+                    }
+                }
+            }
+        });
+        return secretsManager;
+    }
     private AWSSecretsManager mockSecretsManager(final List<ParameterGroup> mockParameterGroups) {
         final AWSSecretsManager secretsManager = mock(AWSSecretsManager.class);
         when(emptyListSecretsResult.getSecretList()).thenReturn(Collections.emptyList());
@@ -152,16 +200,24 @@ public class TestAwsSecretsManagerParameterProvider {
         return secretsManager;
     }
 
-    private List<ParameterGroup> runProviderTest(final AWSSecretsManager secretsManager, final int expectedCount,
-                                                 final ConfigVerificationResult.Outcome expectedOutcome) throws InitializationException {
+    private List<ParameterGroup> runProviderTest(final AWSSecretsManager secretsManager,
+                                                 final int expectedCount,
+                                                 final ConfigVerificationResult.Outcome expectedOutcome,
+                                                 final String listingStrategy,
+                                                 final String secretNames) throws InitializationException {
 
         final AwsSecretsManagerParameterProvider parameterProvider = getParameterProvider();
         doReturn(secretsManager).when(parameterProvider).configureClient(any());
         final MockParameterProviderInitializationContext initContext = new MockParameterProviderInitializationContext("id", "name",
                 new MockComponentLog("providerId", parameterProvider));
         parameterProvider.initialize(initContext);
-
         final Map<PropertyDescriptor, String> properties = new HashMap<>();
+        if (listingStrategy != null) {
+            properties.put(AwsSecretsManagerParameterProvider.SECRET_LISTING_STRATEGY, listingStrategy);
+        }
+        if (secretNames != null) {
+            properties.put(AwsSecretsManagerParameterProvider.SECRET_NAMES, secretNames);
+        }
         final MockConfigurationContext mockConfigurationContext = new MockConfigurationContext(properties, null, null);
 
         List<ParameterGroup> parameterGroups = new ArrayList<>();

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/test/java/org/apache/nifi/parameter/aws/TestAwsSecretsManagerParameterProvider.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/test/java/org/apache/nifi/parameter/aws/TestAwsSecretsManagerParameterProvider.java
@@ -91,39 +91,39 @@ public class TestAwsSecretsManagerParameterProvider {
     public void testFetchParametersWithNoSecrets() throws InitializationException {
         final List<ParameterGroup> expectedGroups = Collections.singletonList(new ParameterGroup("MySecret", Collections.emptyList()));
         runProviderTest(mockSecretsManager(expectedGroups), 0, ConfigVerificationResult.Outcome.SUCCESSFUL,
-                "Pattern", null);
+                "PATTERN", null);
     }
 
     @Test
     public void testFetchParameters() throws InitializationException {
         runProviderTest(mockSecretsManager(mockParameterGroups), 8, ConfigVerificationResult.Outcome.SUCCESSFUL,
-                "Pattern", null);
+                "PATTERN", null);
     }
 
     @Test
     public void testFetchSpecificSecret() throws InitializationException {
         runProviderTest(mockSecretsManagerNoList(mockParameterGroups, "MySecret"), 6, ConfigVerificationResult.Outcome.SUCCESSFUL,
-                "Enumeration", "MySecret");
+                "ENUMERATION", "MySecret");
     }
 
     @Test
     public void testFetchTwoSecrets() throws InitializationException {
         runProviderTest(mockSecretsManagerNoList(mockParameterGroups, "MySecret,OtherSecret"), 8, ConfigVerificationResult.Outcome.SUCCESSFUL,
-                "Enumeration", "MySecret,OtherSecret");
+                "ENUMERATION", "MySecret,OtherSecret");
     }
 
     @Test
     public void testFetchNonExistentSecret() throws InitializationException {
         when(defaultSecretsManager.getSecretValue(argThat(matchesGetSecretValueRequest("MySecretDoesNotExist")))).thenThrow(new ResourceNotFoundException("Fake exception"));
         runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
-                "Enumeration", "BadSecret");
+                "ENUMERATION", "BadSecret");
     }
 
     @Test
     public void testFetchParametersListFailure() throws InitializationException {
         when(defaultSecretsManager.listSecrets(any())).thenThrow(new AWSSecretsManagerException("Fake exception"));
         runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
-                "Pattern", null);
+                "PATTERN", null);
     }
 
     @Test
@@ -134,7 +134,7 @@ public class TestAwsSecretsManagerParameterProvider {
         when(defaultSecretsManager.listSecrets(argThat(ListSecretsRequestMatcher.hasToken(null)))).thenReturn(listSecretsResult);
         when(defaultSecretsManager.getSecretValue(argThat(matchesGetSecretValueRequest("MySecret")))).thenThrow(new AWSSecretsManagerException("Fake exception"));
         runProviderTest(defaultSecretsManager, 0, ConfigVerificationResult.Outcome.FAILED,
-                "Pattern", null);
+                "PATTERN", null);
     }
 
     private AwsSecretsManagerParameterProvider getParameterProvider() {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-12061](https://issues.apache.org/jira/browse/NIFI-12061)
Add `Secret Name` parameter to `AwsSecretsManagerParameterProvider` to allow the provider to work without `ListSecrets` permission. Original behavior where the provider lists all secrets and matches them to `Secret Name Pattern` is preserved by leaving `Secret Name` parameter undefined. The new behavior will skip listing secrets and ignore `Secret Name Pattern` only if `Secret Name` is provided.  I made this change in [Anetac's Nifi fork](https://github.com/Eng-Anetac/nifi) months ago and we are using it in production.

Corresponding PR for 1.x branch: https://github.com/apache/nifi/pull/9386
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-12061`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-12061`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `support/nifi-1.x` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing


- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
