### PR TITLE
NIFI-13731 - Catch NPE when no Provenance Lineage Submission

### DIFF
--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/LuceneEventIndex.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/index/lucene/LuceneEventIndex.java
@@ -758,6 +758,11 @@ public class LuceneEventIndex implements EventIndex {
     @Override
     public AsyncLineageSubmission retrieveLineageSubmission(final String lineageIdentifier, final NiFiUser user) {
         final AsyncLineageSubmission submission = lineageSubmissionMap.get(lineageIdentifier);
+
+        if (submission == null) {
+            throw new AccessDeniedException("Cannot retrieve Provenance Lineage Submission. It has already been deleted or submitted to another NiFi node in the cluster.");
+        }
+
         final String userId = submission.getSubmitterIdentity();
 
         if (user == null && userId == null) {


### PR DESCRIPTION
# Summary

[NIFI-13731](https://issues.apache.org/jira/browse/NIFI-13731) - Catch NPE when no Provenance Lineage Submission

````
2024-11-15 14:06:58,024 ERROR [NiFi Web Server-804] o.a.nifi.web.api.config.ThrowableMapper An unexpected error has occurred: java.lang.NullPointerException: Cannot invoke "org.apache.nifi.provenance.AsyncLineageSubmission.getSubmitterIdentity()" because "submission" is null. Returning Internal Server Error response.
java.lang.NullPointerException: Cannot invoke "org.apache.nifi.provenance.AsyncLineageSubmission.getSubmitterIdentity()" because "submission" is null
	at org.apache.nifi.provenance.index.lucene.LuceneEventIndex.retrieveLineageSubmission(LuceneEventIndex.java:761)
	at org.apache.nifi.provenance.index.lucene.LuceneEventIndex.retrieveLineageSubmission(LuceneEventIndex.java:83)
	at org.apache.nifi.provenance.WriteAheadProvenanceRepository.retrieveLineageSubmission(WriteAheadProvenanceRepository.java:281)
	at org.apache.nifi.web.controller.ControllerFacade.getLineage(ControllerFacade.java:1342)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
````

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
