### PR TITLE
NIFI-14052 Remove non-deterministic build properties

### DIFF
--- a/minifi/minifi-assembly/src/main/resources/build.properties.template
+++ b/minifi/minifi-assembly/src/main/resources/build.properties.template
@@ -17,15 +17,11 @@
 
 Build-Branch:${buildBranch}
 Build-Timestamp:${timestamp}
-Built-By:${user.name}
 MiNiFi-Version:${project.version}
 Build-Revision:${buildRevision}
-Maven-Home:${maven.home}
 Maven-Version:${maven.version}
 Created-By:${maven.build.version}
-Build-Java-Home:${java.home}
 Build-Jdk:${java.version}
 Build-Jdk-Vendor:${java.vendor}
 Build-Arch:${os.arch}
 Build-Os:${os.name}
-Build-Os-Version:${os.version}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/pom.xml
@@ -112,6 +112,7 @@
                     <outputPath>${restApiDirectory}</outputPath>
                     <outputFileName>swagger</outputFileName>
                     <outputFormat>JSONANDYAML</outputFormat>
+                    <sortOutput>true</sortOutput>
                     <prettyPrint>true</prettyPrint>
                     <defaultResponseCode>200</defaultResponseCode>
                     <configurationFilePath>${project.build.outputDirectory}/openapi.yaml</configurationFilePath>

--- a/nifi-manifest/nifi-runtime-manifest/src/main/resources/build.properties
+++ b/nifi-manifest/nifi-runtime-manifest/src/main/resources/build.properties
@@ -17,13 +17,9 @@ Project-Version:${project.version}
 Build-Branch:${buildBranch}
 Build-Revision:${buildRevision}
 Build-Timestamp:${maven.build.timestamp}
-Built-By:${user.name}
-Maven-Home:${maven.home}
 Maven-Version:${maven.version}
 Created-By:${maven.build.version}
-Build-Java-Home:${java.home}
 Build-Jdk:${java.version}
 Build-Jdk-Vendor:${java.vendor}
 Build-Arch:${os.arch}
 Build-Os:${os.name}
-Build-Os-Version:${os.version}

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
@@ -96,6 +96,7 @@
                     <outputPath>${api.docs.dir}</outputPath>
                     <outputFileName>swagger</outputFileName>
                     <outputFormat>JSONANDYAML</outputFormat>
+                    <sortOutput>true</sortOutput>
                     <prettyPrint>true</prettyPrint>
                     <defaultResponseCode>200</defaultResponseCode>
                     <configurationFilePath>${project.build.outputDirectory}/openapi.yaml</configurationFilePath>

--- a/pom.xml
+++ b/pom.xml
@@ -815,6 +815,8 @@
                 <artifactId>hisrc-higherjaxb40-maven-plugin</artifactId>
                 <configuration>
                     <noFileHeader>true</noFileHeader>
+                    <!-- Disable episode file generation with non-reproducible timestamps -->
+                    <episode>false</episode>
                 </configuration>
             </plugin>
             <plugin>
@@ -1006,6 +1008,21 @@
                 <!-- Skip source and javadoc plugins for WAR bundles during release process -->
                 <maven.source.skip>true</maven.source.skip>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
+            </properties>
+        </profile>
+
+        <!-- Set reproducible build properties for Apache Releases -->
+        <profile>
+            <id>apache-release</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <maven.buildNumber.skip>true</maven.buildNumber.skip>
+                <buildTag>rel/nifi-${project.version}</buildTag>
+                <buildRevision>1</buildRevision>
+                <buildBranch>main</buildBranch>
+                <maven.build.timestamp>${project.build.outputTimestamp}</maven.build.timestamp>
             </properties>
         </profile>
 


### PR DESCRIPTION
# Summary

[NIFI-14052](https://issues.apache.org/jira/browse/NIFI-14052) Removes non-deterministic build properties to address several findings from reviews of [reproducible builds](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/nifi/nifi/README.md).

The Runtime Manifest generation process populates several build properties that are specific to the build environment, and none of these properties are used for the manifest itself. The following properties are removed:

- Built-By
- Maven-Home
- Build-Java-Home
- Build-Os-Version

Disabling [episode](https://github.com/highsource/jaxb-tools/wiki/Using-Episodes) file generation for code generated from XML Schema Definitions removes unused files that contain build timestamps.

Enabling the [sortOutput property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties) for Swagger OpenAPI specifications ensures deterministic output for YAML and JSON files that define the REST API.

For the `apache-release` profile, which is used for the release process, disabling the [Build Number Maven Plugin](https://www.mojohaus.org/buildnumber-maven-plugin/) and setting standard values for `buildBranch`, `buildTag`, and `buildRevision` ensures that NAR `MANIFEST.MF` files contain standard values that reflect the release version.

These changes together address the issues highlighted from the output of [diffoscope for NiFi 2.0.0](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/nifi/nifi/nifi-2.0.0.diffoscope).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
