### PR TITLE
NIFI-14012 Add UID and DC Formatting for Certificate Principals

### DIFF
--- a/nifi-commons/nifi-security-cert/src/main/java/org/apache/nifi/security/cert/StandardPrincipalFormatter.java
+++ b/nifi-commons/nifi-security-cert/src/main/java/org/apache/nifi/security/cert/StandardPrincipalFormatter.java
@@ -18,6 +18,7 @@ package org.apache.nifi.security.cert;
 
 import javax.security.auth.x500.X500Principal;
 import java.security.cert.X509Certificate;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -25,6 +26,12 @@ import java.util.Objects;
  */
 public class StandardPrincipalFormatter implements PrincipalFormatter {
     private static final PrincipalFormatter INSTANCE = new StandardPrincipalFormatter();
+
+    /** Map of Object Identifiers to Names not included in the standard set from X500Principal.RFC1779 */
+    private static final Map<String, String> OBJECT_IDENTIFIER_NAMES = Map.of(
+            "0.9.2342.19200300.100.1.1", "UID",
+            "0.9.2342.19200300.100.1.25", "DC"
+    );
 
     private StandardPrincipalFormatter() {
 
@@ -64,6 +71,6 @@ public class StandardPrincipalFormatter implements PrincipalFormatter {
     }
 
     private String getFormatted(final X500Principal principal) {
-        return principal.getName(X500Principal.RFC1779);
+        return principal.getName(X500Principal.RFC1779, OBJECT_IDENTIFIER_NAMES);
     }
 }

--- a/nifi-commons/nifi-security-cert/src/test/java/org/apache/nifi/security/cert/StandardPrincipalFormatterTest.java
+++ b/nifi-commons/nifi-security-cert/src/test/java/org/apache/nifi/security/cert/StandardPrincipalFormatterTest.java
@@ -36,6 +36,12 @@ class StandardPrincipalFormatterTest {
 
     private static final X500Principal SUBJECT_PRINCIPAL = new X500Principal(SUBJECT_CANONICAL);
 
+    private static final String SUBJECT_LDAP_ELEMENTS = "UID=Subject,DC=Apache,DC=NiFi";
+
+    private static final String SUBJECT_LDAP_FORMATTED = "UID=Subject, DC=Apache, DC=NiFi";
+
+    private static final X500Principal SUBJECT_LDAP_PRINCIPAL = new X500Principal(SUBJECT_LDAP_ELEMENTS);
+
     private static final String ISSUER_CANONICAL = "CN=Certificate Authority,O=Organization,C=US";
 
     private static final String ISSUER_FORMATTED = "CN=Certificate Authority, O=Organization, C=US";
@@ -52,6 +58,15 @@ class StandardPrincipalFormatterTest {
         final String subject = StandardPrincipalFormatter.getInstance().getSubject(certificate);
 
         assertEquals(SUBJECT_FORMATTED, subject);
+    }
+
+    @Test
+    void testGetSubjectLdapElements() {
+        when(certificate.getSubjectX500Principal()).thenReturn(SUBJECT_LDAP_PRINCIPAL);
+
+        final String subject = StandardPrincipalFormatter.getInstance().getSubject(certificate);
+
+        assertEquals(SUBJECT_LDAP_FORMATTED, subject);
     }
 
     @Test

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/x509/X509AuthenticationProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/x509/X509AuthenticationProviderTest.java
@@ -52,12 +52,12 @@ import static org.mockito.Mockito.when;
 public class X509AuthenticationProviderTest {
 
     private static final String INVALID_CERTIFICATE = "invalid-certificate";
-    private static final String IDENTITY_1 = "identity-1";
+    private static final String IDENTITY_1 = "CN=identity-1";
     private static final String ANONYMOUS = "";
 
-    private static final String UNTRUSTED_PROXY = "untrusted-proxy";
-    private static final String PROXY_1 = "proxy-1";
-    private static final String PROXY_2 = "proxy-2";
+    private static final String UNTRUSTED_PROXY = "CN=untrusted-proxy";
+    private static final String PROXY_1 = "CN=proxy-1";
+    private static final String PROXY_2 = "CN=proxy-2";
 
 
     private X509AuthenticationProvider x509AuthenticationProvider;
@@ -67,8 +67,6 @@ public class X509AuthenticationProviderTest {
 
     @BeforeEach
     public void setup() {
-
-        System.clearProperty(NiFiProperties.PROPERTIES_FILE_PATH);
         extractor = new SubjectDnX509PrincipalExtractor();
 
         certificateIdentityProvider = mock(X509IdentityProvider.class);
@@ -275,12 +273,7 @@ public class X509AuthenticationProviderTest {
 
     private X509Certificate getX509Certificate(final String identity) {
         final X509Certificate certificate = mock(X509Certificate.class);
-        when(certificate.getSubjectX500Principal()).then(invocation -> {
-            final X500Principal principal = mock(X500Principal.class);
-            when(principal.getName(any())).thenReturn(identity);
-            return principal;
-        });
+        when(certificate.getSubjectX500Principal()).then(invocation -> new X500Principal(identity));
         return certificate;
     }
-
 }


### PR DESCRIPTION
# Summary

[NIFI-14012](https://issues.apache.org/jira/browse/NIFI-14012) Adds standard formatting for Certificate Subject and Issuer principals containing `UID` and `DC` relative distinguished names.

The default behavior of the [X500Principal.RFC1779](https://docs.oracle.com/javase/8/docs/api/javax/security/auth/x500/X500Principal.html#RFC1779) uses the Object Identifier for the `UID` and `DC` names, which is different than earlier behavior in NiFi 1 prior to changes for [NIFI-12272](https://issues.apache.org/jira/browse/NIFI-12272).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
