### PR TITLE
NIFI-13982 - Web client - body as string and get request URI for response entity

### DIFF
--- a/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpRequestBodySpec.java
+++ b/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpRequestBodySpec.java
@@ -31,4 +31,14 @@ public interface HttpRequestBodySpec extends HttpRequestHeadersSpec {
      * @return HTTP Request Headers Specification builder
      */
     HttpRequestHeadersSpec body(InputStream inputStream, OptionalLong contentLength);
+
+    /**
+     * Set Request Body as provided string
+     * This should be used only when the payload is small. For large amount of data,
+     * @see HttpRequestBodySpec#body(InputStream, OptionalLong)
+     *
+     * @param body String representation of the payload
+     * @return HTTP Request Headers Specification builder
+     */
+    HttpRequestHeadersSpec body(String body);
 }

--- a/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpRequestBodySpec.java
+++ b/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpRequestBodySpec.java
@@ -33,11 +33,11 @@ public interface HttpRequestBodySpec extends HttpRequestHeadersSpec {
     HttpRequestHeadersSpec body(InputStream inputStream, OptionalLong contentLength);
 
     /**
-     * Set Request Body as provided string
+     * Set Request Body as provided string encoded as UTF-8.
      * This should be used only when the payload is small. For large amount of data,
      * @see HttpRequestBodySpec#body(InputStream, OptionalLong)
      *
-     * @param body String representation of the payload
+     * @param body String representation of the payload encoded as UTF-8
      * @return HTTP Request Headers Specification builder
      */
     HttpRequestHeadersSpec body(String body);

--- a/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpResponseEntity.java
+++ b/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpResponseEntity.java
@@ -50,5 +50,5 @@ public interface HttpResponseEntity extends Closeable {
      *
      * @return HTTP URI from which the response was retrieved
      */
-    URI getUri();
+    URI uri();
 }

--- a/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpResponseEntity.java
+++ b/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpResponseEntity.java
@@ -50,5 +50,5 @@ public interface HttpResponseEntity extends Closeable {
      *
      * @return HTTP URI from which the response was retrieved
      */
-   URI getUri();
+    URI getUri();
 }

--- a/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpResponseEntity.java
+++ b/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpResponseEntity.java
@@ -46,9 +46,9 @@ public interface HttpResponseEntity extends Closeable {
     InputStream body();
 
     /**
-     * Get the HTTP request endpoint that was accessed to generate this HTTP
+     * Get the endpoint URI that was accessed to generate this HTTP response
      *
-     * @return the HTTP request endpoint
+     * @return HTTP URI from which the response was retrieved
      */
-    URI getRequestEndpoint();
+   URI getUri();
 }

--- a/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpResponseEntity.java
+++ b/nifi-commons/nifi-web-client-api/src/main/java/org/apache/nifi/web/client/api/HttpResponseEntity.java
@@ -18,6 +18,7 @@ package org.apache.nifi.web.client.api;
 
 import java.io.Closeable;
 import java.io.InputStream;
+import java.net.URI;
 
 /**
  * HTTP Response Entity extends Closeable to handle closing Response Body
@@ -43,4 +44,11 @@ public interface HttpResponseEntity extends Closeable {
      * @return HTTP Response Body stream can be empty
      */
     InputStream body();
+
+    /**
+     * Get the HTTP request endpoint that was accessed to generate this HTTP
+     *
+     * @return the HTTP request endpoint
+     */
+    URI getRequestEndpoint();
 }

