### PR TITLE
NIFI-14003: Allow stateless ready queue to update order.

### DIFF
--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/session/AsynchronousCommitTracker.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/session/AsynchronousCommitTracker.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.Stack;
 import java.util.function.Consumer;
 
@@ -41,7 +40,7 @@ public class AsynchronousCommitTracker {
     private static final Logger logger = LoggerFactory.getLogger(AsynchronousCommitTracker.class);
 
     private final ProcessGroup rootGroup;
-    private final Set<Connectable> ready = new LinkedHashSet<>();
+    private final LinkedHashSet<Connectable> ready = new LinkedHashSet<>();
     private final Stack<CommitCallbacks> commitCallbacks = new Stack<>();
     private int flowFilesProduced = 0;
     private long bytesProduced = 0L;
@@ -70,15 +69,17 @@ public class AsynchronousCommitTracker {
         }
     }
 
-
     public Connectable getNextReady() {
         if (ready.isEmpty()) {
             return null;
         }
 
-        Connectable last = null;
-        for (final Connectable connectable : ready) {
-            last = connectable;
+        final Connectable last = ready.getLast();
+
+        //When selecting the next ready Connectable move the selected Connectable to the first position. The Connectable in the first position will be
+        //the last to be executed. This way execution of Connectables gets continuously rotated.  We only need to do this when there is more than one ready.
+        if (ready.size() > 1) {
+            ready.addFirst(last);
         }
 
         return last;

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/test/java/org/apache/nifi/stateless/session/TestAsynchronousCommitTracker.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/test/java/org/apache/nifi/stateless/session/TestAsynchronousCommitTracker.java
@@ -51,17 +51,18 @@ public class TestAsynchronousCommitTracker {
         assertEquals(connectable2, tracker.getNextReady());
 
         tracker.addConnectable(connectable3);
-        assertEquals(Arrays.asList(connectable3, connectable2, connectable1), tracker.getReady());
+        assertEquals(Arrays.asList(connectable3, connectable1, connectable2), tracker.getReady());
         assertEquals(connectable3, tracker.getNextReady());
 
         // connectable1 should now be moved to the start of the List
+        // connectable3 should be at the end from the last call to getNextReady
         tracker.addConnectable(connectable1);
-        assertEquals(Arrays.asList(connectable1, connectable3, connectable2), tracker.getReady());
+        assertEquals(Arrays.asList(connectable1, connectable2, connectable3), tracker.getReady());
         assertEquals(connectable1, tracker.getNextReady());
 
         // Adding connectable1 again should now have effect since it is already first
         tracker.addConnectable(connectable1);
-        assertEquals(Arrays.asList(connectable1, connectable3, connectable2), tracker.getReady());
+        assertEquals(Arrays.asList(connectable1, connectable2, connectable3), tracker.getReady());
         assertEquals(connectable1, tracker.getNextReady());
     }
 


### PR DESCRIPTION
When more than one processor is ready we should allow the order of the queue to change to prevent execution from getting stuck on a single processor.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14003](https://issues.apache.org/jira/browse/NIFI-14003)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
