### PR TITLE
NIFI-13491 InvokeHTTP - new property - Response Header Request Attributes Prefix

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/InvokeHTTPTest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/InvokeHTTPTest.java
@@ -452,8 +452,10 @@ public class InvokeHTTPTest {
 
     @Test
     public void testRunGetHttp200SuccessResponseHeaderRequestAttributes() {
+        final String prefix = "response.";
         setUrlProperty();
         runner.setProperty(InvokeHTTP.RESPONSE_HEADER_REQUEST_ATTRIBUTES_ENABLED, Boolean.TRUE.toString());
+        runner.setProperty(InvokeHTTP.RESPONSE_HEADER_REQUEST_ATTRIBUTES_PREFIX, prefix);
 
         final String firstHeader = String.class.getSimpleName();
         final String secondHeader = Integer.class.getSimpleName();
@@ -470,10 +472,19 @@ public class InvokeHTTPTest {
         assertRelationshipStatusCodeEquals(InvokeHTTP.RESPONSE, HTTP_OK);
 
         final MockFlowFile requestFlowFile = getRequestFlowFile();
-        requestFlowFile.assertAttributeEquals(CONTENT_LENGTH_HEADER, Integer.toString(0));
+        requestFlowFile.assertAttributeEquals(prefix + CONTENT_LENGTH_HEADER, Integer.toString(0));
+        requestFlowFile.assertAttributeNotExists(CONTENT_LENGTH_HEADER);
 
         final String repeatedHeaders = String.format("%s, %s", firstHeader, secondHeader);
-        requestFlowFile.assertAttributeEquals(REPEATED_HEADER, repeatedHeaders);
+        requestFlowFile.assertAttributeEquals(prefix + REPEATED_HEADER, repeatedHeaders);
+        requestFlowFile.assertAttributeNotExists(REPEATED_HEADER);
+
+        final MockFlowFile responseFlowFile = getResponseFlowFile();
+        responseFlowFile.assertAttributeNotExists(prefix + CONTENT_LENGTH_HEADER);
+        responseFlowFile.assertAttributeEquals(CONTENT_LENGTH_HEADER, Integer.toString(0));
+
+        responseFlowFile.assertAttributeNotExists(prefix + REPEATED_HEADER);
+        responseFlowFile.assertAttributeEquals(REPEATED_HEADER, repeatedHeaders);
     }
 
     @Test


### PR DESCRIPTION


<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary
[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-13491)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
