### PR TITLE
NIFI-13976: Adding endpoints to support copying and pasting flow cont…

### DIFF
--- a/nifi-framework-api/src/main/java/org/apache/nifi/authorization/resource/VersionedComponentAuthorizable.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/authorization/resource/VersionedComponentAuthorizable.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.authorization.resource;
+
+import java.util.Optional;
+
+/**
+ * ComponentAuthorizable that also exposes the versioned identifier of the underlying component.
+ */
+public interface VersionedComponentAuthorizable extends ComponentAuthorizable {
+
+    /**
+     * The versioned component identifier of the underlying component.
+     *
+     * @return the versioned component identifier
+     */
+    Optional<String> getVersionedComponentId();
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/CopyRequestEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/CopyRequestEntity.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.api.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlType;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A request to copy a portion of the flow.
+ */
+@XmlType(name = "copyRequestEntity")
+public class CopyRequestEntity extends Entity {
+
+    private Set<String> processGroups = new HashSet<>();
+    private Set<String> remoteProcessGroups = new HashSet<>();
+    private Set<String> processors = new HashSet<>();
+    private Set<String> inputPorts = new HashSet<>();
+    private Set<String> outputPorts = new HashSet<>();
+    private Set<String> connections = new HashSet<>();
+    private Set<String> labels = new HashSet<>();
+    private Set<String> funnels = new HashSet<>();
+
+    /**
+     * @return the ids of the connections to be copied.
+     */
+    @Schema(description = "The ids of the connections to be copied."
+    )
+    public Set<String> getConnections() {
+        return connections;
+    }
+
+    public void setConnections(Set<String> connections) {
+        this.connections = connections;
+    }
+
+    /**
+     * @return the ids of the funnels to be copied.
+     */
+    @Schema(description = "The ids of the funnels to be copied."
+    )
+    public Set<String> getFunnels() {
+        return funnels;
+    }
+
+    public void setFunnels(Set<String> funnels) {
+        this.funnels = funnels;
+    }
+
+    /**
+     * @return the ids of the input port to be copied.
+     */
+    @Schema(description = "The ids of the input ports to be copied."
+    )
+    public Set<String> getInputPorts() {
+        return inputPorts;
+    }
+
+    public void setInputPorts(Set<String> inputPorts) {
+        this.inputPorts = inputPorts;
+    }
+
+    /**
+     * @return the ids of the labels to be copied.
+     */
+    @Schema(description = "The ids of the labels to be copied."
+    )
+    public Set<String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Set<String> labels) {
+        this.labels = labels;
+    }
+
+    /**
+     * @return the ids of the output ports to be copied.
+     */
+    @Schema(description = "The ids of the output ports to be copied."
+    )
+    public Set<String> getOutputPorts() {
+        return outputPorts;
+    }
+
+    public void setOutputPorts(Set<String> outputPorts) {
+        this.outputPorts = outputPorts;
+    }
+
+    /**
+     * @return The ids of the process groups to be copied.
+     */
+    @Schema(description = "The ids of the process groups to be copied."
+    )
+    public Set<String> getProcessGroups() {
+        return processGroups;
+    }
+
+    public void setProcessGroups(Set<String> processGroups) {
+        this.processGroups = processGroups;
+    }
+
+    /**
+     * @return The ids of the processors to be copied.
+     */
+    @Schema(description = "The ids of the processors to be copied."
+    )
+    public Set<String> getProcessors() {
+        return processors;
+    }
+
+    public void setProcessors(Set<String> processors) {
+        this.processors = processors;
+    }
+
+    /**
+     * @return the ids of the remote process groups to be copied.
+     */
+    @Schema(description = "The ids of the remote process groups to be copied."
+    )
+    public Set<String> getRemoteProcessGroups() {
+        return remoteProcessGroups;
+    }
+
+    public void setRemoteProcessGroups(Set<String> remoteProcessGroups) {
+        this.remoteProcessGroups = remoteProcessGroups;
+    }
+
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/CopyResponseEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/CopyResponseEntity.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.api.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlType;
+import org.apache.nifi.flow.ExternalControllerServiceReference;
+import org.apache.nifi.flow.ParameterProviderReference;
+import org.apache.nifi.flow.VersionedConnection;
+import org.apache.nifi.flow.VersionedFunnel;
+import org.apache.nifi.flow.VersionedLabel;
+import org.apache.nifi.flow.VersionedParameterContext;
+import org.apache.nifi.flow.VersionedPort;
+import org.apache.nifi.flow.VersionedProcessGroup;
+import org.apache.nifi.flow.VersionedProcessor;
+import org.apache.nifi.flow.VersionedRemoteProcessGroup;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A response to copy a portion of the flow.
+ */
+@XmlType(name = "copyResponseEntity")
+public class CopyResponseEntity extends Entity {
+
+    private String id;
+
+    private Map<String, ExternalControllerServiceReference> externalControllerServiceReferences;
+    private Map<String, VersionedParameterContext> parameterContexts;
+    private Map<String, ParameterProviderReference> parameterProviders;
+
+    private Set<VersionedProcessGroup> processGroups = new HashSet<>();
+    private Set<VersionedRemoteProcessGroup> remoteProcessGroups = new HashSet<>();
+    private Set<VersionedProcessor> processors = new HashSet<>();
+    private Set<VersionedPort> inputPorts = new HashSet<>();
+    private Set<VersionedPort> outputPorts = new HashSet<>();
+    private Set<VersionedConnection> connections = new HashSet<>();
+    private Set<VersionedLabel> labels = new HashSet<>();
+    private Set<VersionedFunnel> funnels = new HashSet<>();
+
+    /**
+     * The id for this copy action.
+     *
+     * @return The id
+     */
+    @Schema(description = "The id for this copy action."
+    )
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * The external controller service references.
+     *
+     * @return The external controller service reference
+     */
+    @Schema(description = "The external controller service references."
+    )
+    public Map<String, ExternalControllerServiceReference> getExternalControllerServiceReferences() {
+        return externalControllerServiceReferences;
+    }
+
+    public void setExternalControllerServiceReferences(Map<String, ExternalControllerServiceReference> externalControllerServiceReferences) {
+        this.externalControllerServiceReferences = externalControllerServiceReferences;
+    }
+
+    /**
+     * The referenced parameter contexts.
+     *
+     * @return The referenced parameter contexts
+     */
+    @Schema(description = "The referenced parameter contexts."
+    )
+    public Map<String, VersionedParameterContext> getParameterContexts() {
+        return parameterContexts;
+    }
+
+    public void setParameterContexts(Map<String, VersionedParameterContext> parameterContexts) {
+        this.parameterContexts = parameterContexts;
+    }
+
+    /**
+     * The referenced parameter providers.
+     *
+     * @return The referenced parameter providers
+     */
+    @Schema(description = "The referenced parameter providers."
+    )
+    public Map<String, ParameterProviderReference> getParameterProviders() {
+        return parameterProviders;
+    }
+
+    public void setParameterProviders(Map<String, ParameterProviderReference> parameterProviders) {
+        this.parameterProviders = parameterProviders;
+    }
+
+    /**
+     * @return the connections being copied.
+     */
+    @Schema(description = "The connections being copied."
+    )
+    public Set<VersionedConnection> getConnections() {
+        return connections;
+    }
+
+    public void setConnections(Set<VersionedConnection> connections) {
+        this.connections = connections;
+    }
+
+    /**
+     * @return the funnels being copied.
+     */
+    @Schema(description = "The funnels being copied."
+    )
+    public Set<VersionedFunnel> getFunnels() {
+        return funnels;
+    }
+
+    public void setFunnels(Set<VersionedFunnel> funnels) {
+        this.funnels = funnels;
+    }
+
+    /**
+     * @return the input port being copied.
+     */
+    @Schema(description = "The input ports being copied."
+    )
+    public Set<VersionedPort> getInputPorts() {
+        return inputPorts;
+    }
+
+    public void setInputPorts(Set<VersionedPort> inputPorts) {
+        this.inputPorts = inputPorts;
+    }
+
+    /**
+     * @return the labels being copied.
+     */
+    @Schema(description = "The labels being copied."
+    )
+    public Set<VersionedLabel> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Set<VersionedLabel> labels) {
+        this.labels = labels;
+    }
+
+    /**
+     * @return the output ports being copied.
+     */
+    @Schema(description = "The output ports being copied."
+    )
+    public Set<VersionedPort> getOutputPorts() {
+        return outputPorts;
+    }
+
+    public void setOutputPorts(Set<VersionedPort> outputPorts) {
+        this.outputPorts = outputPorts;
+    }
+
+    /**
+     * @return The process groups being copied.
+     */
+    @Schema(description = "The process groups being copied."
+    )
+    public Set<VersionedProcessGroup> getProcessGroups() {
+        return processGroups;
+    }
+
+    public void setProcessGroups(Set<VersionedProcessGroup> processGroups) {
+        this.processGroups = processGroups;
+    }
+
+    /**
+     * @return The processors being copied.
+     */
+    @Schema(description = "The processors being copied."
+    )
+    public Set<VersionedProcessor> getProcessors() {
+        return processors;
+    }
+
+    public void setProcessors(Set<VersionedProcessor> processors) {
+        this.processors = processors;
+    }
+
+    /**
+     * @return the remote process groups being copied.
+     */
+    @Schema(description = "The remote process groups being copied."
+    )
+    public Set<VersionedRemoteProcessGroup> getRemoteProcessGroups() {
+        return remoteProcessGroups;
+    }
+
+    public void setRemoteProcessGroups(Set<VersionedRemoteProcessGroup> remoteProcessGroups) {
+        this.remoteProcessGroups = remoteProcessGroups;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/CopyResponseEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/CopyResponseEntity.java
@@ -29,6 +29,7 @@ import org.apache.nifi.flow.VersionedProcessGroup;
 import org.apache.nifi.flow.VersionedProcessor;
 import org.apache.nifi.flow.VersionedRemoteProcessGroup;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -41,9 +42,9 @@ public class CopyResponseEntity extends Entity {
 
     private String id;
 
-    private Map<String, ExternalControllerServiceReference> externalControllerServiceReferences;
-    private Map<String, VersionedParameterContext> parameterContexts;
-    private Map<String, ParameterProviderReference> parameterProviders;
+    private Map<String, ExternalControllerServiceReference> externalControllerServiceReferences = new HashMap<>();
+    private Map<String, VersionedParameterContext> parameterContexts = new HashMap<>();
+    private Map<String, ParameterProviderReference> parameterProviders = new HashMap<>();
 
     private Set<VersionedProcessGroup> processGroups = new HashSet<>();
     private Set<VersionedRemoteProcessGroup> remoteProcessGroups = new HashSet<>();

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/PasteRequestEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/PasteRequestEntity.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.api.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlType;
+import org.apache.nifi.web.api.dto.RevisionDTO;
+
+/**
+ * A request to paste a portion of the flow.
+ */
+@XmlType(name = "pasteRequestEntity")
+public class PasteRequestEntity extends Entity {
+
+    private CopyResponseEntity copyResponse;
+
+    private RevisionDTO revision;
+    private Boolean disconnectedNodeAcknowledged;
+
+    /**
+     * @return the response from copying
+     */
+    @Schema(description = "The response from copying."
+    )
+    public CopyResponseEntity getCopyResponse() {
+        return copyResponse;
+    }
+
+    public void setCopyResponse(CopyResponseEntity copyResponse) {
+        this.copyResponse = copyResponse;
+    }
+
+    /**
+     * @return revision for this request/response
+     */
+    @Schema(description = "The revision for this request/response. The revision is required for any mutable flow requests and is included in all responses."
+    )
+    public RevisionDTO getRevision() {
+        return revision;
+    }
+
+    public void setRevision(RevisionDTO revision) {
+        this.revision = revision;
+    }
+
+    /**
+     * @return Acknowledges if a node is disconnected from a cluster
+     */
+    public Boolean getDisconnectedNodeAcknowledged() {
+        return disconnectedNodeAcknowledged;
+    }
+
+    public void setDisconnectedNodeAcknowledged(Boolean disconnectedNodeAcknowledged) {
+        this.disconnectedNodeAcknowledged = disconnectedNodeAcknowledged;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/PasteResponseEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/PasteResponseEntity.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.api.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlType;
+import org.apache.nifi.web.api.dto.RevisionDTO;
+import org.apache.nifi.web.api.dto.flow.FlowDTO;
+
+/**
+ * A response to copy a portion of the flow.
+ */
+@XmlType(name = "pasteResponseEntity")
+public class PasteResponseEntity extends Entity {
+
+    private FlowDTO flow;
+
+    private RevisionDTO revision;
+
+    /**
+     * @return flow containing the components that were created as part of this paste action
+     */
+    @Schema(description = "Flow containing the components that were created as part of this paste action."
+    )
+    public FlowDTO getFlow() {
+        return flow;
+    }
+
+    public void setFlow(FlowDTO flow) {
+        this.flow = flow;
+    }
+
+    /**
+     * @return revision for this request/response
+     */
+    @Schema(description = "The revision for this request/response. The revision is required for any mutable flow requests and is included in all responses."
+    )
+    public RevisionDTO getRevision() {
+        return revision;
+    }
+
+    public void setRevision(RevisionDTO revision) {
+        this.revision = revision;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessGroupFlowEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessGroupFlowEntity.java
@@ -18,6 +18,7 @@ package org.apache.nifi.web.api.entity;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.nifi.web.api.dto.PermissionsDTO;
+import org.apache.nifi.web.api.dto.RevisionDTO;
 import org.apache.nifi.web.api.dto.flow.ProcessGroupFlowDTO;
 
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -28,8 +29,22 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "processGroupFlowEntity")
 public class ProcessGroupFlowEntity extends Entity {
 
+    private RevisionDTO revision;
     private PermissionsDTO permissions;
     private ProcessGroupFlowDTO processGroupFlow;
+
+    /**
+     * @return revision for this component
+     */
+    @Schema(description = "The revision for this process group."
+    )
+    public RevisionDTO getRevision() {
+        return revision;
+    }
+
+    public void setRevision(RevisionDTO revision) {
+        this.revision = revision;
+    }
 
     /**
      * The permissions for this component.

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/StandardHttpResponseMapper.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/StandardHttpResponseMapper.java
@@ -65,6 +65,7 @@ import org.apache.nifi.cluster.coordination.http.endpoints.ParameterContextsEndp
 import org.apache.nifi.cluster.coordination.http.endpoints.ParameterProviderEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.ParameterProviderFetchRequestsEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.ParameterProvidersEndpointMerger;
+import org.apache.nifi.cluster.coordination.http.endpoints.PasteEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.PortEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.PortStatusEndpointMerger;
 import org.apache.nifi.cluster.coordination.http.endpoints.PrioritizerTypesEndpointMerger;
@@ -145,6 +146,7 @@ public class StandardHttpResponseMapper implements HttpResponseMapper {
         endpointMergers.add(new ProcessGroupEndpointMerger());
         endpointMergers.add(new ProcessGroupsEndpointMerger());
         endpointMergers.add(new FlowSnippetEndpointMerger());
+        endpointMergers.add(new PasteEndpointMerger());
         endpointMergers.add(new ProvenanceQueryEndpointMerger());
         endpointMergers.add(new ProvenanceEventEndpointMerger());
         endpointMergers.add(new LatestProvenanceEventsMerger());

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/PasteEndpointMerger.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/PasteEndpointMerger.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.cluster.coordination.http.endpoints;
+
+import org.apache.nifi.cluster.manager.ConnectionsEntityMerger;
+import org.apache.nifi.cluster.manager.FunnelsEntityMerger;
+import org.apache.nifi.cluster.manager.LabelsEntityMerger;
+import org.apache.nifi.cluster.manager.NodeResponse;
+import org.apache.nifi.cluster.manager.PortsEntityMerger;
+import org.apache.nifi.cluster.manager.ProcessGroupsEntityMerger;
+import org.apache.nifi.cluster.manager.ProcessorsEntityMerger;
+import org.apache.nifi.cluster.manager.RemoteProcessGroupsEntityMerger;
+import org.apache.nifi.cluster.protocol.NodeIdentifier;
+import org.apache.nifi.web.api.dto.flow.FlowDTO;
+import org.apache.nifi.web.api.entity.ConnectionEntity;
+import org.apache.nifi.web.api.entity.FunnelEntity;
+import org.apache.nifi.web.api.entity.LabelEntity;
+import org.apache.nifi.web.api.entity.PasteResponseEntity;
+import org.apache.nifi.web.api.entity.PortEntity;
+import org.apache.nifi.web.api.entity.ProcessGroupEntity;
+import org.apache.nifi.web.api.entity.ProcessorEntity;
+import org.apache.nifi.web.api.entity.RemoteProcessGroupEntity;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class PasteEndpointMerger extends AbstractSingleDTOEndpoint<PasteResponseEntity, FlowDTO> {
+    public static final Pattern PASTE_INSTANCE_URI_PATTERN = Pattern.compile("/nifi-api/process-groups/(?:(?:root)|(?:[a-f0-9\\-]{36}))/paste");
+
+    @Override
+    public boolean canHandle(final URI uri, final String method) {
+        return "PUT".equalsIgnoreCase(method) && PASTE_INSTANCE_URI_PATTERN.matcher(uri.getPath()).matches();
+    }
+
+    @Override
+    protected Class<PasteResponseEntity> getEntityClass() {
+        return PasteResponseEntity.class;
+    }
+
+    @Override
+    protected FlowDTO getDto(PasteResponseEntity entity) {
+        return entity.getFlow();
+    }
+
+    @Override
+    protected void mergeResponses(final FlowDTO clientDto, final Map<NodeIdentifier, FlowDTO> dtoMap, final Set<NodeResponse> successfulResponses, final Set<NodeResponse> problematicResponses) {
+        final Set<ConnectionEntity> clientConnections = clientDto.getConnections();
+        final Set<ProcessorEntity> clientProcessors = clientDto.getProcessors();
+        final Set<PortEntity> clientInputPorts = clientDto.getInputPorts();
+        final Set<PortEntity> clientOutputPorts = clientDto.getOutputPorts();
+        final Set<RemoteProcessGroupEntity> clientRemoteProcessGroups = clientDto.getRemoteProcessGroups();
+        final Set<ProcessGroupEntity> clientProcessGroups = clientDto.getProcessGroups();
+        final Set<LabelEntity> clientLabels = clientDto.getLabels();
+        final Set<FunnelEntity> clientFunnels = clientDto.getFunnels();
+
+        final Map<String, Map<NodeIdentifier, ConnectionEntity>> connections = new HashMap<>();
+        final Map<String, Map<NodeIdentifier, FunnelEntity>> funnels = new HashMap<>();
+        final Map<String, Map<NodeIdentifier, PortEntity>> inputPorts = new HashMap<>();
+        final Map<String, Map<NodeIdentifier, LabelEntity>> labels = new HashMap<>();
+        final Map<String, Map<NodeIdentifier, PortEntity>> outputPorts = new HashMap<>();
+        final Map<String, Map<NodeIdentifier, ProcessorEntity>> processors = new HashMap<>();
+        final Map<String, Map<NodeIdentifier, RemoteProcessGroupEntity>> rpgs = new HashMap<>();
+        final Map<String, Map<NodeIdentifier, ProcessGroupEntity>> processGroups = new HashMap<>();
+
+        // Create mapping of ComponentID -> [nodeId, entity on that node]
+        for (final Map.Entry<NodeIdentifier, FlowDTO> nodeFlowEntry : dtoMap.entrySet()) {
+            final NodeIdentifier nodeIdentifier = nodeFlowEntry.getKey();
+            final FlowDTO nodeFlowDto = nodeFlowEntry.getValue();
+
+            for (final ConnectionEntity entity : nodeFlowDto.getConnections()) {
+                connections.computeIfAbsent(entity.getId(), id -> new HashMap<>()).computeIfAbsent(nodeIdentifier, nodeId -> entity);
+            }
+
+            for (final FunnelEntity entity : nodeFlowDto.getFunnels()) {
+                funnels.computeIfAbsent(entity.getId(), id -> new HashMap<>()).computeIfAbsent(nodeIdentifier, nodeId -> entity);
+            }
+
+            for (final PortEntity entity : nodeFlowDto.getInputPorts()) {
+                inputPorts.computeIfAbsent(entity.getId(), id -> new HashMap<>()).computeIfAbsent(nodeIdentifier, nodeId -> entity);
+            }
+
+            for (final PortEntity entity : nodeFlowDto.getOutputPorts()) {
+                outputPorts.computeIfAbsent(entity.getId(), id -> new HashMap<>()).computeIfAbsent(nodeIdentifier, nodeId -> entity);
+            }
+
+            for (final LabelEntity entity : nodeFlowDto.getLabels()) {
+                labels.computeIfAbsent(entity.getId(), id -> new HashMap<>()).computeIfAbsent(nodeIdentifier, nodeId -> entity);
+            }
+
+            for (final ProcessorEntity entity : nodeFlowDto.getProcessors()) {
+                processors.computeIfAbsent(entity.getId(), id -> new HashMap<>()).computeIfAbsent(nodeIdentifier, nodeId -> entity);
+            }
+
+            for (final RemoteProcessGroupEntity entity : nodeFlowDto.getRemoteProcessGroups()) {
+                rpgs.computeIfAbsent(entity.getId(), id -> new HashMap<>()).computeIfAbsent(nodeIdentifier, nodeId -> entity);
+            }
+
+            for (final ProcessGroupEntity entity : nodeFlowDto.getProcessGroups()) {
+                processGroups.computeIfAbsent(entity.getId(), id -> new HashMap<>()).computeIfAbsent(nodeIdentifier, nodeId -> entity);
+            }
+        }
+
+        // Merge connections
+        ConnectionsEntityMerger.mergeConnections(clientConnections, connections);
+
+        // Merge funnel statuses
+        FunnelsEntityMerger.mergeFunnels(clientFunnels, funnels);
+
+        // Merge input ports
+        PortsEntityMerger.mergePorts(clientInputPorts, inputPorts);
+
+        // Merge output ports
+        PortsEntityMerger.mergePorts(clientOutputPorts, outputPorts);
+
+        // Merge labels
+        LabelsEntityMerger.mergeLabels(clientLabels, labels);
+
+        // Merge processors
+        ProcessorsEntityMerger.mergeProcessors(clientProcessors, processors);
+
+        // Merge Remote Process Groups
+        RemoteProcessGroupsEntityMerger.mergeRemoteProcessGroups(clientRemoteProcessGroups, rpgs);
+
+        // Merge Process Groups
+        ProcessGroupsEntityMerger.mergeProcessGroups(clientProcessGroups, processGroups);
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -74,6 +74,7 @@ import org.apache.nifi.flow.VersionedRemoteGroupPort;
 import org.apache.nifi.flow.VersionedRemoteProcessGroup;
 import org.apache.nifi.flow.VersionedReportingTask;
 import org.apache.nifi.flowfile.FlowFilePrioritizer;
+import org.apache.nifi.groups.ComponentAdditions;
 import org.apache.nifi.groups.ComponentIdGenerator;
 import org.apache.nifi.groups.FlowFileConcurrency;
 import org.apache.nifi.groups.FlowFileOutboundPolicy;
@@ -84,6 +85,7 @@ import org.apache.nifi.groups.PropertyDecryptor;
 import org.apache.nifi.groups.RemoteProcessGroup;
 import org.apache.nifi.groups.RemoteProcessGroupPortDescriptor;
 import org.apache.nifi.groups.StandardVersionedFlowStatus;
+import org.apache.nifi.groups.VersionedComponentAdditions;
 import org.apache.nifi.logging.LogLevel;
 import org.apache.nifi.migration.ControllerServiceFactory;
 import org.apache.nifi.migration.StandardControllerServiceFactory;
@@ -165,6 +167,146 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
 
     public void setSynchronizationOptions(final FlowSynchronizationOptions syncOptions) {
         this.syncOptions = syncOptions;
+    }
+
+    @Override
+    public ComponentAdditions addVersionedComponentsToProcessGroup(final ProcessGroup group, final VersionedComponentAdditions additions, final FlowSynchronizationOptions options) {
+        updatedVersionedComponentIds.clear();
+        createdAndModifiedExtensions.clear();
+        setSynchronizationOptions(options);
+
+        final ComponentAdditions.Builder additionsBuilder = new ComponentAdditions.Builder();
+
+        // add any controller services first since they may be referenced by components to follow
+        final Map<VersionedControllerService, ControllerServiceNode> instanceMapping = new HashMap<>();
+        additions.getControllerServices().forEach(controllerService -> {
+            final ControllerServiceNode newService = addControllerService(group, controllerService, options.getComponentIdGenerator(), group);
+            instanceMapping.put(controllerService, newService);
+            additionsBuilder.addControllerService(newService);
+        });
+
+        // go through the controller services again and update each to update any service references
+        // to their new identifiers
+        additions.getControllerServices().forEach(controllerService -> {
+            final ControllerServiceNode newService = instanceMapping.get(controllerService);
+            if (newService != null) {
+                updateControllerService(newService, controllerService, group);
+            }
+        });
+
+        // add any processors
+        additions.getProcessors().forEach(processor -> {
+            try {
+                final ProcessorNode newProcessor = addProcessor(group, processor, options.getComponentIdGenerator(), group);
+                additionsBuilder.addProcessor(newProcessor);
+            } catch (final ProcessorInstantiationException pie) {
+                throw new RuntimeException(pie);
+            }
+        });
+
+        // track the proposed port names so they can be updated after adding with guaranteed unique names
+        final Map<Port, String> proposedPortFinalNames = new HashMap<>();
+        final Set<String> existingInputPorts = group.getInputPorts().stream().map(Port::getName).collect(Collectors.toSet());
+        final Set<String> existingOutputPorts = group.getOutputPorts().stream().map(Port::getName).collect(Collectors.toSet());
+
+        // add any input ports
+        additions.getInputPorts().forEach(inputPort -> {
+            // if we're adding to the root group than ports must allow remote access
+            if (group.isRootGroup()) {
+                inputPort.setAllowRemoteAccess(true);
+            }
+
+            final String temporaryName = generateTemporaryPortName(inputPort);
+            final Port newInputPort = addInputPort(group, inputPort, options.getComponentIdGenerator(), temporaryName);
+
+            // if the proposed port name does not conflict with any existing ports include the proposed name for updating later
+            if (!existingInputPorts.contains(inputPort.getName())) {
+                proposedPortFinalNames.put(newInputPort, inputPort.getName());
+            }
+
+            additionsBuilder.addInputPort(newInputPort);
+        });
+
+        // add any output ports
+        additions.getOutputPorts().forEach(outputPort -> {
+            // if we're adding to the root group than ports must allow remote access
+            if (group.isRootGroup()) {
+                outputPort.setAllowRemoteAccess(true);
+            }
+
+            final String temporaryName = generateTemporaryPortName(outputPort);
+            final Port newOutputPort = addOutputPort(group, outputPort, options.getComponentIdGenerator(), temporaryName);
+
+            // if the proposed port name does not conflict with any existing ports include the proposed name for updating later
+            if (!existingOutputPorts.contains(outputPort.getName())) {
+                proposedPortFinalNames.put(newOutputPort, outputPort.getName());
+            }
+
+            additionsBuilder.addOutputPort(newOutputPort);
+        });
+
+        // add any labels
+        additions.getLabels().forEach(label -> {
+            final Label newLabel = addLabel(group, label, options.getComponentIdGenerator());
+            additionsBuilder.addLabel(newLabel);
+        });
+
+        // add any funnels
+        additions.getFunnels().forEach(funnel -> {
+            final Funnel newFunnel = addFunnel(group, funnel, options.getComponentIdGenerator());
+            additionsBuilder.addFunnel(newFunnel);
+        });
+
+        // add any remote process groups
+        additions.getRemoteProcessGroups().forEach(remoteProcessGroup -> {
+            final RemoteProcessGroup newRemoteProcessGroup = addRemoteProcessGroup(group, remoteProcessGroup, options.getComponentIdGenerator());
+            additionsBuilder.addRemoteProcessGroup(newRemoteProcessGroup);
+        });
+
+        // add any process groups
+        additions.getProcessGroups().forEach(processGroup -> {
+            try {
+                final ProcessGroup newProcessGroup = addProcessGroup(group, processGroup, options.getComponentIdGenerator(),
+                        additions.getParameterContexts(), additions.getParameterProviders(), group);
+                additionsBuilder.addProcessGroup(newProcessGroup);
+            } catch (final ProcessorInstantiationException pie) {
+                throw new RuntimeException(pie);
+            }
+        });
+
+        // lastly add any connections with all source/destinations already added
+        additions.getConnections().forEach(connection -> {
+            // null out any instance id's in the connections source/destination since that would be favored
+            // when attaching the connection to the appropriate components
+            if (connection.getSource() != null) {
+                connection.getSource().setInstanceIdentifier(null);
+            }
+            if (connection.getDestination() != null) {
+                connection.getDestination().setInstanceIdentifier(null);
+            }
+
+            final Connection newConnection = addConnection(group, connection, options.getComponentIdGenerator());
+            additionsBuilder.addConnection(newConnection);
+        });
+
+        // update ports to final names
+        updatePortsToFinalNames(proposedPortFinalNames);
+
+        for (final CreatedOrModifiedExtension createdOrModifiedExtension : createdAndModifiedExtensions) {
+            final ComponentNode extension = createdOrModifiedExtension.extension();
+            final Map<String, String> originalPropertyValues = createdOrModifiedExtension.propertyValues();
+
+            final ControllerServiceFactory serviceFactory = new StandardControllerServiceFactory(context.getExtensionManager(), context.getFlowManager(),
+                    context.getControllerServiceProvider(), extension);
+
+            if (extension instanceof final ProcessorNode processor) {
+                processor.migrateConfiguration(originalPropertyValues, serviceFactory);
+            } else if (extension instanceof final ControllerServiceNode service) {
+                service.migrateConfiguration(originalPropertyValues, serviceFactory);
+            }
+        }
+
+        return additionsBuilder.build();
     }
 
     @Override
@@ -363,21 +505,24 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                 flowState = remoteCoordinates.getLatest() ? VersionedFlowState.UP_TO_DATE : VersionedFlowState.STALE;
             }
 
-            final VersionControlInformation vci = new StandardVersionControlInformation.Builder()
-                .registryId(registryId)
-                .registryName(registryName)
-                .branch(branch)
-                .bucketId(bucketId)
-                .bucketName(bucketId)
-                .flowId(flowId)
-                .storageLocation(storageLocation)
-                .flowName(flowId)
-                .version(version)
-                .flowSnapshot(syncOptions.isUpdateGroupVersionControlSnapshot() ? proposed : null)
-                .status(new StandardVersionedFlowStatus(flowState, flowState.getDescription()))
-                .build();
+            // only attempt to set the version control information when an applicable registry client could be discovered
+            if (registryId != null) {
+                final VersionControlInformation vci = new StandardVersionControlInformation.Builder()
+                    .registryId(registryId)
+                    .registryName(registryName)
+                    .branch(branch)
+                    .bucketId(bucketId)
+                    .bucketName(bucketId)
+                    .flowId(flowId)
+                    .storageLocation(storageLocation)
+                    .flowName(flowId)
+                    .version(version)
+                    .flowSnapshot(syncOptions.isUpdateGroupVersionControlSnapshot() ? proposed : null)
+                    .status(new StandardVersionedFlowStatus(flowState, flowState.getDescription()))
+                    .build();
 
-            group.setVersionControlInformation(vci, Collections.emptyMap());
+                group.setVersionControlInformation(vci, Collections.emptyMap());
+            }
         }
 
         // In order to properly update all of the components, we have to follow a specific order of operations, in order to ensure that
@@ -1079,6 +1224,13 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
     }
 
     @Override
+    public void verifyCanAddVersionedComponents(final ProcessGroup group, final VersionedComponentAdditions additions) {
+        verifyCanInstantiateProcessors(group, additions.getProcessors(), additions.getProcessGroups());
+        verifyCanInstantiateControllerServices(group, additions.getControllerServices(), additions.getProcessGroups());
+        verifyCanInstantiateConnections(group, additions.getConnections(), additions.getProcessGroups());
+    }
+
+    @Override
     public void verifyCanSynchronize(final ProcessGroup group, final VersionedProcessGroup flowContents, final boolean verifyConnectionRemoval) {
         // Optionally check that no deleted connections contain data in their queue.
         // Note that this check enforces ancestry among the group components to avoid a scenario where
@@ -1124,13 +1276,19 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
             }
         }
 
+        verifyCanInstantiateProcessors(group, flowContents.getProcessors(), flowContents.getProcessGroups());
+        verifyCanInstantiateControllerServices(group, flowContents.getControllerServices(), flowContents.getProcessGroups());
+        verifyCanInstantiateConnections(group, flowContents.getConnections(), flowContents.getProcessGroups());
+    }
+
+    private void verifyCanInstantiateProcessors(final ProcessGroup group, final Set<VersionedProcessor> processors, final Set<VersionedProcessGroup> childGroups) {
         // Ensure that all Processors are instantiable
         final Map<String, VersionedProcessor> proposedProcessors = new HashMap<>();
-        findAllProcessors(flowContents, proposedProcessors);
+        findAllProcessors(processors, childGroups, proposedProcessors);
 
         group.findAllProcessors()
-            .forEach(proc -> proposedProcessors.remove(proc.getVersionedComponentId().orElse(
-                NiFiRegistryFlowMapper.generateVersionedComponentId(proc.getIdentifier()))));
+                .forEach(proc -> proposedProcessors.remove(proc.getVersionedComponentId().orElse(
+                        NiFiRegistryFlowMapper.generateVersionedComponentId(proc.getIdentifier()))));
 
         for (final VersionedProcessor processorToAdd : proposedProcessors.values()) {
             final String processorToAddClass = processorToAdd.getType();
@@ -1145,21 +1303,23 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                 // Could not resolve the bundle explicitly. Check for possible bundles.
                 final List<org.apache.nifi.bundle.Bundle> possibleBundles = context.getExtensionManager().getBundles(processorToAddClass);
                 final boolean bundleExists = possibleBundles.stream()
-                    .anyMatch(b -> processorToAddCoordinate.equals(b.getBundleDetails().getCoordinate()));
+                        .anyMatch(b -> processorToAddCoordinate.equals(b.getBundleDetails().getCoordinate()));
 
                 if (!bundleExists && possibleBundles.size() != 1) {
                     LOG.warn("Unknown bundle {} for processor type {} - will use Ghosted component instead", processorToAddCoordinate, processorToAddClass);
                 }
             }
         }
+    }
 
+    private void verifyCanInstantiateControllerServices(final ProcessGroup group, final Set<VersionedControllerService> controllerServices, final Set<VersionedProcessGroup> childGroups) {
         // Ensure that all Controller Services are instantiable
         final Map<String, VersionedControllerService> proposedServices = new HashMap<>();
-        findAllControllerServices(flowContents, proposedServices);
+        findAllControllerServices(controllerServices, childGroups, proposedServices);
 
         group.findAllControllerServices()
-            .forEach(service -> proposedServices.remove(service.getVersionedComponentId().orElse(
-                NiFiRegistryFlowMapper.generateVersionedComponentId(service.getIdentifier()))));
+                .forEach(service -> proposedServices.remove(service.getVersionedComponentId().orElse(
+                        NiFiRegistryFlowMapper.generateVersionedComponentId(service.getIdentifier()))));
 
         for (final VersionedControllerService serviceToAdd : proposedServices.values()) {
             final String serviceToAddClass = serviceToAdd.getType();
@@ -1169,24 +1329,26 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
             if (resolved == null) {
                 final List<org.apache.nifi.bundle.Bundle> possibleBundles = context.getExtensionManager().getBundles(serviceToAddClass);
                 final boolean bundleExists = possibleBundles.stream()
-                    .anyMatch(b -> serviceToAddCoordinate.equals(b.getBundleDetails().getCoordinate()));
+                        .anyMatch(b -> serviceToAddCoordinate.equals(b.getBundleDetails().getCoordinate()));
 
                 if (!bundleExists && possibleBundles.size() != 1) {
                     LOG.warn("Unknown bundle {} for processor type {} - will use Ghosted component instead", serviceToAddCoordinate, serviceToAddClass);
                 }
             }
         }
+    }
 
+    private void verifyCanInstantiateConnections(final ProcessGroup group, final Set<VersionedConnection> connections, final Set<VersionedProcessGroup> childGroups) {
         // Ensure that all Prioritizers are instantiable and that any load balancing configuration is correct
         // Enforcing ancestry on connection matching here is not important because all we're interested in is locating
         // new prioritizers and load balance strategy types so if a matching connection existed anywhere in the current
         // flow, then its prioritizer and load balance strategy are already validated
         final Map<String, VersionedConnection> proposedConnections = new HashMap<>();
-        findAllConnections(flowContents, proposedConnections);
+        findAllConnections(connections, childGroups, proposedConnections);
 
         group.findAllConnections()
-            .forEach(conn -> proposedConnections.remove(conn.getVersionedComponentId().orElse(
-                NiFiRegistryFlowMapper.generateVersionedComponentId(conn.getIdentifier()))));
+                .forEach(conn -> proposedConnections.remove(conn.getVersionedComponentId().orElse(
+                        NiFiRegistryFlowMapper.generateVersionedComponentId(conn.getIdentifier()))));
 
         for (final VersionedConnection connectionToAdd : proposedConnections.values()) {
             if (connectionToAdd.getPrioritizers() != null) {
@@ -1205,7 +1367,7 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                     LoadBalanceStrategy.valueOf(loadBalanceStrategyName);
                 } catch (final IllegalArgumentException iae) {
                     throw new IllegalArgumentException("Unable to create Connection with Load Balance Strategy of '" + loadBalanceStrategyName
-                        + "' because this is not a known Load Balance Strategy");
+                            + "' because this is not a known Load Balance Strategy");
                 }
             }
         }
@@ -3725,33 +3887,33 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
             NiFiRegistryFlowMapper.generateVersionedComponentId(group.getIdentifier())).equals(groupId);
     }
 
-    private void findAllProcessors(final VersionedProcessGroup group, final Map<String, VersionedProcessor> map) {
-        for (final VersionedProcessor processor : group.getProcessors()) {
+    private void findAllProcessors(final Set<VersionedProcessor> processors, final Set<VersionedProcessGroup> childGroups, final Map<String, VersionedProcessor> map) {
+        for (final VersionedProcessor processor : processors) {
             map.put(processor.getIdentifier(), processor);
         }
 
-        for (final VersionedProcessGroup childGroup : group.getProcessGroups()) {
-            findAllProcessors(childGroup, map);
+        for (final VersionedProcessGroup childGroup : childGroups) {
+            findAllProcessors(childGroup.getProcessors(), childGroup.getProcessGroups(), map);
         }
     }
 
-    private void findAllControllerServices(final VersionedProcessGroup group, final Map<String, VersionedControllerService> map) {
-        for (final VersionedControllerService service : group.getControllerServices()) {
+    private void findAllControllerServices(final Set<VersionedControllerService> controllerServices, final Set<VersionedProcessGroup> childGroups, final Map<String, VersionedControllerService> map) {
+        for (final VersionedControllerService service : controllerServices) {
             map.put(service.getIdentifier(), service);
         }
 
-        for (final VersionedProcessGroup childGroup : group.getProcessGroups()) {
-            findAllControllerServices(childGroup, map);
+        for (final VersionedProcessGroup childGroup : childGroups) {
+            findAllControllerServices(childGroup.getControllerServices(), childGroup.getProcessGroups(), map);
         }
     }
 
-    private void findAllConnections(final VersionedProcessGroup group, final Map<String, VersionedConnection> map) {
-        for (final VersionedConnection connection : group.getConnections()) {
+    private void findAllConnections(final Set<VersionedConnection> connections, final Set<VersionedProcessGroup> childGroups, final Map<String, VersionedConnection> map) {
+        for (final VersionedConnection connection : connections) {
             map.put(connection.getIdentifier(), connection);
         }
 
-        for (final VersionedProcessGroup childGroup : group.getProcessGroups()) {
-            findAllConnections(childGroup, map);
+        for (final VersionedProcessGroup childGroup : childGroups) {
+            findAllConnections(childGroup.getConnections(), childGroup.getProcessGroups(), map);
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/VersionedComponentSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/VersionedComponentSynchronizer.java
@@ -40,14 +40,34 @@ import org.apache.nifi.flow.VersionedProcessGroup;
 import org.apache.nifi.flow.VersionedProcessor;
 import org.apache.nifi.flow.VersionedRemoteProcessGroup;
 import org.apache.nifi.flow.VersionedReportingTask;
+import org.apache.nifi.groups.ComponentAdditions;
 import org.apache.nifi.groups.FlowSynchronizationOptions;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.groups.RemoteProcessGroup;
+import org.apache.nifi.groups.VersionedComponentAdditions;
 import org.apache.nifi.parameter.ParameterContext;
 
 import java.util.concurrent.TimeoutException;
 
 public interface VersionedComponentSynchronizer {
+
+    /**
+     * Adds versioned components to the specified Process Group.
+     *
+     * @param group the Process Group to append to
+     * @param additions the component additions to add to the Process Group
+     * @param options sync options
+     * @return the component additions
+     */
+    ComponentAdditions addVersionedComponentsToProcessGroup(ProcessGroup group, VersionedComponentAdditions additions, FlowSynchronizationOptions options);
+
+    /**
+     * Verifies that the given additions can be applied to the specified process group.
+     *
+     * @param group the Process Group that will be appended to
+     * @param additions the component additions that will be added to the Process Group
+     */
+    void verifyCanAddVersionedComponents(ProcessGroup group, VersionedComponentAdditions additions);
 
     /**
      * Synchronize the given Process Group to match the proposed flow

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContext.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContext.java
@@ -485,7 +485,7 @@ public class StandardParameterContext implements ParameterContext {
 
             if (hasUserEnteredParameters) {
                 throw new IllegalArgumentException(String.format("A Parameter Provider [%s] cannot be set since there are already user-entered parameters " +
-                        "in Context [%s]", parameterProvider.getIdentifier(), name));
+                        "in Context [%s]", parameterProviderNode.getIdentifier(), name));
             }
 
             this.parameterProvider = parameterProviderNode.getParameterProvider();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/mapping/NiFiRegistryFlowMapper.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/mapping/NiFiRegistryFlowMapper.java
@@ -311,9 +311,13 @@ public class NiFiRegistryFlowMapper {
     }
 
     private String getId(final Optional<String> currentVersionedId, final String componentId) {
-        final String versionedId = flowMappingOptions.getComponentIdLookup().getComponentId(currentVersionedId, componentId);
-        versionedComponentIds.put(componentId, versionedId);
-        return versionedId;
+        if (versionedComponentIds.containsKey(componentId)) {
+            return versionedComponentIds.get(componentId);
+        } else {
+            final String versionedId = flowMappingOptions.getComponentIdLookup().getComponentId(currentVersionedId, componentId);
+            versionedComponentIds.put(componentId, versionedId);
+            return versionedId;
+        }
     }
 
     /**

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/service/ControllerServiceResolver.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/service/ControllerServiceResolver.java
@@ -19,6 +19,8 @@ package org.apache.nifi.controller.service;
 import org.apache.nifi.authorization.user.NiFiUser;
 import org.apache.nifi.registry.flow.FlowSnapshotContainer;
 
+import java.util.Set;
+
 public interface ControllerServiceResolver {
 
     /**
@@ -34,7 +36,8 @@ public interface ControllerServiceResolver {
      *                              snapshots of any child groups that are also under version control
      * @param parentGroupId the id of the process group where the snapshot is being imported
      * @param user the user performing the import
+     * @return Any unresolved Controller Services
      */
-    void resolveInheritedControllerServices(FlowSnapshotContainer flowSnapshotContainer, String parentGroupId, NiFiUser user);
+    Set<String> resolveInheritedControllerServices(FlowSnapshotContainer flowSnapshotContainer, String parentGroupId, NiFiUser user);
 
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/ComponentAdditions.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/ComponentAdditions.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.groups;
+
+import org.apache.nifi.connectable.Connection;
+import org.apache.nifi.connectable.Funnel;
+import org.apache.nifi.connectable.Port;
+import org.apache.nifi.controller.ProcessorNode;
+import org.apache.nifi.controller.label.Label;
+import org.apache.nifi.controller.service.ControllerServiceNode;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ComponentAdditions {
+
+    private Set<ProcessGroup> processGroups;
+    private Set<RemoteProcessGroup> remoteProcessGroups;
+    private Set<ProcessorNode> processors;
+    private Set<Port> inputPorts;
+    private Set<Port> outputPorts;
+    private Set<Connection> connections;
+    private Set<Label> labels;
+    private Set<Funnel> funnels;
+    private Set<ControllerServiceNode> controllerServices;
+
+    private ComponentAdditions(final Builder builder) {
+        this.processGroups = Collections.unmodifiableSet(builder.processGroups);
+        this.remoteProcessGroups = Collections.unmodifiableSet(builder.remoteProcessGroups);
+        this.processors = Collections.unmodifiableSet(builder.processors);
+        this.inputPorts = Collections.unmodifiableSet(builder.inputPorts);
+        this.outputPorts = Collections.unmodifiableSet(builder.outputPorts);
+        this.connections = Collections.unmodifiableSet(builder.connections);
+        this.labels = Collections.unmodifiableSet(builder.labels);
+        this.funnels = Collections.unmodifiableSet(builder.funnels);
+        this.controllerServices = Collections.unmodifiableSet(builder.controllerServices);
+    }
+
+    public Set<ProcessGroup> getProcessGroups() {
+        return processGroups;
+    }
+
+    public Set<RemoteProcessGroup> getRemoteProcessGroups() {
+        return remoteProcessGroups;
+    }
+
+    public Set<ProcessorNode> getProcessors() {
+        return processors;
+    }
+
+    public Set<Port> getInputPorts() {
+        return inputPorts;
+    }
+
+    public Set<Port> getOutputPorts() {
+        return outputPorts;
+    }
+
+    public Set<Connection> getConnections() {
+        return connections;
+    }
+
+    public Set<Label> getLabels() {
+        return labels;
+    }
+
+    public Set<Funnel> getFunnels() {
+        return funnels;
+    }
+
+    public Set<ControllerServiceNode> getControllerServices() {
+        return controllerServices;
+    }
+
+    public static class Builder {
+        private Set<ProcessGroup> processGroups = new HashSet<>();
+        private Set<RemoteProcessGroup> remoteProcessGroups = new HashSet<>();
+        private Set<ProcessorNode> processors = new HashSet<>();
+        private Set<Port> inputPorts = new HashSet<>();
+        private Set<Port> outputPorts = new HashSet<>();
+        private Set<Connection> connections = new HashSet<>();
+        private Set<Label> labels = new HashSet<>();
+        private Set<Funnel> funnels = new HashSet<>();
+        private Set<ControllerServiceNode> controllerServices = new HashSet<>();
+
+        public Builder addProcessGroup(ProcessGroup processGroup) {
+            this.processGroups.add(processGroup);
+            return this;
+        }
+
+        public Builder addRemoteProcessGroup(RemoteProcessGroup remoteProcessGroup) {
+            this.remoteProcessGroups.add(remoteProcessGroup);
+            return this;
+        }
+
+        public Builder addProcessor(ProcessorNode processor) {
+            this.processors.add(processor);
+            return this;
+        }
+
+        public Builder addInputPort(Port inputPort) {
+            this.inputPorts.add(inputPort);
+            return this;
+        }
+
+        public Builder addOutputPort(Port outputPort) {
+            this.outputPorts.add(outputPort);
+            return this;
+        }
+
+        public Builder addConnection(Connection connection) {
+            this.connections.add(connection);
+            return this;
+        }
+
+        public Builder addLabel(Label label) {
+            this.labels.add(label);
+            return this;
+        }
+
+        public Builder addFunnel(Funnel funnel) {
+            this.funnels.add(funnel);
+            return this;
+        }
+
+        public Builder addControllerService(ControllerServiceNode controllerService) {
+            this.controllerServices.add(controllerService);
+            return this;
+        }
+
+        public ComponentAdditions build() {
+            return new ComponentAdditions(this);
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/ProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/ProcessGroup.java
@@ -909,6 +909,15 @@ public interface ProcessGroup extends ComponentAuthorizable, Positionable, Versi
     void move(final Snippet snippet, final ProcessGroup destination);
 
     /**
+     * Adds the versioned component additions to this Process Group.
+     *
+     * @param additions the components to add
+     * @param componentIdSeed a seed value to use when generating ID's for new components
+     * @return the component additions
+     */
+    ComponentAdditions addVersionedComponents(VersionedComponentAdditions additions, String componentIdSeed);
+
+    /**
      * Updates the Process Group to match the proposed flow
      *
      * @param proposedSnapshot the proposed flow

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/VersionedComponentAdditions.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/VersionedComponentAdditions.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.groups;
+
+import org.apache.nifi.flow.ParameterProviderReference;
+import org.apache.nifi.flow.VersionedConnection;
+import org.apache.nifi.flow.VersionedControllerService;
+import org.apache.nifi.flow.VersionedFunnel;
+import org.apache.nifi.flow.VersionedLabel;
+import org.apache.nifi.flow.VersionedParameterContext;
+import org.apache.nifi.flow.VersionedPort;
+import org.apache.nifi.flow.VersionedProcessGroup;
+import org.apache.nifi.flow.VersionedProcessor;
+import org.apache.nifi.flow.VersionedRemoteProcessGroup;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+public class VersionedComponentAdditions {
+
+    private Set<VersionedProcessGroup> processGroups;
+    private Set<VersionedRemoteProcessGroup> remoteProcessGroups;
+    private Set<VersionedProcessor> processors;
+    private Set<VersionedPort> inputPorts;
+    private Set<VersionedPort> outputPorts;
+    private Set<VersionedConnection> connections;
+    private Set<VersionedLabel> labels;
+    private Set<VersionedFunnel> funnels;
+    private Set<VersionedControllerService> controllerServices;
+    private Map<String, VersionedParameterContext> parameterContexts;
+    private Map<String, ParameterProviderReference> parameterProviders;
+
+    private VersionedComponentAdditions(final Builder builder) {
+        this.processGroups = builder.processGroups == null ? Collections.emptySet() : Collections.unmodifiableSet(builder.processGroups);
+        this.remoteProcessGroups = builder.remoteProcessGroups == null ? Collections.emptySet() : Collections.unmodifiableSet(builder.remoteProcessGroups);
+        this.processors = builder.processors == null ? Collections.emptySet() : Collections.unmodifiableSet(builder.processors);
+        this.inputPorts = builder.inputPorts == null ? Collections.emptySet() : Collections.unmodifiableSet(builder.inputPorts);
+        this.outputPorts = builder.outputPorts == null ? Collections.emptySet() : Collections.unmodifiableSet(builder.outputPorts);
+        this.connections = builder.connections == null ? Collections.emptySet() : Collections.unmodifiableSet(builder.connections);
+        this.labels = builder.labels == null ? Collections.emptySet() : Collections.unmodifiableSet(builder.labels);
+        this.funnels = builder.funnels == null ? Collections.emptySet() : Collections.unmodifiableSet(builder.funnels);
+        this.controllerServices = builder.controllerServices == null ? Collections.emptySet() : Collections.unmodifiableSet(builder.controllerServices);
+        this.parameterContexts = builder.parameterContexts == null ? Collections.emptyMap() : Collections.unmodifiableMap(builder.parameterContexts);
+        this.parameterProviders = builder.parameterProviders == null ? Collections.emptyMap() : Collections.unmodifiableMap(builder.parameterProviders);
+    }
+
+    public Set<VersionedProcessGroup> getProcessGroups() {
+        return processGroups;
+    }
+
+    public Set<VersionedRemoteProcessGroup> getRemoteProcessGroups() {
+        return remoteProcessGroups;
+    }
+
+    public Set<VersionedProcessor> getProcessors() {
+        return processors;
+    }
+
+    public Set<VersionedPort> getInputPorts() {
+        return inputPorts;
+    }
+
+    public Set<VersionedPort> getOutputPorts() {
+        return outputPorts;
+    }
+
+    public Set<VersionedConnection> getConnections() {
+        return connections;
+    }
+
+    public Set<VersionedLabel> getLabels() {
+        return labels;
+    }
+
+    public Set<VersionedFunnel> getFunnels() {
+        return funnels;
+    }
+
+    public Set<VersionedControllerService> getControllerServices() {
+        return controllerServices;
+    }
+
+    public Map<String, VersionedParameterContext> getParameterContexts() {
+        return parameterContexts;
+    }
+
+    public Map<String, ParameterProviderReference> getParameterProviders() {
+        return parameterProviders;
+    }
+
+    public static class Builder {
+        private Set<VersionedProcessGroup> processGroups;
+        private Set<VersionedRemoteProcessGroup> remoteProcessGroups;
+        private Set<VersionedProcessor> processors;
+        private Set<VersionedPort> inputPorts;
+        private Set<VersionedPort> outputPorts;
+        private Set<VersionedConnection> connections;
+        private Set<VersionedLabel> labels;
+        private Set<VersionedFunnel> funnels;
+        private Set<VersionedControllerService> controllerServices;
+        private Map<String, VersionedParameterContext> parameterContexts;
+        private Map<String, ParameterProviderReference> parameterProviders;
+
+        public Builder setProcessGroups(Set<VersionedProcessGroup> processGroups) {
+            this.processGroups = processGroups;
+            return this;
+        }
+
+        public Builder setRemoteProcessGroups(Set<VersionedRemoteProcessGroup> remoteProcessGroups) {
+            this.remoteProcessGroups = remoteProcessGroups;
+            return this;
+        }
+
+        public Builder setProcessors(Set<VersionedProcessor> processors) {
+            this.processors = processors;
+            return this;
+        }
+
+        public Builder setInputPorts(Set<VersionedPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            return this;
+        }
+
+        public Builder setOutputPorts(Set<VersionedPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            return this;
+        }
+
+        public Builder setConnections(Set<VersionedConnection> connections) {
+            this.connections = connections;
+            return this;
+        }
+
+        public Builder setLabels(Set<VersionedLabel> labels) {
+            this.labels = labels;
+            return this;
+        }
+
+        public Builder setFunnels(Set<VersionedFunnel> funnels) {
+            this.funnels = funnels;
+            return this;
+        }
+
+        public Builder setControllerServices(Set<VersionedControllerService> controllerServices) {
+            this.controllerServices = controllerServices;
+            return this;
+        }
+
+        public Builder setParameterContexts(Map<String, VersionedParameterContext> parameterContexts) {
+            this.parameterContexts = parameterContexts;
+            return this;
+        }
+
+        public Builder setParameterProviders(Map<String, ParameterProviderReference> parameterProviders) {
+            this.parameterProviders = parameterProviders;
+            return this;
+        }
+
+        public VersionedComponentAdditions build() {
+            return new VersionedComponentAdditions(this);
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/MockProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/MockProcessGroup.java
@@ -35,6 +35,7 @@ import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.apache.nifi.flow.ExecutionEngine;
 import org.apache.nifi.flow.VersionedExternalFlow;
 import org.apache.nifi.groups.BatchCounts;
+import org.apache.nifi.groups.ComponentAdditions;
 import org.apache.nifi.groups.DataValve;
 import org.apache.nifi.groups.FlowFileConcurrency;
 import org.apache.nifi.groups.FlowFileGate;
@@ -46,6 +47,7 @@ import org.apache.nifi.groups.ProcessGroupCounts;
 import org.apache.nifi.groups.RemoteProcessGroup;
 import org.apache.nifi.groups.StatelessGroupNode;
 import org.apache.nifi.groups.StatelessGroupScheduledState;
+import org.apache.nifi.groups.VersionedComponentAdditions;
 import org.apache.nifi.parameter.ParameterContext;
 import org.apache.nifi.parameter.ParameterUpdate;
 import org.apache.nifi.registry.flow.FlowLocation;
@@ -702,6 +704,11 @@ public class MockProcessGroup implements ProcessGroup {
 
     @Override
     public void synchronizeWithFlowRegistry(FlowManager flowRegistry) {
+    }
+
+    @Override
+    public ComponentAdditions addVersionedComponents(VersionedComponentAdditions additions, String componentIdSeed) {
+        return new ComponentAdditions.Builder().build();
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizableLookup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizableLookup.java
@@ -22,6 +22,9 @@ import org.apache.nifi.components.RequiredPermission;
 import org.apache.nifi.parameter.ParameterContext;
 import org.apache.nifi.web.api.dto.BundleDTO;
 
+import java.util.Set;
+import java.util.function.Predicate;
+
 public interface AuthorizableLookup {
 
     /**
@@ -135,6 +138,13 @@ public interface AuthorizableLookup {
     ConnectionAuthorizable getConnection(String id);
 
     /**
+     * Get the authorizable root ProcessGroup.
+     *
+     * @return authorizable
+     */
+    ProcessGroupAuthorizable getRootProcessGroup();
+
+    /**
      * Get the authorizable ProcessGroup.
      *
      * @param id process group id
@@ -165,6 +175,15 @@ public interface AuthorizableLookup {
      * @return authorizable
      */
     Authorizable getFunnel(String id);
+
+    /**
+     * Get the authorizables for all controller services that meet the specified predicate. Non null
+     *
+     * @param groupId the group id
+     * @param filter the filter
+     * @return all encapsulated controller services
+     */
+    Set<ComponentAuthorizable> getControllerServices(String groupId, Predicate<org.apache.nifi.authorization.resource.VersionedComponentAuthorizable> filter);
 
     /**
      * Get the authorizable ControllerService.
@@ -198,6 +217,13 @@ public interface AuthorizableLookup {
      * @return authorizable
      */
     ComponentAuthorizable getFlowAnalysisRule(String id);
+
+    /**
+     * Get the authorizables for all parameter providers that meet the specified predicate. Non null
+     *
+     * @return all encapsulated parameter providers
+     */
+    Set<ComponentAuthorizable> getParameterProviders(Predicate<org.apache.nifi.authorization.resource.ComponentAuthorizable> filter);
 
     /**
      * Get the authorizable ParameterProvider.

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizableLookup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizableLookup.java
@@ -221,7 +221,8 @@ public interface AuthorizableLookup {
     /**
      * Get the authorizables for all parameter providers that meet the specified predicate. Non null
      *
-     * @return all encapsulated parameter providers
+     * @param filter predicate to filter which parameter providers should be included
+     * @return all parameter providers that meet the specified filter
      */
     Set<ComponentAuthorizable> getParameterProviders(Predicate<org.apache.nifi.authorization.resource.ComponentAuthorizable> filter);
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizeControllerServiceReference.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizeControllerServiceReference.java
@@ -30,6 +30,7 @@ import org.apache.nifi.web.ResourceNotFoundException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Authorizes references to Controller Services. Utilizes when Processors, Controller Services, and Reporting Tasks are created and updated.
@@ -163,5 +164,41 @@ public final class AuthorizeControllerServiceReference {
 
             serviceAuthorizable.authorize(authorizer, RequestAction.READ, user);
         });
+    }
+
+    /**
+     * Unresolved Controller Services may be unresolved because
+     * - The identifier matches an existing Controller Service id (unresolved because the proposed id was unchanged from resolved id)
+     * - An applicable Controller Service does not exist
+     * - The user lacks permission to an applicable Controller Service
+     *
+     * If any of those unresolved Controller Services do match a local Controller Service we need to authorize access to it.
+     *
+     * @param groupId the group id
+     * @param unresolvedControllerServices the unresolved Controller Services
+     * @param authorizer the Authorizer
+     * @param lookup the AuthorizableLookup
+     * @param user the current user
+     */
+    public static void authorizeUnresolvedControllerServiceReferences(final String groupId, final Set<String> unresolvedControllerServices,
+                                                                      final Authorizer authorizer, final AuthorizableLookup lookup, final NiFiUser user) {
+
+        // if there are no unresolved Controller Services we can return
+        if (unresolvedControllerServices.isEmpty()) {
+            return;
+        }
+
+        lookup.getControllerServices(groupId, cs -> {
+            // if the unresolved controller service directly contains the id of a locally available service, include it for authorization
+            final boolean containsId = unresolvedControllerServices.contains(cs.getIdentifier());
+            if (containsId) {
+                return true;
+            }
+
+            // if the unresolved controller service contains the versioned id of a locally available service, include it for authorization
+            final Optional<String> versionedId = cs.getVersionedComponentId();
+            return versionedId.filter(unresolvedControllerServices::contains).isPresent();
+        })
+        .forEach(ca -> ca.getAuthorizable().authorize(authorizer, RequestAction.READ, user));
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizeParameterProviders.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/AuthorizeParameterProviders.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.authorization;
+
+import org.apache.nifi.authorization.user.NiFiUser;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class AuthorizeParameterProviders {
+
+    /**
+     * Unresolved Parameter Providers may be unresolved because
+     * - The identifier matches an existing Parameter Provider id (unresolved because the proposed id was unchanged from resolved id)
+     * - An applicable Parameter Provider does not exist
+     * - The user lacks permission to an applicable Parameter Provider
+     *
+     * If any of those unresolved Parameter Providers do match a local Parameter Provider we need to authorize access to it. If
+     * there are unresolved Parameter Providers that do not match a local Parameter Provider we need to ensure the user has
+     * permissions to create one.
+     *
+     * @param unresolvedParameterProviders the unresolved Parameter Providers
+     * @param authorizer the Authorizer
+     * @param lookup the AuthorizableLookup
+     * @param user the current user
+     */
+    public static void authorizeUnresolvedParameterProviders(final Set<String> unresolvedParameterProviders, final Authorizer authorizer,
+                                                             final AuthorizableLookup lookup, final NiFiUser user) {
+
+        // if there are no unresolved Parameter Providers we can return
+        if (unresolvedParameterProviders.isEmpty()) {
+            return;
+        }
+
+        // unresolved parameter providers may be unresolved because
+        // - the identifier matches an existing parameter provider id (unresolved because proposed id was unchanged from resolved id)
+        // - an applicable parameter provider does not exist
+        // - the user lacks permission to an applicable parameter provider
+        // for everything unresolved, if it matches an existing parameter provider we need to authorize it.
+        final Set<String> unknownParameterProviders = new HashSet<>(unresolvedParameterProviders);
+        lookup.getParameterProviders(pp -> {
+            // remove this identifier from unknown/unresolved since it actually exists locally
+            unknownParameterProviders.remove(pp.getIdentifier());
+
+            // if this unresolved parameter provider matches an existing parameter provider it
+            // means the request payload already referenced a local parameter provider so we need
+            // to ensure the user has permissions to read it
+            return unresolvedParameterProviders.contains(pp.getIdentifier());
+        }).forEach(ca -> ca.getAuthorizable().authorize(authorizer, RequestAction.READ, user));
+
+        // if there are remaining unknown parameter providers a new parameter provider will be created,
+        // and we need to ensure the user has those permissions too
+        if (!unknownParameterProviders.isEmpty()) {
+            lookup.getController().authorize(authorizer, RequestAction.WRITE, user);
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/ProcessGroupAuthorizable.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/ProcessGroupAuthorizable.java
@@ -20,6 +20,7 @@ import org.apache.nifi.authorization.resource.Authorizable;
 import org.apache.nifi.groups.ProcessGroup;
 
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Authorizable for a ProcessGroup and its encapsulated components.
@@ -33,11 +34,26 @@ public interface ProcessGroupAuthorizable extends AuthorizableHolder {
     ProcessGroup getProcessGroup();
 
     /**
+     * Returns the Parameter Context Authorizable. May be null if the underlying Process Group is not
+     * bound to a Parameter Context.
+     *
+     * @return the Parameter Context authorizable
+     */
+    Authorizable getParameterContextAuthorizable();
+
+    /**
      * The authorizables for all encapsulated processors. Non null
      *
      * @return all encapsulated processors
      */
     Set<ComponentAuthorizable> getEncapsulatedProcessors();
+
+    /**
+     * The authorizables for all encapsulated processors that meet the specified predicate. Non null
+     *
+     * @return all encapsulated processors
+     */
+    Set<ComponentAuthorizable> getEncapsulatedProcessors(Predicate<org.apache.nifi.authorization.resource.ComponentAuthorizable> filter);
 
     /**
      * The authorizables for all encapsulated connections. Non null
@@ -89,10 +105,17 @@ public interface ProcessGroupAuthorizable extends AuthorizableHolder {
     Set<Authorizable> getEncapsulatedRemoteProcessGroups();
 
     /**
-     * The authorizables for all encapsulated input ports. Non null
+     * The authorizables for all encapsulated controller services. Non null
      *
-     * @return all encapsulated input ports
+     * @return all encapsulated controller services
      */
     Set<ComponentAuthorizable> getEncapsulatedControllerServices();
+
+    /**
+     * The authorizables for all encapsulated controller services that meet the specified predicate. Non null
+     *
+     * @return all encapsulated controller services
+     */
+    Set<ComponentAuthorizable> getEncapsulatedControllerServices(Predicate<org.apache.nifi.authorization.resource.ComponentAuthorizable> filter);
 
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/ProcessGroupAuthorizable.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/ProcessGroupAuthorizable.java
@@ -19,6 +19,7 @@ package org.apache.nifi.authorization;
 import org.apache.nifi.authorization.resource.Authorizable;
 import org.apache.nifi.groups.ProcessGroup;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -34,12 +35,11 @@ public interface ProcessGroupAuthorizable extends AuthorizableHolder {
     ProcessGroup getProcessGroup();
 
     /**
-     * Returns the Parameter Context Authorizable. May be null if the underlying Process Group is not
-     * bound to a Parameter Context.
+     * Returns the optional Parameter Context Authorizable.
      *
      * @return the Parameter Context authorizable
      */
-    Authorizable getParameterContextAuthorizable();
+    Optional<Authorizable> getParameterContextAuthorizable();
 
     /**
      * The authorizables for all encapsulated processors. Non null
@@ -51,7 +51,8 @@ public interface ProcessGroupAuthorizable extends AuthorizableHolder {
     /**
      * The authorizables for all encapsulated processors that meet the specified predicate. Non null
      *
-     * @return all encapsulated processors
+     * @param filter predicate to filter which processors should be included
+     * @return all encapsulated processors that meet the specified predicate
      */
     Set<ComponentAuthorizable> getEncapsulatedProcessors(Predicate<org.apache.nifi.authorization.resource.ComponentAuthorizable> filter);
 
@@ -114,7 +115,8 @@ public interface ProcessGroupAuthorizable extends AuthorizableHolder {
     /**
      * The authorizables for all encapsulated controller services that meet the specified predicate. Non null
      *
-     * @return all encapsulated controller services
+     * @param filter predicate to filter which controller services should be included
+     * @return all controller services that meet the specified predicate
      */
     Set<ComponentAuthorizable> getEncapsulatedControllerServices(Predicate<org.apache.nifi.authorization.resource.ComponentAuthorizable> filter);
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/StandardAuthorizableLookup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/StandardAuthorizableLookup.java
@@ -1259,8 +1259,8 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
         }
 
         @Override
-        public Authorizable getParameterContextAuthorizable() {
-            return processGroup.getParameterContext();
+        public Optional<Authorizable> getParameterContextAuthorizable() {
+            return Optional.ofNullable(processGroup.getParameterContext());
         }
 
         @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/StandardAuthorizableLookup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/StandardAuthorizableLookup.java
@@ -28,6 +28,7 @@ import org.apache.nifi.authorization.resource.ResourceFactory;
 import org.apache.nifi.authorization.resource.ResourceType;
 import org.apache.nifi.authorization.resource.RestrictedComponentsAuthorizableFactory;
 import org.apache.nifi.authorization.resource.TenantAuthorizable;
+import org.apache.nifi.authorization.resource.VersionedComponentAuthorizable;
 import org.apache.nifi.authorization.user.NiFiUser;
 import org.apache.nifi.bundle.BundleCoordinate;
 import org.apache.nifi.components.ConfigurableComponent;
@@ -76,7 +77,9 @@ import org.springframework.stereotype.Component;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Component
@@ -295,6 +298,11 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
     }
 
     @Override
+    public ProcessGroupAuthorizable getRootProcessGroup() {
+        return getProcessGroup(controllerFacade.getRootGroupId());
+    }
+
+    @Override
     public ProcessGroupAuthorizable getProcessGroup(final String id) {
         final ProcessGroup processGroup = processGroupDAO.getProcessGroup(id);
         return new StandardProcessGroupAuthorizable(processGroup, controllerFacade.getExtensionManager());
@@ -313,6 +321,39 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
     @Override
     public Authorizable getFunnel(final String id) {
         return funnelDAO.getFunnel(id);
+    }
+
+    @Override
+    public Set<ComponentAuthorizable> getControllerServices(final String groupId, final Predicate<org.apache.nifi.authorization.resource.VersionedComponentAuthorizable> filter) {
+        return controllerServiceDAO.getControllerServices(groupId, true, false).stream()
+                .filter(cs -> filter.test(new VersionedComponentAuthorizable() {
+                        @Override
+                        public Optional<String> getVersionedComponentId() {
+                            return cs.getVersionedComponentId();
+                        }
+
+                        @Override
+                        public String getIdentifier() {
+                            return cs.getIdentifier();
+                        }
+
+                        @Override
+                        public String getProcessGroupIdentifier() {
+                            return cs.getProcessGroupIdentifier();
+                        }
+
+                        @Override
+                        public Authorizable getParentAuthorizable() {
+                            return cs.getParentAuthorizable();
+                        }
+
+                        @Override
+                        public Resource getResource() {
+                            return cs.getResource();
+                        }
+                    })
+                )
+                .map(controllerServiceNode -> new ControllerServiceComponentAuthorizable(controllerServiceNode, controllerFacade.getExtensionManager())).collect(Collectors.toSet());
     }
 
     @Override
@@ -389,6 +430,13 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
     public ComponentAuthorizable getFlowAnalysisRule(final String id) {
         final FlowAnalysisRuleNode flowAnalysisRuleNode = flowAnalysisRuleDAO.getFlowAnalysisRule(id);
         return new FlowAnalysisRuleComponentAuthorizable(flowAnalysisRuleNode, controllerFacade.getExtensionManager());
+    }
+
+    @Override
+    public Set<ComponentAuthorizable> getParameterProviders(final Predicate<org.apache.nifi.authorization.resource.ComponentAuthorizable> filter) {
+        return parameterProviderDAO.getParameterProviders().stream()
+                .filter(filter)
+                .map(parameterProviderNode -> new ParameterProviderComponentAuthorizable(parameterProviderNode, controllerFacade.getExtensionManager())).collect(Collectors.toSet());
     }
 
     @Override
@@ -1211,6 +1259,11 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
         }
 
         @Override
+        public Authorizable getParameterContextAuthorizable() {
+            return processGroup.getParameterContext();
+        }
+
+        @Override
         public ProcessGroup getProcessGroup() {
             return processGroup;
         }
@@ -1219,6 +1272,13 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
         public Set<ComponentAuthorizable> getEncapsulatedProcessors() {
             return processGroup.findAllProcessors().stream().map(
                     processorNode -> new ProcessorComponentAuthorizable(processorNode, extensionManager)).collect(Collectors.toSet());
+        }
+
+        @Override
+        public Set<ComponentAuthorizable> getEncapsulatedProcessors(Predicate<org.apache.nifi.authorization.resource.ComponentAuthorizable> processorFilter) {
+            return processGroup.findAllProcessors().stream()
+                    .filter(processorFilter)
+                    .map(processorNode -> new ProcessorComponentAuthorizable(processorNode, extensionManager)).collect(Collectors.toSet());
         }
 
         @Override
@@ -1262,6 +1322,13 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
         public Set<ComponentAuthorizable> getEncapsulatedControllerServices() {
             return processGroup.findAllControllerServices().stream().map(
                     controllerServiceNode -> new ControllerServiceComponentAuthorizable(controllerServiceNode, extensionManager)).collect(Collectors.toSet());
+        }
+
+        @Override
+        public Set<ComponentAuthorizable> getEncapsulatedControllerServices(Predicate<org.apache.nifi.authorization.resource.ComponentAuthorizable> serviceFilter) {
+            return processGroup.findAllControllerServices().stream()
+                    .filter(serviceFilter)
+                    .map(controllerServiceNode -> new ControllerServiceComponentAuthorizable(controllerServiceNode, extensionManager)).collect(Collectors.toSet());
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
@@ -206,11 +206,20 @@ public abstract class ApplicationResource {
     }
 
     protected String generateUuid() {
+        return generateUuid(null);
+    }
+
+    protected String generateUuid(final String currentId) {
         final Optional<String> seed = getIdGenerationSeed();
         UUID uuid;
         if (seed.isPresent()) {
             try {
-                UUID seedId = UUID.fromString(seed.get());
+                final UUID seedId;
+                if (currentId == null) {
+                    seedId = UUID.fromString(seed.get());
+                } else {
+                    seedId = UUID.nameUUIDFromBytes((currentId + seed.get()).getBytes(StandardCharsets.UTF_8));
+                }
                 uuid = new UUID(seedId.getMostSignificantBits(), seed.get().hashCode());
             } catch (Exception e) {
                 logger.warn("Provided 'seed' does not represent UUID. Will not be able to extract most significant bits for ID generation.");
@@ -426,18 +435,27 @@ public abstract class ApplicationResource {
      * @param authorizeReferencedServices whether to authorize referenced services
      * @param authorizeControllerServices whether to authorize controller services
      * @param authorizeTransitiveServices whether to authorize transitive services
-     * @param authorizeParameterReferences whether to authorize parameter references
+     * @param authorizeParameterReferences whether to authorize parameter context that contained referenced parameter if applicable
+     * @param authorizeParameterContext whether to authorize the bound parameter context if applicable
      */
     protected void authorizeProcessGroup(final ProcessGroupAuthorizable processGroupAuthorizable, final Authorizer authorizer, final AuthorizableLookup lookup, final RequestAction action,
                                          final boolean authorizeReferencedServices,
                                          final boolean authorizeControllerServices, final boolean authorizeTransitiveServices,
-                                         final boolean authorizeParameterReferences) {
+                                         final boolean authorizeParameterReferences, final boolean authorizeParameterContext) {
 
         final NiFiUser user = NiFiUserUtils.getNiFiUser();
         final Consumer<Authorizable> authorize = authorizable -> authorizable.authorize(authorizer, action, user);
 
         // authorize the process group
         authorize.accept(processGroupAuthorizable.getAuthorizable());
+
+        // authorize the parameter context for the specified process group
+        if (authorizeParameterContext) {
+            final Authorizable parameterContextAuthorizable = processGroupAuthorizable.getParameterContextAuthorizable();
+            if (parameterContextAuthorizable != null) {
+                authorize.accept(parameterContextAuthorizable);
+            }
+        }
 
         // authorize the contents of the group - these methods return all encapsulated components (recursive)
         processGroupAuthorizable.getEncapsulatedProcessors().forEach(processorAuthorizable -> {
@@ -459,7 +477,18 @@ public abstract class ApplicationResource {
         processGroupAuthorizable.getEncapsulatedOutputPorts().forEach(authorize);
         processGroupAuthorizable.getEncapsulatedFunnels().forEach(authorize);
         processGroupAuthorizable.getEncapsulatedLabels().forEach(authorize);
-        processGroupAuthorizable.getEncapsulatedProcessGroups().stream().map(group -> group.getAuthorizable()).forEach(authorize);
+        processGroupAuthorizable.getEncapsulatedProcessGroups().forEach(pga -> {
+            final Authorizable authorizable = pga.getAuthorizable();
+
+            authorize.accept(authorizable);
+
+            if (authorizeParameterContext) {
+                final Authorizable parameterContextAuthorizable = pga.getParameterContextAuthorizable();
+                if (parameterContextAuthorizable != null) {
+                    authorize.accept(parameterContextAuthorizable);
+                }
+            }
+        });
         processGroupAuthorizable.getEncapsulatedRemoteProcessGroups().forEach(authorize);
 
         // authorize controller services if necessary
@@ -488,7 +517,8 @@ public abstract class ApplicationResource {
      * @param action action
      */
     protected void authorizeSnippet(final SnippetAuthorizable snippet, final Authorizer authorizer, final AuthorizableLookup lookup, final RequestAction action,
-                                    final boolean authorizeReferencedServices, final boolean authorizeTransitiveServices, final boolean authorizeParameterReferences) {
+                                    final boolean authorizeReferencedServices, final boolean authorizeTransitiveServices, final boolean authorizeParameterReferences,
+                                    final boolean authorizeParameterContext) {
 
         final NiFiUser user = NiFiUserUtils.getNiFiUser();
         final Consumer<Authorizable> authorize = authorizable -> authorizable.authorize(authorizer, action, user);
@@ -498,7 +528,7 @@ public abstract class ApplicationResource {
             // note - we are not authorizing controller services as they are not considered when using this snippet. however,
             // referenced services are considered so those are explicitly authorized when authorizing a processor
             authorizeProcessGroup(processGroupAuthorizable, authorizer, lookup, action, authorizeReferencedServices,
-                    false, authorizeTransitiveServices, authorizeParameterReferences);
+                    false, authorizeTransitiveServices, authorizeParameterReferences, authorizeParameterContext);
         });
         snippet.getSelectedRemoteProcessGroups().forEach(authorize);
         snippet.getSelectedProcessors().forEach(processorAuthorizable -> {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ApplicationResource.java
@@ -451,10 +451,7 @@ public abstract class ApplicationResource {
 
         // authorize the parameter context for the specified process group
         if (authorizeParameterContext) {
-            final Authorizable parameterContextAuthorizable = processGroupAuthorizable.getParameterContextAuthorizable();
-            if (parameterContextAuthorizable != null) {
-                authorize.accept(parameterContextAuthorizable);
-            }
+            processGroupAuthorizable.getParameterContextAuthorizable().ifPresent(authorize);
         }
 
         // authorize the contents of the group - these methods return all encapsulated components (recursive)
@@ -483,10 +480,7 @@ public abstract class ApplicationResource {
             authorize.accept(authorizable);
 
             if (authorizeParameterContext) {
-                final Authorizable parameterContextAuthorizable = pga.getParameterContextAuthorizable();
-                if (parameterContextAuthorizable != null) {
-                    authorize.accept(parameterContextAuthorizable);
-                }
+                pga.getParameterContextAuthorizable().ifPresent(authorize);
             }
         });
         processGroupAuthorizable.getEncapsulatedRemoteProcessGroups().forEach(authorize);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowUpdateResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowUpdateResource.java
@@ -17,6 +17,8 @@
 package org.apache.nifi.web.api;
 
 import org.apache.nifi.authorization.AuthorizableLookup;
+import org.apache.nifi.authorization.AuthorizeControllerServiceReference;
+import org.apache.nifi.authorization.AuthorizeParameterProviders;
 import org.apache.nifi.authorization.AuthorizeParameterReference;
 import org.apache.nifi.authorization.Authorizer;
 import org.apache.nifi.authorization.ComponentAuthorizable;
@@ -193,10 +195,10 @@ public abstract class FlowUpdateResource<T extends ProcessGroupDescriptorEntity,
         serviceFacade.discoverCompatibleBundles(flowSnapshot.getFlowContents());
 
         // If there are any Controller Services referenced that are inherited from the parent group, resolve those to point to the appropriate Controller Service, if we are able to.
-        serviceFacade.resolveInheritedControllerServices(flowSnapshotContainer, groupId, user);
+        final Set<String> unresolvedControllerServices = serviceFacade.resolveInheritedControllerServices(flowSnapshotContainer, groupId, user);
 
         // If there are any Parameter Providers referenced by Parameter Contexts, resolve these to point to the appropriate Parameter Provider, if we are able to.
-        serviceFacade.resolveParameterProviders(flowSnapshot, user);
+        final Set<String> unresolvedParameterProviders = serviceFacade.resolveParameterProviders(flowSnapshot, user);
 
         // Step 1: Determine which components will be affected by updating the flow
         final Set<AffectedComponentEntity> affectedComponents = serviceFacade.getComponentsAffectedByFlowUpdate(groupId, flowSnapshot);
@@ -211,7 +213,7 @@ public abstract class FlowUpdateResource<T extends ProcessGroupDescriptorEntity,
                 serviceFacade,
                 requestWrapper,
                 requestRevision,
-                lookup -> authorizeFlowUpdate(lookup, user, groupId, flowSnapshot),
+                lookup -> authorizeFlowUpdate(lookup, user, groupId, flowSnapshot, unresolvedControllerServices, unresolvedParameterProviders),
                 () -> {
                     // Step 3: Verify that all components in the snapshot exist on all nodes
                     // Step 4: Verify that Process Group can be updated. Only versioned flows care about the verifyNotDirty flag
@@ -230,13 +232,14 @@ public abstract class FlowUpdateResource<T extends ProcessGroupDescriptorEntity,
      * @param flowSnapshot the new flow contents to examine for restricted components
      */
     protected void authorizeFlowUpdate(final AuthorizableLookup lookup, final NiFiUser user, final String groupId,
-                                       final RegisteredFlowSnapshot flowSnapshot) {
+                                       final RegisteredFlowSnapshot flowSnapshot, final Set<String> unresolvedControllerServices,
+                                       final Set<String> unresolvedParameterProviders) {
         // Step 2: Verify READ and WRITE permissions for user, for every component.
         final ProcessGroupAuthorizable groupAuthorizable = lookup.getProcessGroup(groupId);
         authorizeProcessGroup(groupAuthorizable, authorizer, lookup, RequestAction.READ, true,
-                false, true, true);
+                false, true, false, true);
         authorizeProcessGroup(groupAuthorizable, authorizer, lookup, RequestAction.WRITE, true,
-                false, true, false);
+                false, true, false, false);
 
         final VersionedProcessGroup groupContents = flowSnapshot.getFlowContents();
         final Set<ConfigurableComponent> restrictedComponents = FlowRegistryUtils.getRestrictedComponents(groupContents, serviceFacade);
@@ -251,6 +254,12 @@ public abstract class FlowUpdateResource<T extends ProcessGroupDescriptorEntity,
                     context -> AuthorizeParameterReference.authorizeParameterContextAddition(context, serviceFacade, authorizer, lookup, user)
             );
         }
+
+        // authorize parameter providers
+        AuthorizeParameterProviders.authorizeUnresolvedParameterProviders(unresolvedParameterProviders, authorizer, lookup, user);
+
+        // authorizer controller services
+        AuthorizeControllerServiceReference.authorizeUnresolvedControllerServiceReferences(groupId, unresolvedControllerServices, authorizer, lookup, user);
     }
 
     /**

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
@@ -3129,8 +3129,7 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
 
                         return false;
                     })
-                    .findFirst()
-                    .ifPresent(serviceEntry -> serviceEntry.setValue(serviceIdMapping.get(serviceEntry.getValue())));
+                    .forEach(serviceEntry -> serviceEntry.setValue(serviceIdMapping.get(serviceEntry.getValue())));
         });
         group.getProcessors().forEach(p -> {
             final String newId = generateUuid(p.getIdentifier());
@@ -3149,8 +3148,7 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
 
                         return false;
                     })
-                    .findFirst()
-                    .ifPresent(serviceEntry -> serviceEntry.setValue(serviceIdMapping.get(serviceEntry.getValue())));
+                    .forEach(serviceEntry -> serviceEntry.setValue(serviceIdMapping.get(serviceEntry.getValue())));
         });
         group.getInputPorts().forEach(ip -> {
             final String newId = generateUuid(ip.getIdentifier());

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
@@ -344,7 +344,7 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
      * @return A copyResponseEntity.
      */
     @POST
-    @Consumes(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{id}/copy")
     @Operation(
@@ -373,6 +373,10 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
                     description = "The request including the components to be copied from the specified Process Group.",
                     required = true
             ) final CopyRequestEntity copyRequestEntity) {
+
+        if (copyRequestEntity == null) {
+            throw new IllegalArgumentException("The copy request payload must be specified.");
+        }
 
         // authorize access
         serviceFacade.authorizeAccess(lookup -> {
@@ -3044,7 +3048,7 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
                         authorizeRestrictions(authorizer, restrictedComponentAuthorizable);
                     });
 
-                    // authorizer controller services
+                    // authorize controller services
                     AuthorizeControllerServiceReference.authorizeUnresolvedControllerServiceReferences(groupId, unresolvedControllerServices, authorizer, lookup, user);
 
                     // if the pasted content contains parameter contexts, ensure the user can create them or add to existing matching contexts

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/RemoteProcessGroupResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/RemoteProcessGroupResource.java
@@ -885,7 +885,7 @@ public class RemoteProcessGroupResource extends ApplicationResource {
                 lookup -> {
                     final ProcessGroupAuthorizable processGroup = lookup.getProcessGroup(processGroupId);
 
-                    authorizeProcessGroup(processGroup, authorizer, lookup, RequestAction.READ, false, false, false, false);
+                    authorizeProcessGroup(processGroup, authorizer, lookup, RequestAction.READ, false, false, false, false, false);
 
                     Set<Authorizable> remoteProcessGroups = processGroup.getEncapsulatedRemoteProcessGroups();
                     for (Authorizable remoteProcessGroup : remoteProcessGroups) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/SnippetResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/SnippetResource.java
@@ -115,7 +115,7 @@ public class SnippetResource extends ApplicationResource {
         snippetRequest.getProcessGroups().keySet().stream().map(id -> lookup.getProcessGroup(id)).forEach(processGroupAuthorizable -> {
             // we are not checking referenced services since we do not know how this snippet will be used. these checks should be performed
             // in a subsequent action with this snippet
-            authorizeProcessGroup(processGroupAuthorizable, authorizer, lookup, action, false, false, false, false);
+            authorizeProcessGroup(processGroupAuthorizable, authorizer, lookup, action, false, false, false, false, false);
         });
         snippetRequest.getRemoteProcessGroups().keySet().stream().map(id -> lookup.getRemoteProcessGroup(id)).forEach(authorize);
         snippetRequest.getProcessors().keySet().stream().map(id -> lookup.getProcessor(id).getAuthorizable()).forEach(authorize);
@@ -282,7 +282,7 @@ public class SnippetResource extends ApplicationResource {
                     final SnippetAuthorizable snippet = lookup.getSnippet(snippetId);
 
                     // Note: we are explicitly not authorizing parameter references here because they are being authorized below
-                    authorizeSnippet(snippet, authorizer, lookup, RequestAction.WRITE, false, false, false);
+                    authorizeSnippet(snippet, authorizer, lookup, RequestAction.WRITE, false, false, false, false);
 
                     final ProcessGroup destinationGroup = lookup.getProcessGroup(requestSnippetDTO.getParentGroupId()).getProcessGroup();
 
@@ -356,7 +356,7 @@ public class SnippetResource extends ApplicationResource {
                 lookup -> {
                     // ensure write permission to every component in the snippet excluding referenced services
                     final SnippetAuthorizable snippet = lookup.getSnippet(snippetId);
-                    authorizeSnippet(snippet, authorizer, lookup, RequestAction.WRITE, true, false, false);
+                    authorizeSnippet(snippet, authorizer, lookup, RequestAction.WRITE, true, false, false, false);
 
                     // ensure write permission to the parent process group
                     snippet.getParentProcessGroup().getAuthorizable().authorize(authorizer, RequestAction.WRITE, NiFiUserUtils.getNiFiUser());

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/EntityFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/EntityFactory.java
@@ -219,8 +219,9 @@ public final class EntityFactory {
         return entity;
     }
 
-    public ProcessGroupFlowEntity createProcessGroupFlowEntity(final ProcessGroupFlowDTO dto, final PermissionsDTO permissions) {
+    public ProcessGroupFlowEntity createProcessGroupFlowEntity(final ProcessGroupFlowDTO dto, final RevisionDTO revision, final PermissionsDTO permissions) {
         final ProcessGroupFlowEntity entity = new ProcessGroupFlowEntity();
+        entity.setRevision(revision);
         entity.setProcessGroupFlow(dto);
         entity.setPermissions(permissions);
         return entity;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ProcessGroupDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ProcessGroupDAO.java
@@ -20,7 +20,9 @@ import org.apache.nifi.controller.ScheduledState;
 import org.apache.nifi.controller.queue.DropFlowFileStatus;
 import org.apache.nifi.controller.service.ControllerServiceState;
 import org.apache.nifi.flow.VersionedExternalFlow;
+import org.apache.nifi.groups.ComponentAdditions;
 import org.apache.nifi.groups.ProcessGroup;
+import org.apache.nifi.groups.VersionedComponentAdditions;
 import org.apache.nifi.web.api.dto.ProcessGroupDTO;
 import org.apache.nifi.web.api.dto.VersionControlInformationDTO;
 import org.apache.nifi.web.api.entity.ProcessGroupRecursivity;
@@ -148,6 +150,16 @@ public interface ProcessGroupDAO {
      */
     ProcessGroup updateProcessGroupFlow(String groupId, VersionedExternalFlow proposedSnapshot, VersionControlInformationDTO versionControlInformation, String componentIdSeed,
                                         boolean verifyNotModified, boolean updateSettings, boolean updateDescendantVersionedFlows);
+
+    /**
+     * Adds versioned components to a Process Group
+     *
+     * @param groupId the ID of the process group
+     * @param additions the additions to add to this Process Group
+     * @param componentIdSeed the seed value to use for generating ID's for new components
+     * @return the component additions
+     */
+    ComponentAdditions addVersionedComponents(String groupId, VersionedComponentAdditions additions, String componentIdSeed);
 
     /**
      * Applies the given Version Control Information to the Process Group

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessGroupDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessGroupDAO.java
@@ -31,10 +31,12 @@ import org.apache.nifi.controller.service.ControllerServiceState;
 import org.apache.nifi.flow.ExecutionEngine;
 import org.apache.nifi.flow.VersionedExternalFlow;
 import org.apache.nifi.flow.VersionedProcessGroup;
+import org.apache.nifi.groups.ComponentAdditions;
 import org.apache.nifi.groups.FlowFileConcurrency;
 import org.apache.nifi.groups.FlowFileOutboundPolicy;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.groups.RemoteProcessGroup;
+import org.apache.nifi.groups.VersionedComponentAdditions;
 import org.apache.nifi.parameter.ParameterContext;
 import org.apache.nifi.registry.flow.FlowRegistryClientNode;
 import org.apache.nifi.registry.flow.StandardVersionControlInformation;
@@ -508,6 +510,17 @@ public class StandardProcessGroupDAO extends ComponentDAO implements ProcessGrou
         group.disconnectVersionControl(true);
         group.onComponentModified();
         return group;
+    }
+
+    @Override
+    public ComponentAdditions addVersionedComponents(final String groupId, final VersionedComponentAdditions additions, final String componentIdSeed) {
+        final ProcessGroup group = locateProcessGroup(flowController, groupId);
+        final ComponentAdditions componentAdditions = group.addVersionedComponents(additions, componentIdSeed);
+        group.findAllRemoteProcessGroups().forEach(RemoteProcessGroup::initialize);
+
+        group.onComponentModified();
+
+        return componentAdditions;
     }
 
     @Override

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
@@ -57,7 +57,6 @@ import org.apache.nifi.web.api.dto.ProcessorDTO;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupDTO;
 import org.apache.nifi.web.api.dto.ReportingTaskDTO;
 import org.apache.nifi.web.api.dto.RevisionDTO;
-import org.apache.nifi.web.api.dto.SnippetDTO;
 import org.apache.nifi.web.api.dto.VerifyConfigRequestDTO;
 import org.apache.nifi.web.api.dto.VersionControlInformationDTO;
 import org.apache.nifi.web.api.dto.VersionedFlowDTO;
@@ -75,14 +74,14 @@ import org.apache.nifi.web.api.entity.ConnectionStatusEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceRunStatusEntity;
 import org.apache.nifi.web.api.entity.ControllerServicesEntity;
-import org.apache.nifi.web.api.entity.CopySnippetRequestEntity;
+import org.apache.nifi.web.api.entity.CopyRequestEntity;
+import org.apache.nifi.web.api.entity.CopyResponseEntity;
 import org.apache.nifi.web.api.entity.CountersEntity;
 import org.apache.nifi.web.api.entity.DropRequestEntity;
 import org.apache.nifi.web.api.entity.FlowAnalysisRuleEntity;
 import org.apache.nifi.web.api.entity.FlowAnalysisRuleRunStatusEntity;
 import org.apache.nifi.web.api.entity.FlowAnalysisRulesEntity;
 import org.apache.nifi.web.api.entity.FlowComparisonEntity;
-import org.apache.nifi.web.api.entity.FlowEntity;
 import org.apache.nifi.web.api.entity.FlowFileEntity;
 import org.apache.nifi.web.api.entity.FlowRegistryClientEntity;
 import org.apache.nifi.web.api.entity.ListingRequestEntity;
@@ -99,6 +98,8 @@ import org.apache.nifi.web.api.entity.ParameterProviderEntity;
 import org.apache.nifi.web.api.entity.ParameterProviderParameterApplicationEntity;
 import org.apache.nifi.web.api.entity.ParameterProviderParameterFetchEntity;
 import org.apache.nifi.web.api.entity.ParameterProvidersEntity;
+import org.apache.nifi.web.api.entity.PasteRequestEntity;
+import org.apache.nifi.web.api.entity.PasteResponseEntity;
 import org.apache.nifi.web.api.entity.PortEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupFlowEntity;
@@ -110,7 +111,6 @@ import org.apache.nifi.web.api.entity.ReportingTaskEntity;
 import org.apache.nifi.web.api.entity.ReportingTaskRunStatusEntity;
 import org.apache.nifi.web.api.entity.ReportingTasksEntity;
 import org.apache.nifi.web.api.entity.ScheduleComponentsEntity;
-import org.apache.nifi.web.api.entity.SnippetEntity;
 import org.apache.nifi.web.api.entity.StartVersionControlRequestEntity;
 import org.apache.nifi.web.api.entity.VerifyConfigRequestEntity;
 import org.apache.nifi.web.api.entity.VersionControlInformationEntity;
@@ -2173,22 +2173,16 @@ public class NiFiClientUtil {
             .orElse(null);
     }
 
-    public FlowEntity copyAndPaste(final ProcessGroupEntity pgEntity, final String destinationGroupId) throws NiFiClientException, IOException {
-        final SnippetDTO snippetDto = new SnippetDTO();
-        snippetDto.setProcessGroups(Collections.singletonMap(pgEntity.getId(), pgEntity.getRevision()));
-        snippetDto.setParentGroupId(pgEntity.getComponent().getParentGroupId());
+    public FlowDTO copyAndPaste(final String sourceGroupId, final CopyRequestEntity copyRequestEntity, final RevisionDTO revisionDTO,
+                                final String destinationGroupId) throws NiFiClientException, IOException {
+        final CopyResponseEntity copyResponseEntity = nifiClient.getProcessGroupClient().copy(sourceGroupId, copyRequestEntity);
 
-        final SnippetEntity snippetEntity = new SnippetEntity();
-        snippetEntity.setSnippet(snippetDto);
+        final PasteRequestEntity pasteRequestEntity = new PasteRequestEntity();
+        pasteRequestEntity.setCopyResponse(copyResponseEntity);
+        pasteRequestEntity.setRevision(revisionDTO);
 
-        final SnippetEntity createdSnippetEntity = nifiClient.getSnippetClient().createSnippet(snippetEntity);
-
-        final CopySnippetRequestEntity requestEntity = new CopySnippetRequestEntity();
-        requestEntity.setOriginX(0D);
-        requestEntity.setOriginY(0D);
-        requestEntity.setSnippetId(createdSnippetEntity.getSnippet().getId());
-
-        return nifiClient.getProcessGroupClient().copySnippet(destinationGroupId, requestEntity);
+        final PasteResponseEntity pasteResponseEntity = nifiClient.getProcessGroupClient().paste(destinationGroupId, pasteRequestEntity);
+        return pasteResponseEntity.getFlow();
     }
 
     public ConnectionEntity setFifoPrioritizer(final ConnectionEntity connectionEntity) throws NiFiClientException, IOException {

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/pg/CopyPasteIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/pg/CopyPasteIT.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.tests.system.pg;
+
+import org.apache.nifi.tests.system.NiFiSystemIT;
+import org.apache.nifi.toolkit.client.NiFiClientException;
+import org.apache.nifi.web.api.dto.VersionControlInformationDTO;
+import org.apache.nifi.web.api.dto.flow.FlowDTO;
+import org.apache.nifi.web.api.entity.ControllerServiceEntity;
+import org.apache.nifi.web.api.entity.CopyRequestEntity;
+import org.apache.nifi.web.api.entity.CopyResponseEntity;
+import org.apache.nifi.web.api.entity.FlowRegistryClientEntity;
+import org.apache.nifi.web.api.entity.ParameterContextEntity;
+import org.apache.nifi.web.api.entity.PasteRequestEntity;
+import org.apache.nifi.web.api.entity.PasteResponseEntity;
+import org.apache.nifi.web.api.entity.PortEntity;
+import org.apache.nifi.web.api.entity.ProcessGroupEntity;
+import org.apache.nifi.web.api.entity.ProcessGroupFlowEntity;
+import org.apache.nifi.web.api.entity.ProcessorEntity;
+import org.apache.nifi.web.api.entity.VersionControlInformationEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.apache.nifi.tests.system.registry.RegistryClientIT.FIRST_FLOW_ID;
+import static org.apache.nifi.tests.system.registry.RegistryClientIT.TEST_FLOWS_BUCKET;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CopyPasteIT extends NiFiSystemIT {
+
+    @Test
+    public void testSimpleCopyPaste() throws NiFiClientException, IOException {
+        final ProcessGroupEntity topLevel = getClientUtil().createProcessGroup("parent group", "root");
+        final ProcessGroupEntity childGroup = getClientUtil().createProcessGroup("child group", topLevel.getId());
+
+        final ProcessorEntity generate = getClientUtil().createProcessor("GenerateFlowFile", childGroup.getId());
+        final ProcessorEntity count = getClientUtil().createProcessor("CountEvents", childGroup.getId());
+        getClientUtil().setAutoTerminatedRelationships(count, "success");
+
+        getClientUtil().createConnection(generate, count, "success");
+
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setProcessGroups(Set.of(childGroup.getId()));
+
+        final FlowDTO flowDto = getClientUtil().copyAndPaste(topLevel.getId(), copyRequestEntity, topLevel.getRevision(), topLevel.getId());
+        final ProcessGroupEntity pastedProcessGroup = flowDto.getProcessGroups().iterator().next();
+
+        assertNotNull(pastedProcessGroup);
+        assertEquals("child group", pastedProcessGroup.getComponent().getName());
+
+        final ProcessGroupFlowEntity pastedGroupFlowEntity = getNifiClient().getFlowClient().getProcessGroup(pastedProcessGroup.getId());
+        final FlowDTO childFlowDto = pastedGroupFlowEntity.getProcessGroupFlow().getFlow();
+        assertEquals(2, childFlowDto.getProcessors().size());
+        assertEquals(1, childFlowDto.getConnections().size());
+    }
+
+    @Test
+    public void testPortNameUniquenessCopyPaste() throws NiFiClientException, IOException {
+        final ProcessGroupEntity topLevel = getClientUtil().createProcessGroup("parent group", "root");
+        final PortEntity in = getClientUtil().createInputPort("in", topLevel.getId());
+
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setInputPorts(Set.of(in.getId()));
+
+        // paste into the current group where the port must be renamed to ensure uniqueness
+        final FlowDTO renamePortFlowDto = getClientUtil().copyAndPaste(topLevel.getId(), copyRequestEntity, topLevel.getRevision(), topLevel.getId());
+        final PortEntity renamedPastedPort = renamePortFlowDto.getInputPorts().iterator().next();
+
+        assertNotNull(renamedPastedPort);
+        assertTrue(Pattern.matches("in \\([a-f0-9\\-]{36}\\)", renamedPastedPort.getComponent().getName()));
+
+        final ProcessGroupEntity childGroup = getClientUtil().createProcessGroup("child group", topLevel.getId());
+
+        // paste into a child group where the port name will not conflict, and it's proposed name will not change
+        final FlowDTO notRenamePortFlowDto = getClientUtil().copyAndPaste(topLevel.getId(), copyRequestEntity, childGroup.getRevision(), childGroup.getId());
+        final PortEntity notRenamedPastedPort = notRenamePortFlowDto.getInputPorts().iterator().next();
+
+        assertNotNull(notRenamedPastedPort);
+        assertEquals("in", notRenamedPastedPort.getComponent().getName());
+    }
+
+    @Test
+    public void testPastedPortInRootGroupMustBePublic() throws NiFiClientException, IOException {
+        final ProcessGroupEntity root = getNifiClient().getProcessGroupClient().getProcessGroup("root");
+        final ProcessGroupEntity topLevel = getClientUtil().createProcessGroup("parent group", root.getId());
+        final PortEntity in = getClientUtil().createInputPort("in", topLevel.getId());
+
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setInputPorts(Set.of(in.getId()));
+
+        final CopyResponseEntity copyResponseEntity = getNifiClient().getProcessGroupClient().copy(topLevel.getId(), copyRequestEntity);
+        assertEquals(1, copyResponseEntity.getInputPorts().size());
+        assertFalse(copyResponseEntity.getInputPorts().iterator().next().getAllowRemoteAccess());
+
+        final PasteRequestEntity pasteRequestEntity = new PasteRequestEntity();
+        pasteRequestEntity.setCopyResponse(copyResponseEntity);
+        pasteRequestEntity.setRevision(root.getRevision());
+
+        final PasteResponseEntity pasteResponseEntity = getNifiClient().getProcessGroupClient().paste(root.getId(), pasteRequestEntity);
+        final FlowDTO flowDto = pasteResponseEntity.getFlow();
+        assertEquals(1, flowDto.getInputPorts().size());
+        assertTrue(flowDto.getInputPorts().iterator().next().getComponent().getAllowRemoteAccess());
+    }
+
+    @Test
+    public void testPastedPortInChildGroupHonorsCopiedPayload() throws NiFiClientException, IOException {
+        final ProcessGroupEntity root = getNifiClient().getProcessGroupClient().getProcessGroup("root");
+        final ProcessGroupEntity topLevel = getClientUtil().createProcessGroup("parent group", root.getId());
+        final PortEntity in = getClientUtil().createInputPort("in", topLevel.getId());
+
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setInputPorts(Set.of(in.getId()));
+
+        // not public
+        final CopyResponseEntity copyResponseEntity = getNifiClient().getProcessGroupClient().copy(topLevel.getId(), copyRequestEntity);
+        assertEquals(1, copyResponseEntity.getInputPorts().size());
+        assertFalse(copyResponseEntity.getInputPorts().iterator().next().getAllowRemoteAccess());
+
+        PasteRequestEntity pasteRequestEntity = new PasteRequestEntity();
+        pasteRequestEntity.setCopyResponse(copyResponseEntity);
+        pasteRequestEntity.setRevision(topLevel.getRevision());
+
+        PasteResponseEntity pasteResponseEntity = getNifiClient().getProcessGroupClient().paste(topLevel.getId(), pasteRequestEntity);
+        FlowDTO flowDto = pasteResponseEntity.getFlow();
+        assertEquals(1, flowDto.getInputPorts().size());
+        assertNull(flowDto.getInputPorts().iterator().next().getComponent().getAllowRemoteAccess());
+
+        // public
+        copyResponseEntity.getInputPorts().iterator().next().setAllowRemoteAccess(true);
+
+        pasteRequestEntity.setCopyResponse(copyResponseEntity);
+        pasteRequestEntity.setRevision(topLevel.getRevision());
+
+        pasteResponseEntity = getNifiClient().getProcessGroupClient().paste(topLevel.getId(), pasteRequestEntity);
+        flowDto = pasteResponseEntity.getFlow();
+        assertEquals(1, flowDto.getInputPorts().size());
+        assertTrue(flowDto.getInputPorts().iterator().next().getComponent().getAllowRemoteAccess());
+    }
+
+    @Test
+    public void testGhostComponent() throws NiFiClientException, IOException {
+        final ProcessGroupEntity topLevel = getClientUtil().createProcessGroup("parent group", "root");
+        final ProcessorEntity generate = getClientUtil().createProcessor("GenerateFlowFile", topLevel.getId());
+
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setProcessors(Set.of(generate.getId()));
+
+        final CopyResponseEntity copyResponseEntity = getNifiClient().getProcessGroupClient().copy(topLevel.getId(), copyRequestEntity);
+        assertEquals(1, copyResponseEntity.getProcessors().size());
+
+        // update the type to something unknown
+        copyResponseEntity.getProcessors().iterator().next().setType("NotARealExtensionType");
+
+        final PasteRequestEntity pasteRequestEntity = new PasteRequestEntity();
+        pasteRequestEntity.setCopyResponse(copyResponseEntity);
+        pasteRequestEntity.setRevision(topLevel.getRevision());
+
+        final PasteResponseEntity pasteResponseEntity = getNifiClient().getProcessGroupClient().paste(topLevel.getId(), pasteRequestEntity);
+        final FlowDTO flowDto = pasteResponseEntity.getFlow();
+        assertEquals(1, flowDto.getProcessors().size());
+        assertTrue(flowDto.getProcessors().iterator().next().getComponent().getExtensionMissing());
+    }
+
+    @Test
+    public void testExternalControllerService() throws NiFiClientException, IOException {
+        final ProcessGroupEntity topLevel = getClientUtil().createProcessGroup("parent group", "root");
+        final ControllerServiceEntity service = getClientUtil().createControllerService("StandardCountService", topLevel.getId());
+        final ProcessorEntity count = getClientUtil().createProcessor("CountFlowFiles", topLevel.getId());
+
+        // reference the controller service
+        getClientUtil().updateProcessorProperties(count, Map.of("Count Service", service.getId()));
+
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setProcessors(Set.of(count.getId()));
+
+        final FlowDTO flowDto = getClientUtil().copyAndPaste(topLevel.getId(), copyRequestEntity, topLevel.getRevision(), topLevel.getId());
+        assertEquals(1, flowDto.getProcessors().size());
+        assertEquals(service.getId(), flowDto.getProcessors().iterator().next().getComponent().getConfig().getProperties().get("Count Service"));
+    }
+
+    @Test
+    public void testSensitiveValueCopiedFromInstance() throws NiFiClientException, IOException {
+        final ProcessGroupEntity topLevel = getClientUtil().createProcessGroup("parent group", "root");
+        final ProcessorEntity countEvents = getClientUtil().createProcessor("CountEvents", topLevel.getId());
+
+        // set a sensitive property
+        getClientUtil().updateProcessorProperties(countEvents, Map.of("Sensitive", "sensitive value"));
+
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setProcessors(Set.of(countEvents.getId()));
+
+        final CopyResponseEntity copyResponseEntity = getNifiClient().getProcessGroupClient().copy(topLevel.getId(), copyRequestEntity);
+        assertEquals(1, copyResponseEntity.getProcessors().size());
+        assertNull(copyResponseEntity.getProcessors().iterator().next().getProperties().get("Sensitive"));
+
+        final PasteRequestEntity pasteRequestEntity = new PasteRequestEntity();
+        pasteRequestEntity.setCopyResponse(copyResponseEntity);
+        pasteRequestEntity.setRevision(topLevel.getRevision());
+
+        final PasteResponseEntity pasteResponseEntity = getNifiClient().getProcessGroupClient().paste(topLevel.getId(), pasteRequestEntity);
+        final FlowDTO flowDto = pasteResponseEntity.getFlow();
+        assertEquals(1, flowDto.getProcessors().size());
+        assertEquals("********", flowDto.getProcessors().iterator().next().getComponent().getConfig().getProperties().get("Sensitive"));
+    }
+
+    @Test
+    public void testSensitiveValueNotCopiedFromInstance() throws NiFiClientException, IOException {
+        final ProcessGroupEntity topLevel = getClientUtil().createProcessGroup("parent group", "root");
+        final ProcessorEntity countEvents = getClientUtil().createProcessor("CountEvents", topLevel.getId());
+
+        // set a sensitive property
+        getClientUtil().updateProcessorProperties(countEvents, Map.of("Sensitive", "sensitive value"));
+
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setProcessors(Set.of(countEvents.getId()));
+
+        final CopyResponseEntity copyResponseEntity = getNifiClient().getProcessGroupClient().copy(topLevel.getId(), copyRequestEntity);
+        assertEquals(1, copyResponseEntity.getProcessors().size());
+        assertNull(copyResponseEntity.getProcessors().iterator().next().getProperties().get("Sensitive"));
+
+        // delete the copied component so the sensitive value isn't copied over
+        getClientUtil().deleteAll(topLevel.getId());
+
+        final PasteRequestEntity pasteRequestEntity = new PasteRequestEntity();
+        pasteRequestEntity.setCopyResponse(copyResponseEntity);
+        pasteRequestEntity.setRevision(topLevel.getRevision());
+
+        final PasteResponseEntity pasteResponseEntity = getNifiClient().getProcessGroupClient().paste(topLevel.getId(), pasteRequestEntity);
+        final FlowDTO flowDto = pasteResponseEntity.getFlow();
+        assertEquals(1, flowDto.getProcessors().size());
+        assertNull(flowDto.getProcessors().iterator().next().getComponent().getConfig().getProperties().get("Sensitive"));
+    }
+
+    @Test
+    public void testParameterContextReferencedCopied() throws NiFiClientException, IOException {
+        final ProcessGroupEntity topLevel = getClientUtil().createProcessGroup("parent group", "root");
+        final ProcessGroupEntity childGroup = getClientUtil().createProcessGroup("child group", topLevel.getId());
+        final ParameterContextEntity parameterContextEntity = getClientUtil().createParameterContext("my parameters", "param", "value", false);
+        getClientUtil().setParameterContext(childGroup.getId(), parameterContextEntity);
+
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setProcessGroups(Set.of(childGroup.getId()));
+
+        final FlowDTO flowDto = getClientUtil().copyAndPaste(topLevel.getId(), copyRequestEntity, topLevel.getRevision(), topLevel.getId());
+        assertEquals(1, flowDto.getProcessGroups().size());
+
+        final ProcessGroupEntity pastedProcessGroup = flowDto.getProcessGroups().iterator().next();
+        assertNotNull(pastedProcessGroup.getParameterContext());
+        assertEquals(parameterContextEntity.getId(), pastedProcessGroup.getParameterContext().getId());
+    }
+
+    @Test
+    public void testNewParameterContextCreated() throws NiFiClientException, IOException {
+        final ProcessGroupEntity topLevel = getClientUtil().createProcessGroup("parent group", "root");
+        final ProcessGroupEntity childGroup = getClientUtil().createProcessGroup("child group", topLevel.getId());
+        final ParameterContextEntity parameterContextEntity = getClientUtil().createParameterContext("my parameters", "param", "value", false);
+        getClientUtil().setParameterContext(childGroup.getId(), parameterContextEntity);
+
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setProcessGroups(Set.of(childGroup.getId()));
+
+        final CopyResponseEntity copyResponseEntity = getNifiClient().getProcessGroupClient().copy(topLevel.getId(), copyRequestEntity);
+        assertEquals(1, copyResponseEntity.getProcessGroups().size());
+
+        // delete the parameter contexts before pasting
+        getClientUtil().deleteParameterContexts();
+
+        final PasteRequestEntity pasteRequestEntity = new PasteRequestEntity();
+        pasteRequestEntity.setCopyResponse(copyResponseEntity);
+        pasteRequestEntity.setRevision(topLevel.getRevision());
+
+        final PasteResponseEntity pasteResponseEntity = getNifiClient().getProcessGroupClient().paste(topLevel.getId(), pasteRequestEntity);
+        final FlowDTO flowDto = pasteResponseEntity.getFlow();
+
+        assertEquals(1, flowDto.getProcessGroups().size());
+
+        final ProcessGroupEntity pastedProcessGroup = flowDto.getProcessGroups().iterator().next();
+        assertNotNull(pastedProcessGroup.getParameterContext());
+        assertNotEquals(parameterContextEntity.getId(), pastedProcessGroup.getParameterContext().getId());
+    }
+
+    @Test
+    public void testCopyPasteProcessGroupDoesNotDuplicateVersionedComponentId() throws NiFiClientException, IOException {
+        // Create a top-level PG and version it with nothing in it.
+        final FlowRegistryClientEntity clientEntity = registerClient();
+        final ProcessGroupEntity outerGroup = getClientUtil().createProcessGroup("Outer", "root");
+        getClientUtil().startVersionControl(outerGroup, clientEntity, TEST_FLOWS_BUCKET, FIRST_FLOW_ID);
+
+        // Create a lower level PG and add a Processor.
+        // Commit as Version 2 of the group.
+        final ProcessGroupEntity inner1 = getClientUtil().createProcessGroup("Inner 1", outerGroup.getId());
+        ProcessorEntity terminate1 = getClientUtil().createProcessor("TerminateFlowFile", inner1.getId());
+        VersionControlInformationEntity vciEntity = getClientUtil().startVersionControl(outerGroup, clientEntity, TEST_FLOWS_BUCKET, FIRST_FLOW_ID);
+        assertEquals("2", vciEntity.getVersionControlInformation().getVersion());
+
+        // Get an up-to-date copy of terminate1 because it should now have a non-null versioned component id
+        terminate1 = getNifiClient().getProcessorClient().getProcessor(terminate1.getId());
+        assertNotNull(terminate1.getComponent().getVersionedComponentId());
+
+        // Build the copy request
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setProcessGroups(Set.of(inner1.getId()));
+
+        // Copy and paste the inner Process Group
+        final FlowDTO flowDto = getClientUtil().copyAndPaste(outerGroup.getId(), copyRequestEntity, outerGroup.getRevision(), outerGroup.getId());
+        final ProcessGroupEntity inner2Entity = flowDto.getProcessGroups().iterator().next();
+
+        final ProcessGroupFlowEntity inner2FlowEntity = getNifiClient().getFlowClient().getProcessGroup(inner2Entity.getId());
+        final Set<ProcessorEntity> inner2FlowProcessors = inner2FlowEntity.getProcessGroupFlow().getFlow().getProcessors();
+        assertEquals(1, inner2FlowProcessors.size());
+
+        ProcessorEntity terminate2 = inner2FlowProcessors.iterator().next();
+        assertEquals(terminate1.getComponent().getName(), terminate2.getComponent().getName());
+        assertEquals(terminate1.getComponent().getType(), terminate2.getComponent().getType());
+        assertNotEquals(terminate1.getComponent().getId(), terminate2.getComponent().getId());
+        assertNotEquals(terminate1.getComponent().getVersionedComponentId(), terminate2.getComponent().getVersionedComponentId());
+
+        // First Control again with the newly created components
+        vciEntity = getClientUtil().startVersionControl(outerGroup, clientEntity, TEST_FLOWS_BUCKET, FIRST_FLOW_ID);
+        assertEquals("3", vciEntity.getVersionControlInformation().getVersion());
+
+        // Get new version of terminate2 processor and terminate1 processor. Ensure that both have version control ID's but that they are different.
+        terminate1 = getNifiClient().getProcessorClient().getProcessor(terminate1.getId());
+        terminate2 = getNifiClient().getProcessorClient().getProcessor(terminate2.getId());
+
+        assertNotNull(terminate1.getComponent().getVersionedComponentId());
+        assertNotNull(terminate2.getComponent().getVersionedComponentId());
+        assertNotEquals(terminate1.getComponent().getVersionedComponentId(), terminate2.getComponent().getVersionedComponentId());
+    }
+
+    @Test
+    public void testCopyPasteProcessGroupUnderVersionControlMaintainsVersionedComponentId() throws NiFiClientException, IOException, InterruptedException {
+        // Create a top-level PG and version it with nothing in it.
+        final FlowRegistryClientEntity clientEntity = registerClient();
+        final ProcessGroupEntity topLevel1 = getClientUtil().createProcessGroup("Top Level 1", "root");
+
+        // Create a lower level PG and add a Processor.
+        // Commit as Version 2 of the group.
+        final ProcessGroupEntity innerGroup = getClientUtil().createProcessGroup("Inner 1", topLevel1.getId());
+        ProcessorEntity terminate1 = getClientUtil().createProcessor("TerminateFlowFile", innerGroup.getId());
+        VersionControlInformationEntity vciEntity = getClientUtil().startVersionControl(innerGroup, clientEntity, TEST_FLOWS_BUCKET, FIRST_FLOW_ID);
+        assertEquals("1", vciEntity.getVersionControlInformation().getVersion());
+
+        // Now that the inner group is under version control, copy it and paste it to a new PG.
+        // This should result in the pasted Process Group having a processor with the same Versioned Component ID, because the Processors
+        // have different Versioned groups, so they can have duplicate Versioned Component IDs.
+        final ProcessGroupEntity topLevel2 = getClientUtil().createProcessGroup("Top Level 2", "root");
+
+        // Build the request and copy and paste
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setProcessGroups(Set.of(innerGroup.getId()));
+
+        final FlowDTO flowDto = getClientUtil().copyAndPaste(topLevel1.getId(), copyRequestEntity, topLevel2.getRevision(), topLevel2.getId());
+        final String pastedGroupId = flowDto.getProcessGroups().iterator().next().getId();
+        final ProcessGroupFlowEntity pastedGroupFlowEntity = getNifiClient().getFlowClient().getProcessGroup(pastedGroupId);
+        final ProcessorEntity terminate2 = pastedGroupFlowEntity.getProcessGroupFlow().getFlow().getProcessors().iterator().next();
+
+        // Get an up-to-date copy of terminate1 because it should now have a non-null versioned component id
+        terminate1 = getNifiClient().getProcessorClient().getProcessor(terminate1.getId());
+        assertNotNull(terminate1.getComponent().getVersionedComponentId());
+
+        // Both the pasted Process Group and the original should have the same Version Control Information.
+        final VersionControlInformationDTO originalGroupVci = getNifiClient().getProcessGroupClient().getProcessGroup(innerGroup.getId()).getComponent().getVersionControlInformation();
+        final VersionControlInformationDTO pastedGroupVci = getNifiClient().getProcessGroupClient().getProcessGroup(pastedGroupId).getComponent().getVersionControlInformation();
+        assertNotNull(originalGroupVci);
+        assertNotNull(pastedGroupVci);
+        assertEquals(originalGroupVci.getBucketId(), pastedGroupVci.getBucketId());
+        assertEquals(originalGroupVci.getFlowId(), pastedGroupVci.getFlowId());
+        assertEquals(originalGroupVci.getVersion(), pastedGroupVci.getVersion());
+
+        // Wait for the Version Control Information to show a state of UP_TO_DATE. We have to wait for this because it initially is set to SYNC_FAILURE and a background task
+        // is kicked off to determine the state.
+        waitFor(() -> VersionControlInformationDTO.UP_TO_DATE.equals(getClientUtil().getVersionControlState(innerGroup.getId())) );
+        waitFor(() -> VersionControlInformationDTO.UP_TO_DATE.equals(getClientUtil().getVersionControlState(pastedGroupId)) );
+
+        // The two processors should have the same Versioned Component ID
+        assertEquals(terminate1.getComponent().getName(), terminate2.getComponent().getName());
+        assertEquals(terminate1.getComponent().getType(), terminate2.getComponent().getType());
+        assertNotEquals(terminate1.getComponent().getId(), terminate2.getComponent().getId());
+        assertEquals(terminate1.getComponent().getVersionedComponentId(), terminate2.getComponent().getVersionedComponentId());
+    }
+}

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/RegistryClientIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/RegistryClientIT.java
@@ -25,16 +25,13 @@ import org.apache.nifi.web.api.dto.FlowSnippetDTO;
 import org.apache.nifi.web.api.dto.ProcessorDTO;
 import org.apache.nifi.web.api.dto.RevisionDTO;
 import org.apache.nifi.web.api.dto.SnippetDTO;
-import org.apache.nifi.web.api.dto.VersionControlInformationDTO;
 import org.apache.nifi.web.api.dto.flow.FlowDTO;
 import org.apache.nifi.web.api.dto.flow.ProcessGroupFlowDTO;
 import org.apache.nifi.web.api.entity.ConnectionEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceEntity;
-import org.apache.nifi.web.api.entity.FlowEntity;
 import org.apache.nifi.web.api.entity.FlowRegistryClientEntity;
 import org.apache.nifi.web.api.entity.PortEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupEntity;
-import org.apache.nifi.web.api.entity.ProcessGroupFlowEntity;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
 import org.apache.nifi.web.api.entity.SnippetEntity;
 import org.apache.nifi.web.api.entity.VersionControlInformationEntity;
@@ -56,9 +53,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RegistryClientIT extends NiFiSystemIT {
-    private static final String TEST_FLOWS_BUCKET = "test-flows";
+    public static final String TEST_FLOWS_BUCKET = "test-flows";
 
-    private static final String FIRST_FLOW_ID = "first-flow";
+    public static final String FIRST_FLOW_ID = "first-flow";
 
     /**
      * Test a scenario where we have Parent Process Group with a child process group. The child group is under Version Control.
@@ -370,99 +367,6 @@ public class RegistryClientIT extends NiFiSystemIT {
 
         versionedFlowState = getClientUtil().getVersionedFlowState(group.getId(), "root");
         assertEquals("UP_TO_DATE", versionedFlowState);
-    }
-
-
-    @Test
-    public void testCopyPasteProcessGroupDoesNotDuplicateVersionedComponentId() throws NiFiClientException, IOException {
-        // Create a top-level PG and version it with nothing in it.
-        final FlowRegistryClientEntity clientEntity = registerClient();
-        final ProcessGroupEntity outerGroup = getClientUtil().createProcessGroup("Outer", "root");
-        getClientUtil().startVersionControl(outerGroup, clientEntity, TEST_FLOWS_BUCKET, FIRST_FLOW_ID);
-
-        // Create a lower level PG and add a Processor.
-        // Commit as Version 2 of the group.
-        final ProcessGroupEntity inner1 = getClientUtil().createProcessGroup("Inner 1", outerGroup.getId());
-        ProcessorEntity terminate1 = getClientUtil().createProcessor("TerminateFlowFile", inner1.getId());
-        VersionControlInformationEntity vciEntity = getClientUtil().startVersionControl(outerGroup, clientEntity, TEST_FLOWS_BUCKET, FIRST_FLOW_ID);
-        assertEquals("2", vciEntity.getVersionControlInformation().getVersion());
-
-        // Get an up-to-date copy of terminate1 because it should now have a non-null versioned component id
-        terminate1 = getNifiClient().getProcessorClient().getProcessor(terminate1.getId());
-        assertNotNull(terminate1.getComponent().getVersionedComponentId());
-
-        // Copy and paste the inner Process Group
-        final FlowEntity flowEntity = getClientUtil().copyAndPaste(inner1, outerGroup.getId());
-        final ProcessGroupEntity inner2Entity = flowEntity.getFlow().getProcessGroups().iterator().next();
-
-        final ProcessGroupFlowEntity inner2FlowEntity = getNifiClient().getFlowClient().getProcessGroup(inner2Entity.getId());
-        final Set<ProcessorEntity> inner2FlowProcessors = inner2FlowEntity.getProcessGroupFlow().getFlow().getProcessors();
-        assertEquals(1, inner2FlowProcessors.size());
-
-        ProcessorEntity terminate2 = inner2FlowProcessors.iterator().next();
-        assertEquals(terminate1.getComponent().getName(), terminate2.getComponent().getName());
-        assertEquals(terminate1.getComponent().getType(), terminate2.getComponent().getType());
-        assertNotEquals(terminate1.getComponent().getId(), terminate2.getComponent().getId());
-        assertNotEquals(terminate1.getComponent().getVersionedComponentId(), terminate2.getComponent().getVersionedComponentId());
-
-        // First Control again with the newly created components
-        vciEntity = getClientUtil().startVersionControl(outerGroup, clientEntity, TEST_FLOWS_BUCKET, FIRST_FLOW_ID);
-        assertEquals("3", vciEntity.getVersionControlInformation().getVersion());
-
-        // Get new version of terminate2 processor and terminate1 processor. Ensure that both have version control ID's but that they are different.
-        terminate1 = getNifiClient().getProcessorClient().getProcessor(terminate1.getId());
-        terminate2 = getNifiClient().getProcessorClient().getProcessor(terminate2.getId());
-
-        assertNotNull(terminate1.getComponent().getVersionedComponentId());
-        assertNotNull(terminate2.getComponent().getVersionedComponentId());
-        assertNotEquals(terminate1.getComponent().getVersionedComponentId(), terminate2.getComponent().getVersionedComponentId());
-    }
-
-    @Test
-    public void testCopyPasteProcessGroupUnderVersionControlMaintainsVersionedComponentId() throws NiFiClientException, IOException, InterruptedException {
-        // Create a top-level PG and version it with nothing in it.
-        final FlowRegistryClientEntity clientEntity = registerClient();
-        final ProcessGroupEntity topLevel1 = getClientUtil().createProcessGroup("Top Level 1", "root");
-
-        // Create a lower level PG and add a Processor.
-        // Commit as Version 2 of the group.
-        final ProcessGroupEntity innerGroup = getClientUtil().createProcessGroup("Inner 1", topLevel1.getId());
-        ProcessorEntity terminate1 = getClientUtil().createProcessor("TerminateFlowFile", innerGroup.getId());
-        VersionControlInformationEntity vciEntity = getClientUtil().startVersionControl(innerGroup, clientEntity, TEST_FLOWS_BUCKET, FIRST_FLOW_ID);
-        assertEquals("1", vciEntity.getVersionControlInformation().getVersion());
-
-        // Now that the inner group is under version control, copy it and paste it to a new PG.
-        // This should result in the pasted Process Group having a processor with the same Versioned Component ID, because the Processors
-        // have different Versioned groups, so they can have duplicate Versioned Component IDs.
-        final ProcessGroupEntity topLevel2 = getClientUtil().createProcessGroup("Top Level 2", "root");
-        final FlowEntity flowEntity = getClientUtil().copyAndPaste(innerGroup, topLevel2.getId());
-        final String pastedGroupId = flowEntity.getFlow().getProcessGroups().iterator().next().getId();
-        final ProcessGroupFlowEntity pastedGroupFlowEntity = getNifiClient().getFlowClient().getProcessGroup(pastedGroupId);
-        final ProcessorEntity terminate2 = pastedGroupFlowEntity.getProcessGroupFlow().getFlow().getProcessors().iterator().next();
-
-        // Get an up-to-date copy of terminate1 because it should now have a non-null versioned component id
-        terminate1 = getNifiClient().getProcessorClient().getProcessor(terminate1.getId());
-        assertNotNull(terminate1.getComponent().getVersionedComponentId());
-
-        // Both the pasted Process Group and the original should have the same Version Control Information.
-        final VersionControlInformationDTO originalGroupVci = getNifiClient().getProcessGroupClient().getProcessGroup(innerGroup.getId()).getComponent().getVersionControlInformation();
-        final VersionControlInformationDTO pastedGroupVci = getNifiClient().getProcessGroupClient().getProcessGroup(pastedGroupId).getComponent().getVersionControlInformation();
-        assertNotNull(originalGroupVci);
-        assertNotNull(pastedGroupVci);
-        assertEquals(originalGroupVci.getBucketId(), pastedGroupVci.getBucketId());
-        assertEquals(originalGroupVci.getFlowId(), pastedGroupVci.getFlowId());
-        assertEquals(originalGroupVci.getVersion(), pastedGroupVci.getVersion());
-
-        // Wait for the Version Control Information to show a state of UP_TO_DATE. We have to wait for this because it initially is set to SYNC_FAILURE and a background task
-        // is kicked off to determine the state.
-        waitFor(() -> VersionControlInformationDTO.UP_TO_DATE.equals(getClientUtil().getVersionControlState(innerGroup.getId())) );
-        waitFor(() -> VersionControlInformationDTO.UP_TO_DATE.equals(getClientUtil().getVersionControlState(pastedGroupId)) );
-
-        // The two processors should have the same Versioned Component ID
-        assertEquals(terminate1.getComponent().getName(), terminate2.getComponent().getName());
-        assertEquals(terminate1.getComponent().getType(), terminate2.getComponent().getType());
-        assertNotEquals(terminate1.getComponent().getId(), terminate2.getComponent().getId());
-        assertEquals(terminate1.getComponent().getVersionedComponentId(), terminate2.getComponent().getVersionedComponentId());
     }
 
 }

--- a/nifi-toolkit/nifi-toolkit-client/src/main/java/org/apache/nifi/toolkit/client/ProcessGroupClient.java
+++ b/nifi-toolkit/nifi-toolkit-client/src/main/java/org/apache/nifi/toolkit/client/ProcessGroupClient.java
@@ -17,10 +17,14 @@
 package org.apache.nifi.toolkit.client;
 
 import org.apache.nifi.web.api.entity.ControllerServiceEntity;
+import org.apache.nifi.web.api.entity.CopyRequestEntity;
+import org.apache.nifi.web.api.entity.CopyResponseEntity;
 import org.apache.nifi.web.api.entity.CopySnippetRequestEntity;
 import org.apache.nifi.web.api.entity.DropRequestEntity;
 import org.apache.nifi.web.api.entity.FlowComparisonEntity;
 import org.apache.nifi.web.api.entity.FlowEntity;
+import org.apache.nifi.web.api.entity.PasteRequestEntity;
+import org.apache.nifi.web.api.entity.PasteResponseEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupImportEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupReplaceRequestEntity;
@@ -67,4 +71,8 @@ public interface ProcessGroupClient {
     DropRequestEntity emptyQueues(String processGroupId) throws NiFiClientException, IOException;
 
     DropRequestEntity getEmptyQueuesRequest(String processGroupId, String requestId) throws NiFiClientException, IOException;
+
+    CopyResponseEntity copy(String processGroupId, CopyRequestEntity copyRequestEntity) throws NiFiClientException, IOException;
+
+    PasteResponseEntity paste(String processGroupId, PasteRequestEntity pasteRequestEntity) throws NiFiClientException, IOException;
 }

--- a/nifi-toolkit/nifi-toolkit-client/src/main/java/org/apache/nifi/toolkit/client/impl/JerseyProcessGroupClient.java
+++ b/nifi-toolkit/nifi-toolkit-client/src/main/java/org/apache/nifi/toolkit/client/impl/JerseyProcessGroupClient.java
@@ -25,10 +25,14 @@ import org.apache.nifi.toolkit.client.NiFiClientException;
 import org.apache.nifi.toolkit.client.ProcessGroupClient;
 import org.apache.nifi.toolkit.client.RequestConfig;
 import org.apache.nifi.web.api.entity.ControllerServiceEntity;
+import org.apache.nifi.web.api.entity.CopyRequestEntity;
+import org.apache.nifi.web.api.entity.CopyResponseEntity;
 import org.apache.nifi.web.api.entity.CopySnippetRequestEntity;
 import org.apache.nifi.web.api.entity.DropRequestEntity;
 import org.apache.nifi.web.api.entity.FlowComparisonEntity;
 import org.apache.nifi.web.api.entity.FlowEntity;
+import org.apache.nifi.web.api.entity.PasteRequestEntity;
+import org.apache.nifi.web.api.entity.PasteResponseEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupImportEntity;
 import org.apache.nifi.web.api.entity.ProcessGroupReplaceRequestEntity;
@@ -333,4 +337,45 @@ public class JerseyProcessGroupClient extends AbstractJerseyClient implements Pr
         }
     }
 
+    @Override
+    public CopyResponseEntity copy(String processGroupId, CopyRequestEntity copyRequestEntity) throws NiFiClientException, IOException {
+        if (StringUtils.isBlank(processGroupId)) {
+            throw new IllegalArgumentException("Process group id cannot be null or blank");
+        }
+
+        if (copyRequestEntity == null) {
+            throw new IllegalArgumentException("Copy Request Entity cannot be null");
+        }
+
+        return executeAction("Error copying", () -> {
+            final WebTarget target = processGroupsTarget
+                    .path("{id}/copy")
+                    .resolveTemplate("id", processGroupId);
+
+            return getRequestBuilder(target).post(
+                    Entity.entity(copyRequestEntity, MediaType.APPLICATION_JSON_TYPE),
+                    CopyResponseEntity.class);
+        });
+    }
+
+    @Override
+    public PasteResponseEntity paste(String processGroupId, PasteRequestEntity pasteRequestEntity) throws NiFiClientException, IOException {
+        if (StringUtils.isBlank(processGroupId)) {
+            throw new IllegalArgumentException("Process group id cannot be null or blank");
+        }
+
+        if (pasteRequestEntity == null) {
+            throw new IllegalArgumentException("Paste Request Entity cannot be null");
+        }
+
+        return executeAction("Error pasting", () -> {
+            final WebTarget target = processGroupsTarget
+                    .path("{id}/paste")
+                    .resolveTemplate("id", processGroupId);
+
+            return getRequestBuilder(target).put(
+                    Entity.entity(pasteRequestEntity, MediaType.APPLICATION_JSON_TYPE),
+                    PasteResponseEntity.class);
+        });
+    }
 }


### PR DESCRIPTION
…ents.

- Including the revision for the current Process Group in the flow response.
- Introduce a method propose built for adding new versioned components to an existing Process Group.
- Updating the paste response payload to only include the entities for the components that were just added.
- Always generating new IDs when copying components.
- Creating an ID for the copy action.
- Code clean up.
- Mapping IDs on paste to ensure connections are created correctly.
- Authorizing any components whose instance IDs are specified.
- Copying any sensitive properties from copied instances when pasting.
- Fixing mapping of copy response to ensure that nested Controller Services can be referenced.
- Including external Controller Services in copy response to they can be resolved on paste.
- Excluding unreferenced services from copy response.
- Including property descriptors to allow external services to resolve when pasting.
- Including Parameters and Parameter Providers in copy response.
- Fixing issue returning unreferenced services in the current process group.
- Reverting changes building up external service references.
- Only including external services that are references by the copy selection.
- Adding some additional test coverage.
- Adding consideration for the current ids in the paste id mapping.
- Adding an endpoint response merger for the paste endpoint.
- Including version control information in copy response.
- Being more lenient when pasting unknown registry clients.
- Ensuring groups IDs are mapped correctly when and when not versioned.
- Including registry client id in vci of versioned process groups.
- Updating copy/paste logic in existing system tests to leverage new endpoints.
- Restoring originally proposed port name if possible.
- Allow ports to be pasted into the root group.
- Fixing authorization issue when pasting a flow containing Parameter Providers.
- Fixing issue when authorizing exporting a Flow that contains a Process Group bound to a Parameter Context.
- Introducing some Copy/Paste system tests.
- Adding system tests for verify various copy paste functionality.
- Fix checkstyle issue.
- Fixing checkstyle issues.
- Ensuring appropriate access around Parameter Providers following resolution based on locally available Parameter Providers.
- Ensuring user has access to controller services directly referenced.
- Fixing NPE in log message of Parameter Context.
- Adding more copy/paste system tests.
- Moving copy/paste version tests into the CopyPasteIT.
- Fixing unit test mocking.
- Include service authorization based on versioned component id since it may resolve during synchronization.
- Skipping properties with no values when resolving service identifiers.

This PR can be tested with the corresponding front end changes available in this PR [1].

[1] https://github.com/apache/nifi/pull/9536