### PR TITLE
NIFI-13985 fixed typo which caused keystore file to not load by StandardSSLContextService

### DIFF
--- a/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
@@ -250,7 +250,7 @@ public class StandardSSLContextService extends AbstractControllerService impleme
             final StandardSslContextBuilder sslContextBuilder = new StandardSslContextBuilder().protocol(protocol);
 
             final TrustManager trustManager;
-            final String trustStoreFile = getKeyStoreFile();
+            final String trustStoreFile = getTrustStoreFile();
             if (trustStoreFile == null || trustStoreFile.isBlank()) {
                 getLogger().debug("Trust Store File not configured");
             } else {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

There was a simple typo in StandardSSLContextService which caused the keystore file to be used where the truststore file was expected. This resulted in a StandardSSLContextService configuration with only a truststore and no keystore to be inaccurate.

[NIFI-13985](https://issues.apache.org/jira/browse/NIFI-13985)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

- Performed a clean build using `-Pcontrib-check` profile
- Successfully passed a custom processor unit test which previously failed as a result of this bug
- 
### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
