### PR TITLE
NIFI-14046: Cast error for binary type in Iceberg data converter (nifi-1.x)

### DIFF
--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-common/src/main/java/org/apache/nifi/processors/iceberg/converter/GenericDataConverters.java
@@ -144,7 +144,7 @@ public class GenericDataConverters {
         }
     }
 
-    static class FixedConverter extends DataConverter<Byte[], byte[]> {
+    static class FixedConverter extends DataConverter<Object[], byte[]> {
 
         private final int length;
 
@@ -153,23 +153,33 @@ public class GenericDataConverters {
         }
 
         @Override
-        public byte[] convert(Byte[] data) {
+        public byte[] convert(Object[] data) {
             if (data == null) {
                 return null;
             }
             Validate.isTrue(data.length == length, String.format("Cannot write byte array of length %s as fixed[%s]", data.length, length));
-            return ArrayUtils.toPrimitive(data);
+
+            Byte[] byteArray = new Byte[data.length];
+            for (int i = 0; i < data.length; i++) {
+                byteArray[i] = DataTypeUtils.toByte(data[i], null);
+            }
+            return ArrayUtils.toPrimitive(byteArray);
         }
     }
 
-    static class BinaryConverter extends DataConverter<Byte[], ByteBuffer> {
+    static class BinaryConverter extends DataConverter<Object[], ByteBuffer> {
 
         @Override
-        public ByteBuffer convert(Byte[] data) {
+        public ByteBuffer convert(Object[] data) {
             if (data == null) {
                 return null;
             }
-            return ByteBuffer.wrap(ArrayUtils.toPrimitive(data));
+
+            Byte[] byteArray = new Byte[data.length];
+            for (int i = 0; i < data.length; i++) {
+                byteArray[i] = DataTypeUtils.toByte(data[i], null);
+            }
+            return ByteBuffer.wrap(ArrayUtils.toPrimitive(byteArray));
         }
     }
 

--- a/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
+++ b/nifi-nar-bundles/nifi-iceberg-bundle/nifi-iceberg-processors/src/test/java/org/apache/nifi/processors/iceberg/TestIcebergRecordConverter.java
@@ -467,8 +467,8 @@ public class TestIcebergRecordConverter {
         values.put("decimal", new BigDecimal("12345678.12"));
         values.put("decimalLowerScore", 12345678.1);
         values.put("boolean", true);
-        values.put("fixed", "hello".getBytes());
-        values.put("binary", "hello".getBytes());
+        values.put("fixed", new Object[]{104, 101, 108, 108, 111});
+        values.put("binary", new Object[]{104, 101, 108, 108, 111});
         values.put("date", localDate);
         values.put("time", Time.valueOf(localTime));
         values.put("timestamp", Timestamp.from(offsetDateTime.toInstant()));
@@ -491,8 +491,8 @@ public class TestIcebergRecordConverter {
         values.put("double", 3.14159D);
         values.put("decimal", new BigDecimal("12345678.12"));
         values.put("boolean", true);
-        values.put("fixed", "hello".getBytes());
-        values.put("binary", "hello".getBytes());
+        values.put("fixed", new Object[]{104, 101, 108, 108, 111});
+        values.put("binary", new Object[]{104, 101, 108, 108, 111});
         values.put("date", localDate);
         values.put("time", Time.valueOf(localTime));
         values.put("timestamp", Timestamp.from(offsetDateTime.toInstant()));
@@ -512,8 +512,8 @@ public class TestIcebergRecordConverter {
         values.put("long", 42L);
         values.put("double", 3.14159);
         values.put("decimal", 12345678.12);
-        values.put("fixed", "hello".getBytes());
-        values.put("binary", "hello".getBytes());
+        values.put("fixed", new Object[]{104, 101, 108, 108, 111});
+        values.put("binary", new Object[]{104, 101, 108, 108, 111});
         values.put("date", "2017-04-04");
         values.put("time", "14:20:33.000");
         values.put("timestamp", "2017-04-04 14:20:33.789-0500");


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14046](https://issues.apache.org/jira/browse/NIFI-14046)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
