### PR TITLE
NIFI-13998 - Add OIDC Client Credentials Flow support to NiFi CLI

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/NiFiClientFactory.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/NiFiClientFactory.java
@@ -84,9 +84,9 @@ public class NiFiClientFactory implements ClientFactory<NiFiClient> {
         final String basicAuthUsername = properties.getProperty(CommandOption.BASIC_AUTH_USER.getLongName());
         final String basicAuthPassword = properties.getProperty(CommandOption.BASIC_AUTH_PASSWORD.getLongName());
 
-        final String oidcUrl = properties.getProperty(CommandOption.OIDC_URL.getLongName());
-        final String oidcId = properties.getProperty(CommandOption.OIDC_CLIENT_ID.getLongName());
-        final String oidcSecret = properties.getProperty(CommandOption.OIDC_CLIENT_SECRET.getLongName());
+        final String oidcTokenUrl = properties.getProperty(CommandOption.OIDC_TOKEN_URL.getLongName());
+        final String oidcClientId = properties.getProperty(CommandOption.OIDC_CLIENT_ID.getLongName());
+        final String oidcClientSecret = properties.getProperty(CommandOption.OIDC_CLIENT_SECRET.getLongName());
 
         final String bearerToken = properties.getProperty(CommandOption.BEARER_TOKEN.getLongName());
 
@@ -123,14 +123,14 @@ public class NiFiClientFactory implements ClientFactory<NiFiClient> {
                     + " is required when specifying " + CommandOption.BASIC_AUTH_PASSWORD.getLongName());
         }
 
-        if (!StringUtils.isBlank(oidcUrl) && StringUtils.isBlank(oidcId)) {
+        if (!StringUtils.isBlank(oidcTokenUrl) && StringUtils.isBlank(oidcClientId)) {
             throw new MissingOptionException(CommandOption.OIDC_CLIENT_ID.getLongName()
-                    + " is required when specifying " + CommandOption.OIDC_URL.getLongName());
+                    + " is required when specifying " + CommandOption.OIDC_TOKEN_URL.getLongName());
         }
 
-        if (!StringUtils.isBlank(oidcUrl) && StringUtils.isBlank(oidcSecret)) {
+        if (!StringUtils.isBlank(oidcTokenUrl) && StringUtils.isBlank(oidcClientSecret)) {
             throw new MissingOptionException(CommandOption.OIDC_CLIENT_SECRET.getLongName()
-                    + " is required when specifying " + CommandOption.OIDC_URL.getLongName());
+                    + " is required when specifying " + CommandOption.OIDC_TOKEN_URL.getLongName());
         }
 
         final NiFiClientConfig.Builder clientConfigBuilder = new NiFiClientConfig.Builder()
