### PR TITLE
NIFI-14064: Descriptions are not shown for Python processors

### DIFF
--- a/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
+++ b/nifi-extension-bundles/nifi-py4j-extension-bundle/nifi-py4j-integration-tests/src/test/java/org.apache.nifi.py4j/PythonControllerInteractionIT.java
@@ -160,6 +160,7 @@ public class PythonControllerInteractionIT {
             .orElseThrow(() -> new RuntimeException("Could not find ConvertCsvToExcel"));
 
         assertEquals("0.0.1-SNAPSHOT", convertCsvToExcel.getProcessorVersion());
+        assertEquals(List.of("csv", "excel"), convertCsvToExcel.getTags());
         assertEquals(new File("target/python/extensions/ConvertCsvToExcel.py").getAbsolutePath(),
             new File(convertCsvToExcel.getSourceLocation()).getAbsolutePath());
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/manifest/StandardRuntimeManifestService.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/manifest/StandardRuntimeManifestService.java
@@ -191,6 +191,7 @@ public class StandardRuntimeManifestService implements RuntimeManifestService {
         final Extension extension = new Extension();
         extension.setDescription(pythonProcessorDetails.getCapabilityDescription());
         extension.setName(pythonProcessorDetails.getProcessorType());
+        extension.setTags(pythonProcessorDetails.getTags());
         extension.setInputRequirement(InputRequirement.INPUT_REQUIRED);
         extension.setSupportsBatching(true);
         extension.setType(ExtensionType.PROCESSOR);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/manifest/StandardRuntimeManifestServiceTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/manifest/StandardRuntimeManifestServiceTest.java
@@ -25,7 +25,12 @@ import org.apache.nifi.c2.protocol.component.api.ProcessorDefinition;
 import org.apache.nifi.c2.protocol.component.api.RuntimeManifest;
 import org.apache.nifi.extension.manifest.parser.ExtensionManifestParser;
 import org.apache.nifi.extension.manifest.parser.jaxb.JAXBExtensionManifestParser;
+import org.apache.nifi.nar.ExtensionDefinition;
+import org.apache.nifi.nar.ExtensionDefinition.ExtensionRuntime;
 import org.apache.nifi.nar.ExtensionManager;
+import org.apache.nifi.nar.PythonBundle;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.python.PythonProcessorDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +38,9 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import static java.util.Collections.emptySet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -43,6 +50,7 @@ public class StandardRuntimeManifestServiceTest {
 
     private Bundle frameworkBundle;
     private Bundle testComponentsBundle;
+    private Bundle testPythonComponentsBundle;
     private ExtensionManager extensionManager;
     private ExtensionManifestParser extensionManifestParser;
     private RuntimeManifestService runtimeManifestService;
@@ -68,6 +76,13 @@ public class StandardRuntimeManifestServiceTest {
                 .build();
 
         testComponentsBundle = new Bundle(testComponentsBundleDetails, this.getClass().getClassLoader());
+
+        final BundleDetails testPythonComponentsBundleDetails = new BundleDetails.Builder()
+                .coordinate(PythonBundle.PYTHON_BUNDLE_COORDINATE)
+                .workingDir(new File("src/test/resources/TestRuntimeManifest/nifi-test-python-components-nar"))
+                .build();
+
+        testPythonComponentsBundle = new Bundle(testPythonComponentsBundleDetails, this.getClass().getClassLoader());
 
         extensionManager = mock(ExtensionManager.class);
         extensionManifestParser = new JAXBExtensionManifestParser();
@@ -103,6 +118,49 @@ public class StandardRuntimeManifestServiceTest {
 
         final List<ControllerServiceDefinition> controllerServiceDefinitions = testComponentsManifest.getControllerServices();
         assertEquals(1, controllerServiceDefinitions.size());
+    }
+
+    @Test
+    public void testGetPythonManifest() {
+        final String CLASS_NAME = "ClassName";
+        final List<String> EXPECTED_TAGS = List.of("tag1", "tag2");
+
+        when(extensionManager.getAllBundles()).thenReturn(emptySet());
+        when(extensionManager.getExtensions(Processor.class)).thenReturn(Set.of(
+                new ExtensionDefinition.Builder()
+                        .implementationClassName(CLASS_NAME)
+                        .runtime(ExtensionRuntime.PYTHON)
+                        .bundle(testPythonComponentsBundle)
+                        .extensionType(Processor.class)
+                        .tags(EXPECTED_TAGS)
+                        .version(PythonBundle.VERSION)
+                        .build()
+        ));
+
+        final PythonProcessorDetails pythonProcessorDetails = mock(PythonProcessorDetails.class);
+        when(pythonProcessorDetails.getTags()).thenReturn(EXPECTED_TAGS);
+
+        when(extensionManager.getPythonProcessorDetails(CLASS_NAME, PythonBundle.VERSION)).thenReturn(pythonProcessorDetails);
+
+        final List<org.apache.nifi.c2.protocol.component.api.Bundle> bundles = runtimeManifestService.getManifest().getBundles();
+        assertNotNull(bundles);
+        assertEquals(1, bundles.size());
+
+        final org.apache.nifi.c2.protocol.component.api.Bundle testPythonComponentsManifestBundle = bundles.getFirst();
+        assertEquals(PythonBundle.GROUP_ID, testPythonComponentsManifestBundle.getGroup());
+        assertEquals(PythonBundle.ARTIFACT_ID, testPythonComponentsManifestBundle.getArtifact());
+        assertEquals(PythonBundle.VERSION, testPythonComponentsManifestBundle.getVersion());
+
+        final ComponentManifest testComponentsManifest = testPythonComponentsManifestBundle.getComponentManifest();
+        assertNotNull(testComponentsManifest);
+
+        final List<ProcessorDefinition> processorDefinitions = testComponentsManifest.getProcessors();
+        assertEquals(1, processorDefinitions.size());
+
+        assertEquals(new HashSet<>(EXPECTED_TAGS), processorDefinitions.getFirst().getTags());
+
+        final List<ControllerServiceDefinition> controllerServiceDefinitions = testComponentsManifest.getControllerServices();
+        assertEquals(0, controllerServiceDefinitions.size());
     }
 
     /**

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/TestRuntimeManifest/nifi-test-python-components-nar/META-INF/docs/extension-manifest.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/resources/TestRuntimeManifest/nifi-test-python-components-nar/META-INF/docs/extension-manifest.xml
@@ -1,0 +1,51 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<extensionManifest>
+    <systemApiVersion>1.8.0</systemApiVersion>
+    <extensions>
+        <extension>
+            <name>TestProcessor1</name>
+            <type>PROCESSOR</type>
+            <description>Test processor 1.</description>
+            <tags>
+                <tag>test</tag>
+                <tag>processor</tag>
+            </tags>
+            <triggerSerially>true</triggerSerially>
+            <triggerWhenEmpty>true</triggerWhenEmpty>
+            <triggerWhenAnyDestinationAvailable>true</triggerWhenAnyDestinationAvailable>
+            <primaryNodeOnly>true</primaryNodeOnly>
+            <supportsBatching>true</supportsBatching>
+            <sideEffectFree>true</sideEffectFree>
+            <defaultSettings>
+                <yieldDuration>10 secs</yieldDuration>
+                <penaltyDuration>20 secs</penaltyDuration>
+                <bulletinLevel>DEBUG</bulletinLevel>
+            </defaultSettings>
+            <defaultSchedule>
+                <strategy>CRON_DRIVEN</strategy>
+                <period>* 1 * * *</period>
+                <concurrentTasks>5</concurrentTasks>
+            </defaultSchedule>
+        </extension>
+        <extension>
+            <name>TestProcessor2</name>
+            <type>PROCESSOR</type>
+            <description/>
+            <tags>
+            </tags>
+        </extension>
+    </extensions>
+</extensionManifest>


### PR DESCRIPTION
Bug's been present since fb2a82c035 / PR #9288 , which changed the way documentations are generated. The new view dyamically fetches the information to be shown from the NIFI API, which did not return the component tags for Python processors in the manifest. Since the new documentation viewer always expects the tags to be returned, it has errored out when a python component was selected, which resulted in none of the documentation had been shown.

This PR attempts to fix this issue by adding the missing information to the API response.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14064](https://issues.apache.org/jira/browse/NIFI-14064)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
