### PR TITLE
NIFI-13682 - Versioning breaks in case of style change on labels

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/label/StandardLabel.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/label/StandardLabel.java
@@ -29,8 +29,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class StandardLabel implements Label {
     public static final long DEFAULT_Z_INDEX = 0;
@@ -112,10 +112,7 @@ public class StandardLabel implements Label {
         if (style != null) {
             boolean updated = false;
             while (!updated) {
-                final Map<String, String> existingStyles = this.style.get();
-                final Map<String, String> updatedStyles = new HashMap<>(existingStyles);
-                updatedStyles.putAll(style);
-                updated = this.style.compareAndSet(existingStyles, Collections.unmodifiableMap(updatedStyles));
+                updated = this.style.compareAndSet(this.style.get(), Collections.unmodifiableMap(style));
             }
         }
     }


### PR DESCRIPTION
# Summary

[NIFI-13682](https://issues.apache.org/jira/browse/NIFI-13682) - Versioning breaks in case of style change on labels

Style for labels is a map which can have up to two keys: `font-size` and `background-color`. If between two versions, this map has a different key set, the current code creates an issue where we would always block any version change / any revert local changes because the current code merges the changes of the two versions and it will show as local changes that we'll never be able to revert. This PR changes the code to not merge the styles, but strictly apply the style of the desired version.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
