### PR TITLE
[NIFI-14042] - Display the branch information for version controlled Process Groups

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/process-group-manager.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/manager/process-group-manager.service.ts
@@ -26,7 +26,8 @@ import {
     selectFlowLoadingStatus,
     selectProcessGroups,
     selectAnySelectedComponentIds,
-    selectTransitionRequired
+    selectTransitionRequired,
+    selectRegistryClients
 } from '../../state/flow/flow.selectors';
 import { CanvasUtils } from '../canvas-utils.service';
 import { enterProcessGroup } from '../../state/flow/flow.actions';
@@ -40,6 +41,7 @@ import { ComponentType, NiFiCommon, TextTip } from '@nifi/shared';
 })
 export class ProcessGroupManager implements OnDestroy {
     private destroyed$: Subject<boolean> = new Subject();
+    private registryClients = this.store.selectSignal(selectRegistryClients);
 
     private dimensions: Dimension = {
         width: 384,
@@ -1116,7 +1118,8 @@ export class ProcessGroupManager implements OnDestroy {
                     versionControl.each(function (this: any) {
                         if (self.isUnderVersionControl(processGroupData)) {
                             self.canvasUtils.canvasTooltip(VersionControlTip, d3.select(this), {
-                                versionControlInformation: processGroupData.component.versionControlInformation
+                                versionControlInformation: processGroupData.component.versionControlInformation,
+                                registryClients: self.registryClients()
                             });
                         } else {
                             self.canvasUtils.resetCanvasTooltip(d3.select(this));

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
@@ -110,7 +110,7 @@ import {
     VersionControlInformationEntity
 } from './index';
 import { StatusHistoryRequest } from '../../../../state/status-history';
-import { FetchComponentVersionsRequest } from '../../../../state/shared';
+import { FetchComponentVersionsRequest, RegistryClientEntity } from '../../../../state/shared';
 import { ErrorContext } from '../../../../state/error';
 import { CopyRequest, CopyResponseContext, CopyResponseEntity } from '../../../../state/copy';
 
@@ -159,6 +159,11 @@ export const loadChildProcessGroupSuccess = createAction(
 export const startProcessGroupPolling = createAction(`${CANVAS_PREFIX} Start Process Group Polling`);
 
 export const stopProcessGroupPolling = createAction(`${CANVAS_PREFIX} Stop Process Group Polling`);
+
+export const setRegistryClients = createAction(
+    `${CANVAS_PREFIX} Set Registry Clients`,
+    props<{ request: RegistryClientEntity[] }>()
+);
 
 export const loadConnectionsForComponent = createAction(
     `${CANVAS_PREFIX} Load Connections For Component`,

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -169,6 +169,7 @@ import { ErrorContextKey } from '../../../../state/error';
 import {
     disableComponent,
     enableComponent,
+    setRegistryClients,
     startComponent,
     startPollingProcessorUntilStopped,
     stopComponent
@@ -253,9 +254,10 @@ export class FlowEffects {
                 combineLatest([
                     this.flowService.getFlow(request.id),
                     this.flowService.getFlowStatus(),
-                    this.flowService.getControllerBulletins()
+                    this.flowService.getControllerBulletins(),
+                    this.registryService.getRegistryClients()
                 ]).pipe(
-                    map(([flow, flowStatus, controllerBulletins]) => {
+                    map(([flow, flowStatus, controllerBulletins, registryClientsResponse]) => {
                         this.store.dispatch(resetPollingFlowAnalysis());
                         return FlowActions.loadProcessGroupSuccess({
                             response: {
@@ -263,7 +265,8 @@ export class FlowEffects {
                                 flow: flow,
                                 flowStatus: flowStatus,
                                 controllerBulletins: controllerBulletins,
-                                connectedStateChanged
+                                connectedStateChanged,
+                                registryClients: registryClientsResponse.registries
                             }
                         });
                     }),
@@ -358,7 +361,7 @@ export class FlowEffects {
                                     request,
                                     registryClients: response.registries
                                 };
-
+                                this.store.dispatch(setRegistryClients({ request: response.registries }));
                                 return FlowActions.openImportFromRegistryDialog({ request: dialogRequest });
                             }),
                             catchError((errorResponse: HttpErrorResponse) =>
@@ -3699,7 +3702,7 @@ export class FlowEffects {
                             revision: versionInfo.processGroupRevision,
                             registryClients: registryClients.registries
                         };
-
+                        this.store.dispatch(setRegistryClients({ request: registryClients.registries }));
                         return FlowActions.openSaveVersionDialog({ request: dialogRequest });
                     }),
                     catchError((errorResponse: HttpErrorResponse) => of(this.snackBarOrFullScreenError(errorResponse)))

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.reducer.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.reducer.ts
@@ -65,6 +65,7 @@ import {
     setFlowAnalysisOpen,
     setNavigationCollapsed,
     setOperationCollapsed,
+    setRegistryClients,
     setSkipTransform,
     setTransitionRequired,
     startComponent,
@@ -164,6 +165,7 @@ export const initialState: FlowState = {
         parameterProviderBulletins: [],
         reportingTaskBulletins: []
     },
+    registryClients: [],
     dragging: false,
     saving: false,
     versionSaving: false,
@@ -275,11 +277,16 @@ export const flowReducer = createReducer(
             };
             draftState.flowStatus = response.flowStatus;
             draftState.controllerBulletins = response.controllerBulletins;
+            draftState.registryClients = response.registryClients;
             draftState.addedCache = [];
             draftState.removedCache = [];
             draftState.status = 'success' as const;
         });
     }),
+    on(setRegistryClients, (state, { request }) => ({
+        ...state,
+        registryClients: request
+    })),
     on(loadProcessGroupComplete, (state) => ({
         ...state,
         status: 'complete' as const

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.selectors.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.selectors.ts
@@ -252,6 +252,8 @@ export const selectControllerBulletins = createSelector(
     (state: FlowState) => state.controllerBulletins.bulletins // TODO - include others?
 );
 
+export const selectRegistryClients = createSelector(selectFlowState, (state: FlowState) => state.registryClients);
+
 export const selectNavigationCollapsed = createSelector(
     selectFlowState,
     (state: FlowState) => state.navigationCollapsed

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/index.ts
@@ -72,6 +72,7 @@ export interface LoadProcessGroupResponse {
     flowStatus: ControllerStatusEntity;
     controllerBulletins: ControllerBulletinsEntity;
     connectedStateChanged: boolean;
+    registryClients: RegistryClientEntity[];
 }
 
 export interface LoadConnectionSuccess {
@@ -556,6 +557,7 @@ export interface CopiedSnippet {
 
 export interface VersionControlTipInput {
     versionControlInformation: VersionControlInformation;
+    registryClients?: RegistryClientEntity[];
 }
 
 /*
@@ -652,6 +654,7 @@ export interface FlowState {
     flowStatus: ControllerStatusEntity;
     refreshRpgDetails: RefreshRemoteProcessGroupPollingDetailsRequest | null;
     controllerBulletins: ControllerBulletinsEntity;
+    registryClients: RegistryClientEntity[];
     dragging: boolean;
     transitionRequired: boolean;
     skipTransform: boolean;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/import-from-registry/import-from-registry.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/import-from-registry/import-from-registry.component.ts
@@ -144,9 +144,12 @@ export class ImportFromRegistry extends CloseOnEscapeDialog implements OnInit {
                 this.timeOffset = timeOffset;
             });
 
-        const sortedRegistries = dialogRequest.registryClients.slice().sort((a, b) => {
-            return this.nifiCommon.compareString(a.component.name, b.component.name);
-        });
+        const sortedRegistries = dialogRequest.registryClients
+            .slice()
+            .filter((registry) => registry.permissions.canRead)
+            .sort((a, b) => {
+                return this.nifiCommon.compareString(a.component.name, b.component.name);
+            });
 
         sortedRegistries.forEach((registryClient: RegistryClientEntity) => {
             if (registryClient.permissions.canRead) {
@@ -159,8 +162,9 @@ export class ImportFromRegistry extends CloseOnEscapeDialog implements OnInit {
             this.clientBranchingSupportMap.set(registryClient.id, registryClient.component.supportsBranching);
         });
 
+        const initialRegistry = this.registryClientOptions.length > 0 ? this.registryClientOptions[0].value : null;
         this.importFromRegistryForm = this.formBuilder.group({
-            registry: new FormControl(this.registryClientOptions[0].value, Validators.required),
+            registry: new FormControl(initialRegistry, Validators.required),
             branch: new FormControl(null),
             bucket: new FormControl(null, Validators.required),
             flow: new FormControl(null, Validators.required),

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/save-version-dialog/save-version-dialog.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/save-version-dialog/save-version-dialog.component.ts
@@ -91,9 +91,12 @@ export class SaveVersionDialog extends CloseOnEscapeDialog implements OnInit {
         this.forceCommit = !!dialogRequest.forceCommit;
 
         if (dialogRequest.registryClients) {
-            const sortedRegistries = dialogRequest.registryClients.slice().sort((a, b) => {
-                return this.nifiCommon.compareString(a.component.name, b.component.name);
-            });
+            const sortedRegistries = dialogRequest.registryClients
+                .slice()
+                .filter((registry) => registry.permissions.canRead)
+                .sort((a, b) => {
+                    return this.nifiCommon.compareString(a.component.name, b.component.name);
+                });
 
             sortedRegistries.forEach((registryClient: RegistryClientEntity) => {
                 if (registryClient.permissions.canRead) {
@@ -106,8 +109,9 @@ export class SaveVersionDialog extends CloseOnEscapeDialog implements OnInit {
                 this.clientBranchingSupportMap.set(registryClient.id, registryClient.component.supportsBranching);
             });
 
+            const initialRegistry = this.registryClientOptions.length > 0 ? this.registryClientOptions[0].value : null;
             this.saveVersionForm = formBuilder.group({
-                registry: new FormControl(this.registryClientOptions[0].value, Validators.required),
+                registry: new FormControl(initialRegistry, Validators.required),
                 branch: new FormControl(null),
                 bucket: new FormControl(null, Validators.required),
                 flowName: new FormControl(null, Validators.required),

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/common/tooltips/version-control-tip/version-control-tip.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/common/tooltips/version-control-tip/version-control-tip.component.html
@@ -16,10 +16,33 @@
   -->
 
 <div class="tooltip" [style.left.px]="left" [style.top.px]="top">
-    <div>
-        {{ getTrackingMessage() }}
-    </div>
-    <div>
+    @if (data?.versionControlInformation; as vci) {
+        <div class="flex flex-col gap-y-2 mb-3">
+            <div>
+                <div>Flow Name</div>
+                <div class="tertiary-color font-medium">{{ vci.flowName }}</div>
+            </div>
+            <div>
+                <div>Version</div>
+                <div class="tertiary-color font-medium">{{ vci.version }}</div>
+            </div>
+            <div>
+                <div>Registry</div>
+                <div class="tertiary-color font-medium">{{ vci.registryName }}</div>
+            </div>
+            @if (supportsBranching() && vci.branch) {
+                <div>
+                    <div>Branch</div>
+                    <div class="tertiary-color font-medium">{{ vci.branch }}</div>
+                </div>
+            }
+            <div>
+                <div>Bucket</div>
+                <div class="tertiary-color font-medium">{{ vci.bucketName }}</div>
+            </div>
+        </div>
+    }
+    <div class="italic">
         {{ data?.versionControlInformation?.stateExplanation }}
     </div>
 </div>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/common/tooltips/version-control-tip/version-control-tip.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/common/tooltips/version-control-tip/version-control-tip.component.html
@@ -20,25 +20,25 @@
         <div class="flex flex-col gap-y-2 mb-3">
             <div>
                 <div>Flow Name</div>
-                <div class="tertiary-color font-medium">{{ vci.flowName }}</div>
+                <div class="tertiary-color font-medium truncate" [title]="vci.flowName">{{ vci.flowName }}</div>
             </div>
             <div>
                 <div>Version</div>
-                <div class="tertiary-color font-medium">{{ vci.version }}</div>
+                <div class="tertiary-color font-medium truncate" [title]="vci.version">{{ vci.version }}</div>
             </div>
             <div>
                 <div>Registry</div>
-                <div class="tertiary-color font-medium">{{ vci.registryName }}</div>
+                <div class="tertiary-color font-medium truncate" [title]="vci.registryName">{{ vci.registryName }}</div>
             </div>
             @if (supportsBranching() && vci.branch) {
                 <div>
                     <div>Branch</div>
-                    <div class="tertiary-color font-medium">{{ vci.branch }}</div>
+                    <div class="tertiary-color font-medium truncate" [title]="vci.branch">{{ vci.branch }}</div>
                 </div>
             }
             <div>
                 <div>Bucket</div>
-                <div class="tertiary-color font-medium">{{ vci.bucketName }}</div>
+                <div class="tertiary-color font-medium truncate" [title]="vci.bucketName">{{ vci.bucketName }}</div>
             </div>
         </div>
     }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/common/tooltips/version-control-tip/version-control-tip.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/common/tooltips/version-control-tip/version-control-tip.component.ts
@@ -17,6 +17,7 @@
 
 import { Component, Input } from '@angular/core';
 import { VersionControlInformation, VersionControlTipInput } from '../../../../state/flow';
+import { RegistryClientEntity } from '../../../../../../state/shared';
 
 @Component({
     selector: 'version-control-tip',
@@ -35,5 +36,15 @@ export class VersionControlTip {
         }
 
         return '';
+    }
+
+    supportsBranching(): boolean {
+        if (this.data?.registryClients && this.data?.registryClients.length > 0) {
+            const vci = this.data.versionControlInformation;
+            return this.data.registryClients.some((client: RegistryClientEntity) => {
+                return client.id === vci.registryId && client.component.supportsBranching;
+            });
+        }
+        return false;
     }
 }


### PR DESCRIPTION
[NIFI-14042](https://issues.apache.org/jira/browse/NIFI-14042)

* Updated the version control tooltip to be more detailed
* If the backing registry client supports branching, display the branch as part of the updated tooltip
<img width="393" alt="Screenshot 2024-11-22 at 1 11 03 PM" src="https://github.com/user-attachments/assets/ecad1179-18b1-4f61-b9e9-16dfc39faf73">


* Fixed bugs in other registry-related dialogs where they would attempt to access registry client data that wasn't readable due to permissions (no "view" for "access to the controller"). Now, registry clients that aren't readable are not included.