@@ -194,8 +194,8 @@ public class NiFiClientFactory implements ClientFactory<NiFiClient> {
         } else if (!StringUtils.isBlank(basicAuthUsername) && !StringUtils.isBlank(basicAuthPassword)) {
             final RequestConfig basicAuthConfig = new BasicAuthRequestConfig(basicAuthUsername, basicAuthPassword);
             return new NiFiClientWithRequestConfig(client, basicAuthConfig);
-        } else if (!StringUtils.isBlank(oidcUrl) && !StringUtils.isBlank(oidcId) && !StringUtils.isBlank(oidcSecret)) {
-            final RequestConfig oidcAuthConfig = new OIDCClientCredentialsRequestConfig(clientConfigBuilder.build(), oidcUrl, oidcId, oidcSecret);
+        } else if (!StringUtils.isBlank(oidcTokenUrl) && !StringUtils.isBlank(oidcClientId) && !StringUtils.isBlank(oidcClientSecret)) {
+            final RequestConfig oidcAuthConfig = new OIDCClientCredentialsRequestConfig(clientConfigBuilder.build(), oidcTokenUrl, oidcClientId, oidcClientSecret);
             return new NiFiClientWithRequestConfig(client, oidcAuthConfig);
         } else {
             return client;

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/NiFiClientFactory.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/NiFiClientFactory.java
@@ -46,6 +46,7 @@ import org.apache.nifi.toolkit.cli.impl.client.nifi.VersionsClient;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.impl.JerseyNiFiClient;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.impl.request.BasicAuthRequestConfig;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.impl.request.BearerTokenRequestConfig;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.impl.request.OIDCClientCredentialsRequestConfig;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.impl.request.ProxiedEntityRequestConfig;
 import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
 
@@ -83,6 +84,10 @@ public class NiFiClientFactory implements ClientFactory<NiFiClient> {
         final String basicAuthUsername = properties.getProperty(CommandOption.BASIC_AUTH_USER.getLongName());
         final String basicAuthPassword = properties.getProperty(CommandOption.BASIC_AUTH_PASSWORD.getLongName());
 
+        final String oidcUrl = properties.getProperty(CommandOption.OIDC_URL.getLongName());
+        final String oidcId = properties.getProperty(CommandOption.OIDC_CLIENT_ID.getLongName());
+        final String oidcSecret = properties.getProperty(CommandOption.OIDC_CLIENT_SECRET.getLongName());
+
         final String bearerToken = properties.getProperty(CommandOption.BEARER_TOKEN.getLongName());
 
         final boolean secureUrl = url.startsWith("https");
@@ -116,6 +121,16 @@ public class NiFiClientFactory implements ClientFactory<NiFiClient> {
         if (!StringUtils.isBlank(basicAuthPassword) && StringUtils.isBlank(basicAuthUsername)) {
             throw new MissingOptionException(CommandOption.BASIC_AUTH_USER.getLongName()
                     + " is required when specifying " + CommandOption.BASIC_AUTH_PASSWORD.getLongName());
+        }
+
+        if (!StringUtils.isBlank(oidcUrl) && StringUtils.isBlank(oidcId)) {
+            throw new MissingOptionException(CommandOption.OIDC_CLIENT_ID.getLongName()
+                    + " is required when specifying " + CommandOption.OIDC_URL.getLongName());
+        }
+
+        if (!StringUtils.isBlank(oidcUrl) && StringUtils.isBlank(oidcSecret)) {
+            throw new MissingOptionException(CommandOption.OIDC_CLIENT_SECRET.getLongName()
+                    + " is required when specifying " + CommandOption.OIDC_URL.getLongName());
         }
 
         final NiFiClientConfig.Builder clientConfigBuilder = new NiFiClientConfig.Builder()
@@ -179,6 +194,9 @@ public class NiFiClientFactory implements ClientFactory<NiFiClient> {
         } else if (!StringUtils.isBlank(basicAuthUsername) && !StringUtils.isBlank(basicAuthPassword)) {
             final RequestConfig basicAuthConfig = new BasicAuthRequestConfig(basicAuthUsername, basicAuthPassword);
             return new NiFiClientWithRequestConfig(client, basicAuthConfig);
+        } else if (!StringUtils.isBlank(oidcUrl) && !StringUtils.isBlank(oidcId) && !StringUtils.isBlank(oidcSecret)) {
+            final RequestConfig oidcAuthConfig = new OIDCClientCredentialsRequestConfig(clientConfigBuilder.build(), oidcUrl, oidcId, oidcSecret);
+            return new NiFiClientWithRequestConfig(client, oidcAuthConfig);
         } else {
             return client;
         }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/request/OIDCClientCredentialsRequestConfig.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/request/OIDCClientCredentialsRequestConfig.java
@@ -41,10 +41,10 @@ public class OIDCClientCredentialsRequestConfig implements RequestConfig {
 
     private final String token;
 
-    public OIDCClientCredentialsRequestConfig(NiFiClientConfig niFiClientConfig, final String oidcUrl, final String clientId, final String clientSecret) {
-        Objects.requireNonNull(oidcUrl);
-        Objects.requireNonNull(clientId);
-        Objects.requireNonNull(clientSecret);
+    public OIDCClientCredentialsRequestConfig(NiFiClientConfig niFiClientConfig, final String oidcTokenUrl, final String oidcClientId, final String oidcClientSecret) {
+        Objects.requireNonNull(oidcTokenUrl);
+        Objects.requireNonNull(oidcClientId);
+        Objects.requireNonNull(oidcClientSecret);
         Objects.requireNonNull(niFiClientConfig);
 
         final SSLContext sslContext = niFiClientConfig.getSslContext();
@@ -60,10 +60,10 @@ public class OIDCClientCredentialsRequestConfig implements RequestConfig {
 
         final Form form = new Form();
         form.param("grant_type", "client_credentials");
-        form.param("client_id", clientId);
-        form.param("client_secret", clientSecret);
+        form.param("client_id", oidcClientId);
+        form.param("client_secret", oidcClientSecret);
 
-        final WebTarget target = clientBuilder.build().target(oidcUrl);
+        final WebTarget target = clientBuilder.build().target(oidcTokenUrl);
         final String response = target.request().post(Entity.form(form), String.class);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/request/OIDCClientCredentialsRequestConfig.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/request/OIDCClientCredentialsRequestConfig.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.client.nifi.impl.request;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Form;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientConfig;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.RequestConfig;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Implementation of RequestConfig when using the OAuth Client Credentials Flow
+ */
+public class OIDCClientCredentialsRequestConfig implements RequestConfig {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER = "Bearer";
+
+    private final String token;
+
+    public OIDCClientCredentialsRequestConfig(NiFiClientConfig niFiClientConfig, final String oidcUrl, final String clientId, final String clientSecret) {
+        Objects.requireNonNull(oidcUrl);
+        Objects.requireNonNull(clientId);
+        Objects.requireNonNull(clientSecret);
+        Objects.requireNonNull(niFiClientConfig);
+
+        final SSLContext sslContext = niFiClientConfig.getSslContext();
+        final HostnameVerifier hostnameVerifier = niFiClientConfig.getHostnameVerifier();
+
+        final ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+        if (sslContext != null) {
+            clientBuilder.sslContext(sslContext);
+        }
+        if (hostnameVerifier != null) {
+            clientBuilder.hostnameVerifier(hostnameVerifier);
+        }
+
+        final Form form = new Form();
+        form.param("grant_type", "client_credentials");
+        form.param("client_id", clientId);
+        form.param("client_secret", clientSecret);
+
+        final WebTarget target = clientBuilder.build().target(oidcUrl);
+        final String response = target.request().post(Entity.form(form), String.class);
+
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            this.token = mapper.readTree(response).get("access_token").textValue();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(AUTHORIZATION_HEADER, BEARER + " " + token);
+        return headers;
+    }
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
@@ -177,7 +177,7 @@ public enum CommandOption {
     USERNAME("usr", "username", "The username for authentication when obtaining an access token", true),
     PASSWORD("pwd", "password", "The password for authentication when obtaining an access token", true),
 
-    OIDC_URL("oidcurl", "oidcUrl", "The OIDC URL to access the token endpoint for the OAuth Client Credentials Flow", true),
+    OIDC_TOKEN_URL("oidctokenurl", "oidcTokenUrl", "The OIDC URL to access the token endpoint for the OAuth Client Credentials Flow", true),
     OIDC_CLIENT_ID("oidcid", "oidcClientId", "The Client ID for the OAuth Client Credentials Flow", true),
     OIDC_CLIENT_SECRET("oidcsecret", "oidcClientSecret", "The Client Secret for the OAuth Client Credentials Flow", true),
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
@@ -177,6 +177,10 @@ public enum CommandOption {
     USERNAME("usr", "username", "The username for authentication when obtaining an access token", true),
     PASSWORD("pwd", "password", "The password for authentication when obtaining an access token", true),
 
+    OIDC_URL("oidcurl", "oidcUrl", "The OIDC URL to access the token endpoint for the OAuth Client Credentials Flow", true),
+    OIDC_CLIENT_ID("oidcid", "oidcClientId", "The Client ID for the OAuth Client Credentials Flow", true),
+    OIDC_CLIENT_SECRET("oidcsecret", "oidcClientSecret", "The Client Secret for the OAuth Client Credentials Flow", true),
+
     KERBEROS_PRINCIPAL("krbPr", "kerberosPrincipal", "The kerberos principal", true),
     KERBEROS_KEYTAB("krbKt", "kerberosKeytab", "The keytab for a kerberos principal", true, true),
     KERBEROS_PASSWORD("krbPw", "kerberosPassword", "The password for a kerberos principal", true),
@@ -206,7 +210,6 @@ public enum CommandOption {
         this.hasArg = hasArg;
         this.isFile = isFile;
     }
-
 
     public String getShortName() {
         return shortName;


### PR DESCRIPTION
# Summary

[NIFI-13998](https://issues.apache.org/jira/browse/NIFI-13998) - Add OIDC Client Credentials Flow support to NiFi CLI

With [NIFI-5302](https://issues.apache.org/jira/browse/NIFI-5302) #8532, we added support for Client Credentials Flow with OIDC. This should also be made available to the NiFi CLI.

````
$ cat nifi-cli-oidc.properties

baseUrl=https://localhost:8443
truststore=...
truststoreType=PKCS12
truststorePasswd=...
oidcTokenUrl=http://localhost:8080/realms/nifi/protocol/openid-connect/token
oidcClientId=...
oidcClientSecret=...
````

````
./bin/cli.sh nifi pg-list -p nifi-cli-oidc.properties

#   Name            Id                                     Running   Stopped   Disabled   Invalid
-   -------------   ------------------------------------   -------   -------   --------   -------
1   MyPG            b8bb5737-0191-1000-8462-b9822d6117f3   0         13        546        1
````

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
