### PR TITLE
NIFI-13608 - Handle NPE from Empty All Queues when there is no queue

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -1573,6 +1573,14 @@ public final class StandardProcessGroup implements ProcessGroup {
         List<Connection> connections = findAllConnections(this);
 
         DropFlowFileRequest aggregateDropFlowFileStatus = new DropFlowFileRequest(dropRequestId);
+
+        if (connections.isEmpty()) {
+            aggregateDropFlowFileStatus.setState(DropFlowFileState.COMPLETE);
+            aggregateDropFlowFileStatus.setCurrentSize(new QueueSize(0, 0L));
+            aggregateDropFlowFileStatus.setOriginalSize(new QueueSize(0, 0L));
+            return aggregateDropFlowFileStatus;
+        }
+
         aggregateDropFlowFileStatus.setState(null);
 
         AtomicBoolean processedAtLeastOne = new AtomicBoolean(false);


### PR DESCRIPTION
# Summary

[NIFI-13608](https://issues.apache.org/jira/browse/NIFI-13608) - Handle NPE from Empty All Queues when there is no queue

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
