### PR TITLE
NIFI-14005 - GetFileResource processor

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFileResource.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFileResource.java
@@ -62,6 +62,7 @@ import java.util.Set;
 @WritesAttributes(
     {
             @WritesAttribute(attribute = "mime.type", description = "Sets the MIME type of the output if the 'MIME Type' property is set"),
+            @WritesAttribute(attribute = "Dynamic property key", description = "Value for the corresponding dynamic property, if any is set")
     }
 )
 @DefaultSchedule(strategy = SchedulingStrategy.TIMER_DRIVEN, period = "1 min")
@@ -105,6 +106,7 @@ public class GetFileResource extends AbstractProcessor {
         return new PropertyDescriptor.Builder()
                 .name(propertyDescriptorName)
                 .required(false)
+                .description("Specifies an attribute on generated FlowFiles defined by the Dynamic Property's key and value.")
                 .addValidator(StandardValidators.createAttributeExpressionLanguageValidator(AttributeExpression.ResultType.STRING, true))
                 .addValidator(StandardValidators.ATTRIBUTE_KEY_PROPERTY_NAME_VALIDATOR)
                 .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFileResource.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFileResource.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.annotation.behavior.DynamicProperty;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.Restricted;
+import org.apache.nifi.annotation.behavior.Restriction;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.configuration.DefaultSchedule;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.RequiredPermission;
+import org.apache.nifi.components.resource.ResourceCardinality;
+import org.apache.nifi.components.resource.ResourceType;
+import org.apache.nifi.expression.AttributeExpression;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.io.OutputStreamCallback;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.scheduling.SchedulingStrategy;
+import org.apache.nifi.stream.io.StreamUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Tags({"test", "file", "generate", "load"})
+@InputRequirement(Requirement.INPUT_FORBIDDEN)
+@CapabilityDescription("This processor creates FlowFiles with the content of the configured File Resource. GetFileResource "
+        + "is useful for load testing, configuration, and simulation.")
+@DynamicProperty(name = "Generated FlowFile attribute name", value = "Generated FlowFile attribute value",
+        expressionLanguageScope = ExpressionLanguageScope.ENVIRONMENT,
+        description = "Specifies an attribute on generated FlowFiles defined by the Dynamic Property's key and value." +
+        " If Expression Language is used, evaluation will be performed only once per batch of generated FlowFiles.")
+@WritesAttributes({
+        @WritesAttribute(attribute = "mime.type", description = "Sets the MIME type of the output if the 'Mime Type' property is set"),
+})
+@DefaultSchedule(strategy = SchedulingStrategy.TIMER_DRIVEN, period = "1 min")
+@Restricted(
+        restrictions = {
+                @Restriction(
+                        requiredPermission = RequiredPermission.READ_FILESYSTEM,
+                        explanation = "Provides operator the ability to read from any file that NiFi has access to."),
+                @Restriction(
+                        requiredPermission = RequiredPermission.REFERENCE_REMOTE_RESOURCES,
+                        explanation = "File Resource can reference resources over HTTP/HTTPS"
+                )
+        }
+)
+public class GetFileResource extends AbstractProcessor {
+
+    public static final PropertyDescriptor FILE_RESOURCE = new PropertyDescriptor.Builder()
+            .name("File Resource")
+            .description("Location of the File Resource (Local File or URL). This file will be used as content of the generated FlowFiles.")
+            .required(true)
+            .identifiesExternalResource(ResourceCardinality.SINGLE, ResourceType.FILE, ResourceType.URL)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+    public static final PropertyDescriptor MIME_TYPE = new PropertyDescriptor.Builder()
+            .name("Mime Type")
+            .description("Specifies the value to set for the \"mime.type\" attribute.")
+            .required(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(FILE_RESOURCE, MIME_TYPE);
+
+    public static final Relationship SUCCESS = new Relationship.Builder()
+            .name("success")
+            .build();
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(SUCCESS);
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTIES;
+    }
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        return new PropertyDescriptor.Builder()
+                .name(propertyDescriptorName)
+                .required(false)
+                .addValidator(StandardValidators.createAttributeExpressionLanguageValidator(AttributeExpression.ResultType.STRING, true))
+                .addValidator(StandardValidators.ATTRIBUTE_KEY_PROPERTY_NAME_VALIDATOR)
+                .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+                .dynamic(true)
+                .build();
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return RELATIONSHIPS;
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) {
+        Map<PropertyDescriptor, String> processorProperties = context.getProperties();
+        Map<String, String> generatedAttributes = new HashMap<String, String>();
+        for (final Map.Entry<PropertyDescriptor, String> entry : processorProperties.entrySet()) {
+            PropertyDescriptor property = entry.getKey();
+            if (property.isDynamic() && property.isExpressionLanguageSupported()) {
+                String dynamicValue = context.getProperty(property).evaluateAttributeExpressions().getValue();
+                generatedAttributes.put(property.getName(), dynamicValue);
+            }
+        }
+
+        if (context.getProperty(MIME_TYPE).isSet()) {
+            generatedAttributes.put(CoreAttributes.MIME_TYPE.key(), context.getProperty(MIME_TYPE).getValue());
+        }
+
+        FlowFile flowFile = session.create();
+
+        try (final InputStream inputStream = context.getProperty(FILE_RESOURCE).asResource().read()) {
+            flowFile = session.write(flowFile, new OutputStreamCallback() {
+                @Override
+                public void process(final OutputStream out) throws IOException {
+                    StreamUtils.copy(inputStream, out);
+                }
+            });
+        } catch (IOException e) {
+            getLogger().error("Could not create FlowFile with specified Custom Content", e);
+        }
+
+        flowFile = session.putAllAttributes(flowFile, generatedAttributes);
+        session.getProvenanceReporter().create(flowFile);
+        session.transfer(flowFile, SUCCESS);
+    }
+}

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -52,6 +52,7 @@ org.apache.nifi.processors.standard.GenerateRecord
 org.apache.nifi.processors.standard.GenerateFlowFile
 org.apache.nifi.processors.standard.GenerateTableFetch
 org.apache.nifi.processors.standard.GetFile
