### PR TITLE
NIFI-13980: Edit Parameter Context action needs to be completed even …

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
@@ -396,8 +396,8 @@ export class ParameterContextListingEffects {
                                     }
                                 })
                             );
-                            this.store.dispatch(ParameterContextListingActions.editParameterContextComplete());
                         }
+                        this.store.dispatch(ParameterContextListingActions.editParameterContextComplete());
                     });
                 })
             ),


### PR DESCRIPTION
…when the user is routed away by following a link to a referencing component.

To reproduce the issue...

- Create a Parameter Context with a Parameter
- Associate the Parameter Context with the current Process Group
- Reference the Parameter in a Processor and save it.
- Open the Processor configuration and in the Property Table select go to Parameter where it's referenced.
- Edit the Parameter value and Apply.
- Let the update complete.
- Rather than closing the dialog, select the link to the referencing component shown in the dialog.
- Open the Processor configuration and go to the Parameter again.

Without this fix, the previous update response is still shown in the dialog. With this fix, the user will be presented with the ability to reconfigure the Parameter.