### PR TITLE
NIFI-14006 Fix RuntimeManifestEndpointMerger to avoid reading the cli…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/RuntimeManifestEndpointMerger.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/RuntimeManifestEndpointMerger.java
@@ -51,7 +51,7 @@ public class RuntimeManifestEndpointMerger implements EndpointResponseMerger {
         final Set<Bundle> responseBundles = responseManifest.getBundles() == null ? new LinkedHashSet<>() : new LinkedHashSet<>(responseManifest.getBundles());
 
         for (final NodeResponse nodeResponse : successfulResponses) {
-            final RuntimeManifestEntity nodeResponseEntity = nodeResponse.getClientResponse().readEntity(RuntimeManifestEntity.class);
+            final RuntimeManifestEntity nodeResponseEntity = nodeResponse == clientResponse ? responseEntity : nodeResponse.getClientResponse().readEntity(RuntimeManifestEntity.class);
             final RuntimeManifest nodeResponseManifest = nodeResponseEntity.getRuntimeManifest();
             final List<Bundle> nodeResponseBundles = nodeResponseManifest.getBundles() == null ? Collections.emptyList() : nodeResponseManifest.getBundles();
             responseBundles.retainAll(nodeResponseBundles);


### PR DESCRIPTION
…ent response twice

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14006](https://issues.apache.org/jira/browse/NIFI-14006)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
