### PR TITLE
NIFI-13986 - Upgrade dependencies jackson, jetty, kafka and plugins

### DIFF
--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-service/pom.xml
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-service/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.8.0</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,8 +132,8 @@
         <org.slf4j.version>2.0.16</org.slf4j.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <derby.version>10.17.1.0</derby.version>
-        <jetty.version>12.0.14</jetty.version>
-        <jackson.bom.version>2.18.0</jackson.bom.version>
+        <jetty.version>12.0.15</jetty.version>
+        <jackson.bom.version>2.18.1</jackson.bom.version>
         <avro.version>1.11.4</avro.version>
         <jaxb.runtime.version>4.0.5</jaxb.runtime.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
@@ -673,7 +673,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -717,7 +717,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.43.4</version>
+                    <version>0.45.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -732,12 +732,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>10.18.2</version>
+                            <version>10.20.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -782,7 +782,7 @@
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>3.0.63</version>
+                    <version>3.0.64</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1102,7 +1102,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>10.0.4</version>
+                        <version>11.1.0</version>
                         <executions>
                             <execution>
                                 <inherited>false</inherited>


### PR DESCRIPTION
# Summary

[NIFI-13986](https://issues.apache.org/jira/browse/NIFI-13986) - Upgrade dependencies jackson, jetty, kafka and plugins

- kafka-clients from 3.8.0 to 3.9.0
- jetty from 12.0.14 to 12.0.15
- jackson from 2.18.0 to 2.18.1
- exec-maven-plugin from 3.4.1 to 3.5.0
- docker-maven-plugin from 0.43.4 to 0.45.1
- maven-checkstyle from 3.5.0 to 3.6.0
- checkstyle from 10.18.2 to 10.20.0
- swagger-codegen from 3.0.63 to 3.0.64
- dependency-check from 10.0.4 to 11.1.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
