### PR TITLE
NIFI-13016 Added groups mapping from OIDC token claim for Registry

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/StandardManagedAuthorizer.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/StandardManagedAuthorizer.java
@@ -37,6 +37,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 public class StandardManagedAuthorizer implements ManagedAuthorizer {
@@ -95,17 +97,34 @@ public class StandardManagedAuthorizer implements ManagedAuthorizer {
 
         final UserAndGroups userAndGroups = userGroupProvider.getUserAndGroups(request.getIdentity());
 
-        final User user = userAndGroups.getUser();
-        if (user == null) {
-            return AuthorizationResult.denied(String.format("Unknown user with identity '%s'.", request.getIdentity()));
-        }
+        // combine groups from incoming request with groups from UserAndGroups because the request may contain groups from
+        // an external identity provider and the membership may not be maintained with in any of the UserGroupProviders
+        final Set<Group> userGroups = new HashSet<>();
+        userGroups.addAll(userAndGroups.getGroups() == null ? Collections.emptySet() : userAndGroups.getGroups());
+        userGroups.addAll(getGroups(request.getGroups()));
 
-        final Set<Group> userGroups = userAndGroups.getGroups();
-        if (policy.getUsers().contains(user.getIdentifier()) || containsGroup(userGroups, policy)) {
+        if (containsUser(userAndGroups.getUser(), policy) || containsGroup(userGroups, policy)) {
             return AuthorizationResult.approved();
         }
 
         return AuthorizationResult.denied(request.getExplanationSupplier().get());
+    }
+
+    private Set<Group> getGroups(final Set<String> groupNames) {
+        if (groupNames == null || groupNames.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        final Set<Group> groups = new HashSet<>();
+
+        for (final String requestGroupName : groupNames) {
+            final Group requestGroup = userGroupProvider.getGroupByName(requestGroupName);
+            if (requestGroup != null) {
+                groups.add(requestGroup);
+            }
+        }
+
+        return groups;
     }
 
     /**
@@ -127,6 +146,20 @@ public class StandardManagedAuthorizer implements ManagedAuthorizer {
         }
 
         return false;
+    }
+
+    /**
+     * Determines if the policy contains the user's identifier.
+     *
+     * @param user the user
+     * @param policy the policy
+     * @return true if the user is non-null and the user's identifies is contained in the policy's users
+     */
+    private boolean containsUser(final User user, final AccessPolicy policy) {
+        if (user == null || policy.getUsers().isEmpty()) {
+            return false;
+        }
+        return policy.getUsers().contains(user.getIdentifier());
     }
 
     @Override

--- a/nifi-registry/nifi-registry-core/nifi-registry-properties/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryProperties.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-properties/src/main/java/org/apache/nifi/registry/properties/NiFiRegistryProperties.java
@@ -117,6 +117,7 @@ public class NiFiRegistryProperties extends ApplicationProperties {
     public static final String SECURITY_USER_OIDC_PREFERRED_JWSALGORITHM = "nifi.registry.security.user.oidc.preferred.jwsalgorithm";
     public static final String SECURITY_USER_OIDC_ADDITIONAL_SCOPES = "nifi.registry.security.user.oidc.additional.scopes";
     public static final String SECURITY_USER_OIDC_CLAIM_IDENTIFYING_USER = "nifi.registry.security.user.oidc.claim.identifying.user";
+    public static final String SECURITY_USER_OIDC_CLAIM_GROUPS = "nifi.registry.security.user.oidc.claim.groups";
 
     // Revision Management Properties
     public static final String REVISIONS_ENABLED = "nifi.registry.revisions.enabled";
@@ -480,6 +481,16 @@ public class NiFiRegistryProperties extends ApplicationProperties {
      */
     public String getOidcClaimIdentifyingUser() {
         return getProperty(SECURITY_USER_OIDC_CLAIM_IDENTIFYING_USER, "email").trim();
+    }
+    /**
+     * Returns the claim to be used to extract user groups from the OIDC payload.
+     * Claim must be requested by adding the scope for it.
+     * Default is 'groups'.
+     *
+     * @return The claim to be used to extract user groups.
+     */
+    public String getOidcClaimGroups() {
+        return getProperty(SECURITY_USER_OIDC_CLAIM_GROUPS, "groups").trim();
     }
 
     /**

--- a/nifi-registry/nifi-registry-core/nifi-registry-security-api/src/main/java/org/apache/nifi/registry/security/authentication/AuthenticationResponse.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-security-api/src/main/java/org/apache/nifi/registry/security/authentication/AuthenticationResponse.java
@@ -17,6 +17,8 @@
 package org.apache.nifi.registry.security.authentication;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * Authentication response for a user login attempt.
@@ -27,6 +29,7 @@ public class AuthenticationResponse implements Serializable {
     private final String username;
     private final long expiration;
     private final String issuer;
+    private final Set<String> groups;
 
     /**
      * Creates an authentication response. The username and how long the authentication is valid in milliseconds
@@ -37,10 +40,24 @@ public class AuthenticationResponse implements Serializable {
      * @param issuer The issuer of the token
      */
     public AuthenticationResponse(final String identity, final String username, final long expiration, final String issuer) {
+        this(identity, username, expiration, issuer, Collections.emptySet());
+    }
+
+    /**
+     * Creates an authentication response. The username and how long the authentication is valid in milliseconds
+     *
+     * @param identity The user identity
+     * @param username The username
+     * @param expiration The expiration in milliseconds
+     * @param issuer The issuer of the token
+     * @param groups The user groups
+     */
+    public AuthenticationResponse(final String identity, final String username, final long expiration, final String issuer, final Set<String> groups) {
         this.identity = identity;
         this.username = username;
         this.expiration = expiration;
         this.issuer = issuer;
+        this.groups = groups;
     }
 
     public String getIdentity() {
@@ -62,6 +79,10 @@ public class AuthenticationResponse implements Serializable {
      */
     public long getExpiration() {
         return expiration;
+    }
+
+    public Set<String> getGroups() {
+        return groups;
     }
 
     @Override

--- a/nifi-registry/nifi-registry-core/nifi-registry-security-api/src/main/java/org/apache/nifi/registry/security/authorization/UserGroupProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-security-api/src/main/java/org/apache/nifi/registry/security/authorization/UserGroupProvider.java
@@ -76,6 +76,30 @@ public interface UserGroupProvider {
     Group getGroup(String identifier) throws AuthorizationAccessException;
 
     /**
+     * Retrieves a Group by name.
+     *
+     * @param name the name of the group to retrieve
+     * @return the Group with the given name, or null if no matching group was found
+     * @throws AuthorizationAccessException if there was an unexpected error performing the operation
+     */
+    default Group getGroupByName(String name) throws AuthorizationAccessException {
+        final Set<Group> allGroups = getGroups();
+        if (allGroups == null) {
+            return null;
+        }
+
+        Group matchingGroup = null;
+        for (Group group : allGroups) {
+            if (group.getName().equals(name)) {
+                matchingGroup = group;
+                break;
+            }
+        }
+
+        return matchingGroup;
+    }
+
+    /**
      * Gets a user and their groups. Must be non null. If the user is not known the UserAndGroups.getUser() and
      * UserAndGroups.getGroups() should return null
      *

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/IdentityAuthenticationProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/IdentityAuthenticationProvider.java
@@ -36,6 +36,7 @@ import org.springframework.security.core.AuthenticationException;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class IdentityAuthenticationProvider implements AuthenticationProvider {
 
@@ -94,7 +95,7 @@ public class IdentityAuthenticationProvider implements AuthenticationProvider {
         return new AuthenticationSuccessToken(new NiFiUserDetails(
                 new StandardNiFiUser.Builder()
                         .identity(mappedIdentity)
-                        .groups(getUserGroups(mappedIdentity))
+                        .groups(getUserGroups(mappedIdentity, response))
                         .clientAddress(requestToken.getClientAddress())
                         .build()));
     }
@@ -110,6 +111,12 @@ public class IdentityAuthenticationProvider implements AuthenticationProvider {
 
     protected Set<String> getUserGroups(final String identity) {
         return getUserGroups(authorizer, identity);
+    }
+
+    protected Set<String> getUserGroups(final String identity, AuthenticationResponse response) {
+        return Stream
+                .concat(getUserGroups(authorizer, identity).stream(), response.getGroups().stream())
+                .collect(Collectors.toSet());
     }
 
     private static Set<String> getUserGroups(final Authorizer authorizer, final String userIdentity) {

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/jwt/JwtIdentityProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/jwt/JwtIdentityProvider.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -70,7 +71,8 @@ public class JwtIdentityProvider extends BearerAuthIdentityProvider implements I
 
         try {
             final String jwtPrincipal = jwtService.getUserIdentityFromToken(jwtAuthToken);
-            return new AuthenticationResponse(jwtPrincipal, jwtPrincipal, expiration, issuer);
+            final Set<String> groups = jwtService.getUserGroupsFromToken(jwtAuthToken);
+            return new AuthenticationResponse(jwtPrincipal, jwtPrincipal, expiration, issuer, groups);
         } catch (JwtException e) {
             throw new InvalidAuthenticationException(e.getMessage(), e);
         }

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProvider.java
@@ -21,9 +21,11 @@ import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -39,6 +41,7 @@ import org.apache.nifi.registry.web.security.authentication.jwt.JwtService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -401,6 +404,10 @@ public class StandardOidcIdentityProvider implements OidcIdentityProvider {
         String identityClaim = properties.getOidcClaimIdentifyingUser();
         String identity = claimsSet.getStringClaim(identityClaim);
 
+        // Attempt to extract groups from the configured claim; default is 'groups'
+        String groupsClaim = properties.getOidcClaimGroups();
+        List<String> groups = claimsSet.getStringListClaim(groupsClaim);
+
         // If default identity not available, attempt secondary identity extraction
         if (StringUtils.isBlank(identity)) {
             // Provide clear message to admin that desired claim is missing and present available claims
@@ -424,8 +431,15 @@ public class StandardOidcIdentityProvider implements OidcIdentityProvider {
         final long expiresIn = expiration.getTime() - now.getTimeInMillis();
         final String issuer = claimsSet.getIssuer().getValue();
 
+        Set<SimpleGrantedAuthority> authorities = groups != null ? groups.stream().map(
+                SimpleGrantedAuthority::new).collect(
+                Collectors.collectingAndThen(
+                        Collectors.toSet(),
+                        Collections::unmodifiableSet
+                )) : null;
+
         // convert into a nifi jwt for retrieval later
-        return jwtService.generateSignedToken(identity, identity, issuer, issuer, expiresIn);
+        return jwtService.generateSignedToken(identity, identity, issuer, issuer, expiresIn, authorities);
     }
 
     private String retrieveIdentityFromUserInfoEndpoint(OIDCTokens oidcTokens) throws IOException {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13016](https://issues.apache.org/jira/browse/NIFI-13016)

This PR adds support for respecting groups returned by an external OIDC token to nifi-registry.

### History
The support was added to nifi proper in [NIFI-7823](https://issues.apache.org/jira/browse/NIFI-7823). I've tried to make the implementation in nifi-registry as similar as possible. However, a major overhaul to OIDC was done as part of [NIFI-4890](https://issues.apache.org/jira/browse/NIFI-4890), and those changes were not ported to nifi-registry.

### Questions / Thoughts
- I'm using Spring `SimpleGrantedAuthority` because that's what the current implementation of nifi uses, but as far as I can tell there's no real reason to use it - I'm just packing the group name into it and pulling it out later. It'd probably be cleaner to just pass around the group names.
- I haven't added any unit tests yet - as this is my first PR I'd like to get confirmation that the implementation direction makes sense before I add tests.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
- [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
