### PR TITLE
NIFI-14061 Add support for file scheme in OIDC Discovery URL

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -569,7 +569,8 @@ OpenID Connect integration supports the following settings in _nifi.properties_.
 [options="header"]
 |==================================================================================================================================================
 | Property Name                                             | Description
-|`nifi.security.user.oidc.discovery.url`                    | The link:http://openid.net/specs/openid-connect-discovery-1_0.html[Discovery Configuration URL^] for the OpenID Connect Provider
+|`nifi.security.user.oidc.discovery.url`                    | The link:http://openid.net/specs/openid-connect-discovery-1_0.html[Discovery Configuration URL^]
+                                                              for the OpenID Connect Provider. Supports URLs with `https` or `file` schemes.
 |`nifi.security.user.oidc.connect.timeout`                  | Socket Connect timeout when communicating with the OpenID Connect Provider. The default value is `5 secs`
 |`nifi.security.user.oidc.read.timeout`                     | Socket Read timeout when communicating with the OpenID Connect Provider. The default value is `5 secs`
 |`nifi.security.user.oidc.client.id`                        | The Client ID for NiFi registered with the OpenID Connect Provider


### PR DESCRIPTION
# Summary

[NIFI-14061](https://issues.apache.org/jira/browse/NIFI-14061) Adds support for OpenID Connect Discovery URLs having the `file` scheme, while maintaining existing support for URLs with the standard `https` scheme.

This optional feature enables use cases where overriding individual OAuth 2 endpoints is necessary based on the network location of NiFi relative to the Identity Provider.

Changes include updating the Provider Metadata retrieval method, as well as adding unit tests and updating the Admin Guide property documentation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
