### PR TITLE
NIFI-14010 Upgrade Netty to 4.1.115 and Bouncy Castle to 1.79

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <org.apache.commons.text.version>1.12.0</org.apache.commons.text.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
-        <org.bouncycastle.version>1.78.1</org.bouncycastle.version>
+        <org.bouncycastle.version>1.79</org.bouncycastle.version>
         <testcontainers.version>1.20.3</testcontainers.version>
         <org.slf4j.version>2.0.16</org.slf4j.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
@@ -152,7 +152,7 @@
         <mockito.version>5.14.2</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.3</snakeyaml.version>
-        <netty.4.version>4.1.114.Final</netty.4.version>
+        <netty.4.version>4.1.115.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.version>6.1.14</spring.version>
         <spring.security.version>6.3.4</spring.security.version>


### PR DESCRIPTION
# Summary

[NIFI-14010](https://issues.apache.org/jira/browse/NIFI-14010) Upgrades Netty dependencies from 4.1.114 to [4.1.115](https://netty.io/news/2024/11/12/4-1-115-Final.html) and also upgrades Bouncy Castle dependencies from 1.78.1 to [1.79](https://www.bouncycastle.org/download/bouncy-castle-java/?filter=java%3Drelease-1-79).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
