### PR TITLE
NIFI-13865: Add HeapDumpOnOutOfMemoryError description to Admin Guide

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -4076,6 +4076,15 @@ NiFi can be configured to automatically execute the diagnostics command in the e
 
 In the case of a lengthy diagnostic, NiFi may terminate before the command execution ends. In this case, the `graceful.shutdown.seconds` property should be set to a higher value in the `bootstrap.conf` configuration file.
 
+=== Automatic heap dump on Out of Memory Errors
+
+It is possible to set properties in `bootstrap.conf` to configure NiFi to generate a heap dump when an Out of Memory (OOM) error occurs. This can be helpful to analyze for memory leaks. An example of properties to be added to `bootstrap.conf` follows:
+
+    java.arg.heapDumpPath=-XX:HeapDumpPath=./work
+    java.arg.heapDumpOnOutOfMemory=-XX:+HeapDumpOnOutOfMemoryError
+
+These property values (as set in the example) will cause a heap dump to be generated into the `./work` directory. The location of the heap dump is configurable by changing the location of the `-XX:HeapDumpPath=` argument.
+
 [[jmx_metrics]]
 == JMX Metrics
 


### PR DESCRIPTION
# Summary

[NIFI-13865](https://issues.apache.org/jira/browse/NIFI-13865)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