+org.apache.nifi.processors.standard.GetFileResource
 org.apache.nifi.processors.standard.GetFTP
 org.apache.nifi.processors.standard.GetSFTP
 org.apache.nifi.processors.standard.HandleHttpRequest

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetFileResource.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetFileResource.java
@@ -32,12 +32,13 @@ public class TestGetFileResource {
 
     @Test
     public void testGetFileResource() throws IOException {
+        final String filePath = "src/test/resources/TestCountText/jabberwocky.txt";
         final TestRunner runner = TestRunners.newTestRunner(new GetFileResource());
 
         runner.setProperty(GetFileResource.FILE_RESOURCE, "");
         runner.assertNotValid();
 
-        runner.setProperty(GetFileResource.FILE_RESOURCE, "src/test/resources/TestCountText/jabberwocky.txt");
+        runner.setProperty(GetFileResource.FILE_RESOURCE, filePath);
         runner.setProperty(GetFileResource.MIME_TYPE, "text/plain");
         runner.setProperty("foo", "foo");
         runner.assertValid();
@@ -46,7 +47,7 @@ public class TestGetFileResource {
 
         runner.assertTransferCount(GenerateFlowFile.SUCCESS, 1);
         final MockFlowFile ff = runner.getFlowFilesForRelationship(GenerateFlowFile.SUCCESS).get(0);
-        ff.assertContentEquals(new File("src/test/resources/TestCountText/jabberwocky.txt"));
+        ff.assertContentEquals(new File(filePath));
         ff.assertAttributeEquals("foo", "foo");
         ff.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "text/plain");
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetFileResource.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetFileResource.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard;
+
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Unit tests for the GetFileResource processor.
+ */
+public class TestGetFileResource {
+
+    @Test
+    public void testGetFileResource() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new GetFileResource());
+
+        runner.setProperty(GetFileResource.FILE_RESOURCE, "");
+        runner.assertNotValid();
+
+        runner.setProperty(GetFileResource.FILE_RESOURCE, "src/test/resources/TestCountText/jabberwocky.txt");
+        runner.setProperty(GetFileResource.MIME_TYPE, "text/plain");
+        runner.setProperty("foo", "foo");
+        runner.assertValid();
+
+        runner.run();
+
+        runner.assertTransferCount(GenerateFlowFile.SUCCESS, 1);
+        final MockFlowFile ff = runner.getFlowFilesForRelationship(GenerateFlowFile.SUCCESS).get(0);
+        ff.assertContentEquals(new File("src/test/resources/TestCountText/jabberwocky.txt"));
+        ff.assertAttributeEquals("foo", "foo");
+        ff.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "text/plain");
+    }
+
+}

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetFileResource.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetFileResource.java
@@ -31,12 +31,16 @@ import java.io.IOException;
 public class TestGetFileResource {
 
     @Test
+    public void testInvalidConfiguration() {
+        final TestRunner runner = TestRunners.newTestRunner(new GetFileResource());
+        runner.setProperty(GetFileResource.FILE_RESOURCE, "");
+        runner.assertNotValid();
+    }
+
+    @Test
     public void testGetFileResource() throws IOException {
         final String filePath = "src/test/resources/TestCountText/jabberwocky.txt";
         final TestRunner runner = TestRunners.newTestRunner(new GetFileResource());
-
-        runner.setProperty(GetFileResource.FILE_RESOURCE, "");
-        runner.assertNotValid();
 
         runner.setProperty(GetFileResource.FILE_RESOURCE, filePath);
         runner.setProperty(GetFileResource.MIME_TYPE, "text/plain");


### PR DESCRIPTION
# Summary

[NIFI-14005](https://issues.apache.org/jira/browse/NIFI-14005) - GetFileResource processor

The goal of this new GetFileResource processor is to provide a way for a user to inject a File Resource as a FlowFile with custom attributes. It means that the processor would be able to specify a path to a file and its content would be used as FlowFile's content. By leveraging the asset feature, it makes it easy to load a test dataset as a FlowFile in a cloud native environment (container based).

Alternatives that have been considered:
- GenerateFlowFile with a "Custom File/Content" property. However, a processor being able to access the local file system needs to be associated with a specific set of permissions and that would be a significant breaking change for all users already using GenerateFlowFile processor where such permissions are enforced.
- GetFile with some specific improvements. However, longer term we would likely want to completely remove this processor and only have ListFile/FetchFile. Beside, its configuration is overly complex for the intended goal here.

Testing:
- tested with local file reference
- tested with file referenced via URL
- tested using Asset feature and Parameter reference

For information:

````
$ ./bin/cli.sh nifi create-asset -p nifi-cli.properties -pcid dc39db55-1eb2-3d26-9a8a-caaf097cfcc2 -af /Users/pierre/dev/myFile.txt

b099141f-2bc4-3073-8dc0-243dac470f08

$ ./bin/cli.sh nifi add-asset-reference -p nifi-cli.properties -aid b099141f-2bc4-3073-8dc0-243dac470f08 -pcid dc39db55-1eb2-3d26-9a8a-caaf097cfcc2 -pn MyAsset
````

The parameter `#{MyAsset}` can then be used in the processor (assuming proper Parameter Context binding on the Process Group).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