--- a/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardHttpResponseEntity.java
+++ b/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardHttpResponseEntity.java
@@ -33,18 +33,18 @@ class StandardHttpResponseEntity implements HttpResponseEntity {
 
     private final InputStream body;
 
-    private final URI requestEndpoint;
+    private final URI uri;
 
     StandardHttpResponseEntity(
             final int statusCode,
             final HttpEntityHeaders headers,
             final InputStream body,
-            final URI requestEndpoint
+            final URI uri
     ) {
         this.statusCode = statusCode;
         this.headers = headers;
         this.body = body;
-        this.requestEndpoint = requestEndpoint;
+        this.uri = uri;
     }
 
     @Override
@@ -68,7 +68,7 @@ class StandardHttpResponseEntity implements HttpResponseEntity {
     }
 
     @Override
-    public URI getRequestEndpoint() {
-        return requestEndpoint;
+    public URI getUri() {
+        return uri;
     }
 }

--- a/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardHttpResponseEntity.java
+++ b/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardHttpResponseEntity.java
@@ -21,6 +21,7 @@ import org.apache.nifi.web.client.api.HttpResponseEntity;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 
 /**
  * Standard implementation of HTTP Response Entity for Standard Web Client Service
@@ -32,14 +33,18 @@ class StandardHttpResponseEntity implements HttpResponseEntity {
 
     private final InputStream body;
 
+    private final URI requestEndpoint;
+
     StandardHttpResponseEntity(
             final int statusCode,
             final HttpEntityHeaders headers,
-            final InputStream body
+            final InputStream body,
+            final URI requestEndpoint
     ) {
         this.statusCode = statusCode;
         this.headers = headers;
         this.body = body;
+        this.requestEndpoint = requestEndpoint;
     }
 
     @Override
@@ -60,5 +65,10 @@ class StandardHttpResponseEntity implements HttpResponseEntity {
     @Override
     public void close() throws IOException {
         body.close();
+    }
+
+    @Override
+    public URI getRequestEndpoint() {
+        return requestEndpoint;
     }
 }

--- a/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardHttpResponseEntity.java
+++ b/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardHttpResponseEntity.java
@@ -68,7 +68,7 @@ class StandardHttpResponseEntity implements HttpResponseEntity {
     }
 
     @Override
-    public URI getUri() {
+    public URI uri() {
         return uri;
     }
 }

--- a/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardWebClientService.java
+++ b/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardWebClientService.java
@@ -346,7 +346,7 @@ public class StandardWebClientService implements WebClientService, Closeable {
             final InputStream responseBody = response.body();
             final InputStream body = responseBody == null ? new ByteArrayInputStream(EMPTY_BYTES) : responseBody;
 
-            return new StandardHttpResponseEntity(code, headers, body, request.uri());
+            return new StandardHttpResponseEntity(code, headers, body, response.uri());
         }
 
         private HttpResponse<InputStream> getResponse(final HttpRequest request) {

--- a/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardWebClientService.java
+++ b/nifi-commons/nifi-web-client/src/main/java/org/apache/nifi/web/client/StandardWebClientService.java
@@ -31,7 +31,6 @@ import org.apache.nifi.web.client.ssl.SSLContextProvider;
 import org.apache.nifi.web.client.ssl.StandardSSLContextProvider;
 import org.apache.nifi.web.client.ssl.TlsContext;
 
-import javax.net.ssl.SSLContext;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -48,11 +47,14 @@ import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.Flow;
+
+import javax.net.ssl.SSLContext;
 
 /**
  * Standard implementation of Web Client Service using Java HttpClient
@@ -318,6 +320,12 @@ public class StandardWebClientService implements WebClientService, Closeable {
         }
 
         @Override
+        public HttpRequestHeadersSpec body(final String body) {
+            final byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            return body(new ByteArrayInputStream(bytes), OptionalLong.of(bytes.length));
+        }
+
+        @Override
         public HttpRequestBodySpec header(final String headerName, final String headerValue) {
             Objects.requireNonNull(headerName, "Header Name required");
             Objects.requireNonNull(headerValue, "Header Value required");
@@ -338,7 +346,7 @@ public class StandardWebClientService implements WebClientService, Closeable {
             final InputStream responseBody = response.body();
             final InputStream body = responseBody == null ? new ByteArrayInputStream(EMPTY_BYTES) : responseBody;
 
-            return new StandardHttpResponseEntity(code, headers, body);
+            return new StandardHttpResponseEntity(code, headers, body, request.uri());
         }
 
         private HttpResponse<InputStream> getResponse(final HttpRequest request) {


### PR DESCRIPTION
# Summary

[NIFI-13982](https://issues.apache.org/jira/browse/NIFI-13982) - Web client - body as string and get request URI for response entity

In the web client API, we currently have in `HttpRequestBodySpec`:

````java
HttpRequestHeadersSpec body(InputStream inputStream, OptionalLong contentLength) 
````

It would be convenient to also have:

````java
HttpRequestHeadersSpec body(String body); 
````

Especially when the payload is very small and easy to craft.

In addition, in `HttpResponseEntity`, there is no way to know what endpoint has been accessed to generate that response. Having the possibility to retrieved the requested endpoint from the response entity might be useful when there is a separation between processors and controller services, in particular when generating the provenance events at processor level where adding the transit URI is useful for data lineage.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
