### PR TITLE
NIFI-14016 Resolved issue for onPropertyModified() where oldValue was always null

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
@@ -555,10 +555,11 @@ public abstract class AbstractComponentNode implements ComponentNode {
 
     // Keep setProperty/removeProperty private so that all calls go through setProperties
     private void setProperty(final PropertyDescriptor descriptor, final PropertyConfiguration propertyConfiguration, final Function<PropertyDescriptor, PropertyConfiguration> valueToCompareFunction) {
+        final PropertyConfiguration propertyModComparisonValue = valueToCompareFunction.apply(descriptor);
+
         // Remove current PropertyDescriptor to force updated instance references
         final PropertyConfiguration removed = properties.remove(descriptor);
 
-        final PropertyConfiguration propertyModComparisonValue = valueToCompareFunction.apply(descriptor);
         properties.put(descriptor, propertyConfiguration);
         final String effectiveValue = propertyConfiguration.getEffectiveValue(getParameterContext());
         final String resolvedValue = resolveAllowableValue(effectiveValue, descriptor);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/test/java/org/apache/nifi/controller/TestAbstractComponentNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/test/java/org/apache/nifi/controller/TestAbstractComponentNode.java
@@ -307,6 +307,37 @@ public class TestAbstractComponentNode {
     }
 
     @Test
+    public void testSetPropertiesPropertyModified() {
+        final String propertyValueModified = PROPERTY_VALUE + "-modified";
+        final List<PropertyModification> propertyModifications = new ArrayList<>();
+        final AbstractComponentNode node = new LocalComponentNode() {
+            @Override
+            protected void onPropertyModified(final PropertyDescriptor descriptor, final String oldValue, final String newValue) {
+                propertyModifications.add(new PropertyModification(descriptor, oldValue, newValue));
+                super.onPropertyModified(descriptor, oldValue, newValue);
+            }
+        };
+
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(PROPERTY_NAME, PROPERTY_VALUE);
+        node.setProperties(properties);
+
+        assertEquals(1, propertyModifications.size());
+        PropertyModification mod = propertyModifications.get(0);
+        assertNull(mod.getPreviousValue());
+        assertEquals(PROPERTY_VALUE, mod.getUpdatedValue());
+        propertyModifications.clear();
+
+        properties.put(PROPERTY_NAME, propertyValueModified);
+        node.setProperties(properties);
+
+        assertEquals(1, propertyModifications.size());
+        mod = propertyModifications.get(0);
+        assertEquals(PROPERTY_VALUE, mod.getPreviousValue());
+        assertEquals(propertyValueModified, mod.getUpdatedValue());
+    }
+
+    @Test
     public void testSetPropertiesSensitiveDynamicPropertyNames() {
         final AbstractComponentNode node = new LocalComponentNode();
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14016](https://issues.apache.org/jira/browse/NIFI-14016)

To test fix:

Put QuerySalesforceObject on nifi graph.
Change Bulletin level to DEBUG (i.e. double click processor -> Settings -> Bulletin Level -> DEBUG)
Give some random value for `sObject Name` property (and click "Apply")
Notice that no bulletin appears.

Give another value for `sObject Name` property (and click "Apply")
Notice that a bulletin appears in processor's upper right corner noting that the [value has changed](https://github.com/apache/nifi/blob/rel/nifi-2.0.0/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/QuerySalesforceObject.java#L358-#L359).

Prior to fix, the bulletin would not appear in this situation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
