### PR TITLE
NIFI-14082 Refactored the rest of the Processors to be uniform when creating properties and relationships

### DIFF
--- a/nifi-extension-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/main/java/org/apache/nifi/processors/airtable/QueryAirtableTable.java
+++ b/nifi-extension-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/main/java/org/apache/nifi/processors/airtable/QueryAirtableTable.java
@@ -27,7 +27,6 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -195,7 +194,7 @@ public class QueryAirtableTable extends AbstractProcessor {
             .description("For FlowFiles created as a result of a successful query.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             API_URL,
             PAT,
             BASE_ID,
@@ -206,9 +205,11 @@ public class QueryAirtableTable extends AbstractProcessor {
             WEB_CLIENT_SERVICE_PROVIDER,
             QUERY_PAGE_SIZE,
             MAX_RECORDS_PER_FLOWFILE
-    ));
+    );
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.singleton(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     private static final String LAST_QUERY_TIME_WINDOW_END = "last_query_time_window_end";
 

--- a/nifi-extension-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/test/java/org/apache/nifi/processors/airtable/TestQueryAirtableTable.java
+++ b/nifi-extension-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/test/java/org/apache/nifi/processors/airtable/TestQueryAirtableTable.java
@@ -85,7 +85,7 @@ public class TestQueryAirtableTable {
 
             final List<MockFlowFile> results = runner.getFlowFilesForRelationship(QueryAirtableTable.REL_SUCCESS);
             assertEquals(1, results.size());
-            final MockFlowFile flowFile = results.get(0);
+            final MockFlowFile flowFile = results.getFirst();
             assertEquals("1", flowFile.getAttribute("record.count"));
             final String content = flowFile.getContent();
             assertEquals("[" + EXPECTED_RECORD_CONTENT + "]", content);
@@ -106,7 +106,7 @@ public class TestQueryAirtableTable {
 
             final List<MockFlowFile> results = runner.getFlowFilesForRelationship(QueryAirtableTable.REL_SUCCESS);
             assertEquals(1, results.size());
-            final MockFlowFile flowFile = results.get(0);
+            final MockFlowFile flowFile = results.getFirst();
             assertEquals("2", flowFile.getAttribute("record.count"));
             final String content = flowFile.getContent();
             assertEquals("[" + EXPECTED_RECORD_CONTENT + "," + EXPECTED_RECORD_CONTENT + "]", content);
@@ -128,7 +128,7 @@ public class TestQueryAirtableTable {
 
             final List<MockFlowFile> results = runner.getFlowFilesForRelationship(QueryAirtableTable.REL_SUCCESS);
             assertEquals(2, results.size());
-            final MockFlowFile firstFlowFile = results.get(0);
+            final MockFlowFile firstFlowFile = results.getFirst();
             assertEquals("1", firstFlowFile.getAttribute("record.count"));
             final String firstContent = firstFlowFile.getContent();
             assertEquals("[" + EXPECTED_RECORD_CONTENT + "]", firstContent);

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -39,8 +39,6 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.stream.io.StreamUtils;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +46,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 @Tags({ "amqp", "rabbit", "put", "message", "send", "publish" })
 @InputRequirement(Requirement.INPUT_REQUIRED)
@@ -133,21 +132,21 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
             .description("All FlowFiles that cannot be routed to the AMQP destination are routed to this relationship")
             .build();
 
-    private final static List<PropertyDescriptor> propertyDescriptors;
+    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            Stream.of(
+                    EXCHANGE,
+                    ROUTING_KEY,
+                    HEADERS_SOURCE,
+                    HEADERS_PATTERN,
+                    HEADER_SEPARATOR
+            ),
+            getCommonPropertyDescriptors().stream()
+    ).toList();
 
-    private final static Set<Relationship> relationships;
-
-    static {
-        List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(EXCHANGE);
-        properties.add(ROUTING_KEY);
-        properties.add(HEADERS_SOURCE);
-        properties.add(HEADERS_PATTERN);
-        properties.add(HEADER_SEPARATOR);
-        properties.addAll(getCommonPropertyDescriptors());
-        propertyDescriptors = Collections.unmodifiableList(properties);
-        relationships = Set.of(REL_SUCCESS, REL_FAILURE);
-    }
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     /**
      * Will construct AMQP message by extracting its body from the incoming {@link FlowFile}. AMQP Properties will be extracted from the
@@ -204,12 +203,12 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/PublishAMQPTest.java
@@ -72,7 +72,7 @@ public class PublishAMQPTest {
 
         runner.run();
 
-        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
+        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).getFirst();
         assertNotNull(successFF);
 
         final Channel channel = ((LocalPublishAMQP) pubProc).getConnection().createChannel();
@@ -119,7 +119,7 @@ public class PublishAMQPTest {
 
         runner.run();
 
-        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
+        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).getFirst();
         assertNotNull(successFF);
 
         final Channel channel = ((LocalPublishAMQP) pubProc).getConnection().createChannel();
@@ -161,7 +161,7 @@ public class PublishAMQPTest {
 
         runner.run();
 
-        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
+        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).getFirst();
         assertNotNull(successFF);
 
         final Channel channel = ((LocalPublishAMQP) pubProc).getConnection().createChannel();
@@ -187,7 +187,7 @@ public class PublishAMQPTest {
         runner.run();
 
         assertTrue(runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).isEmpty());
-        assertNotNull(runner.getFlowFilesForRelationship(PublishAMQP.REL_FAILURE).get(0));
+        assertNotNull(runner.getFlowFilesForRelationship(PublishAMQP.REL_FAILURE).getFirst());
     }
 
     @Test
@@ -220,7 +220,7 @@ public class PublishAMQPTest {
 
         runner.run();
 
-        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).get(0);
+        final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishAMQP.REL_SUCCESS).getFirst();
         assertNotNull(successFF);
 
         final Channel channel = ((LocalPublishAMQP) pubProc).getConnection().createChannel();

--- a/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/main/java/org/apache/nifi/processors/avro/ExtractAvroMetadata.java
+++ b/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/main/java/org/apache/nifi/processors/avro/ExtractAvroMetadata.java
@@ -20,8 +20,6 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -117,33 +115,30 @@ public class ExtractAvroMetadata extends AbstractProcessor {
     static final String SCHEMA_FINGERPRINT_ATTR = "schema.fingerprint";
     static final String ITEM_COUNT_ATTR = "item.count";
 
-    private List<PropertyDescriptor> properties;
-    private Set<Relationship> relationships;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            FINGERPRINT_ALGORITHM,
+            METADATA_KEYS,
+            COUNT_ITEMS
+    );
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     @Override
     protected void init(ProcessorInitializationContext context) {
         super.init(context);
-
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(FINGERPRINT_ALGORITHM);
-        properties.add(METADATA_KEYS);
-        properties.add(COUNT_ITEMS);
-        this.properties = Collections.unmodifiableList(properties);
-
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_FAILURE);
-        this.relationships = Collections.unmodifiableSet(relationships);
     }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/test/java/org/apache/nifi/processors/avro/TestExtractAvroMetadata.java
+++ b/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/test/java/org/apache/nifi/processors/avro/TestExtractAvroMetadata.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 public class TestExtractAvroMetadata {
@@ -48,7 +49,7 @@ public class TestExtractAvroMetadata {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ExtractAvroMetadata.REL_SUCCESS, 1);
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).get(0);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_FINGERPRINT_ATTR, "b2d1d8d3de2833ce");
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_TYPE_ATTR, Schema.Type.RECORD.getName());
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_NAME_ATTR, "User");
@@ -67,7 +68,7 @@ public class TestExtractAvroMetadata {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ExtractAvroMetadata.REL_SUCCESS, 1);
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).get(0);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(ExtractAvroMetadata.ITEM_COUNT_ATTR, "6000");
     }
 
@@ -82,7 +83,7 @@ public class TestExtractAvroMetadata {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ExtractAvroMetadata.REL_SUCCESS, 1);
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).get(0);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_FINGERPRINT_ATTR, "b2d1d8d3de2833ce");
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_TYPE_ATTR, Schema.Type.RECORD.getName());
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_NAME_ATTR, "User");
@@ -100,7 +101,7 @@ public class TestExtractAvroMetadata {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ExtractAvroMetadata.REL_SUCCESS, 1);
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).get(0);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_FINGERPRINT_ATTR, "3c6a7bee8994be20314dd28c6a3af4f2");
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_TYPE_ATTR, Schema.Type.RECORD.getName());
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_NAME_ATTR, "User");
@@ -119,7 +120,7 @@ public class TestExtractAvroMetadata {
 
         runner.assertAllFlowFilesTransferred(ExtractAvroMetadata.REL_SUCCESS, 1);
 
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).get(0);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_FINGERPRINT_ATTR, "683f8f51ecd208038f4f0d39820ee9dd0ef3e32a3bee9371de0a2016d501b113");
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_TYPE_ATTR, Schema.Type.RECORD.getName());
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_NAME_ATTR, "User");
@@ -138,7 +139,7 @@ public class TestExtractAvroMetadata {
 
         runner.assertAllFlowFilesTransferred(ExtractAvroMetadata.REL_SUCCESS, 1);
 
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).get(0);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).getFirst();
         flowFile.assertAttributeExists(ExtractAvroMetadata.SCHEMA_FINGERPRINT_ATTR);
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_TYPE_ATTR, Schema.Type.RECORD.getName());
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_NAME_ATTR, "User");
@@ -157,7 +158,7 @@ public class TestExtractAvroMetadata {
 
         runner.assertAllFlowFilesTransferred(ExtractAvroMetadata.REL_SUCCESS, 1);
 
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).get(0);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).getFirst();
         flowFile.assertAttributeExists(ExtractAvroMetadata.SCHEMA_FINGERPRINT_ATTR);
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_TYPE_ATTR, Schema.Type.RECORD.getName());
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_NAME_ATTR, "User");
@@ -186,7 +187,7 @@ public class TestExtractAvroMetadata {
 
         runner.assertAllFlowFilesTransferred(ExtractAvroMetadata.REL_SUCCESS, 1);
 
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).get(0);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).getFirst();
         flowFile.assertAttributeExists(ExtractAvroMetadata.SCHEMA_FINGERPRINT_ATTR);
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_TYPE_ATTR, Schema.Type.ARRAY.getName());
         flowFile.assertAttributeEquals(ExtractAvroMetadata.SCHEMA_NAME_ATTR, "array");
@@ -215,7 +216,7 @@ public class TestExtractAvroMetadata {
 
         runner.assertAllFlowFilesTransferred(ExtractAvroMetadata.REL_SUCCESS, 1);
 
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).get(0);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractAvroMetadata.REL_SUCCESS).getFirst();
         flowFile.assertAttributeEquals("avro.codec", "deflate");
     }
 
@@ -224,7 +225,7 @@ public class TestExtractAvroMetadata {
         final TestRunner runner = TestRunners.newTestRunner(new ExtractAvroMetadata());
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        out.write("not avro".getBytes("UTF-8"));
+        out.write("not avro".getBytes(StandardCharsets.UTF_8));
         out.flush();
 
         runner.enqueue(out.toByteArray());

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/AbstractAWSCredentialsProviderProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/AbstractAWSCredentialsProviderProcessor.java
@@ -132,7 +132,10 @@ public abstract class AbstractAWSCredentialsProviderProcessor<ClientType extends
             .description("If the Processor is unable to process a given FlowFile, it will be routed to this Relationship.")
             .build();
 
-    public static final Set<Relationship> relationships = Set.of(REL_SUCCESS, REL_FAILURE);
+    public static final Set<Relationship> COMMON_RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
 
     // Member variables
@@ -143,7 +146,7 @@ public abstract class AbstractAWSCredentialsProviderProcessor<ClientType extends
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return COMMON_RELATIONSHIPS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/AbstractDynamoDBProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/AbstractDynamoDBProcessor.java
@@ -34,10 +34,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -156,12 +153,15 @@ public abstract class AbstractDynamoDBProcessor extends AbstractAwsSyncProcessor
             .defaultValue(Charset.defaultCharset().name())
             .build();
 
-    public static final Set<Relationship> dynamoDBrelationships = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE, REL_UNPROCESSED)));
+    public static final Set<Relationship> COMMON_RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_UNPROCESSED
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
-        return dynamoDBrelationships;
+        return COMMON_RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/ml/AbstractAwsMachineLearningJobStarter.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/ml/AbstractAwsMachineLearningJobStarter.java
@@ -88,11 +88,16 @@ public abstract class AbstractAwsMachineLearningJobStarter<
             .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
             .findAndAddModules()
             .build();
-    private static final Set<Relationship> relationships = Set.of(REL_ORIGINAL, REL_SUCCESS, REL_FAILURE);
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_ORIGINAL,
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/ml/AbstractAwsMachineLearningJobStatusProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/ml/AbstractAwsMachineLearningJobStatusProcessor.java
@@ -99,10 +99,10 @@ public abstract class AbstractAwsMachineLearningJobStatusProcessor<
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
-    private static final Set<Relationship> relationships = Set.of(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_ORIGINAL,
             REL_SUCCESS,
             REL_RUNNING,

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsProcessor.java
@@ -100,7 +100,10 @@ public abstract class AbstractAwsProcessor<T extends SdkClient> extends Abstract
             .description("FlowFiles are routed to failure relationship")
             .build();
 
-    private static final Set<Relationship> relationships = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     public static final PropertyDescriptor REGION = new PropertyDescriptor.Builder()
             .name("Region")
@@ -180,7 +183,7 @@ public abstract class AbstractAwsProcessor<T extends SdkClient> extends Abstract
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
@@ -66,8 +66,10 @@ import java.util.stream.Collectors;
 @Tags({"amazon", "aws", "cloudwatch", "metrics", "put", "publish"})
 public class PutCloudWatchMetric extends AbstractAwsSyncProcessor<CloudWatchClient, CloudWatchClientBuilder> {
 
-    public static final Set<Relationship> relationships = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE)));
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     public static final Set<String> units = Arrays.stream(StandardUnit.values())
             .map(StandardUnit::toString).collect(Collectors.toSet());
@@ -188,7 +190,7 @@ public class PutCloudWatchMetric extends AbstractAwsSyncProcessor<CloudWatchClie
             .addValidator(DOUBLE_VALIDATOR)
             .build();
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
         NAMESPACE,
         METRIC_NAME,
         REGION,
@@ -214,7 +216,7 @@ public class PutCloudWatchMetric extends AbstractAwsSyncProcessor<CloudWatchClie
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override
@@ -242,7 +244,7 @@ public class PutCloudWatchMetric extends AbstractAwsSyncProcessor<CloudWatchClie
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/DeleteDynamoDB.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/DeleteDynamoDB.java
@@ -70,7 +70,7 @@ import java.util.Map;
     })
 public class DeleteDynamoDB extends AbstractDynamoDBProcessor {
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
         TABLE,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -88,7 +88,7 @@ public class DeleteDynamoDB extends AbstractDynamoDBProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/GetDynamoDB.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/GetDynamoDB.java
@@ -46,9 +46,7 @@ import software.amazon.awssdk.utils.CollectionUtils;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -85,7 +83,7 @@ public class GetDynamoDB extends AbstractDynamoDBProcessor {
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
         TABLE,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -105,17 +103,21 @@ public class GetDynamoDB extends AbstractDynamoDBProcessor {
     public static final Relationship REL_NOT_FOUND = new Relationship.Builder().name("not found")
             .description("FlowFiles are routed to not found relationship if key not found in the table").build();
 
-    public static final Set<Relationship> getDynamoDBrelationships = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE, REL_UNPROCESSED, REL_NOT_FOUND)));
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_UNPROCESSED,
+            REL_NOT_FOUND
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
-        return getDynamoDBrelationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/PutDynamoDB.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/PutDynamoDB.java
@@ -77,7 +77,7 @@ import java.util.Map;
 @SystemResourceConsideration(resource = SystemResource.MEMORY)
 public class PutDynamoDB extends AbstractDynamoDBProcessor {
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
         TABLE,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -99,7 +99,7 @@ public class PutDynamoDB extends AbstractDynamoDBProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/firehose/PutKinesisFirehose.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/firehose/PutKinesisFirehose.java
@@ -87,7 +87,7 @@ public class PutKinesisFirehose extends AbstractAwsSyncProcessor<FirehoseClient,
             .sensitive(false)
             .build();
 
-    private static final List<PropertyDescriptor> properties = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
         KINESIS_FIREHOSE_DELIVERY_STREAM_NAME,
         BATCH_SIZE,
         REGION,
@@ -101,7 +101,7 @@ public class PutKinesisFirehose extends AbstractAwsSyncProcessor<FirehoseClient,
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -86,9 +86,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -317,7 +315,7 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
                     " the contents of the message will be routed to this Relationship as its own individual FlowFile.")
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
             // Kinesis Stream specific properties
             KINESIS_STREAM_NAME,
             APPLICATION_NAME,
@@ -350,8 +348,14 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
     private static final Object WORKER_LOCK = new Object();
     private static final String SCHEDULER_THREAD_NAME_TEMPLATE = ConsumeKinesisStream.class.getSimpleName() + "-" + Scheduler.class.getSimpleName() + "-";
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.singleton(REL_SUCCESS);
-    private static final Set<Relationship> RECORD_RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(REL_SUCCESS, REL_PARSE_FAILURE)));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
+
+    private static final Set<Relationship> RECORD_RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_PARSE_FAILURE
+    );
 
     private static final PropertyUtilsBean PROPERTY_UTILS_BEAN;
     private static final BeanUtilsBean BEAN_UTILS_BEAN;
@@ -384,7 +388,7 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/PutKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/PutKinesisStream.java
@@ -113,7 +113,7 @@ public class PutKinesisStream extends AbstractAwsSyncProcessor<KinesisClient, Ki
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
         KINESIS_STREAM_NAME,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -129,7 +129,7 @@ public class PutKinesisStream extends AbstractAwsSyncProcessor<KinesisClient, Ki
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/lambda/PutLambda.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/lambda/PutLambda.java
@@ -98,7 +98,7 @@ public class PutLambda extends AbstractAwsSyncProcessor<LambdaClient, LambdaClie
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
             AWS_LAMBDA_FUNCTION_NAME,
             AWS_LAMBDA_FUNCTION_QUALIFIER,
             REGION,
@@ -111,7 +111,7 @@ public class PutLambda extends AbstractAwsSyncProcessor<LambdaClient, LambdaClie
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ml/textract/GetAwsTextractJobStatus.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ml/textract/GetAwsTextractJobStatus.java
@@ -40,9 +40,7 @@ import software.amazon.awssdk.services.textract.model.ProvisionedThroughputExcee
 import software.amazon.awssdk.services.textract.model.TextractResponse;
 import software.amazon.awssdk.services.textract.model.ThrottlingException;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.nifi.processors.aws.ml.textract.StartAwsTextractJob.TEXTRACT_TYPE_ATTRIBUTE;
@@ -74,8 +72,10 @@ public class GetAwsTextractJobStatus extends AbstractAwsMachineLearningJobStatus
             .defaultValue(String.format("${%s}", TEXTRACT_TYPE_ATTRIBUTE))
             .addValidator(TEXTRACT_TYPE_VALIDATOR)
             .build();
-    private static final List<PropertyDescriptor> TEXTRACT_PROPERTIES =
-            Collections.unmodifiableList(Stream.concat(PROPERTIES.stream(), Stream.of(TEXTRACT_TYPE)).collect(Collectors.toList()));
+    private static final List<PropertyDescriptor> TEXTRACT_PROPERTIES = Stream.concat(
+            PROPERTIES.stream(),
+            Stream.of(TEXTRACT_TYPE)
+    ).toList();
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ml/textract/StartAwsTextractJob.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ml/textract/StartAwsTextractJob.java
@@ -38,9 +38,7 @@ import software.amazon.awssdk.services.textract.model.StartExpenseAnalysisRespon
 import software.amazon.awssdk.services.textract.model.TextractRequest;
 import software.amazon.awssdk.services.textract.model.TextractResponse;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.nifi.processors.aws.ml.textract.TextractType.DOCUMENT_ANALYSIS;
@@ -65,8 +63,10 @@ public class StartAwsTextractJob extends AbstractAwsMachineLearningJobStarter<
             .allowableValues(TextractType.TEXTRACT_TYPES)
             .defaultValue(DOCUMENT_ANALYSIS.getType())
             .build();
-    private static final List<PropertyDescriptor> TEXTRACT_PROPERTIES =
-        Collections.unmodifiableList(Stream.concat(PROPERTIES.stream(), Stream.of(TEXTRACT_TYPE)).collect(Collectors.toList()));
+    private static final List<PropertyDescriptor> TEXTRACT_PROPERTIES = Stream.concat(
+            PROPERTIES.stream(),
+            Stream.of(TEXTRACT_TYPE)
+    ).toList();
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/CopyS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/CopyS3Object.java
@@ -86,7 +86,7 @@ public class CopyS3Object extends AbstractS3Processor {
             .defaultValue("${filename}-1")
             .build();
 
-    static final List<PropertyDescriptor> properties = List.of(
+    static final List<PropertyDescriptor> PROPERTIES = List.of(
             SOURCE_BUCKET,
             SOURCE_KEY,
             DESTINATION_BUCKET,
@@ -111,7 +111,7 @@ public class CopyS3Object extends AbstractS3Processor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/DeleteS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/DeleteS3Object.java
@@ -62,7 +62,7 @@ public class DeleteS3Object extends AbstractS3Processor {
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
             BUCKET_WITH_DEFAULT_VALUE,
             KEY,
             AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -84,7 +84,7 @@ public class DeleteS3Object extends AbstractS3Processor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
@@ -271,7 +271,7 @@ public class FetchS3Object extends AbstractS3Processor {
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
         BUCKET_WITH_DEFAULT_VALUE,
         KEY,
         S3_REGION,
@@ -291,7 +291,7 @@ public class FetchS3Object extends AbstractS3Processor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/GetS3ObjectMetadata.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/GetS3ObjectMetadata.java
@@ -86,7 +86,7 @@ public class GetS3ObjectMetadata extends AbstractS3Processor {
             .dependsOn(METADATA_TARGET, TARGET_ATTRIBUTES)
             .build();
 
-    private static final List<PropertyDescriptor> properties = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             METADATA_TARGET,
             ATTRIBUTE_INCLUDE_PATTERN,
             BUCKET_WITH_DEFAULT_VALUE,
@@ -116,7 +116,11 @@ public class GetS3ObjectMetadata extends AbstractS3Processor {
             .description("No object was found in the bucket the supplied key")
             .build();
 
-    private static final Set<Relationship> relationships = Set.of(REL_FOUND, REL_NOT_FOUND,  REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_FOUND,
+            REL_NOT_FOUND,
+            REL_FAILURE
+    );
 
     private static final String ATTRIBUTE_FORMAT = "s3.%s";
 
@@ -124,12 +128,12 @@ public class GetS3ObjectMetadata extends AbstractS3Processor {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/ListS3.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/ListS3.java
@@ -291,7 +291,7 @@ public class ListS3 extends AbstractS3Processor implements VerifiableProcessor {
         .build();
 
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
         BUCKET_WITHOUT_DEFAULT_VALUE,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -318,7 +318,9 @@ public class ListS3 extends AbstractS3Processor implements VerifiableProcessor {
         LIST_TYPE,
         REQUESTER_PAYS);
 
-    public static final Set<Relationship> relationships = Collections.singleton(REL_SUCCESS);
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     private static final Set<PropertyDescriptor> TRACKING_RESET_PROPERTIES = Set.of(
             BUCKET_WITHOUT_DEFAULT_VALUE,
@@ -426,12 +428,12 @@ public class ListS3 extends AbstractS3Processor implements VerifiableProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     private Set<String> extractKeys(final StateMap stateMap) {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -264,7 +264,7 @@ public class PutS3Object extends AbstractS3Processor {
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
             BUCKET_WITH_DEFAULT_VALUE,
             KEY,
             S3_REGION,
@@ -331,7 +331,7 @@ public class PutS3Object extends AbstractS3Processor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/TagS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/TagS3Object.java
@@ -105,7 +105,7 @@ public class TagS3Object extends AbstractS3Processor {
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
             BUCKET_WITH_DEFAULT_VALUE,
             KEY,
             S3_REGION,
@@ -124,7 +124,7 @@ public class TagS3Object extends AbstractS3Processor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sns/PutSNS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sns/PutSNS.java
@@ -122,7 +122,7 @@ public class PutSNS extends AbstractAwsSyncProcessor<SnsClient, SnsClientBuilder
             .build();
 
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
             ARN,
             ARN_TYPE,
             SUBJECT,
@@ -141,7 +141,7 @@ public class PutSNS extends AbstractAwsSyncProcessor<SnsClient, SnsClientBuilder
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/DeleteSQS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/DeleteSQS.java
@@ -63,7 +63,7 @@ public class DeleteSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuil
             .defaultValue("${sqs.receipt.handle}")
             .build();
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
         QUEUE_URL,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -75,7 +75,7 @@ public class DeleteSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuil
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/GetSQS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/GetSQS.java
@@ -116,7 +116,7 @@ public class GetSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
             .addValidator(StandardValidators.createTimePeriodValidator(0, TimeUnit.SECONDS, 20, TimeUnit.SECONDS))  // 20 seconds is the maximum allowed by SQS
             .build();
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
         QUEUE_URL,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -132,7 +132,7 @@ public class GetSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/PutSQS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/PutSQS.java
@@ -102,7 +102,7 @@ public class PutSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
-    public static final List<PropertyDescriptor> properties = List.of(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
         QUEUE_URL,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -118,7 +118,7 @@ public class PutSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/credentials/provider/service/MockAWSProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/credentials/provider/service/MockAWSProcessor.java
@@ -26,7 +26,6 @@ import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processors.aws.AbstractAWSCredentialsProviderProcessor;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderControllerService.ASSUME_ROLE_ARN;
@@ -49,7 +48,7 @@ import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCre
  */
 public class MockAWSProcessor extends AbstractAWSCredentialsProviderProcessor<AmazonS3Client> {
 
-    public final List<PropertyDescriptor> properties = Arrays.asList(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
             USE_DEFAULT_CREDENTIALS,
             PROFILE_NAME,
             USE_ANONYMOUS_CREDENTIALS,
@@ -67,7 +66,7 @@ public class MockAWSProcessor extends AbstractAWSCredentialsProviderProcessor<Am
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureBlobProcessor_v12.java
@@ -71,7 +71,10 @@ public abstract class AbstractAzureBlobProcessor_v12 extends AbstractProcessor {
             .description("Unsuccessful operations will be transferred to the failure relationship.")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     private volatile BlobServiceClientFactory clientFactory;
 

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureDataLakeStorageProcessor.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/AbstractAzureDataLakeStorageProcessor.java
@@ -45,7 +45,10 @@ public abstract class AbstractAzureDataLakeStorageProcessor extends AbstractProc
             .description("Files that could not be written to Azure storage for some reason are transferred to this relationship")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     public static final String TEMP_FILE_DIRECTORY = "_nifitempdirectory";
 

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/PutAzureCosmosDBRecord.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/PutAzureCosmosDBRecord.java
@@ -92,20 +92,24 @@ public class PutAzureCosmosDBRecord extends AbstractAzureCosmosDBProcessor {
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .build();
 
-    private final static Set<Relationship> relationships = Set.of(REL_SUCCESS, REL_FAILURE);
-    private final static List<PropertyDescriptor> propertyDescriptors = Stream.concat(
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
+
+    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
             descriptors.stream(),
             Stream.of(RECORD_READER_FACTORY, INSERT_BATCH_SIZE, CONFLICT_HANDLE_STRATEGY)
     ).toList();
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     protected void bulkInsert(final List<Map<String, Object>> records) throws CosmosException {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/PutAzureDataExplorer.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/PutAzureDataExplorer.java
@@ -175,13 +175,16 @@ public class PutAzureDataExplorer extends AbstractProcessor {
             INGEST_STATUS_POLLING_INTERVAL
     );
 
-    private static final Set<Relationship> relationships = Set.of(SUCCESS, FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
 
     private transient KustoIngestService service;
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/QueryAzureDataExplorer.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/QueryAzureDataExplorer.java
@@ -90,9 +90,16 @@ public class QueryAzureDataExplorer extends AbstractProcessor {
 
     protected static final String APPLICATION_JSON = "application/json";
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(SUCCESS, FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(KUSTO_QUERY_SERVICE, DATABASE_NAME, QUERY);
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            KUSTO_QUERY_SERVICE,
+            DATABASE_NAME,
+            QUERY
+    );
 
     private volatile KustoQueryService service;
 
@@ -103,7 +110,7 @@ public class QueryAzureDataExplorer extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
@@ -303,9 +303,17 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
                     " the contents of the message will be routed to this Relationship as its own individual FlowFile.")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
-    private static final Set<Relationship> RECORD_RELATIONSHIPS = Set.of(REL_SUCCESS, REL_PARSE_FAILURE);
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(NAMESPACE,
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
+
+    private static final Set<Relationship> RECORD_RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_PARSE_FAILURE
+    );
+
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            NAMESPACE,
             EVENT_HUB_NAME,
             SERVICE_BUS_ENDPOINT,
             TRANSPORT_TYPE,

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
@@ -159,7 +159,7 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
             .description("Any FlowFile that is successfully received from the event hub will be transferred to this Relationship.")
             .build();
 
-    private final static List<PropertyDescriptor> propertyDescriptors = List.of(
+    private final static List<PropertyDescriptor> PROPERTIES = List.of(
             NAMESPACE,
             EVENT_HUB_NAME,
             SERVICE_BUS_ENDPOINT,
@@ -173,7 +173,10 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
             RECEIVER_FETCH_TIMEOUT,
             PROXY_CONFIGURATION_SERVICE
     );
-    private final static Set<Relationship> relationships = Set.of(REL_SUCCESS);
+
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     private final Map<String, EventPosition> partitionEventPositions = new ConcurrentHashMap<>();
 
@@ -191,12 +194,12 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
@@ -119,7 +119,7 @@ public class PutAzureEventHub extends AbstractProcessor implements AzureEventHub
             .description("Any FlowFile that could not be sent to the event hub will be transferred to this Relationship.")
             .build();
 
-    private final static List<PropertyDescriptor> propertyDescriptors = List.of(
+    private final static List<PropertyDescriptor> PROPERTIES = List.of(
             NAMESPACE,
             EVENT_HUB_NAME,
             SERVICE_BUS_ENDPOINT,
@@ -131,18 +131,22 @@ public class PutAzureEventHub extends AbstractProcessor implements AzureEventHub
             MAX_BATCH_SIZE,
             PROXY_CONFIGURATION_SERVICE
     );
-    private final static Set<Relationship> relationships = Set.of(REL_SUCCESS, REL_FAILURE);
+
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     private EventHubProducerClient eventHubProducerClient;
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/AbstractAzureQueueStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/AbstractAzureQueueStorage_v12.java
@@ -93,7 +93,10 @@ public abstract class AbstractAzureQueueStorage_v12 extends AbstractProcessor {
             .description("Unsuccessful operations will be transferred to the failure relationship.")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     static final String URI_ATTRIBUTE = "azure.queue.uri";
     static final String INSERTION_TIME_ATTRIBUTE = "azure.queue.insertionTime";

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/GetAzureQueueStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/GetAzureQueueStorage_v12.java
@@ -106,7 +106,9 @@ public class GetAzureQueueStorage_v12 extends AbstractAzureQueueStorage_v12 {
             REQUEST_TIMEOUT,
             ProxyConfiguration.createProxyConfigPropertyDescriptor(PROXY_SPECS)
     );
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     // 7 days is the maximum timeout as per https://learn.microsoft.com/en-us/rest/api/storageservices/get-messages
     private static final Duration MAX_VISIBILITY_TIMEOUT = Duration.ofDays(7);

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/FetchBoxFile.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/FetchBoxFile.java
@@ -53,9 +53,6 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -97,15 +94,15 @@ public class FetchBoxFile extends AbstractProcessor {
                     .description("A FlowFile will be routed here for each File for which fetch was attempted but failed.")
                     .build();
 
-    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
-    )));
+    );
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             BoxClientService.BOX_CLIENT_SERVICE,
             FILE_ID
-    ));
+    );
 
     private volatile BoxAPIConnection boxAPIConnection;
 

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ListBoxFile.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ListBoxFile.java
@@ -31,8 +31,6 @@ import com.box.sdk.BoxFolder;
 import com.box.sdk.BoxItem;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -130,7 +128,7 @@ public class ListBoxFile extends AbstractListProcessor<BoxFileInfo> {
         .dependsOn(LISTING_STRATEGY, BY_ENTITIES)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
         BoxClientService.BOX_CLIENT_SERVICE,
         FOLDER_ID,
         RECURSIVE_SEARCH,
@@ -140,7 +138,7 @@ public class ListBoxFile extends AbstractListProcessor<BoxFileInfo> {
         TRACKING_TIME_WINDOW,
         INITIAL_LISTING_TARGET,
         RECORD_WRITER
-    ));
+    );
 
     private volatile BoxAPIConnection boxAPIConnection;
 
@@ -233,8 +231,7 @@ public class ListBoxFile extends AbstractListProcessor<BoxFileInfo> {
             "content_modified_at",
             "path_collection"
         )) {
-            if (itemInfo instanceof BoxFile.Info) {
-                BoxFile.Info info = (BoxFile.Info) itemInfo;
+            if (itemInfo instanceof BoxFile.Info info) {
 
                 long createdAt = itemInfo.getCreatedAt().getTime();
 
@@ -249,8 +246,7 @@ public class ListBoxFile extends AbstractListProcessor<BoxFileInfo> {
                         .build();
                     listing.add(boxFileInfo);
                 }
-            } else if (recursive && itemInfo instanceof BoxFolder.Info) {
-                BoxFolder.Info info = (BoxFolder.Info) itemInfo;
+            } else if (recursive && itemInfo instanceof BoxFolder.Info info) {
                 listFolder(listing, info.getID(), recursive, createdAtMax);
             }
         }

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/PutBoxFile.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/PutBoxFile.java
@@ -19,7 +19,6 @@ package org.apache.nifi.processors.box;
 
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
-import static java.util.Arrays.asList;
 import static org.apache.nifi.processor.util.StandardValidators.createRegexMatchingValidator;
 import static org.apache.nifi.processors.box.BoxFileAttributes.ERROR_CODE;
 import static org.apache.nifi.processors.box.BoxFileAttributes.ERROR_CODE_DESC;
@@ -46,7 +45,6 @@ import com.box.sdk.BoxItem;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -162,7 +160,7 @@ public class PutBoxFile extends AbstractProcessor {
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(asList(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
             BoxClientService.BOX_CLIENT_SERVICE,
             FOLDER_ID,
             SUBFOLDER_NAME,
@@ -170,7 +168,7 @@ public class PutBoxFile extends AbstractProcessor {
             FILE_NAME,
             CONFLICT_RESOLUTION,
             CHUNKED_UPLOAD_THRESHOLD
-    ));
+    );
 
     public static final Relationship REL_SUCCESS =
             new Relationship.Builder()
@@ -184,10 +182,10 @@ public class PutBoxFile extends AbstractProcessor {
                     .description("Files that could not be written to Box for some reason are transferred to this relationship.")
                     .build();
 
-    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(asList(
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
-    )));
+    );
 
     private static final int CONFLICT_RESPONSE_CODE = 409;
     private static final int NOT_FOUND_RESPONSE_CODE = 404;
@@ -361,7 +359,7 @@ public class PutBoxFile extends AbstractProcessor {
         try {
             Optional<BoxFolder> createdFolder = getFolderByName(folderName, parentFolder);
 
-            for (int i = 0; i < NUMBER_OF_RETRIES && !createdFolder.isPresent(); i++) {
+            for (int i = 0; i < NUMBER_OF_RETRIES && createdFolder.isEmpty(); i++) {
                 getLogger().debug("Subfolder [{}] under [{}] has not been created yet, waiting {} ms",
                         folderName, parentFolder.getID(), WAIT_TIME_MS);
                 Thread.sleep(WAIT_TIME_MS);

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/ListBoxFileTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/ListBoxFileTest.java
@@ -62,7 +62,7 @@ public class ListBoxFileTest extends AbstractBoxFileTest implements FileListingT
         testRunner.run();
 
         testRunner.assertAllFlowFilesTransferred(ListBoxFile.REL_SUCCESS);
-        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(ListBoxFile.REL_SUCCESS).get(0);
+        final MockFlowFile ff0 = testRunner.getFlowFilesForRelationship(ListBoxFile.REL_SUCCESS).getFirst();
 
         ff0.assertAttributeEquals(ID, TEST_FILE_ID);
         ff0.assertAttributeEquals(CoreAttributes.FILENAME.key(), TEST_FILENAME);

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/PutBoxFileTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/PutBoxFileTest.java
@@ -104,7 +104,7 @@ public class PutBoxFileTest extends AbstractBoxFileTest {
 
         testRunner.assertAllFlowFilesTransferred(PutBoxFile.REL_SUCCESS, 1);
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(PutBoxFile.REL_SUCCESS);
-        final MockFlowFile ff0 = flowFiles.get(0);
+        final MockFlowFile ff0 = flowFiles.getFirst();
         assertOutFlowFileAttributes(ff0);
         assertProvenanceEvent(ProvenanceEventType.SEND);
     }
@@ -138,7 +138,7 @@ public class PutBoxFileTest extends AbstractBoxFileTest {
 
         testRunner.assertAllFlowFilesTransferred(PutBoxFile.REL_SUCCESS, 1);
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(PutBoxFile.REL_SUCCESS);
-        final MockFlowFile ff0 = flowFiles.get(0);
+        final MockFlowFile ff0 = flowFiles.getFirst();
         assertOutFlowFileAttributes(ff0, format("/%s/%s/%s", TEST_FOLDER_NAME, "sub1", "sub2"));
         assertProvenanceEvent(ProvenanceEventType.SEND);
     }
@@ -181,7 +181,7 @@ public class PutBoxFileTest extends AbstractBoxFileTest {
 
         testRunner.assertAllFlowFilesTransferred(PutBoxFile.REL_SUCCESS, 1);
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(PutBoxFile.REL_SUCCESS);
-        final MockFlowFile ff0 = flowFiles.get(0);
+        final MockFlowFile ff0 = flowFiles.getFirst();
         assertOutFlowFileAttributes(ff0, format("/%s/%s/%s", TEST_FOLDER_NAME, "new1", "new2"));
         assertProvenanceEvent(ProvenanceEventType.SEND);
         verify(mockBoxFolder).createFolder("new1");
@@ -205,7 +205,7 @@ public class PutBoxFileTest extends AbstractBoxFileTest {
 
         testRunner.assertAllFlowFilesTransferred(PutBoxFile.REL_FAILURE, 1);
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(PutBoxFile.REL_FAILURE);
-        final MockFlowFile ff0 = flowFiles.get(0);
+        final MockFlowFile ff0 = flowFiles.getFirst();
         ff0.assertAttributeEquals(BoxFileAttributes.ERROR_MESSAGE, "Upload error");
         assertNoProvenanceEvent();
     }

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
@@ -177,7 +177,9 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
             .description("Successfully created FlowFile from SQL query result set.")
             .build();
 
-    protected static Set<Relationship> relationships = Set.of(REL_SUCCESS);
+    protected static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     private static final AllowableValue SSL_MODE_DISABLED = new AllowableValue(SSLMode.DISABLED.toString(),
             SSLMode.DISABLED.toString(),
@@ -449,7 +451,7 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
                     SSL_MODE_VERIFY_IDENTITY)
             .build();
 
-    private static final List<PropertyDescriptor> propDescriptors = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             HOSTS,
             DRIVER_NAME,
             DRIVER_LOCATION,
@@ -508,12 +510,12 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propDescriptors;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/DecryptContentAge.java
+++ b/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/DecryptContentAge.java
@@ -115,9 +115,12 @@ public class DecryptContentAge extends AbstractProcessor implements VerifiablePr
             .dependsOn(PRIVATE_KEY_SOURCE, KeySource.RESOURCES)
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(SUCCESS, FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             PRIVATE_KEY_SOURCE,
             PRIVATE_KEY_IDENTITIES,
             PRIVATE_KEY_IDENTITY_RESOURCES
@@ -160,7 +163,7 @@ public class DecryptContentAge extends AbstractProcessor implements VerifiablePr
      */
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/EncryptContentAge.java
+++ b/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/EncryptContentAge.java
@@ -122,9 +122,12 @@ public class EncryptContentAge extends AbstractProcessor implements VerifiablePr
             .dependsOn(PUBLIC_KEY_SOURCE, KeySource.RESOURCES)
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(SUCCESS, FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             FILE_ENCODING,
             PUBLIC_KEY_SOURCE,
             PUBLIC_KEY_RECIPIENTS,
@@ -161,7 +164,7 @@ public class EncryptContentAge extends AbstractProcessor implements VerifiablePr
      */
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/VerifyContentMAC.java
+++ b/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/VerifyContentMAC.java
@@ -28,12 +28,9 @@ import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -135,16 +132,20 @@ public class VerifyContentMAC extends AbstractProcessor {
     protected static final String MAC_CALCULATED_ATTRIBUTE = "mac.calculated";
     protected static final String MAC_ALGORITHM_ATTRIBUTE = "mac.algorithm";
     protected static final String MAC_ENCODING_ATTRIBUTE = "mac.encoding";
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(
-            Arrays.asList(
+
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
                     MAC_ALGORITHM,
                     MAC_ENCODING,
                     MAC,
                     SECRET_KEY_ENCODING,
                     SECRET_KEY
-            )
     );
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(SUCCESS, FAILURE)));
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
+
     private static final int BUFFER_SIZE = 512000;
 
     private SecretKeySpec secretKeySpec;

--- a/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/FetchDropbox.java
+++ b/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/FetchDropbox.java
@@ -36,9 +36,6 @@ import com.dropbox.core.DbxException;
 import com.dropbox.core.v2.DbxClientV2;
 import com.dropbox.core.v2.files.FileMetadata;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -103,16 +100,16 @@ public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
                     .description("A FlowFile will be routed here for each File for which fetch was attempted but failed.")
                     .build();
 
-    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
-    )));
+    );
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             CREDENTIAL_SERVICE,
             FILE,
             ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxySpec.HTTP_AUTH)
-    ));
+    );
 
     private volatile DbxClientV2 dropboxApiClient;
 

--- a/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
+++ b/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
@@ -38,8 +38,6 @@ import com.dropbox.core.v2.files.FileMetadata;
 import com.dropbox.core.v2.files.ListFolderResult;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -145,7 +143,7 @@ public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implemen
             .dependsOn(LISTING_STRATEGY, BY_ENTITIES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             CREDENTIAL_SERVICE,
             FOLDER,
             RECURSIVE_SEARCH,
@@ -156,7 +154,7 @@ public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implemen
             INITIAL_LISTING_TARGET,
             RECORD_WRITER,
             ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxySpec.HTTP_AUTH)
-    ));
+    );
 
     private volatile DbxClientV2 dropboxApiClient;
 

--- a/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/FetchDropboxTest.java
+++ b/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/FetchDropboxTest.java
@@ -78,7 +78,7 @@ public class FetchDropboxTest extends AbstractDropboxTest {
 
         testRunner.assertAllFlowFilesTransferred(FetchDropbox.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(FetchDropbox.REL_SUCCESS);
-        MockFlowFile ff0 = flowFiles.get(0);
+        MockFlowFile ff0 = flowFiles.getFirst();
         ff0.assertContentEquals("content");
         assertOutFlowFileAttributes(ff0);
         assertProvenanceEvent(ProvenanceEventType.FETCH);
@@ -98,7 +98,7 @@ public class FetchDropboxTest extends AbstractDropboxTest {
 
         testRunner.assertAllFlowFilesTransferred(FetchDropbox.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(FetchDropbox.REL_SUCCESS);
-        MockFlowFile ff0 = flowFiles.get(0);
+        MockFlowFile ff0 = flowFiles.getFirst();
         ff0.assertContentEquals("contentByPath");
         assertOutFlowFileAttributes(ff0);
         assertProvenanceEvent(ProvenanceEventType.FETCH);
@@ -116,7 +116,7 @@ public class FetchDropboxTest extends AbstractDropboxTest {
 
         testRunner.assertAllFlowFilesTransferred(FetchDropbox.REL_FAILURE, 1);
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(FetchDropbox.REL_FAILURE);
-        MockFlowFile ff0 = flowFiles.get(0);
+        MockFlowFile ff0 = flowFiles.getFirst();
         ff0.assertAttributeEquals(ERROR_MESSAGE, "Error in Dropbox");
         assertOutFlowFileAttributes(ff0);
         assertNoProvenanceEvent();

--- a/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/ListDropboxTest.java
+++ b/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/test/java/org/apache/nifi/processors/dropbox/ListDropboxTest.java
@@ -130,7 +130,7 @@ public class ListDropboxTest extends AbstractDropboxTest {
 
         testRunner.assertAllFlowFilesTransferred(ListDropbox.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ListDropbox.REL_SUCCESS);
-        MockFlowFile ff0 = flowFiles.get(0);
+        MockFlowFile ff0 = flowFiles.getFirst();
         assertOutFlowFileAttributes(ff0, folderName);
     }
 
@@ -151,7 +151,7 @@ public class ListDropboxTest extends AbstractDropboxTest {
 
         testRunner.assertAllFlowFilesTransferred(ListDropbox.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ListDropbox.REL_SUCCESS);
-        MockFlowFile ff0 = flowFiles.get(0);
+        MockFlowFile ff0 = flowFiles.getFirst();
         assertOutFlowFileAttributes(ff0);
     }
 
@@ -171,7 +171,7 @@ public class ListDropboxTest extends AbstractDropboxTest {
 
         testRunner.assertAllFlowFilesTransferred(ListDropbox.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ListDropbox.REL_SUCCESS);
-        MockFlowFile ff0 = flowFiles.get(0);
+        MockFlowFile ff0 = flowFiles.getFirst();
         assertOutFlowFileAttributes(ff0);
     }
 
@@ -192,7 +192,7 @@ public class ListDropboxTest extends AbstractDropboxTest {
 
         testRunner.assertAllFlowFilesTransferred(ListDropbox.REL_SUCCESS, 1);
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ListDropbox.REL_SUCCESS);
-        MockFlowFile ff0 = flowFiles.get(0);
+        MockFlowFile ff0 = flowFiles.getFirst();
         List<String> expectedFileNames = Arrays.asList(FILENAME_1, FILENAME_2);
         List<String> actualFileNames = getFilenames(ff0.getContent());
 

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/AbstractEmailProcessor.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/AbstractEmailProcessor.java
@@ -41,9 +41,7 @@ import jakarta.mail.MessagingException;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -163,28 +161,24 @@ abstract class AbstractEmailProcessor<T extends AbstractMailReceiver> extends Ab
             .description("All messages that are the are successfully received from Email server and converted to FlowFiles are routed to this relationship")
             .build();
 
-    final static List<PropertyDescriptor> SHARED_DESCRIPTORS = new ArrayList<>();
-
-    final static Set<Relationship> SHARED_RELATIONSHIPS = new HashSet<>();
-
     /*
      * Will ensure that list of PropertyDescriptors is build only once, since
      * all other lifecycle methods are invoked multiple times.
      */
-    static {
-        SHARED_DESCRIPTORS.add(HOST);
-        SHARED_DESCRIPTORS.add(PORT);
-        SHARED_DESCRIPTORS.add(AUTHORIZATION_MODE);
-        SHARED_DESCRIPTORS.add(OAUTH2_ACCESS_TOKEN_PROVIDER);
-        SHARED_DESCRIPTORS.add(USER);
-        SHARED_DESCRIPTORS.add(PASSWORD);
-        SHARED_DESCRIPTORS.add(FOLDER);
-        SHARED_DESCRIPTORS.add(FETCH_SIZE);
-        SHARED_DESCRIPTORS.add(SHOULD_DELETE_MESSAGES);
-        SHARED_DESCRIPTORS.add(CONNECTION_TIMEOUT);
+    final static List<PropertyDescriptor> SHARED_DESCRIPTORS = List.of(
+            HOST,
+            PORT,
+            AUTHORIZATION_MODE,
+            OAUTH2_ACCESS_TOKEN_PROVIDER,
+            USER,
+            PASSWORD,
+            FOLDER,
+            FETCH_SIZE,
+            SHOULD_DELETE_MESSAGES,
+            CONNECTION_TIMEOUT
+    );
 
-        SHARED_RELATIONSHIPS.add(REL_SUCCESS);
-    }
+    final static Set<Relationship> SHARED_RELATIONSHIPS = Set.of(REL_SUCCESS);
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/AbstractEmailProcessor.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/AbstractEmailProcessor.java
@@ -178,7 +178,9 @@ abstract class AbstractEmailProcessor<T extends AbstractMailReceiver> extends Ab
             CONNECTION_TIMEOUT
     );
 
-    final static Set<Relationship> SHARED_RELATIONSHIPS = Set.of(REL_SUCCESS);
+    final static Set<Relationship> SHARED_RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeIMAP.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeIMAP.java
@@ -16,9 +16,8 @@
  */
 package org.apache.nifi.processors.email;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -52,14 +51,10 @@ public class ConsumeIMAP extends AbstractEmailProcessor<ImapMailReceiver> {
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .build();
 
-    static final List<PropertyDescriptor> DESCRIPTORS;
-
-    static {
-        List<PropertyDescriptor> descriptors = new ArrayList<>(SHARED_DESCRIPTORS);
-        descriptors.add(SHOULD_MARK_READ);
-        descriptors.add(USE_SSL);
-        DESCRIPTORS = Collections.unmodifiableList(descriptors);
-    }
+    static final List<PropertyDescriptor> DESCRIPTORS = Stream.concat(
+            SHARED_DESCRIPTORS.stream(),
+            Stream.of(SHOULD_MARK_READ, USE_SSL)
+    ).toList();
 
     @Override
     protected ImapMailReceiver buildMessageReceiver(ProcessContext processContext) {

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeIMAP.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeIMAP.java
@@ -53,7 +53,10 @@ public class ConsumeIMAP extends AbstractEmailProcessor<ImapMailReceiver> {
 
     static final List<PropertyDescriptor> DESCRIPTORS = Stream.concat(
             SHARED_DESCRIPTORS.stream(),
-            Stream.of(SHOULD_MARK_READ, USE_SSL)
+            Stream.of(
+                    SHOULD_MARK_READ,
+                    USE_SSL
+            )
     ).toList();
 
     @Override

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailHeaders.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailHeaders.java
@@ -127,9 +127,15 @@ public class ExtractEmailHeaders extends AbstractProcessor {
 
     private static final String ATTACHMENT_DISPOSITION = "attachment";
 
-    private static final Set<Relationship> relationships = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final Set<Relationship> relationships = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
-    private static final List<PropertyDescriptor> descriptors = List.of(CAPTURED_HEADERS, STRICT_PARSING);
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            CAPTURED_HEADERS,
+            STRICT_PARSING
+    );
 
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) {
@@ -220,7 +226,7 @@ public class ExtractEmailHeaders extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return descriptors;
+        return PROPERTIES;
     }
 
     private static void putAddressListInAttributes(

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestConsumeEmail.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/test/java/org/apache/nifi/processors/email/TestConsumeEmail.java
@@ -92,7 +92,7 @@ public class TestConsumeEmail {
 
         runner.assertTransferCount(ConsumeIMAP.REL_SUCCESS, 2);
         final List<MockFlowFile> messages = runner.getFlowFilesForRelationship(ConsumeIMAP.REL_SUCCESS);
-        String result = new String(runner.getContentAsByteArray(messages.get(0)));
+        String result = new String(runner.getContentAsByteArray(messages.getFirst()));
 
         // Verify body
         assertTrue(result.contains("test test test chocolate"));
@@ -123,7 +123,7 @@ public class TestConsumeEmail {
 
         runner.assertTransferCount(ConsumePOP3.REL_SUCCESS, 2);
         final List<MockFlowFile> messages = runner.getFlowFilesForRelationship(ConsumePOP3.REL_SUCCESS);
-        String result = new String(runner.getContentAsByteArray(messages.get(0)));
+        String result = new String(runner.getContentAsByteArray(messages.getFirst()));
 
         // Verify body
         assertTrue(result.contains("test test test chocolate"));

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/AbstractEnrichIP.java
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/AbstractEnrichIP.java
@@ -26,7 +26,6 @@ import org.apache.nifi.expression.AttributeExpression;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.StopWatch;
@@ -36,9 +35,6 @@ import org.apache.nifi.util.file.monitor.SynchronousFileWatcher;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -94,8 +90,17 @@ public abstract class AbstractEnrichIP extends AbstractProcessor {
         DEBUG, INFO, WARN, ERROR
     }
 
-    private Set<Relationship> relationships;
-    private List<PropertyDescriptor> propertyDescriptors;
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_FOUND,
+            REL_NOT_FOUND
+    );
+
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            GEO_DATABASE_FILE,
+            IP_ADDRESS_ATTRIBUTE,
+            LOG_LEVEL
+        );
+
     final AtomicReference<DatabaseReader> databaseReaderRef = new AtomicReference<>(null);
     private volatile SynchronousFileWatcher watcher;
 
@@ -107,12 +112,12 @@ public abstract class AbstractEnrichIP extends AbstractProcessor {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     @OnScheduled
@@ -136,20 +141,6 @@ public abstract class AbstractEnrichIP extends AbstractProcessor {
         if (reader != null) {
             reader.close();
         }
-    }
-
-    @Override
-    protected void init(final ProcessorInitializationContext context) {
-        final Set<Relationship> rels = new HashSet<>();
-        rels.add(REL_FOUND);
-        rels.add(REL_NOT_FOUND);
-        this.relationships = Collections.unmodifiableSet(rels);
-
-        final List<PropertyDescriptor> props = new ArrayList<>();
-        props.add(GEO_DATABASE_FILE);
-        props.add(IP_ADDRESS_ATTRIBUTE);
-        props.add(LOG_LEVEL);
-        this.propertyDescriptors = Collections.unmodifiableList(props);
     }
 
     protected SynchronousFileWatcher getWatcher() {

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/GeoEnrichIPRecord.java
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/GeoEnrichIPRecord.java
@@ -48,10 +48,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -151,18 +148,35 @@ public class GeoEnrichIPRecord extends AbstractEnrichIP {
             .description("The original input flowfile goes to this relationship regardless of whether the content was enriched or not.")
             .build();
 
-    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            REL_ORIGINAL, REL_FOUND, REL_NOT_FOUND
-    )));
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_ORIGINAL,
+            REL_FOUND,
+            REL_NOT_FOUND
+    );
 
-    public static final List<PropertyDescriptor> GEO_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
-            GEO_CITY, GEO_LATITUDE, GEO_LONGITUDE, GEO_COUNTRY, GEO_COUNTRY_ISO, GEO_POSTAL_CODE
-    ));
+    public static final List<PropertyDescriptor> GEO_PROPERTIES = List.of(
+            GEO_CITY,
+            GEO_LATITUDE,
+            GEO_LONGITUDE,
+            GEO_COUNTRY,
+            GEO_COUNTRY_ISO,
+            GEO_POSTAL_CODE
+    );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
-            GEO_DATABASE_FILE, READER, WRITER, SPLIT_FOUND_NOT_FOUND, IP_RECORD_PATH, GEO_CITY, GEO_LATITUDE,
-            GEO_LONGITUDE, GEO_COUNTRY, GEO_COUNTRY_ISO, GEO_POSTAL_CODE, LOG_LEVEL
-    ));
+    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+            GEO_DATABASE_FILE,
+            READER,
+            WRITER,
+            SPLIT_FOUND_NOT_FOUND,
+            IP_RECORD_PATH,
+            GEO_CITY,
+            GEO_LATITUDE,
+            GEO_LONGITUDE,
+            GEO_COUNTRY,
+            GEO_COUNTRY_ISO,
+            GEO_POSTAL_CODE,
+            LOG_LEVEL
+    );
 
     @Override
     public Set<Relationship> getRelationships() {

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/test/java/org/apache/nifi/processors/TestGeoEnrichIP.java
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/test/java/org/apache/nifi/processors/TestGeoEnrichIP.java
@@ -99,7 +99,7 @@ public class TestGeoEnrichIP {
         assertEquals(0, notFound.size());
         assertEquals(1, found.size());
 
-        FlowFile finishedFound = found.get(0);
+        FlowFile finishedFound = found.getFirst();
         assertNotNull(finishedFound.getAttribute("ip.geo.lookup.micros"));
         assertEquals("Minneapolis", finishedFound.getAttribute("ip.geo.city"));
         assertEquals("44.98", finishedFound.getAttribute("ip.geo.latitude"));
@@ -135,7 +135,7 @@ public class TestGeoEnrichIP {
         assertEquals(0, notFound.size());
         assertEquals(1, found.size());
 
-        FlowFile finishedFound = found.get(0);
+        FlowFile finishedFound = found.getFirst();
         assertNotNull(finishedFound.getAttribute("ip.geo.lookup.micros"));
         assertEquals("Minneapolis", finishedFound.getAttribute("ip.geo.city"));
         assertNull(finishedFound.getAttribute("ip.geo.latitude"));
@@ -172,7 +172,7 @@ public class TestGeoEnrichIP {
         assertEquals(0, notFound.size());
         assertEquals(1, found.size());
 
-        FlowFile finishedFound = found.get(0);
+        FlowFile finishedFound = found.getFirst();
         assertNotNull(finishedFound.getAttribute("ip0.geo.lookup.micros"));
         assertEquals("Minneapolis", finishedFound.getAttribute("ip0.geo.city"));
         assertNull(finishedFound.getAttribute("ip0.geo.latitude"));

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/test/java/org/apache/nifi/processors/TestGeoEnrichIPRecord.java
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/test/java/org/apache/nifi/processors/TestGeoEnrichIPRecord.java
@@ -42,11 +42,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.net.InetAddress;
-import java.util.Arrays;
-import java.util.Collections;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.apache.nifi.processors.GeoEnrichTestUtils.getFullCityResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -74,7 +74,7 @@ public class TestGeoEnrichIPRecord {
 
 
         try (InputStream is = getClass().getResourceAsStream("/avro/record_schema.avsc")) {
-            String raw = IOUtils.toString(is, "UTF-8");
+            String raw = IOUtils.toString(is, StandardCharsets.UTF_8);
             RecordSchema parsed = AvroTypeUtil.createSchema(new Schema.Parser().parse(raw));
             ((MockSchemaRegistry) registry).addSchema("record", parsed);
 
@@ -114,13 +114,13 @@ public class TestGeoEnrichIPRecord {
     }
 
     @Test
-    public void testSplitOutput() throws Exception {
+    public void testSplitOutput() {
         runner.setProperty(GeoEnrichIPRecord.SPLIT_FOUND_NOT_FOUND, "true");
         commonTest("/json/two_records_for_split.json", 1, 1, 1);
     }
 
     @Test
-    public void testEnrichSendToNotFound() throws Exception {
+    public void testEnrichSendToNotFound() {
         commonTest("/json/one_record_no_geo.json", 1, 0, 0);
     }
 
@@ -128,7 +128,7 @@ public class TestGeoEnrichIPRecord {
     public void testEnrichSendToFound() throws Exception {
         commonTest("/json/one_record.json", 0, 1, 0);
 
-        MockFlowFile ff = runner.getFlowFilesForRelationship(GeoEnrichIPRecord.REL_FOUND).get(0);
+        MockFlowFile ff = runner.getFlowFilesForRelationship(GeoEnrichIPRecord.REL_FOUND).getFirst();
         byte[] raw = runner.getContentAsByteArray(ff);
         String content = new String(raw);
         ObjectMapper mapper = new ObjectMapper();
@@ -137,7 +137,7 @@ public class TestGeoEnrichIPRecord {
         assertNotNull(result);
         assertEquals(1, result.size());
 
-        Map<String, Object> element = result.get(0);
+        Map<String, Object> element = result.getFirst();
         Map<String, Object> geo = (Map<String, Object>) element.get("geo");
 
         assertNotNull(geo);
@@ -154,10 +154,18 @@ public class TestGeoEnrichIPRecord {
 
         @Override
         protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-            return Collections.unmodifiableList(Arrays.asList(
-                    READER, WRITER, IP_RECORD_PATH, SPLIT_FOUND_NOT_FOUND, GEO_CITY, GEO_LATITUDE, GEO_LONGITUDE,
-                    GEO_COUNTRY, GEO_COUNTRY_ISO, GEO_POSTAL_CODE, LOG_LEVEL
-            ));
+            return Stream.of(
+                    READER,
+                    WRITER,
+                    IP_RECORD_PATH,
+                    SPLIT_FOUND_NOT_FOUND,
+                    GEO_CITY,
+                    GEO_LATITUDE,
+                    GEO_LONGITUDE,
+                    GEO_COUNTRY,
+                    GEO_COUNTRY_ISO,
+                    GEO_POSTAL_CODE,
+                    LOG_LEVEL).toList();
         }
         @Override
         @OnScheduled

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/test/java/org/apache/nifi/processors/TestGeoEnrichIPRecord.java
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/test/java/org/apache/nifi/processors/TestGeoEnrichIPRecord.java
@@ -46,7 +46,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.apache.nifi.processors.GeoEnrichTestUtils.getFullCityResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -154,7 +153,7 @@ public class TestGeoEnrichIPRecord {
 
         @Override
         protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-            return Stream.of(
+            return List.of(
                     READER,
                     WRITER,
                     IP_RECORD_PATH,
@@ -165,7 +164,8 @@ public class TestGeoEnrichIPRecord {
                     GEO_COUNTRY,
                     GEO_COUNTRY_ISO,
                     GEO_POSTAL_CODE,
-                    LOG_LEVEL).toList();
+                    LOG_LEVEL
+            );
         }
         @Override
         @OnScheduled

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/test/java/org/apache/nifi/processors/TestISPEnrichIP.java
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/test/java/org/apache/nifi/processors/TestISPEnrichIP.java
@@ -84,7 +84,7 @@ public class TestISPEnrichIP {
         testRunner.setProperty(ISPEnrichIP.GEO_DATABASE_FILE, "./");
         testRunner.setProperty(ISPEnrichIP.IP_ADDRESS_ATTRIBUTE, "ip");
 
-        final IspResponse ispResponse = getIspResponse("1.2.3.4");
+        final IspResponse ispResponse = getIspResponse();
 
         when(databaseReader.isp(InetAddress.getByName("1.2.3.4"))).thenReturn(ispResponse);
 
@@ -101,7 +101,7 @@ public class TestISPEnrichIP {
         assertEquals(0, notFound.size());
         assertEquals(1, found.size());
 
-        FlowFile finishedFound = found.get(0);
+        FlowFile finishedFound = found.getFirst();
         assertNotNull(finishedFound.getAttribute("ip.isp.lookup.micros"));
         assertEquals("Apache NiFi - Test ISP", finishedFound.getAttribute("ip.isp.name"));
         assertEquals("Apache NiFi - Test Organization", finishedFound.getAttribute("ip.isp.organization"));
@@ -132,7 +132,7 @@ public class TestISPEnrichIP {
         assertEquals(0, notFound.size());
         assertEquals(1, found.size());
 
-        FlowFile finishedFound = found.get(0);
+        FlowFile finishedFound = found.getFirst();
         assertNotNull(finishedFound.getAttribute("ip.isp.lookup.micros"));
         assertNotNull(finishedFound.getAttribute("ip.isp.lookup.micros"));
         assertEquals("Apache NiFi - Test ISP", finishedFound.getAttribute("ip.isp.name"));
@@ -146,7 +146,7 @@ public class TestISPEnrichIP {
         testRunner.setProperty(ISPEnrichIP.GEO_DATABASE_FILE, "./");
         testRunner.setProperty(ISPEnrichIP.IP_ADDRESS_ATTRIBUTE, "${ip.fields:substringBefore(',')}");
 
-        final IspResponse ispResponse = getIspResponse("1.2.3.4");
+        final IspResponse ispResponse = getIspResponse();
         when(databaseReader.isp(InetAddress.getByName("1.2.3.4"))).thenReturn(ispResponse);
 
         final Map<String, String> attributes = new HashMap<>();
@@ -163,7 +163,7 @@ public class TestISPEnrichIP {
         assertEquals(0, notFound.size());
         assertEquals(1, found.size());
 
-        FlowFile finishedFound = found.get(0);
+        FlowFile finishedFound = found.getFirst();
         assertNotNull(finishedFound.getAttribute("ip0.isp.lookup.micros"));
         assertEquals("Apache NiFi - Test ISP", finishedFound.getAttribute("ip0.isp.name"));
         assertEquals("Apache NiFi - Test Organization", finishedFound.getAttribute("ip0.isp.organization"));
@@ -263,16 +263,8 @@ public class TestISPEnrichIP {
         verifyNoMoreInteractions(databaseReader);
     }
 
-    private IspResponse getIspResponse(final String ipAddress) throws Exception {
-        String maxMindIspResponse = "{\n" +
-            "         \"isp\" : \"Apache NiFi - Test ISP\",\n" +
-            "         \"organization\" : \"Apache NiFi - Test Organization\",\n" +
-            "         \"autonomous_system_number\" : 1337,\n" +
-            "         \"autonomous_system_organization\" : \"Apache NiFi - Test Chocolate\", \n" +
-            "         \"ip_address\" : \"" + ipAddress + "\"\n" +
-            "      }\n";
-
-        maxMindIspResponse = JSON.std
+    private IspResponse getIspResponse() throws Exception {
+        String maxMindIspResponse = JSON.std
                 .composeString()
                 .startObject()
                 .put("autonomous_system_number", 1337)

--- a/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/main/java/org/apache/nifi/processors/evtx/ParseEvtx.java
+++ b/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/main/java/org/apache/nifi/processors/evtx/ParseEvtx.java
@@ -46,9 +46,6 @@ import org.apache.nifi.processors.evtx.parser.Record;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -97,7 +94,12 @@ public class ParseEvtx extends AbstractProcessor {
             .build();
 
     @VisibleForTesting
-    static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE, REL_ORIGINAL, REL_BAD_CHUNK)));
+    static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_ORIGINAL,
+            REL_BAD_CHUNK
+    );
 
     @VisibleForTesting
     static final PropertyDescriptor GRANULARITY = new PropertyDescriptor.Builder()
@@ -110,7 +112,9 @@ public class ParseEvtx extends AbstractProcessor {
             .build();
 
     @VisibleForTesting
-    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(GRANULARITY));
+    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            GRANULARITY
+    );
 
     private final FileHeaderFactory fileHeaderFactory;
     private final MalformedChunkHandler malformedChunkHandler;
@@ -165,9 +169,7 @@ public class ParseEvtx extends AbstractProcessor {
             // File granularity will emit a FlowFile for each input
             FlowFile original = session.clone(flowFile);
             AtomicReference<Exception> exceptionReference = new AtomicReference<>(null);
-            FlowFile updated = session.write(flowFile, (in, out) -> {
-                processFileGranularity(session, logger, original, basename, exceptionReference, in, out);
-            });
+            FlowFile updated = session.write(flowFile, (in, out) -> processFileGranularity(session, logger, original, basename, exceptionReference, in, out));
             session.transfer(original, REL_ORIGINAL);
             resultProcessor.process(session, logger, updated, exceptionReference.get(), getName(basename, null, null, XML_EXTENSION));
         } else {

--- a/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/test/java/org/apache/nifi/processors/evtx/ParseEvtxTest.java
+++ b/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/test/java/org/apache/nifi/processors/evtx/ParseEvtxTest.java
@@ -48,15 +48,14 @@ import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -70,7 +69,7 @@ import static org.mockito.Mockito.when;
 public class ParseEvtxTest {
     public static final String USER_DATA = "UserData";
     public static final String EVENT_DATA = "EventData";
-    public static final Set DATA_TAGS = new HashSet<>(Arrays.asList(EVENT_DATA, USER_DATA));
+    public static final Set<String> DATA_TAGS = Set.of(EVENT_DATA, USER_DATA);
     public static final int EXPECTED_SUCCESSFUL_EVENT_COUNT = 1053;
 
     @Mock
@@ -349,7 +348,7 @@ public class ParseEvtxTest {
 
         List<MockFlowFile> originalFlowFiles = testRunner.getFlowFilesForRelationship(ParseEvtx.REL_ORIGINAL);
         assertEquals(1, originalFlowFiles.size());
-        MockFlowFile originalFlowFile = originalFlowFiles.get(0);
+        MockFlowFile originalFlowFile = originalFlowFiles.getFirst();
         originalFlowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), name);
         originalFlowFile.assertContentEquals(this.getClass().getClassLoader().getResourceAsStream("application-logs.evtx"));
 
@@ -382,7 +381,7 @@ public class ParseEvtxTest {
 
         List<MockFlowFile> originalFlowFiles = testRunner.getFlowFilesForRelationship(ParseEvtx.REL_ORIGINAL);
         assertEquals(1, originalFlowFiles.size());
-        MockFlowFile originalFlowFile = originalFlowFiles.get(0);
+        MockFlowFile originalFlowFile = originalFlowFiles.getFirst();
         originalFlowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), name);
         originalFlowFile.assertContentEquals(this.getClass().getClassLoader().getResourceAsStream("application-logs.evtx"));
 
@@ -415,7 +414,7 @@ public class ParseEvtxTest {
 
         List<MockFlowFile> originalFlowFiles = testRunner.getFlowFilesForRelationship(ParseEvtx.REL_ORIGINAL);
         assertEquals(1, originalFlowFiles.size());
-        MockFlowFile originalFlowFile = originalFlowFiles.get(0);
+        MockFlowFile originalFlowFile = originalFlowFiles.getFirst();
         originalFlowFile.assertAttributeEquals(CoreAttributes.FILENAME.key(), name);
         originalFlowFile.assertContentEquals(this.getClass().getClassLoader().getResourceAsStream("application-logs.evtx"));
 
@@ -469,7 +468,7 @@ public class ParseEvtxTest {
     }
 
     private int validateFlowFiles(List<MockFlowFile> successFlowFiles) {
-        assertTrue(successFlowFiles.size() > 0);
+        assertFalse(successFlowFiles.isEmpty());
         int totalSize = 0;
         for (MockFlowFile successFlowFile : successFlowFiles) {
             // Verify valid XML output
@@ -503,7 +502,7 @@ public class ParseEvtxTest {
                 Node eventDataNode = eventChildNodes.item(1);
                 String eventDataNodeNodeName = eventDataNode.getNodeName();
                 assertTrue(DATA_TAGS.contains(eventDataNodeNodeName));
-                assertTrue(userId.length() == 0 || userId.startsWith("S-"));
+                assertTrue(userId.isEmpty() || userId.startsWith("S-"));
             }
         }
         return totalSize;

--- a/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/test/java/org/apache/nifi/processors/evtx/ParseEvtxTest.java
+++ b/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/test/java/org/apache/nifi/processors/evtx/ParseEvtxTest.java
@@ -69,7 +69,11 @@ import static org.mockito.Mockito.when;
 public class ParseEvtxTest {
     public static final String USER_DATA = "UserData";
     public static final String EVENT_DATA = "EventData";
-    public static final Set<String> DATA_TAGS = Set.of(EVENT_DATA, USER_DATA);
+    public static final Set<String> DATA_TAGS = Set.of(
+            EVENT_DATA,
+            USER_DATA
+    );
+
     public static final int EXPECTED_SUCCESSFUL_EVENT_COUNT = 1053;
 
     @Mock

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/AbstractBigQueryProcessor.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/bigquery/AbstractBigQueryProcessor.java
@@ -61,7 +61,10 @@ public abstract class AbstractBigQueryProcessor extends AbstractGCPProcessor<Big
             .description("FlowFiles are routed to this relationship if the Google BigQuery operation fails.")
             .build();
 
-    public static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     public static final PropertyDescriptor DATASET = new PropertyDescriptor.Builder()
             .name(BigQueryAttributes.DATASET_ATTR)

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -240,7 +240,10 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
         GOOGLE_DRAWING_EXPORT_TYPE
     );
 
-    public static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     private volatile Drive driveService;
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
@@ -56,9 +56,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -150,7 +148,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
             .dependsOn(LISTING_STRATEGY, BY_ENTITIES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             GoogleUtils.GCP_CREDENTIALS_PROVIDER_SERVICE,
             FOLDER_ID,
             RECURSIVE_SEARCH,
@@ -161,7 +159,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
             INITIAL_LISTING_TARGET,
             RECORD_WRITER,
             ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxyAwareTransportFactory.PROXY_SPECS)
-    ));
+    );
 
     private volatile Drive driveService;
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
@@ -63,9 +63,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -75,7 +73,6 @@ import java.util.concurrent.TimeUnit;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
 import static org.apache.nifi.processor.util.StandardValidators.DATA_SIZE_VALIDATOR;
@@ -161,7 +158,7 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(asList(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
             GCP_CREDENTIALS_PROVIDER_SERVICE,
             FOLDER_ID,
             FILE_NAME,
@@ -169,7 +166,7 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
             CHUNKED_UPLOAD_THRESHOLD,
             CHUNKED_UPLOAD_SIZE,
             ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxyAwareTransportFactory.PROXY_SPECS)
-    ));
+    );
 
     public static final Relationship REL_SUCCESS =
             new Relationship.Builder()
@@ -183,10 +180,10 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
                     .description("Files that could not be written to Google Drive for some reason are transferred to this relationship.")
                     .build();
 
-    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(asList(
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
-    )));
+    );
 
     public static final String MULTIPART_UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&supportsAllDrives=true";
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/AbstractGCPubSubProcessor.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/AbstractGCPubSubProcessor.java
@@ -30,9 +30,7 @@ import org.apache.nifi.processor.VerifiableProcessor;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.gcp.AbstractGCPProcessor;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -91,11 +89,14 @@ public abstract class AbstractGCPubSubProcessor extends AbstractGCPProcessor imp
             .description("FlowFiles are routed to this relationship if the Google Cloud Pub/Sub operation fails.")
             .build();
 
-    private static final Set<Relationship> relationships = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE)));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/ConsumeGCPubSub.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/ConsumeGCPubSub.java
@@ -95,7 +95,7 @@ public class ConsumeGCPubSub extends AbstractGCPubSubWithProxyProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             GCP_CREDENTIALS_PROVIDER_SERVICE,
             PROJECT_ID,
             SUBSCRIPTION,
@@ -104,7 +104,9 @@ public class ConsumeGCPubSub extends AbstractGCPubSubWithProxyProcessor {
             PROXY_CONFIGURATION_SERVICE
     );
 
-    public static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     private SubscriberStub subscriber = null;
     private PullRequest pullRequest;
@@ -113,7 +115,7 @@ public class ConsumeGCPubSub extends AbstractGCPubSubWithProxyProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PublishGCPubSub.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PublishGCPubSub.java
@@ -173,7 +173,7 @@ public class PublishGCPubSub extends AbstractGCPubSubWithProxyProcessor {
             .description("FlowFiles are routed to this relationship if the Google Cloud Pub/Sub operation fails but attempting the operation again may succeed.")
             .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             GCP_CREDENTIALS_PROVIDER_SERVICE,
             PROJECT_ID,
             TOPIC_NAME,
@@ -189,13 +189,17 @@ public class PublishGCPubSub extends AbstractGCPubSubWithProxyProcessor {
             PROXY_CONFIGURATION_SERVICE
     );
 
-    public static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE, REL_RETRY);
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_RETRY
+    );
 
     protected Publisher publisher = null;
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/AbstractGCSProcessor.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/AbstractGCSProcessor.java
@@ -59,7 +59,10 @@ public abstract class AbstractGCSProcessor extends AbstractGCPProcessor<Storage,
                     .description("FlowFiles are routed to this relationship if the Google Cloud Storage operation fails.")
                     .build();
 
-    public static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     @Override
     public Set<Relationship> getRelationships() {

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/ListGCSBucket.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/ListGCSBucket.java
@@ -280,7 +280,9 @@ public class ListGCSBucket extends AbstractGCSProcessor {
         return DESCRIPTORS;
     }
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     @Override
     public Set<Relationship> getRelationships() {

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractGcpVisionProcessor.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractGcpVisionProcessor.java
@@ -23,9 +23,7 @@ import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.vision.v1.ImageAnnotatorClient;
 import com.google.cloud.vision.v1.ImageAnnotatorSettings;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
+
 import java.util.List;
 import java.util.Set;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
@@ -44,24 +42,25 @@ public abstract class AbstractGcpVisionProcessor extends AbstractProcessor  {
     public static final Relationship REL_FAILURE = new Relationship.Builder().name("failure")
             .description("FlowFiles are routed to failure relationship").build();
 
-    protected static final Set<Relationship> relationships = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    protected static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
-    )));
-    protected static final List<PropertyDescriptor> properties = Collections.unmodifiableList(Arrays.asList(
-            GCP_CREDENTIALS_PROVIDER_SERVICE)
+    );
+
+    protected static final List<PropertyDescriptor> COMMON_PROPERTIES = List.of(
+            GCP_CREDENTIALS_PROVIDER_SERVICE
     );
 
     private ImageAnnotatorClient vision;
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return COMMON_PROPERTIES;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractGetGcpVisionAnnotateOperationStatus.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractGetGcpVisionAnnotateOperationStatus.java
@@ -26,12 +26,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import com.google.rpc.Status;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
@@ -61,14 +57,17 @@ abstract public class AbstractGetGcpVisionAnnotateOperationStatus extends Abstra
             .description("Upon successful completion, the original FlowFile will be routed to this relationship.")
             .autoTerminateDefault(true)
             .build();
-    private static final List<PropertyDescriptor> PROPERTIES =
-            Collections.unmodifiableList(Stream.concat(properties.stream(), Stream.of(OPERATION_KEY)).collect(Collectors.toList()));
-    private static final Set<Relationship> relationships = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            COMMON_PROPERTIES.stream(),
+            Stream.of(OPERATION_KEY)
+    ).toList();
+
+    private static final Set<Relationship> COMMON_RELATIONSHIPS = Set.of(
             REL_ORIGINAL,
             REL_SUCCESS,
             REL_FAILURE,
             REL_RUNNING
-    )));
+    );
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
@@ -77,7 +76,7 @@ abstract public class AbstractGetGcpVisionAnnotateOperationStatus extends Abstra
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return COMMON_RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateFilesOperation.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateFilesOperation.java
@@ -21,8 +21,7 @@ import static org.apache.nifi.processors.gcp.util.GoogleUtils.GCP_CREDENTIALS_PR
 
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.vision.v1.AsyncBatchAnnotateFilesRequest;
-import java.util.Arrays;
-import java.util.Collections;
+
 import java.util.List;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
@@ -69,8 +68,13 @@ public class StartGcpVisionAnnotateFilesOperation extends AbstractStartGcpVision
                     "}")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
-            JSON_PAYLOAD, GCP_CREDENTIALS_PROVIDER_SERVICE, OUTPUT_BUCKET, FEATURE_TYPE));
+
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            JSON_PAYLOAD,
+            GCP_CREDENTIALS_PROVIDER_SERVICE,
+            OUTPUT_BUCKET,
+            FEATURE_TYPE
+    );
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateImagesOperation.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateImagesOperation.java
@@ -21,8 +21,7 @@ import static org.apache.nifi.processors.gcp.util.GoogleUtils.GCP_CREDENTIALS_PR
 
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.vision.v1.AsyncBatchAnnotateImagesRequest;
-import java.util.Arrays;
-import java.util.Collections;
+
 import java.util.List;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
 import org.apache.nifi.annotation.behavior.WritesAttributes;
@@ -47,29 +46,34 @@ public class StartGcpVisionAnnotateImagesOperation extends AbstractStartGcpVisio
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .required(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .defaultValue("{\n" +
-                    "    \"requests\": [{\n" +
-                    "        \"image\": {\n" +
-                    "            \"source\": {\n" +
-                    "                \"imageUri\": \"gs://${gcs.bucket}/${filename}\"\n" +
-                    "            }\n" +
-                    "        },\n" +
-                    "        \"features\": [{\n" +
-                    "            \"type\": \"${vision-feature-type}\",\n" +
-                    "            \"maxResults\": 4\n" +
-                    "        }]\n" +
-                    "    }],\n" +
-                    "    \"outputConfig\": {\n" +
-                    "        \"gcsDestination\": {\n" +
-                    "            \"uri\": \"gs://${output-bucket}/${filename}/\"\n" +
-                    "        },\n" +
-                    "        \"batchSize\": 2\n" +
-                    "    }\n" +
-                    "}")
+            .defaultValue("""
+                    {
+                        "requests": [{
+                            "image": {
+                                "source": {
+                                    "imageUri": "gs://${gcs.bucket}/${filename}"
+                                }
+                            },
+                            "features": [{
+                                "type": "${vision-feature-type}",
+                                "maxResults": 4
+                            }]
+                        }],
+                        "outputConfig": {
+                            "gcsDestination": {
+                                "uri": "gs://${output-bucket}/${filename}/"
+                            },
+                            "batchSize": 2
+                        }
+                    }""")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
-            JSON_PAYLOAD, GCP_CREDENTIALS_PROVIDER_SERVICE, OUTPUT_BUCKET, FEATURE_TYPE));
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            JSON_PAYLOAD,
+            GCP_CREDENTIALS_PROVIDER_SERVICE,
+            OUTPUT_BUCKET,
+            FEATURE_TYPE
+    );
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveIT.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveIT.java
@@ -56,7 +56,7 @@ public class PutGoogleDriveIT extends AbstractGoogleDriveIT<PutGoogleDrive> impl
         testRunner.assertTransferCount(PutGoogleDrive.REL_SUCCESS, 1);
         testRunner.assertTransferCount(PutGoogleDrive.REL_FAILURE, 0);
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(PutGoogleDrive.REL_SUCCESS);
-        final MockFlowFile ff0 = flowFiles.get(0);
+        final MockFlowFile ff0 = flowFiles.getFirst();
         assertFlowFileAttributes(ff0);
     }
 
@@ -96,7 +96,7 @@ public class PutGoogleDriveIT extends AbstractGoogleDriveIT<PutGoogleDrive> impl
         testRunner.assertTransferCount(PutGoogleDrive.REL_FAILURE, 0);
 
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(PutGoogleDrive.REL_SUCCESS);
-        final MockFlowFile ff0 = flowFiles.get(0);
+        final MockFlowFile ff0 = flowFiles.getFirst();
         ff0.assertAttributeEquals(GoogleDriveAttributes.SIZE, "9");
     }
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateFilesOperationTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateFilesOperationTest.java
@@ -52,7 +52,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class StartGcpVisionAnnotateFilesOperationTest {
     private TestRunner runner = null;
-    private StartGcpVisionAnnotateFilesOperation processor;
     private static final Path FlowFileContent = Paths.get("src/test/resources/vision/annotate-image.json");
     @Mock
     private ImageAnnotatorClient vision;
@@ -72,7 +71,7 @@ public class StartGcpVisionAnnotateFilesOperationTest {
     @BeforeEach
     public void setUp() throws InitializationException {
         gcpCredentialsService = new GCPCredentialsControllerService();
-        processor = new StartGcpVisionAnnotateFilesOperation() {
+        StartGcpVisionAnnotateFilesOperation processor = new StartGcpVisionAnnotateFilesOperation() {
             @Override
             protected ImageAnnotatorClient getVisionClient() {
                 return mockVisionClient;

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateImagesOperationTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateImagesOperationTest.java
@@ -46,24 +46,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class StartGcpVisionAnnotateImagesOperationTest {
     private TestRunner runner = null;
-    private StartGcpVisionAnnotateImagesOperation processor;
-    private String operationName = "operationName";
+    private final String operationName = "operationName";
     @Mock
     private OperationFuture operationFuture;
     @Mock
     private ApiFuture<OperationSnapshot> apiFuture;
     @Mock
     private ImageAnnotatorClient mockVisionClient;
-    private GCPCredentialsService gcpCredentialsService;
     @Mock
     private OperationSnapshot operationSnapshot;
-    private String jsonPayloadValue;
 
     @BeforeEach
     public void setUp() throws InitializationException, IOException {
-        jsonPayloadValue = FileUtils.readFileToString(new File("src/test/resources/vision/annotate-image.json"), "UTF-8");
-        gcpCredentialsService = new GCPCredentialsControllerService();
-        processor = new StartGcpVisionAnnotateImagesOperation() {
+        String jsonPayloadValue = FileUtils.readFileToString(new File("src/test/resources/vision/annotate-image.json"), "UTF-8");
+        GCPCredentialsService gcpCredentialsService = new GCPCredentialsControllerService();
+        StartGcpVisionAnnotateImagesOperation processor = new StartGcpVisionAnnotateImagesOperation() {
             @Override
             protected ImageAnnotatorClient getVisionClient() {
                 return mockVisionClient;
@@ -78,7 +75,7 @@ public class StartGcpVisionAnnotateImagesOperationTest {
     }
 
     @Test
-    public void testAnnotateImageJob() throws ExecutionException, InterruptedException, IOException {
+    public void testAnnotateImageJob() throws ExecutionException, InterruptedException {
         when(mockVisionClient.asyncBatchAnnotateImagesAsync(any())).thenReturn(operationFuture);
         when(operationFuture.getName()).thenReturn(operationName);
 
@@ -89,7 +86,7 @@ public class StartGcpVisionAnnotateImagesOperationTest {
     }
 
     @Test
-    public void testAnnotateFilesJob() throws ExecutionException, InterruptedException, IOException {
+    public void testAnnotateFilesJob() throws ExecutionException, InterruptedException {
         when(mockVisionClient.asyncBatchAnnotateImagesAsync(any())).thenReturn(operationFuture);
         when(operationFuture.getName()).thenReturn(operationName);
         runner.run();

--- a/nifi-extension-bundles/nifi-geohash-bundle/nifi-geohash-processors/src/main/java/org/apache/nifi/processors/geohash/GeohashRecord.java
+++ b/nifi-extension-bundles/nifi-geohash-bundle/nifi-geohash-processors/src/main/java/org/apache/nifi/processors/geohash/GeohashRecord.java
@@ -56,12 +56,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Optional;
@@ -209,12 +207,24 @@ public class GeohashRecord extends AbstractProcessor {
             .description("The original input flowfile will be sent to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> RECORD_PATH_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
-            LATITUDE_RECORD_PATH, LONGITUDE_RECORD_PATH, GEOHASH_RECORD_PATH
-    ));
+    private static final List<PropertyDescriptor> RECORD_PATH_PROPERTIES = List.of(
+            LATITUDE_RECORD_PATH,
+            LONGITUDE_RECORD_PATH,
+            GEOHASH_RECORD_PATH
+    );
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(REL_SUCCESS, REL_ORIGINAL, REL_FAILURE)));
-    private static final Set<Relationship> SPLIT_RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(REL_MATCHED, REL_NOT_MATCHED, REL_ORIGINAL, REL_FAILURE)));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_ORIGINAL,
+            REL_FAILURE
+    );
+
+    private static final Set<Relationship> SPLIT_RELATIONSHIPS = Set.of(
+            REL_MATCHED,
+            REL_NOT_MATCHED,
+            REL_ORIGINAL,
+            REL_FAILURE
+    );
 
     private RoutingStrategyExecutor routingStrategyExecutor;
     private static boolean isSplit;
@@ -449,7 +459,7 @@ public class GeohashRecord extends AbstractProcessor {
         Optional<FieldValue> latitudeField = latitudeResult.getSelectedFields().findFirst();
         Optional<FieldValue> longitudeField = longitudeResult.getSelectedFields().findFirst();
 
-        if (!latitudeField.isPresent() || !longitudeField.isPresent()) {
+        if (latitudeField.isEmpty() || longitudeField.isEmpty()) {
             return null;
         }
 
@@ -477,7 +487,7 @@ public class GeohashRecord extends AbstractProcessor {
         RecordPathResult geohashResult = geohashPath.evaluate(record);
         Optional<FieldValue> geohashField = geohashResult.getSelectedFields().findFirst();
 
-        if (!geohashField.isPresent()) {
+        if (geohashField.isEmpty()) {
             return null;
         }
 
@@ -508,13 +518,13 @@ public class GeohashRecord extends AbstractProcessor {
         RecordPathResult result = path.evaluate(record);
 
         final Optional<FieldValue> fieldValueOption = result.getSelectedFields().findFirst();
-        if (!fieldValueOption.isPresent()) {
+        if (fieldValueOption.isEmpty()) {
             return false;
         }
 
         final FieldValue fieldValue = fieldValueOption.get();
 
-        if (!fieldValue.getParent().isPresent() || fieldValue.getParent().get().getValue() == null) {
+        if (fieldValue.getParent().isEmpty() || fieldValue.getParent().get().getValue() == null) {
             return false;
         }
 

--- a/nifi-extension-bundles/nifi-geohash-bundle/nifi-geohash-processors/src/test/java/org/apache/nifi/processors/geohash/GeohashRecordTest.java
+++ b/nifi-extension-bundles/nifi-geohash-bundle/nifi-geohash-processors/src/test/java/org/apache/nifi/processors/geohash/GeohashRecordTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +60,7 @@ public class GeohashRecordTest {
         runner.addControllerService("registry", registry);
 
         try (InputStream is = getClass().getResourceAsStream("/record_schema.avsc")) {
-            String raw = IOUtils.toString(is, "UTF-8");
+            String raw = IOUtils.toString(is, StandardCharsets.UTF_8);
             RecordSchema parsed = AvroTypeUtil.createSchema(new Schema.Parser().parse(raw));
             ((MockSchemaRegistry) registry).addSchema("record", parsed);
 
@@ -105,7 +106,7 @@ public class GeohashRecordTest {
 
         assertTransfers("/encode-records-with-illegal-arguments.json", 0, 1, 0, 0, 1);
 
-        MockFlowFile outSuccess = runner.getFlowFilesForRelationship(GeohashRecord.REL_SUCCESS).get(0);
+        MockFlowFile outSuccess = runner.getFlowFilesForRelationship(GeohashRecord.REL_SUCCESS).getFirst();
         byte[] raw = runner.getContentAsByteArray(outSuccess);
         String content = new String(raw);
         ObjectMapper mapper = new ObjectMapper();
@@ -114,7 +115,7 @@ public class GeohashRecordTest {
         assertNotNull(result);
         assertEquals(3, result.size());
 
-        Map<String, Object> element = result.get(0);
+        Map<String, Object> element = result.getFirst();
         String geohash = (String) element.get("geohash");
         assertNotNull(geohash);
     }
@@ -136,8 +137,8 @@ public class GeohashRecordTest {
 
         assertTransfers("/encode-records-with-illegal-arguments.json", 0, 0, 1, 1, 1);
 
-        final MockFlowFile outNotMatched = runner.getFlowFilesForRelationship(GeohashRecord.REL_NOT_MATCHED).get(0);
-        final MockFlowFile outMatched = runner.getFlowFilesForRelationship(GeohashRecord.REL_MATCHED).get(0);
+        final MockFlowFile outNotMatched = runner.getFlowFilesForRelationship(GeohashRecord.REL_NOT_MATCHED).getFirst();
+        final MockFlowFile outMatched = runner.getFlowFilesForRelationship(GeohashRecord.REL_MATCHED).getFirst();
 
         byte[] rawNotMatched = runner.getContentAsByteArray(outNotMatched);
         byte[] rawMatched = runner.getContentAsByteArray(outMatched);
@@ -157,7 +158,7 @@ public class GeohashRecordTest {
             assertNull(geohashNotMatched);
         }
 
-        Map<String, Object> elementMatched = resultMatched.get(0);
+        Map<String, Object> elementMatched = resultMatched.getFirst();
         String geohashMatched = (String) elementMatched.get("geohash");
         assertNotNull(geohashMatched);
     }

--- a/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
+++ b/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
@@ -36,10 +36,8 @@ import ca.uhn.hl7v2.validation.impl.ValidationContextFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -141,23 +139,27 @@ public class ExtractHL7Attributes extends AbstractProcessor {
             .description("A FlowFile is routed to this relationship if it cannot be mapped to FlowFile Attributes. This would happen if the FlowFile does not contain valid HL7 data")
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            CHARACTER_SET,
+            USE_SEGMENT_NAMES,
+            PARSE_SEGMENT_FIELDS,
+            SKIP_VALIDATION,
+            HL7_INPUT_VERSION
+    );
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
+
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(CHARACTER_SET);
-        properties.add(USE_SEGMENT_NAMES);
-        properties.add(PARSE_SEGMENT_FIELDS);
-        properties.add(SKIP_VALIDATION);
-        properties.add(HL7_INPUT_VERSION);
-        return properties;
+        return PROPERTIES;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_FAILURE);
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/RouteHL7.java
+++ b/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/RouteHL7.java
@@ -19,7 +19,6 @@ package org.apache.nifi.processors.hl7;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -94,6 +93,15 @@ public class RouteHL7 extends AbstractProcessor {
             .description("The original FlowFile that comes into this processor will be routed to this relationship, unless it is routed to 'failure'")
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            CHARACTER_SET
+    );
+
+    private static final Set<Relationship> BASIC_RELATIONSHIPS = Set.of(
+            REL_FAILURE,
+            REL_ORIGINAL
+    );
+
     private volatile Map<Relationship, HL7Query> queries = new HashMap<>();
 
     @Override
@@ -109,9 +117,7 @@ public class RouteHL7 extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(CHARACTER_SET);
-        return properties;
+        return PROPERTIES;
     }
 
     @Override
@@ -136,8 +142,7 @@ public class RouteHL7 extends AbstractProcessor {
     @Override
     public Set<Relationship> getRelationships() {
         final Set<Relationship> relationships = new HashSet<>(queries.keySet());
-        relationships.add(REL_FAILURE);
-        relationships.add(REL_ORIGINAL);
+        relationships.addAll(BASIC_RELATIONSHIPS);
         return relationships;
     }
 
@@ -205,7 +210,7 @@ public class RouteHL7 extends AbstractProcessor {
                 final List<Class<?>> returnTypes = hl7Query.getReturnTypes();
                 if (returnTypes.size() != 1) {
                     error = "RouteHL7 requires that the HL7 Query return exactly 1 element of type MESSAGE";
-                } else if (!HL7Message.class.isAssignableFrom(returnTypes.get(0))) {
+                } else if (!HL7Message.class.isAssignableFrom(returnTypes.getFirst())) {
                     error = "RouteHL7 requires that the HL7 Query return exactly 1 element of type MESSAGE";
                 }
             } catch (final HL7QueryParsingException e) {

--- a/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/RouteHL7.java
+++ b/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/RouteHL7.java
@@ -97,7 +97,7 @@ public class RouteHL7 extends AbstractProcessor {
             CHARACTER_SET
     );
 
-    private static final Set<Relationship> BASIC_RELATIONSHIPS = Set.of(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_FAILURE,
             REL_ORIGINAL
     );
@@ -142,7 +142,7 @@ public class RouteHL7 extends AbstractProcessor {
     @Override
     public Set<Relationship> getRelationships() {
         final Set<Relationship> relationships = new HashSet<>(queries.keySet());
-        relationships.addAll(BASIC_RELATIONSHIPS);
+        relationships.addAll(RELATIONSHIPS);
         return relationships;
     }
 

--- a/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/test/java/org/apache/nifi/processors/hl7/TestExtractHL7Attributes.java
+++ b/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/test/java/org/apache/nifi/processors/hl7/TestExtractHL7Attributes.java
@@ -40,7 +40,7 @@ public class TestExtractHL7Attributes {
         runner.run();
         runner.assertAllFlowFilesTransferred(ExtractHL7Attributes.REL_SUCCESS, 1);
 
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractHL7Attributes.REL_SUCCESS).get(0);
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExtractHL7Attributes.REL_SUCCESS).getFirst();
 
         final SortedMap<String, String> actualAttributes = new TreeMap<>(flowFile.getAttributes());
         final SortedMap<String, Integer> actualSegments = new TreeMap<>();
@@ -50,7 +50,7 @@ public class TestExtractHL7Attributes {
         for (final Map.Entry<String, String> entry : actualAttributes.entrySet()) {
             final String key = entry.getKey();
             if (!(key.equals("filename") || key.equals("path") || key.equals("uuid"))) {
-                final String segment = key.replaceAll("^([^\\.]+)\\.\\d+", "$1");
+                final String segment = key.replaceAll("^([^.]+)\\.\\d+", "$1");
                 actualSegments.put(segment, actualSegments.getOrDefault(segment, 0) + 1);
             }
         }
@@ -58,7 +58,7 @@ public class TestExtractHL7Attributes {
         // Get map of expected segment counts
         for (final Map.Entry<String, String> entry : expectedAttributes.entrySet()) {
             final String key = entry.getKey();
-            final String segment = key.replaceAll("^([^\\.]+)\\.\\d+", "$1");
+            final String segment = key.replaceAll("^([^.]+)\\.\\d+", "$1");
             expectedSegments.put(segment, expectedSegments.getOrDefault(segment, 0) + 1);
         }
 
@@ -85,12 +85,14 @@ public class TestExtractHL7Attributes {
 
     @Test
     public void testExtract() {
-        final String message = "MSH|^~\\&|XXXXXXXX||HealthProvider||||ORU^R01|Q1111111111111111111|P|2.3|\r\n" +
-            "PID|||12345^^^XYZ^MR||SMITH^JOHN||19700100|M||||||||||111111111111|123456789|\r\n" +
-            "PD1||||1234567890^LAST^FIRST^M^^^^^NPI|\r\n" +
-            "ORC|NW|987654321^EPC|123456789^EPC||||||20161003000000|||SMITH\r\n" +
-            "OBR|1|341856649^HNAM_ORDERID|000000000000000000|648088^Basic Metabolic Panel|||20150101000000|||||||||1620^Johnson^Corey^A||||||20150101000000|||F|||||||||||20150101000000|\r\n" +
-            "OBX|1|NM|GLU^Glucose Lvl|59|mg/dL|65-99^65^99|L|||F|||20150102000000|\r\n";
+        final String message = """
+                MSH|^~\\&|XXXXXXXX||HealthProvider||||ORU^R01|Q1111111111111111111|P|2.3|\r
+                PID|||12345^^^XYZ^MR||SMITH^JOHN||19700100|M||||||||||111111111111|123456789|\r
+                PD1||||1234567890^LAST^FIRST^M^^^^^NPI|\r
+                ORC|NW|987654321^EPC|123456789^EPC||||||20161003000000|||SMITH\r
+                OBR|1|341856649^HNAM_ORDERID|000000000000000000|648088^Basic Metabolic Panel|||20150101000000|||||||||1620^Johnson^Corey^A||||||20150101000000|||F|||||||||||20150101000000|\r
+                OBX|1|NM|GLU^Glucose Lvl|59|mg/dL|65-99^65^99|L|||F|||20150102000000|\r
+                """;
 
         final SortedMap<String, String> expectedAttributes = new TreeMap<>();
 
@@ -143,12 +145,14 @@ public class TestExtractHL7Attributes {
 
     @Test
     public void testExtractWithSegmentNames() {
-        final String message = "MSH|^~\\&|XXXXXXXX||HealthProvider||||ORU^R01|Q1111111111111111111|P|2.3|\r\n" +
-            "PID|||12345^^^XYZ^MR||SMITH^JOHN||19700100|M||||||||||111111111111|123456789|\r\n" +
-            "PD1||||1234567890^LAST^FIRST^M^^^^^NPI|\r\n" +
-            "ORC|NW|987654321^EPC|123456789^EPC||||||20161003000000|||SMITH\r\n" +
-            "OBR|1|341856649^HNAM_ORDERID|000000000000000000|648088^Basic Metabolic Panel|||20150101000000|||||||||1620^Johnson^Corey^A||||||20150101000000|||F|||||||||||20150101000000|\r\n" +
-            "OBX|1|NM|GLU^Glucose Lvl|59|mg/dL|65-99^65^99|L|||F|||20150102000000|\r\n";
+        final String message = """
+                MSH|^~\\&|XXXXXXXX||HealthProvider||||ORU^R01|Q1111111111111111111|P|2.3|\r
+                PID|||12345^^^XYZ^MR||SMITH^JOHN||19700100|M||||||||||111111111111|123456789|\r
+                PD1||||1234567890^LAST^FIRST^M^^^^^NPI|\r
+                ORC|NW|987654321^EPC|123456789^EPC||||||20161003000000|||SMITH\r
+                OBR|1|341856649^HNAM_ORDERID|000000000000000000|648088^Basic Metabolic Panel|||20150101000000|||||||||1620^Johnson^Corey^A||||||20150101000000|||F|||||||||||20150101000000|\r
+                OBX|1|NM|GLU^Glucose Lvl|59|mg/dL|65-99^65^99|L|||F|||20150102000000|\r
+                """;
 
         final SortedMap<String, String> expectedAttributes = new TreeMap<>();
 
@@ -201,12 +205,14 @@ public class TestExtractHL7Attributes {
 
     @Test
     public void testExtractWithSegmentNamesAndFields() {
-        final String message = "MSH|^~\\&|XXXXXXXX||HealthProvider||||ORU^R01|Q1111111111111111111|P|2.3|\r\n" +
-            "PID|||12345^^^XYZ^MR||SMITH^JOHN||19700100|M||||||||||111111111111|123456789|\r\n" +
-            "PD1||||1234567890^LAST^FIRST^M^^^^^NPI|\r\n" +
-            "ORC|NW|987654321^EPC|123456789^EPC||||||20161003000000|||SMITH\r\n" +
-            "OBR|1|341856649^HNAM_ORDERID|000000000000000000|648088^Basic Metabolic Panel|||20150101000000|||||||||1620^Johnson^Corey^A||||||20150101000000|||F|||||||||||20150101000000|\r\n" +
-            "OBX|1|NM|GLU^Glucose Lvl|59|mg/dL|65-99^65^99|L|||F|||20150102000000|\r\n";
+        final String message = """
+                MSH|^~\\&|XXXXXXXX||HealthProvider||||ORU^R01|Q1111111111111111111|P|2.3|\r
+                PID|||12345^^^XYZ^MR||SMITH^JOHN||19700100|M||||||||||111111111111|123456789|\r
+                PD1||||1234567890^LAST^FIRST^M^^^^^NPI|\r
+                ORC|NW|987654321^EPC|123456789^EPC||||||20161003000000|||SMITH\r
+                OBR|1|341856649^HNAM_ORDERID|000000000000000000|648088^Basic Metabolic Panel|||20150101000000|||||||||1620^Johnson^Corey^A||||||20150101000000|||F|||||||||||20150101000000|\r
+                OBX|1|NM|GLU^Glucose Lvl|59|mg/dL|65-99^65^99|L|||F|||20150102000000|\r
+                """;
 
         final SortedMap<String, String> expectedAttributes = new TreeMap<>();
 
@@ -277,8 +283,10 @@ public class TestExtractHL7Attributes {
 
     @Test
     public void testExtractWithRepeatableField() {
-        final String message = "MSH|^~\\&|XXXXXXXX||HealthProvider||||SIU^S12|Q1111111111111111111|P|2.5.1|\r\n" +
-                "AIP|1||123456^SMITH^JOHN^A^^^^^NPI^^^^NPI~123457^SMITH^JOHN^A^^^^^OD^^^^OD~123458^SMITH^JOHN^A^^^^^MD^^^^MD|100^M.D.||20231010133000|0|MIN|45|MIN\r\n";
+        final String message = """
+                MSH|^~\\&|XXXXXXXX||HealthProvider||||SIU^S12|Q1111111111111111111|P|2.5.1|\r
+                AIP|1||123456^SMITH^JOHN^A^^^^^NPI^^^^NPI~123457^SMITH^JOHN^A^^^^^OD^^^^OD~123458^SMITH^JOHN^A^^^^^MD^^^^MD|100^M.D.||20231010133000|0|MIN|45|MIN\r
+                """;
 
         final SortedMap<String, String> expectedAttributes = new TreeMap<>();
 

--- a/nifi-extension-bundles/nifi-hubspot-bundle/nifi-hubspot-processors/src/main/java/org/apache/nifi/processors/hubspot/GetHubSpot.java
+++ b/nifi-extension-bundles/nifi-hubspot-bundle/nifi-hubspot-processors/src/main/java/org/apache/nifi/processors/hubspot/GetHubSpot.java
@@ -182,7 +182,7 @@ public class GetHubSpot extends AbstractProcessor {
     private volatile WebClientServiceProvider webClientServiceProvider;
     private volatile boolean isObjectTypeModified;
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             OBJECT_TYPE,
             ACCESS_TOKEN,
             RESULT_LIMIT,
@@ -192,11 +192,13 @@ public class GetHubSpot extends AbstractProcessor {
             WEB_CLIENT_SERVICE_PROVIDER
     );
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hubspot-bundle/nifi-hubspot-processors/src/main/java/org/apache/nifi/processors/hubspot/GetHubSpot.java
+++ b/nifi-extension-bundles/nifi-hubspot-bundle/nifi-hubspot-processors/src/main/java/org/apache/nifi/processors/hubspot/GetHubSpot.java
@@ -61,7 +61,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -183,7 +182,7 @@ public class GetHubSpot extends AbstractProcessor {
     private volatile WebClientServiceProvider webClientServiceProvider;
     private volatile boolean isObjectTypeModified;
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             OBJECT_TYPE,
             ACCESS_TOKEN,
             RESULT_LIMIT,
@@ -191,9 +190,9 @@ public class GetHubSpot extends AbstractProcessor {
             INCREMENTAL_DELAY,
             INCREMENTAL_INITIAL_START_TIME,
             WEB_CLIENT_SERVICE_PROVIDER
-    ));
+    );
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.singleton(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-hubspot-bundle/nifi-hubspot-processors/src/test/java/org/apache/nifi/processors/hubspot/GetHubSpotTest.java
+++ b/nifi-extension-bundles/nifi-hubspot-bundle/nifi-hubspot-processors/src/test/java/org/apache/nifi/processors/hubspot/GetHubSpotTest.java
@@ -101,7 +101,7 @@ class GetHubSpotTest {
         runner.run(1);
 
         final List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(GetHubSpot.REL_SUCCESS);
-        final MockFlowFile flowFile = flowFiles.get(0);
+        final MockFlowFile flowFile = flowFiles.getFirst();
 
         final String expectedFlowFileContent = getResourceAsString("expected_flowfile_content.json");
 
@@ -111,7 +111,7 @@ class GetHubSpotTest {
         flowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         assertEquals(expectedJsonNode, actualJsonNode);
         List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();
-        assertEquals(baseUrl.toString(), provenanceEvents.get(0).getTransitUri());
+        assertEquals(baseUrl.toString(), provenanceEvents.getFirst().getTransitUri());
     }
 
     @Test
@@ -179,7 +179,7 @@ class GetHubSpotTest {
 
         assertEquals(OBJECT_MAPPER.readTree(expectedJsonString), OBJECT_MAPPER.readTree(requestBodyString));
         List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();
-        assertEquals(baseUrl.toString(), provenanceEvents.get(0).getTransitUri());
+        assertEquals(baseUrl.toString(), provenanceEvents.getFirst().getTransitUri());
     }
 
     @Test
@@ -228,7 +228,7 @@ class GetHubSpotTest {
 
         assertEquals(OBJECT_MAPPER.readTree(expectedJsonString), OBJECT_MAPPER.readTree(requestBodyString));
         List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();
-        assertEquals(baseUrl.toString(), provenanceEvents.get(0).getTransitUri());
+        assertEquals(baseUrl.toString(), provenanceEvents.getFirst().getTransitUri());
     }
 
     static class MockGetHubSpot extends GetHubSpot {

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/ConsumeJMS.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/ConsumeJMS.java
@@ -56,10 +56,8 @@ import org.springframework.jms.support.JmsHeaders;
 import jakarta.jms.Session;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -225,50 +223,44 @@ public class ConsumeJMS extends AbstractJMSProcessor<JMSConsumer> {
             .autoTerminateDefault(true) // to make sure flow are still valid after upgrades
             .build();
 
-    private final static Set<Relationship> relationships;
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_PARSE_FAILURE
+    );
 
-    private final static List<PropertyDescriptor> propertyDescriptors;
+    private static final PropertyDescriptor CHARSET_WITH_EL_VALIDATOR_PROPERTY = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(CHARSET)
+            .addValidator(StandardValidators.CHARACTER_SET_VALIDATOR_WITH_EVALUATION)
+            .build();
 
-    static {
-        List<PropertyDescriptor> _propertyDescriptors = new ArrayList<>();
+    private static final List<PropertyDescriptor> OTHER_PROPERTIES = Stream.concat(
+            JNDI_JMS_CF_PROPERTIES.stream(),
+            JMS_CF_PROPERTIES.stream()
+    ).toList();
 
-        _propertyDescriptors.add(CF_SERVICE);
-        _propertyDescriptors.add(DESTINATION);
-        _propertyDescriptors.add(DESTINATION_TYPE);
-        _propertyDescriptors.add(MESSAGE_SELECTOR);
-        _propertyDescriptors.add(USER);
-        _propertyDescriptors.add(PASSWORD);
-        _propertyDescriptors.add(CLIENT_ID);
-
-        // change the validator on CHARSET property
-        PropertyDescriptor charsetWithELValidatorProperty = new PropertyDescriptor.Builder()
-                .fromPropertyDescriptor(CHARSET)
-                .addValidator(StandardValidators.CHARACTER_SET_VALIDATOR_WITH_EVALUATION)
-                .build();
-        _propertyDescriptors.add(charsetWithELValidatorProperty);
-
-        _propertyDescriptors.add(ACKNOWLEDGEMENT_MODE);
-        _propertyDescriptors.add(DURABLE_SUBSCRIBER);
-        _propertyDescriptors.add(SHARED_SUBSCRIBER);
-        _propertyDescriptors.add(SUBSCRIPTION_NAME);
-        _propertyDescriptors.add(TIMEOUT);
-        _propertyDescriptors.add(MAX_BATCH_SIZE);
-        _propertyDescriptors.add(ERROR_QUEUE);
-
-        _propertyDescriptors.add(RECORD_READER);
-        _propertyDescriptors.add(RECORD_WRITER);
-        _propertyDescriptors.add(OUTPUT_STRATEGY);
-
-        _propertyDescriptors.addAll(JNDI_JMS_CF_PROPERTIES);
-        _propertyDescriptors.addAll(JMS_CF_PROPERTIES);
-
-        propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
-
-        Set<Relationship> _relationships = new HashSet<>();
-        _relationships.add(REL_SUCCESS);
-        _relationships.add(REL_PARSE_FAILURE);
-        relationships = Collections.unmodifiableSet(_relationships);
-    }
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            Stream.of(
+                    CF_SERVICE,
+                    DESTINATION,
+                    DESTINATION_TYPE,
+                    MESSAGE_SELECTOR,
+                    USER,
+                    PASSWORD,
+                    CLIENT_ID,
+                    CHARSET_WITH_EL_VALIDATOR_PROPERTY,
+                    ACKNOWLEDGEMENT_MODE,
+                    DURABLE_SUBSCRIBER,
+                    SHARED_SUBSCRIBER,
+                    SUBSCRIPTION_NAME,
+                    TIMEOUT,
+                    MAX_BATCH_SIZE,
+                    ERROR_QUEUE,
+                    RECORD_READER,
+                    RECORD_WRITER,
+                    OUTPUT_STRATEGY
+            ),
+            OTHER_PROPERTIES.stream()
+    ).toList();
 
     @Override
     public void migrateProperties(PropertyConfiguration config) {
@@ -477,12 +469,12 @@ public class ConsumeJMS extends AbstractJMSProcessor<JMSConsumer> {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
@@ -56,14 +56,12 @@ import jakarta.jms.Destination;
 import jakarta.jms.Message;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static org.apache.nifi.jms.processors.ioconcept.reader.record.ProvenanceEventTemplates.PROVENANCE_EVENT_DETAILS_ON_RECORDSET_FAILURE;
 import static org.apache.nifi.jms.processors.ioconcept.reader.record.ProvenanceEventTemplates.PROVENANCE_EVENT_DETAILS_ON_RECORDSET_RECOVER;
@@ -163,42 +161,32 @@ public class PublishJMS extends AbstractJMSProcessor<JMSPublisher> {
             .description("All FlowFiles that cannot be sent to JMS destination are routed to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> propertyDescriptors;
-    private final static Set<Relationship> relationships;
+    private static final List<PropertyDescriptor> COMMON_PROPERTIES = Stream.concat(
+            JNDI_JMS_CF_PROPERTIES.stream(),
+            JMS_CF_PROPERTIES.stream()
+    ).toList();
 
-    /*
-     * Will ensure that the list of property descriptors is build only once.
-     * Will also create a Set of relationships
-     */
-    static {
-        List<PropertyDescriptor> _propertyDescriptors = new ArrayList<>();
-
-        _propertyDescriptors.add(CF_SERVICE);
-        _propertyDescriptors.add(DESTINATION);
-        _propertyDescriptors.add(DESTINATION_TYPE);
-        _propertyDescriptors.add(USER);
-        _propertyDescriptors.add(PASSWORD);
-        _propertyDescriptors.add(CLIENT_ID);
-
-        _propertyDescriptors.add(MESSAGE_BODY);
-        _propertyDescriptors.add(CHARSET);
-        _propertyDescriptors.add(ALLOW_ILLEGAL_HEADER_CHARS);
-        _propertyDescriptors.add(ATTRIBUTES_AS_HEADERS_REGEX);
-        _propertyDescriptors.add(MAX_BATCH_SIZE);
-
-        _propertyDescriptors.add(RECORD_READER);
-        _propertyDescriptors.add(RECORD_WRITER);
-
-        _propertyDescriptors.addAll(JNDI_JMS_CF_PROPERTIES);
-        _propertyDescriptors.addAll(JMS_CF_PROPERTIES);
-
-        propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
-
-        Set<Relationship> _relationships = new HashSet<>();
-        _relationships.add(REL_SUCCESS);
-        _relationships.add(REL_FAILURE);
-        relationships = Collections.unmodifiableSet(_relationships);
-    }
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            Stream.of(
+                    CF_SERVICE,
+                    DESTINATION,
+                    DESTINATION_TYPE,
+                    USER,
+                    PASSWORD,
+                    CLIENT_ID,
+                    MESSAGE_BODY,
+                    CHARSET,
+                    ALLOW_ILLEGAL_HEADER_CHARS,
+                    ATTRIBUTES_AS_HEADERS_REGEX,
+                    MAX_BATCH_SIZE,
+                    RECORD_READER,
+                    RECORD_WRITER),
+            COMMON_PROPERTIES.stream()
+    ).toList();
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     volatile Boolean allowIllegalChars;
     volatile Pattern attributeHeaderPattern;
@@ -306,7 +294,7 @@ public class PublishJMS extends AbstractJMSProcessor<JMSPublisher> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     /**
@@ -314,7 +302,7 @@ public class PublishJMS extends AbstractJMSProcessor<JMSPublisher> {
      */
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConnectionFactoryConfigIT.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConnectionFactoryConfigIT.java
@@ -168,9 +168,9 @@ public class ConnectionFactoryConfigIT {
 
     private void assertResult() {
         publisher.assertAllFlowFilesTransferred(PublishJMS.REL_SUCCESS, 1);
-        publisher.getFlowFilesForRelationship(ConsumeJMS.REL_SUCCESS).get(0).assertContentEquals(TEST_MESSAGE);
+        publisher.getFlowFilesForRelationship(ConsumeJMS.REL_SUCCESS).getFirst().assertContentEquals(TEST_MESSAGE);
 
         consumer.assertAllFlowFilesTransferred(ConsumeJMS.REL_SUCCESS, 1);
-        consumer.getFlowFilesForRelationship(ConsumeJMS.REL_SUCCESS).get(0).assertContentEquals(TEST_MESSAGE);
+        consumer.getFlowFilesForRelationship(ConsumeJMS.REL_SUCCESS).getFirst().assertContentEquals(TEST_MESSAGE);
     }
 }

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSIT.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/test/java/org/apache/nifi/jms/processors/ConsumeJMSIT.java
@@ -111,7 +111,7 @@ public class ConsumeJMSIT {
 
             runner.run(1, false);
             //
-            final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishJMS.REL_SUCCESS).get(0);
+            final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishJMS.REL_SUCCESS).getFirst();
             assertNotNull(successFF);
             successFF.assertAttributeExists(JmsHeaders.DESTINATION);
             successFF.assertAttributeEquals(JmsHeaders.DESTINATION, destinationName);
@@ -254,7 +254,7 @@ public class ConsumeJMSIT {
             runner.setProperty(ConsumeJMS.DESTINATION_TYPE, ConsumeJMS.QUEUE);
             runner.run(1, false);
             //
-            final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishJMS.REL_SUCCESS).get(0);
+            final MockFlowFile successFF = runner.getFlowFilesForRelationship(PublishJMS.REL_SUCCESS).getFirst();
             assertNotNull(successFF);
 
             successFF.assertAttributeExists(ConsumeJMS.JMS_MESSAGETYPE);
@@ -299,7 +299,7 @@ public class ConsumeJMSIT {
             final String destinationName = "validateNifi6915";
 
             TestRunner c1Consumer = createNonSharedDurableConsumer(cf, destinationName);
-            // 1. Start a durable non shared consumer C1 with client id client1 subscribed to topic T.
+            // 1. Start a durable non-shared consumer C1 with client id client1 subscribed to topic T.
             boolean stopConsumer = true;
             c1Consumer.run(1, stopConsumer);
             List<MockFlowFile> flowFiles = c1Consumer.getFlowFilesForRelationship(ConsumeJMS.REL_SUCCESS);
@@ -312,7 +312,7 @@ public class ConsumeJMSIT {
             assertEquals(1, flowFiles.size());
 
             // It is expected C1 receives message M1.
-            final MockFlowFile successFF = flowFiles.get(0);
+            final MockFlowFile successFF = flowFiles.getFirst();
             assertNotNull(successFF);
             successFF.assertAttributeExists(JmsHeaders.DESTINATION);
             successFF.assertAttributeEquals(JmsHeaders.DESTINATION, destinationName);
@@ -379,7 +379,7 @@ public class ConsumeJMSIT {
             final AtomicReference<TcpTransport> tcpTransport = new AtomicReference<>();
             TcpTransportFactory.registerTransportFactory("validateNIFI7034", new TcpTransportFactory() {
                 @Override
-                protected TcpTransport createTcpTransport(WireFormat wf, SocketFactory socketFactory, URI location, URI localLocation) throws UnknownHostException, IOException {
+                protected TcpTransport createTcpTransport(WireFormat wf, SocketFactory socketFactory, URI location, URI localLocation) throws IOException {
                     TcpTransport transport = super.createTcpTransport(wf, socketFactory, location, localLocation);
                     tcpTransport.set(transport);
                     return transport;
@@ -509,7 +509,7 @@ public class ConsumeJMSIT {
 
             List<MockFlowFile> successFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeJMS.REL_SUCCESS);
             assertEquals(1, successFlowFiles.size());
-            assertEquals(expectedRecordSet.toString(), new String(successFlowFiles.get(0).toByteArray()));
+            assertEquals(expectedRecordSet.toString(), new String(successFlowFiles.getFirst().toByteArray()));
 
             List<MockFlowFile> parseFailedFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeJMS.REL_PARSE_FAILURE);
             assertEquals(0, parseFailedFlowFiles.size());
@@ -544,7 +544,7 @@ public class ConsumeJMSIT {
             // checking whether the processor was able to construct a valid recordSet from the properly formatted messages
             List<MockFlowFile> successFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeJMS.REL_SUCCESS);
             assertEquals(1, successFlowFiles.size());
-            assertEquals(expectedRecordSet.toString(), new String(successFlowFiles.get(0).toByteArray()));
+            assertEquals(expectedRecordSet.toString(), new String(successFlowFiles.getFirst().toByteArray()));
 
             // and checking whether it creates separate FlowFiles for the malformed messages
             List<MockFlowFile> parseFailedFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeJMS.REL_PARSE_FAILURE);
@@ -577,7 +577,7 @@ public class ConsumeJMSIT {
 
             List<MockFlowFile> successFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeJMS.REL_SUCCESS);
             assertEquals(1, successFlowFiles.size());
-            JsonNode flowFileContentAsJson = deserializeToJsonNode(new String(successFlowFiles.get(0).toByteArray()));
+            JsonNode flowFileContentAsJson = deserializeToJsonNode(new String(successFlowFiles.getFirst().toByteArray()));
             // checking that the output contains at least a part of the original input
             assertEquals(inputRecordSet.get(0).get("firstAttribute").asText(), flowFileContentAsJson.get(0).get("firstAttribute").asText());
             assertEquals(inputRecordSet.get(1).get("firstAttribute").asText(), flowFileContentAsJson.get(1).get("firstAttribute").asText());
@@ -619,7 +619,7 @@ public class ConsumeJMSIT {
 
             List<MockFlowFile> successFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeJMS.REL_SUCCESS);
             assertEquals(1, successFlowFiles.size());
-            JsonNode flowFileContentAsJson = deserializeToJsonNode(new String(successFlowFiles.get(0).toByteArray()));
+            JsonNode flowFileContentAsJson = deserializeToJsonNode(new String(successFlowFiles.getFirst().toByteArray()));
             // checking that the original json is equal to the leaf
             assertEquals(inputRecordSet.get(0), flowFileContentAsJson.get(0).get(valueKey));
             assertEquals(inputRecordSet.get(1), flowFileContentAsJson.get(1).get(valueKey));

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/JoltTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/JoltTransformJSON.java
@@ -45,11 +45,10 @@ import org.apache.nifi.util.file.classloader.ClassLoaderUtils;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 @SideEffectFree
 @SupportsBatching
@@ -88,17 +87,21 @@ public class JoltTransformJSON extends AbstractJoltTransform {
             .description("If a FlowFile fails processing for any reason (for example, the FlowFile is not valid JSON), it will be routed to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES;
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            AbstractJoltTransform.PROPERTIES.stream(),
+            Stream.of(
+                    PRETTY_PRINT,
+                    MAX_STRING_LENGTH
+            )
+    ).toList();
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
+
     private volatile ClassLoader customClassLoader;
     private volatile JsonUtil jsonUtil;
-
-    static {
-        final List<PropertyDescriptor> tmp = new ArrayList<>(AbstractJoltTransform.PROPERTIES);
-        tmp.add(PRETTY_PRINT);
-        tmp.add(MAX_STRING_LENGTH);
-        PROPERTIES = Collections.unmodifiableList(tmp);
-    }
 
     @Override
     public Set<Relationship> getRelationships() {

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/JoltTransformRecord.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/JoltTransformRecord.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @SideEffectFree
 @SupportsBatching
@@ -105,17 +106,19 @@ public class JoltTransformRecord extends AbstractJoltTransform {
             .description("The original FlowFile that was transformed. If the FlowFile fails processing, nothing will be sent to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES;
-    private static final Set<Relationship> RELATIONSHIPS;
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            AbstractJoltTransform.PROPERTIES.stream(),
+            Stream.of(
+                    RECORD_READER,
+                    RECORD_WRITER
+            )
+    ).toList();
 
-    static {
-        final List<PropertyDescriptor> tmp = new ArrayList<>(AbstractJoltTransform.PROPERTIES);
-        tmp.add(RECORD_READER);
-        tmp.add(RECORD_WRITER);
-        PROPERTIES = Collections.unmodifiableList(tmp);
-
-        RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE, REL_ORIGINAL);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_ORIGINAL
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -179,7 +182,7 @@ public class JoltTransformRecord extends AbstractJoltTransform {
                     throw new ProcessException("Error transforming the first record");
                 }
 
-                final Record transformedFirstRecord = transformedFirstRecords.get(0);
+                final Record transformedFirstRecord = transformedFirstRecords.getFirst();
                 if (transformedFirstRecord == null) {
                     throw new ProcessException("Error transforming the first record");
                 }

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/test/java/org/apache/nifi/processors/jolt/TestJoltTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/test/java/org/apache/nifi/processors/jolt/TestJoltTransformJSON.java
@@ -200,13 +200,13 @@ class TestJoltTransformJSON {
     @ParameterizedTest(name = "{index} {1}")
     @MethodSource("getChainrArguments")
     /*NOTE: Even though description is not used in the actual test, it needs to be declared in order to use it in the ParameterizedTest name argument*/
-    void testTransformInputWithChainr(Path specPath, String description) throws IOException {
+    void testTransformInputWithChainr(Path specPath, String ignoredDescription) throws IOException {
         final String spec = Files.readString(specPath);
         runner.setProperty(JoltTransformJSON.JOLT_SPEC, spec);
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
@@ -222,7 +222,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
@@ -238,7 +238,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
@@ -258,7 +258,7 @@ class TestJoltTransformJSON {
         runner.enqueue(addAccentedChars(Files.readString(JSON_INPUT)));
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
@@ -274,7 +274,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
         Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestJoltTransformJson/defaultrOutput.json")));
         assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
@@ -288,7 +288,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
         Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestJoltTransformJson/removrOutput.json")));
         assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
@@ -302,7 +302,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
         Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestJoltTransformJson/cardrOutput.json")));
         assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
@@ -314,7 +314,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
@@ -333,7 +333,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
         Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestJoltTransformJson/defaultrELOutput.json")));
         assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
@@ -347,7 +347,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
         Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestJoltTransformJson/modifierDefaultOutput.json")));
         assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
@@ -361,7 +361,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
         Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestJoltTransformJson/modifierDefineOutput.json")));
         assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
@@ -375,7 +375,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
         Object compareJson = JsonUtils.jsonToObject(Files.newInputStream(Paths.get("src/test/resources/TestJoltTransformJson/modifierOverwriteOutput.json")));
         assertTrue(DIFFY.diff(compareJson, transformedJson).isEmpty());
@@ -388,7 +388,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
@@ -408,7 +408,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
@@ -432,7 +432,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT, customSpecs);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
@@ -450,7 +450,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
@@ -467,7 +467,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
@@ -486,7 +486,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));
@@ -504,7 +504,7 @@ class TestJoltTransformJSON {
         runner.enqueue(JSON_INPUT, attributes);
         runner.run();
         runner.assertAllFlowFilesTransferred(JoltTransformJSON.REL_SUCCESS);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformJSON.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         Object transformedJson = JsonUtils.jsonToObject(new ByteArrayInputStream(transformed.toByteArray()));

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/test/java/org/apache/nifi/processors/jolt/TestJoltTransformRecord.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/test/java/org/apache/nifi/processors/jolt/TestJoltTransformRecord.java
@@ -285,7 +285,7 @@ public class TestJoltTransformRecord {
 
     @ParameterizedTest(name = "{index} {1}")
     @MethodSource("getChainrArguments")
-    public void testTransformInputWithChainr(Path specPath, String description) throws IOException {
+    public void testTransformInputWithChainr(Path specPath, String ignoredDescription) throws IOException {
         generateTestData(1, null);
         final String outputSchemaText = Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/chainrOutputSchema.avsc"));
         runner.setProperty(writer, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
@@ -298,7 +298,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/chainrOutput.json")),
@@ -320,15 +320,11 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/shiftrOutput.json")),
                 new String(transformed.toByteArray()));
-    }
-
-    String addAccentedChars(String input) {
-        return input.replace("\"primary\"", "\"primaryÄÖÜ\"");
     }
 
     @Test
@@ -346,7 +342,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE .key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/shiftrOutput.json")),
@@ -386,7 +382,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/shiftrOutputMultipleOutputRecords.json")),
@@ -408,7 +404,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/shiftrOutput.json")),
@@ -430,7 +426,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/defaultrOutput.json")),
                 new String(transformed.toByteArray()));
     }
@@ -450,7 +446,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/removrOutput.json")),
                 new String(transformed.toByteArray()));
 
@@ -471,7 +467,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/cardrOutput.json")),
                 new String(transformed.toByteArray()));
 
@@ -490,7 +486,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/sortrOutput.json")),
@@ -513,7 +509,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/defaultrELOutput.json")),
                 new String(transformed.toByteArray()));
 
@@ -534,7 +530,7 @@ public class TestJoltTransformRecord {
         runner.enqueue(new byte[0]);
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/modifierDefaultOutput.json")),
                 new String(transformed.toByteArray()));
     }
@@ -554,7 +550,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/modifierDefineOutput.json")),
                 new String(transformed.toByteArray()));
     }
@@ -574,7 +570,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/modifierOverwriteOutput.json")),
                 new String(transformed.toByteArray()));
     }
@@ -593,7 +589,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/sortrOutput.json")),
@@ -618,7 +614,7 @@ public class TestJoltTransformRecord {
         runner.run();
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         transformed.assertAttributeExists(CoreAttributes.MIME_TYPE.key());
         transformed.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/defaultrOutput.json")),
@@ -673,7 +669,7 @@ public class TestJoltTransformRecord {
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
 
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/defaultrOutput.json")),
                 new String(transformed.toByteArray()));
     }
@@ -710,7 +706,7 @@ public class TestJoltTransformRecord {
         runner.assertTransferCount(JoltTransformRecord.REL_SUCCESS, 1);
         runner.assertTransferCount(JoltTransformRecord.REL_ORIGINAL, 1);
 
-        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile transformed = runner.getFlowFilesForRelationship(JoltTransformRecord.REL_SUCCESS).getFirst();
         assertEquals(Files.readString(Paths.get("src/test/resources/TestJoltTransformRecord/flattenedOutput.json")),
                 new String(transformed.toByteArray()));
     }
@@ -723,11 +719,11 @@ public class TestJoltTransformRecord {
 
     private void generateTestData(int numRecords, final BiFunction<Integer, MockRecordParser, Void> recordGenerator) {
         if (recordGenerator == null) {
-            final RecordSchema primarySchema = new SimpleRecordSchema(Arrays.asList(
+            final RecordSchema primarySchema = new SimpleRecordSchema(List.of(
                     new RecordField("value", RecordFieldType.INT.getDataType())));
-            final RecordSchema seriesSchema = new SimpleRecordSchema(Arrays.asList(
+            final RecordSchema seriesSchema = new SimpleRecordSchema(List.of(
                     new RecordField("value", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.INT.getDataType()))));
-            final RecordSchema qualitySchema = new SimpleRecordSchema(Arrays.asList(
+            final RecordSchema qualitySchema = new SimpleRecordSchema(List.of(
                     new RecordField("value", RecordFieldType.INT.getDataType())));
             final RecordSchema ratingSchema = new SimpleRecordSchema(Arrays.asList(
                     new RecordField("primary", RecordFieldType.RECORD.getDataType()),
@@ -737,10 +733,9 @@ public class TestJoltTransformRecord {
             parser.addSchemaField("rating", RecordFieldType.RECORD);
 
             for (int i = 0; i < numRecords; i++) {
-                final int index = i;
 
-                final Record primaryRecord = new MapRecord(primarySchema, Map.of("value", (10 * index) + 3));
-                final Record seriesRecord = new MapRecord(seriesSchema, Map.of("value", new Integer[]{(10 * index) + 5, (10 * index) + 4}));
+                final Record primaryRecord = new MapRecord(primarySchema, Map.of("value", (10 * i) + 3));
+                final Record seriesRecord = new MapRecord(seriesSchema, Map.of("value", new Integer[]{(10 * i) + 5, (10 * i) + 4}));
                 final Record qualityRecord = new MapRecord(qualitySchema, Map.of("value", 3));
 
                 Record ratingRecord = new MapRecord(ratingSchema, Map.of("primary", primaryRecord,

--- a/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/test/java/org/apache/nifi/processors/jslt/TestJSLTTransformJSON.java
@@ -207,7 +207,7 @@ public class TestJSLTTransformJSON {
         runner.run();
         runner.assertTransferCount(JSLTTransformJSON.REL_SUCCESS, 1);
         runner.assertTransferCount(JSLTTransformJSON.REL_FAILURE, 0);
-        return runner.getFlowFilesForRelationship(JSLTTransformJSON.REL_SUCCESS).iterator().next();
+        return runner.getFlowFilesForRelationship(JSLTTransformJSON.REL_SUCCESS).getFirst();
     }
 
     private String getResource(final String fileName) {

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/AbstractMongoProcessor.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/AbstractMongoProcessor.java
@@ -157,7 +157,7 @@ public abstract class AbstractMongoProcessor extends AbstractProcessor {
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
 
-    static final List<PropertyDescriptor> descriptors = List.of(
+    static final List<PropertyDescriptor> DESCRIPTORS = List.of(
             CLIENT_SERVICE,
             DATABASE_NAME,
             COLLECTION_NAME

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/DeleteMongo.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/DeleteMongo.java
@@ -39,10 +39,9 @@ import org.bson.Document;
 
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
 @Tags({ "delete", "mongo", "mongodb" })
@@ -56,9 +55,6 @@ import java.util.Set;
             "configured to use this option. Acceptable values are 'one' and 'many.'"
 )
 public class DeleteMongo extends AbstractMongoProcessor {
-
-    private final static Set<Relationship> relationships;
-    private final static List<PropertyDescriptor> propertyDescriptors;
 
     static final AllowableValue DELETE_ONE = new AllowableValue("one", "Delete One", "Delete only the first document that matches the query.");
     static final AllowableValue DELETE_MANY = new AllowableValue("many", "Delete Many", "Delete every document that matches the query.");
@@ -91,27 +87,27 @@ public class DeleteMongo extends AbstractMongoProcessor {
     static final Relationship REL_FAILURE = new Relationship.Builder().name("failure")
             .description("All FlowFiles that cannot be written to MongoDB are routed to this relationship").build();
 
-    static {
-        List<PropertyDescriptor> _propertyDescriptors = new ArrayList<>();
-        _propertyDescriptors.addAll(descriptors);
-        _propertyDescriptors.add(DELETE_MODE);
-        _propertyDescriptors.add(FAIL_ON_NO_DELETE);
-        propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
-        final Set<Relationship> _relationships = new HashSet<>();
-        _relationships.add(REL_SUCCESS);
-        _relationships.add(REL_FAILURE);
-        relationships = Collections.unmodifiableSet(_relationships);
-    }
+    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            AbstractMongoProcessor.DESCRIPTORS.stream(),
+            Stream.of(
+                    DELETE_MODE,
+                    FAIL_ON_NO_DELETE
+            )
+    ).toList();
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     private static final List<String> ALLOWED_DELETE_VALUES;

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongo.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongo.java
@@ -47,11 +47,10 @@ import org.bson.json.JsonWriterSettings;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 @Tags({ "mongodb", "read", "get" })
 @InputRequirement(Requirement.INPUT_ALLOWED)
@@ -86,33 +85,31 @@ public class GetMongo extends AbstractMongoQueryProcessor {
             .addValidator(Validator.VALID)
             .build();
 
-    private final static Set<Relationship> relationships;
-    private final static List<PropertyDescriptor> propertyDescriptors;
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_ORIGINAL
+    );
+
+    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            AbstractMongoProcessor.DESCRIPTORS.stream(),
+            Stream.of(
+                    JSON_TYPE,
+                    USE_PRETTY_PRINTING,
+                    CHARSET,
+                    QUERY,
+                    QUERY_ATTRIBUTE,
+                    PROJECTION,
+                    SORT,
+                    LIMIT,
+                    BATCH_SIZE,
+                    RESULTS_PER_FLOWFILE,
+                    DATE_FORMAT,
+                    SEND_EMPTY_RESULTS
+            )
+    ).toList();
+
     private ComponentLog logger;
-
-    static {
-        List<PropertyDescriptor> _propertyDescriptors = new ArrayList<>();
-        _propertyDescriptors.addAll(descriptors);
-        _propertyDescriptors.add(JSON_TYPE);
-        _propertyDescriptors.add(USE_PRETTY_PRINTING);
-        _propertyDescriptors.add(CHARSET);
-        _propertyDescriptors.add(QUERY);
-        _propertyDescriptors.add(QUERY_ATTRIBUTE);
-        _propertyDescriptors.add(PROJECTION);
-        _propertyDescriptors.add(SORT);
-        _propertyDescriptors.add(LIMIT);
-        _propertyDescriptors.add(BATCH_SIZE);
-        _propertyDescriptors.add(RESULTS_PER_FLOWFILE);
-        _propertyDescriptors.add(DATE_FORMAT);
-        _propertyDescriptors.add(SEND_EMPTY_RESULTS);
-        propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
-
-        final Set<Relationship> _relationships = new HashSet<>();
-        _relationships.add(REL_SUCCESS);
-        _relationships.add(REL_FAILURE);
-        _relationships.add(REL_ORIGINAL);
-        relationships = Collections.unmodifiableSet(_relationships);
-    }
 
     private boolean sendEmpty;
     @OnScheduled
@@ -122,12 +119,12 @@ public class GetMongo extends AbstractMongoQueryProcessor {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     //Turn a list of Mongo result documents into a String representation of a JSON array

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongoRecord.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongoRecord.java
@@ -50,7 +50,6 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 @CapabilityDescription("A record-based version of GetMongo that uses the Record writers to write the MongoDB result set.")
 @Tags({"mongo", "mongodb", "get", "fetch", "record", "json"})
@@ -77,7 +76,7 @@ public class GetMongoRecord extends AbstractMongoQueryProcessor {
         .required(true)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             CLIENT_SERVICE,
             WRITER_FACTORY,
             DATABASE_NAME,
@@ -89,7 +88,7 @@ public class GetMongoRecord extends AbstractMongoQueryProcessor {
             SORT,
             LIMIT,
             BATCH_SIZE
-    ).toList();
+    );
 
     private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongoRecord.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongoRecord.java
@@ -47,12 +47,10 @@ import org.bson.Document;
 import org.bson.types.ObjectId;
 
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 @CapabilityDescription("A record-based version of GetMongo that uses the Record writers to write the MongoDB result set.")
 @Tags({"mongo", "mongodb", "get", "fetch", "record", "json"})
@@ -79,35 +77,29 @@ public class GetMongoRecord extends AbstractMongoQueryProcessor {
         .required(true)
         .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS;
-    private static final Set<Relationship> RELATIONSHIPS;
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.of(
+            CLIENT_SERVICE,
+            WRITER_FACTORY,
+            DATABASE_NAME,
+            COLLECTION_NAME,
+            SCHEMA_NAME,
+            QUERY_ATTRIBUTE,
+            QUERY,
+            PROJECTION,
+            SORT,
+            LIMIT,
+            BATCH_SIZE
+    ).toList();
 
-    static {
-        List<PropertyDescriptor> _temp = new ArrayList<>();
-        _temp.add(CLIENT_SERVICE);
-        _temp.add(WRITER_FACTORY);
-        _temp.add(DATABASE_NAME);
-        _temp.add(COLLECTION_NAME);
-        _temp.add(SCHEMA_NAME);
-        _temp.add(QUERY_ATTRIBUTE);
-        _temp.add(QUERY);
-        _temp.add(PROJECTION);
-        _temp.add(SORT);
-        _temp.add(LIMIT);
-        _temp.add(BATCH_SIZE);
-
-        DESCRIPTORS = Collections.unmodifiableList(_temp);
-
-        Set<Relationship> _rels = new HashSet<>();
-        _rels.add(REL_SUCCESS);
-        _rels.add(REL_FAILURE);
-        _rels.add(REL_ORIGINAL);
-        RELATIONSHIPS = Collections.unmodifiableSet(_rels);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_ORIGINAL
+    );
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @Override
@@ -191,7 +183,6 @@ public class GetMongoRecord extends AbstractMongoQueryProcessor {
                 session.transfer(input, REL_ORIGINAL);
             }
         } catch (Exception ex) {
-            ex.printStackTrace();
             getLogger().error("Error writing record set from Mongo query.", ex);
             session.remove(output);
             if (input != null) {

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongo.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongo.java
@@ -52,10 +52,10 @@ import org.bson.types.ObjectId;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 @Tags({ "mongodb", "insert", "update", "write", "put" })
 @InputRequirement(Requirement.INPUT_REQUIRED)
@@ -146,30 +146,32 @@ public class PutMongo extends AbstractMongoProcessor {
         .defaultValue("UTF-8")
         .build();
 
-    private final static Set<Relationship> relationships = Set.of(REL_SUCCESS, REL_FAILURE);
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
-    private final static List<PropertyDescriptor> propertyDescriptors;
-
-    static {
-      List<PropertyDescriptor> _propertyDescriptors = new ArrayList<>(descriptors);
-        _propertyDescriptors.add(MODE);
-        _propertyDescriptors.add(UPSERT);
-        _propertyDescriptors.add(UPDATE_QUERY_KEY);
-        _propertyDescriptors.add(UPDATE_QUERY);
-        _propertyDescriptors.add(UPDATE_OPERATION_MODE);
-        _propertyDescriptors.add(UPDATE_METHOD);
-        _propertyDescriptors.add(CHARACTER_SET);
-        propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
-    }
+    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            AbstractMongoProcessor.DESCRIPTORS.stream(),
+            Stream.of(
+                    MODE,
+                    UPSERT,
+                    UPDATE_QUERY_KEY,
+                    UPDATE_QUERY,
+                    UPDATE_OPERATION_MODE,
+                    UPDATE_METHOD,
+                    CHARACTER_SET
+            )
+    ).toList();
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoBulkOperations.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoBulkOperations.java
@@ -92,18 +92,24 @@ public class PutMongoBulkOperations extends AbstractMongoProcessor {
         .defaultValue("UTF-8")
         .build();
 
-    private final static Set<Relationship> relationships = Set.of(REL_SUCCESS, REL_FAILURE);
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
-    private final static List<PropertyDescriptor> propertyDescriptors = Stream.concat(descriptors.stream(), Stream.of(ORDERED, CHARACTER_SET)).toList();
+    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            AbstractMongoProcessor.DESCRIPTORS.stream(),
+            Stream.of(ORDERED, CHARACTER_SET)
+    ).toList();
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoRecord.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoRecord.java
@@ -52,11 +52,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 @Tags({"mongodb", "insert", "update", "upsert", "record", "put"})
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
@@ -137,31 +137,31 @@ public class PutMongoRecord extends AbstractMongoProcessor {
         .defaultValue(UpdateMethod.UPDATE_ONE)
         .build();
 
-    private final static Set<Relationship> relationships;
-    private final static List<PropertyDescriptor> propertyDescriptors;
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
-    static {
-        List<PropertyDescriptor> _propertyDescriptors = new ArrayList<>();
-        _propertyDescriptors.addAll(descriptors);
-        _propertyDescriptors.add(RECORD_READER_FACTORY);
-        _propertyDescriptors.add(INSERT_COUNT);
-        _propertyDescriptors.add(ORDERED);
-        _propertyDescriptors.add(BYPASS_VALIDATION);
-        _propertyDescriptors.add(UPDATE_KEY_FIELDS);
-        _propertyDescriptors.add(UPDATE_MODE);
-        propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
-
-        relationships = Set.of(REL_SUCCESS, REL_FAILURE);
-    }
+    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            AbstractMongoProcessor.DESCRIPTORS.stream(),
+            Stream.of(
+                    RECORD_READER_FACTORY,
+                    INSERT_COUNT,
+                    ORDERED,
+                    BYPASS_VALIDATION,
+                    UPDATE_KEY_FIELDS,
+                    UPDATE_MODE
+            )
+    ).toList();
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/RunMongoAggregation.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/RunMongoAggregation.java
@@ -41,20 +41,16 @@ import org.bson.conversions.Bson;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 @Tags({"mongo", "aggregation", "aggregate"})
 @CapabilityDescription("A processor that runs an aggregation query whenever a flowfile is received.")
 @InputRequirement(InputRequirement.Requirement.INPUT_ALLOWED)
 public class RunMongoAggregation extends AbstractMongoProcessor {
-
-    private final static Set<Relationship> relationships;
-    private final static List<PropertyDescriptor> propertyDescriptors;
 
     static final Relationship REL_ORIGINAL = new Relationship.Builder()
             .description("The input flowfile gets sent to this relationship when the query succeeds.")
@@ -102,40 +98,40 @@ public class RunMongoAggregation extends AbstractMongoProcessor {
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .build();
 
-    static {
-        List<PropertyDescriptor> _propertyDescriptors = new ArrayList<>();
-        _propertyDescriptors.addAll(descriptors);
-        _propertyDescriptors.add(CHARSET);
-        _propertyDescriptors.add(QUERY);
-        _propertyDescriptors.add(ALLOW_DISK_USE);
-        _propertyDescriptors.add(JSON_TYPE);
-        _propertyDescriptors.add(QUERY_ATTRIBUTE);
-        _propertyDescriptors.add(BATCH_SIZE);
-        _propertyDescriptors.add(RESULTS_PER_FLOWFILE);
-        _propertyDescriptors.add(DATE_FORMAT);
-        propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
+    private final static Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_RESULTS,
+            REL_ORIGINAL,
+            REL_FAILURE
+    );
 
-        final Set<Relationship> _relationships = new HashSet<>();
-        _relationships.add(REL_RESULTS);
-        _relationships.add(REL_ORIGINAL);
-        _relationships.add(REL_FAILURE);
-        relationships = Collections.unmodifiableSet(_relationships);
-    }
+    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            AbstractMongoProcessor.DESCRIPTORS.stream(),
+            Stream.of(
+                    CHARSET,
+                    QUERY,
+                    ALLOW_DISK_USE,
+                    JSON_TYPE,
+                    QUERY_ATTRIBUTE,
+                    BATCH_SIZE,
+                    RESULTS_PER_FLOWFILE,
+                    DATE_FORMAT
+            )
+    ).toList();
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     private String buildBatch(List<Document> batch) {
         String retVal;
         try {
-            retVal = objectMapper.writeValueAsString(batch.size() > 1 ? batch : batch.get(0));
+            retVal = objectMapper.writeValueAsString(batch.size() > 1 ? batch : batch.getFirst());
         } catch (Exception e) {
             retVal = null;
         }
@@ -165,7 +161,7 @@ public class RunMongoAggregation extends AbstractMongoProcessor {
         configureMapper(jsonTypeSetting, dateFormat);
 
         Map<String, String> attrs = new HashMap<>();
-        if (queryAttr != null && queryAttr.trim().length() > 0) {
+        if (queryAttr != null && !queryAttr.trim().isEmpty()) {
             attrs.put(queryAttr, query);
         }
 

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/PutMongoIT.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/PutMongoIT.java
@@ -401,14 +401,14 @@ public class PutMongoIT extends MongoWriteTestBase {
     public void testInsertOne() throws Exception {
         TestRunner runner = init(PutMongo.class);
         runner.setProperty(PutMongo.UPDATE_QUERY_KEY, "_id");
-        Document doc = DOCUMENTS.get(0);
+        Document doc = DOCUMENTS.getFirst();
         byte[] bytes = documentToByteArray(doc);
 
         runner.enqueue(bytes);
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutMongo.REL_SUCCESS, 1);
-        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_SUCCESS).get(0);
+        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_SUCCESS).getFirst();
         out.assertContentEquals(bytes);
 
         // verify 1 doc inserted into the collection
@@ -440,7 +440,7 @@ public class PutMongoIT extends MongoWriteTestBase {
         TestRunner runner = init(PutMongo.class);
         runner.setProperty(PutMongo.UPDATE_QUERY_KEY, "_id");
         // pre-insert one document
-        collection.insertOne(DOCUMENTS.get(0));
+        collection.insertOne(DOCUMENTS.getFirst());
 
         for (Document doc : DOCUMENTS) {
             runner.enqueue(documentToByteArray(doc));
@@ -449,8 +449,8 @@ public class PutMongoIT extends MongoWriteTestBase {
 
         // first doc failed, other 2 succeeded
         runner.assertTransferCount(PutMongo.REL_FAILURE, 1);
-        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_FAILURE).get(0);
-        out.assertContentEquals(documentToByteArray(DOCUMENTS.get(0)));
+        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_FAILURE).getFirst();
+        out.assertContentEquals(documentToByteArray(DOCUMENTS.getFirst()));
 
         runner.assertTransferCount(PutMongo.REL_SUCCESS, 2);
         List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(PutMongo.REL_SUCCESS);
@@ -470,7 +470,7 @@ public class PutMongoIT extends MongoWriteTestBase {
     public void testUpdateDoesNotInsert() throws Exception {
         TestRunner runner = init(PutMongo.class);
         runner.setProperty(PutMongo.UPDATE_QUERY_KEY, "_id");
-        Document doc = DOCUMENTS.get(0);
+        Document doc = DOCUMENTS.getFirst();
         byte[] bytes = documentToByteArray(doc);
 
         runner.setProperty(PutMongo.MODE, PutMongo.MODE_UPDATE);
@@ -478,7 +478,7 @@ public class PutMongoIT extends MongoWriteTestBase {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutMongo.REL_SUCCESS, 1);
-        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_SUCCESS).get(0);
+        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_SUCCESS).getFirst();
         out.assertContentEquals(bytes);
         out.assertAttributeNotExists(PutMongo.ATTRIBUTE_UPSERT_ID);
         out.assertAttributeEquals(PutMongo.ATTRIBUTE_UPDATE_MODIFY_COUNT, String.valueOf(0));
@@ -496,7 +496,7 @@ public class PutMongoIT extends MongoWriteTestBase {
     public void testUpsert() throws Exception {
         TestRunner runner = init(PutMongo.class);
         runner.setProperty(PutMongo.UPDATE_QUERY_KEY, "_id");
-        Document doc = DOCUMENTS.get(0);
+        Document doc = DOCUMENTS.getFirst();
         byte[] bytes = documentToByteArray(doc);
 
         runner.setProperty(PutMongo.MODE, PutMongo.MODE_UPDATE);
@@ -505,7 +505,7 @@ public class PutMongoIT extends MongoWriteTestBase {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutMongo.REL_SUCCESS, 1);
-        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_SUCCESS).get(0);
+        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_SUCCESS).getFirst();
         out.assertContentEquals(bytes);
 
         out.assertAttributeEquals(PutMongo.ATTRIBUTE_UPSERT_ID, doc.getString("_id"));
@@ -529,7 +529,7 @@ public class PutMongoIT extends MongoWriteTestBase {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutMongo.REL_SUCCESS, 1);
-        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_SUCCESS).get(0);
+        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_SUCCESS).getFirst();
         out.assertContentEquals(bytes);
 
         out.assertAttributeEquals(PutMongo.ATTRIBUTE_UPSERT_ID, oidDocument.getObjectId("_id").toString());
@@ -545,7 +545,7 @@ public class PutMongoIT extends MongoWriteTestBase {
     public void testUpdate() throws Exception {
         TestRunner runner = init(PutMongo.class);
         runner.setProperty(PutMongo.UPDATE_QUERY_KEY, "_id");
-        Document doc = DOCUMENTS.get(0);
+        Document doc = DOCUMENTS.getFirst();
 
         // pre-insert document
         collection.insertOne(doc);
@@ -562,7 +562,7 @@ public class PutMongoIT extends MongoWriteTestBase {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutMongo.REL_SUCCESS, 1);
-        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_SUCCESS).get(0);
+        MockFlowFile out = runner.getFlowFilesForRelationship(PutMongo.REL_SUCCESS).getFirst();
         out.assertContentEquals(bytes);
         out.assertAttributeNotExists(PutMongo.ATTRIBUTE_UPSERT_ID);
         out.assertAttributeEquals(PutMongo.ATTRIBUTE_UPDATE_MODIFY_COUNT, String.valueOf(1));

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/ConsumeMQTT.java
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/ConsumeMQTT.java
@@ -64,11 +64,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -209,7 +206,7 @@ public class ConsumeMQTT extends AbstractMQTTProcessor {
             .autoTerminateDefault(true) // to make sure flow are still valid after upgrades
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             PROP_BROKER_URI,
             PROP_MQTT_VERSION,
             PROP_USERNAME,
@@ -232,12 +229,12 @@ public class ConsumeMQTT extends AbstractMQTTProcessor {
             PROP_LAST_WILL_RETAIN,
             PROP_LAST_WILL_QOS,
             PROP_MAX_QUEUE_SIZE
-    ));
+    );
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_MESSAGE,
             REL_PARSE_FAILURE
-    )));
+    );
 
     @Override
     public void onPropertyModified(PropertyDescriptor descriptor, String oldValue, String newValue) {

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/PublishMQTT.java
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/PublishMQTT.java
@@ -55,14 +55,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static java.util.Optional.ofNullable;
 
@@ -129,7 +127,7 @@ public class PublishMQTT extends AbstractMQTTProcessor {
             .description("FlowFiles that failed to send to the destination are transferred to this relationship.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.of(
             PROP_BROKER_URI,
             PROP_MQTT_VERSION,
             PROP_USERNAME,
@@ -150,12 +148,12 @@ public class PublishMQTT extends AbstractMQTTProcessor {
             PROP_LAST_WILL_TOPIC,
             PROP_LAST_WILL_RETAIN,
             PROP_LAST_WILL_QOS
-    ));
+    ).toList();
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
-    )));
+    );
 
     static final String ATTR_PUBLISH_FAILED_INDEX_SUFFIX = ".mqtt.publish.failed.index";
     private String publishFailedIndexAttributeName;

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/PublishMQTT.java
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/PublishMQTT.java
@@ -60,7 +60,6 @@ import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
 import static java.util.Optional.ofNullable;
 
@@ -127,7 +126,7 @@ public class PublishMQTT extends AbstractMQTTProcessor {
             .description("FlowFiles that failed to send to the destination are transferred to this relationship.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             PROP_BROKER_URI,
             PROP_MQTT_VERSION,
             PROP_USERNAME,
@@ -148,7 +147,7 @@ public class PublishMQTT extends AbstractMQTTProcessor {
             PROP_LAST_WILL_TOPIC,
             PROP_LAST_WILL_RETAIN,
             PROP_LAST_WILL_QOS
-    ).toList();
+    );
 
     private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestConsumeMQTT.java
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestConsumeMQTT.java
@@ -27,7 +27,6 @@ import org.apache.nifi.processors.mqtt.common.StandardMqttMessage;
 import org.apache.nifi.provenance.ProvenanceEventRecord;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.reporting.InitializationException;
-import org.apache.nifi.security.util.TlsException;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
@@ -54,6 +53,7 @@ import static org.apache.nifi.processors.mqtt.common.MqttConstants.ALLOWABLE_VAL
 import static org.apache.nifi.processors.mqtt.common.MqttTestUtil.createJsonRecordSetReaderService;
 import static org.apache.nifi.processors.mqtt.common.MqttTestUtil.createJsonRecordSetWriterService;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -200,7 +200,7 @@ public class TestConsumeMQTT {
         assertProvenanceEvents(1);
 
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        final MockFlowFile flowFile = flowFiles.get(0);
+        final MockFlowFile flowFile = flowFiles.getFirst();
 
         flowFile.assertContentEquals("testMessage");
         flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, BROKER_URI);
@@ -245,7 +245,7 @@ public class TestConsumeMQTT {
         assertProvenanceEvents(1);
 
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        final MockFlowFile flowFile = flowFiles.get(0);
+        final MockFlowFile flowFile = flowFiles.getFirst();
 
         flowFile.assertContentEquals("testMessage");
         flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, BROKER_URI);
@@ -279,9 +279,9 @@ public class TestConsumeMQTT {
         testRunner.run(1, false, false);
 
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        assertTrue(flowFiles.size() > 0);
+        assertFalse(flowFiles.isEmpty());
         assertProvenanceEvents(flowFiles.size());
-        final MockFlowFile flowFile = flowFiles.get(0);
+        final MockFlowFile flowFile = flowFiles.getFirst();
 
         flowFile.assertContentEquals("testMessage");
         flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, BROKER_URI);
@@ -325,9 +325,9 @@ public class TestConsumeMQTT {
         testRunner.assertTransferCount(ConsumeMQTT.REL_MESSAGE, 1);
 
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        assertTrue(flowFiles.size() > 0);
+        assertFalse(flowFiles.isEmpty());
         assertProvenanceEvents(flowFiles.size());
-        final MockFlowFile flowFile = flowFiles.get(0);
+        final MockFlowFile flowFile = flowFiles.getFirst();
 
         flowFile.assertContentEquals("testMessage");
         flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, BROKER_URI);
@@ -365,7 +365,7 @@ public class TestConsumeMQTT {
         assertProvenanceEvents(flowFiles.size());
 
         if (flowFiles.size() == 1) {
-            MockFlowFile flowFile = flowFiles.get(0);
+            MockFlowFile flowFile = flowFiles.getFirst();
 
             flowFile.assertContentEquals("testMessage");
             flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, BROKER_URI);
@@ -411,7 +411,7 @@ public class TestConsumeMQTT {
         assertProvenanceEvents(1);
 
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        final MockFlowFile flowFile = flowFiles.get(0);
+        final MockFlowFile flowFile = flowFiles.getFirst();
 
         flowFile.assertContentEquals("testMessage");
         flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, BROKER_URI);
@@ -457,7 +457,7 @@ public class TestConsumeMQTT {
         assertProvenanceEvents(2);
 
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
-        final MockFlowFile flowFile = flowFiles.get(0);
+        final MockFlowFile flowFile = flowFiles.getFirst();
 
         flowFile.assertContentEquals("testMessage");
         flowFile.assertAttributeEquals(BROKER_ATTRIBUTE_KEY, BROKER_URI);
@@ -497,11 +497,11 @@ public class TestConsumeMQTT {
         assertEquals(1, flowFiles.size());
         assertEquals("[{\"name\":\"Apache NiFi\",\"_topic\":\"testTopic\",\"_qos\":0,\"_isDuplicate\":false,\"_isRetained\":false},"
                         + "{\"name\":\"Apache NiFi\",\"_topic\":\"testTopic\",\"_qos\":0,\"_isDuplicate\":false,\"_isRetained\":false}]",
-                new String(flowFiles.get(0).toByteArray()));
+                new String(flowFiles.getFirst().toByteArray()));
 
         final List<MockFlowFile> badFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_PARSE_FAILURE);
         assertEquals(1, badFlowFiles.size());
-        assertEquals(THIS_IS_NOT_JSON, new String(badFlowFiles.get(0).toByteArray()));
+        assertEquals(THIS_IS_NOT_JSON, new String(badFlowFiles.getFirst().toByteArray()));
     }
 
     @Test
@@ -534,7 +534,7 @@ public class TestConsumeMQTT {
         assertEquals("{\"name\":\"Apache NiFi\"}\\n"
                         + THIS_IS_NOT_JSON + "\\n"
                         + "{\"name\":\"Apache NiFi\"}",
-                new String(flowFiles.get(0).toByteArray()));
+                new String(flowFiles.getFirst().toByteArray()));
 
         final List<MockFlowFile> badFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_PARSE_FAILURE);
         assertEquals(0, badFlowFiles.size());
@@ -569,11 +569,11 @@ public class TestConsumeMQTT {
 
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_MESSAGE);
         assertEquals(1, flowFiles.size());
-        assertEquals("[{\"name\":\"Apache NiFi\"},{\"name\":\"Apache NiFi\"}]", new String(flowFiles.get(0).toByteArray()));
+        assertEquals("[{\"name\":\"Apache NiFi\"},{\"name\":\"Apache NiFi\"}]", new String(flowFiles.getFirst().toByteArray()));
 
         final List<MockFlowFile> badFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_PARSE_FAILURE);
         assertEquals(1, badFlowFiles.size());
-        assertEquals(THIS_IS_NOT_JSON, new String(badFlowFiles.get(0).toByteArray()));
+        assertEquals(THIS_IS_NOT_JSON, new String(badFlowFiles.getFirst().toByteArray()));
     }
 
     @Test
@@ -603,11 +603,11 @@ public class TestConsumeMQTT {
 
         final List<MockFlowFile> badFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeMQTT.REL_PARSE_FAILURE);
         assertEquals(1, badFlowFiles.size());
-        assertEquals(THIS_IS_NOT_JSON, new String(badFlowFiles.get(0).toByteArray()));
+        assertEquals(THIS_IS_NOT_JSON, new String(badFlowFiles.getFirst().toByteArray()));
     }
 
     @Test
-    public void testSslContextService() throws InitializationException, TlsException {
+    public void testSslContextService() throws InitializationException {
         testRunner = initializeTestRunner();
         testRunner.setEnvironmentVariableValue("brokerURI",  "ssl://localhost:8883");
         testRunner.setProperty(ConsumeMQTT.PROP_BROKER_URI, "${brokerURI}");
@@ -709,7 +709,7 @@ public class TestConsumeMQTT {
         assertNotNull(provenanceEvents);
         assertEquals(count, provenanceEvents.size());
         if (count > 0) {
-            assertEquals(ProvenanceEventType.RECEIVE, provenanceEvents.get(0).getEventType());
+            assertEquals(ProvenanceEventType.RECEIVE, provenanceEvents.getFirst().getEventType());
         }
     }
 

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestPublishMQTT.java
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestPublishMQTT.java
@@ -222,7 +222,7 @@ public class TestPublishMQTT {
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
         assertEquals(1, flowFiles.size());
 
-        final MockFlowFile successfulFlowFile = flowFiles.get(0);
+        final MockFlowFile successfulFlowFile = flowFiles.getFirst();
         final String publishFailedIndexAttributeName = testRunner.getProcessor().getIdentifier() + ATTR_PUBLISH_FAILED_INDEX_SUFFIX;
         assertFalse(successfulFlowFile.getAttributes().containsKey(publishFailedIndexAttributeName), "Failed attribute should not be present on the FlowFile");
     }
@@ -256,7 +256,7 @@ public class TestPublishMQTT {
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(REL_FAILURE);
         assertEquals(1, flowFiles.size());
 
-        final MockFlowFile failedFlowFile = flowFiles.get(0);
+        final MockFlowFile failedFlowFile = flowFiles.getFirst();
         final String publishFailedIndexAttributeName = testRunner.getProcessor().getIdentifier() + ATTR_PUBLISH_FAILED_INDEX_SUFFIX;
         assertEquals("1", failedFlowFile.getAttribute(publishFailedIndexAttributeName), "Only one record is expected to be published successfully.");
     }
@@ -293,7 +293,7 @@ public class TestPublishMQTT {
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(REL_FAILURE);
         assertEquals(1, flowFiles.size());
 
-        final MockFlowFile failedFlowFile = flowFiles.get(0);
+        final MockFlowFile failedFlowFile = flowFiles.getFirst();
         assertEquals("2", failedFlowFile.getAttribute(publishFailedIndexAttributeName), "Only one record is expected to be published successfully.");
     }
 
@@ -328,7 +328,7 @@ public class TestPublishMQTT {
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
         assertEquals(1, flowFiles.size());
 
-        final MockFlowFile successfulFlowFile = flowFiles.get(0);
+        final MockFlowFile successfulFlowFile = flowFiles.getFirst();
         assertNull(successfulFlowFile.getAttribute(publishFailedIndexAttributeName),
                 publishFailedIndexAttributeName + " is expected to be removed after all remaining records have been published successfully.");
     }
@@ -362,7 +362,7 @@ public class TestPublishMQTT {
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
         assertEquals(1, flowFiles.size());
 
-        final MockFlowFile successfulFlowFile = flowFiles.get(0);
+        final MockFlowFile successfulFlowFile = flowFiles.getFirst();
         final String publishFailedIndexAttributeName = testRunner.getProcessor().getIdentifier() + ATTR_PUBLISH_FAILED_INDEX_SUFFIX;
         assertFalse(successfulFlowFile.getAttributes().containsKey(publishFailedIndexAttributeName), "Failed attribute should not be present on the FlowFile");
     }
@@ -391,13 +391,13 @@ public class TestPublishMQTT {
         assertProvenanceEvent(String.format(PROVENANCE_EVENT_DETAILS_ON_DEMARCATED_MESSAGE_FAILURE, 1));
 
         verify(mqttTestClient, Mockito.times(2)).publish(any(), any());
-        verifyPublishedMessage(testInput.get(0).getBytes(), 2, false);
+        verifyPublishedMessage(testInput.getFirst().getBytes(), 2, false);
         verifyNoMorePublished();
 
         List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(REL_FAILURE);
         assertEquals(1, flowFiles.size());
 
-        final MockFlowFile failedFlowFile = flowFiles.get(0);
+        final MockFlowFile failedFlowFile = flowFiles.getFirst();
         final String publishFailedIndexAttributeName = testRunner.getProcessor().getIdentifier() + ATTR_PUBLISH_FAILED_INDEX_SUFFIX;
         assertEquals("1", failedFlowFile.getAttribute(publishFailedIndexAttributeName), "Only one record is expected to be published successfully.");
     }
@@ -435,7 +435,7 @@ public class TestPublishMQTT {
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(REL_FAILURE);
         assertEquals(1, flowFiles.size());
 
-        final MockFlowFile failedFlowFile = flowFiles.get(0);
+        final MockFlowFile failedFlowFile = flowFiles.getFirst();
         assertEquals("2", failedFlowFile.getAttribute(publishFailedIndexAttributeName), "Only one record is expected to be published successfully.");
     }
 
@@ -471,7 +471,7 @@ public class TestPublishMQTT {
         final List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
         assertEquals(1, flowFiles.size());
 
-        final MockFlowFile successfulFlowFile = flowFiles.get(0);
+        final MockFlowFile successfulFlowFile = flowFiles.getFirst();
         assertNull(successfulFlowFile.getAttribute(publishFailedIndexAttributeName),
                 publishFailedIndexAttributeName + " is expected to be removed after all remaining records have been published successfully.");
     }
@@ -495,7 +495,7 @@ public class TestPublishMQTT {
         assertNotNull(provenanceEvents);
         assertEquals(1, provenanceEvents.size());
 
-        final ProvenanceEventRecord event = provenanceEvents.get(0);
+        final ProvenanceEventRecord event = provenanceEvents.getFirst();
         assertEquals(ProvenanceEventType.SEND, event.getEventType());
 
         return event;

--- a/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/ParseNetflowv5.java
+++ b/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/ParseNetflowv5.java
@@ -46,10 +46,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -70,7 +67,7 @@ import static org.apache.nifi.processors.network.parser.Netflowv5Parser.getRecor
 public class ParseNetflowv5 extends AbstractProcessor {
     private String destination;
     // Add mapper
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public static final String FLOWFILE_CONTENT = "flowfile-content";
     public static final String FLOWFILE_ATTRIBUTE = "flowfile-attribute";
@@ -89,8 +86,15 @@ public class ParseNetflowv5 extends AbstractProcessor {
     public static final Relationship REL_SUCCESS = new Relationship.Builder().name("success")
             .description("Any FlowFile that is successfully parsed as a netflowv5 data will be transferred to this Relationship.").build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(FIELDS_DESTINATION));
-    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(REL_FAILURE, REL_ORIGINAL, REL_SUCCESS)));
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+            FIELDS_DESTINATION
+    );
+
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_FAILURE,
+            REL_ORIGINAL,
+            REL_SUCCESS
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -164,10 +168,10 @@ public class ParseNetflowv5 extends AbstractProcessor {
         FlowFile recordFlowFile = flowFile;
         int record = 0;
         while (numberOfRecords-- > 0) {
-            ObjectNode results = mapper.createObjectNode();
+            ObjectNode results = MAPPER.createObjectNode();
             // Add Port number and message format
-            results.set("port", mapper.valueToTree(parser.getPortNumber()));
-            results.set("format", mapper.valueToTree("netflowv5"));
+            results.set("port", MAPPER.valueToTree(parser.getPortNumber()));
+            results.set("format", MAPPER.valueToTree("netflowv5"));
 
             recordFlowFile = session.create(flowFile);
             // Add JSON Objects
@@ -177,7 +181,7 @@ public class ParseNetflowv5 extends AbstractProcessor {
                 @Override
                 public void process(OutputStream out) throws IOException {
                     try (OutputStream outputStream = new BufferedOutputStream(out)) {
-                        outputStream.write(mapper.writeValueAsBytes(results));
+                        outputStream.write(MAPPER.writeValueAsBytes(results));
                     }
                 }
             });
@@ -216,22 +220,22 @@ public class ParseNetflowv5 extends AbstractProcessor {
     }
 
     private void generateJSONUtil(final ObjectNode results, final Netflowv5Parser parser, final int record) {
-        final ObjectNode header = mapper.createObjectNode();
+        final ObjectNode header = MAPPER.createObjectNode();
 
         // Process KVs of the Flow Header fields
         String fieldname[] = getHeaderFields();
         Object fieldvalue[] = parser.getHeaderData();
         for (int i = 0; i < fieldname.length; i++) {
-            header.set(fieldname[i], mapper.valueToTree(fieldvalue[i]));
+            header.set(fieldname[i], MAPPER.valueToTree(fieldvalue[i]));
         }
         results.set("header", header);
 
-        final ObjectNode data = mapper.createObjectNode();
+        final ObjectNode data = MAPPER.createObjectNode();
         // Process KVs of the Flow Record fields
         fieldname = getRecordFields();
         fieldvalue = parser.getRecordData()[record];
         for (int i = 0; i < fieldname.length; i++) {
-            data.set(fieldname[i], mapper.valueToTree(fieldvalue[i]));
+            data.set(fieldname[i], MAPPER.valueToTree(fieldvalue[i]));
         }
         results.set("record", data);
     }

--- a/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/pcap/SplitPCAP.java
+++ b/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/pcap/SplitPCAP.java
@@ -111,9 +111,15 @@ public class SplitPCAP extends AbstractProcessor {
             .description("The individual PCAP 'segments' of the original PCAP FlowFile will be routed to this relationship.")
             .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(PCAP_MAX_SIZE);
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            PCAP_MAX_SIZE
+    );
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_ORIGINAL, REL_FAILURE, REL_SPLIT);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_ORIGINAL,
+            REL_FAILURE,
+            REL_SPLIT
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -122,7 +128,7 @@ public class SplitPCAP extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/test/java/org/apache/nifi/processors/network/TestParseNetflowv5.java
+++ b/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/test/java/org/apache/nifi/processors/network/TestParseNetflowv5.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.processors.network;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.nifi.util.MockFlowFile;
@@ -32,12 +31,12 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestParseNetflowv5 {
-    private static final byte sample1[] = {
+    private static final byte[] sample1 = {
             // Header
             0, 5, 0, 1, 4, -48, 19, 36, 88, 71, -44, 73, 0, 0, 0, 0, 0, 0, 17, -22, 0, 0, 0, 0,
             // Record 1
             10, 0, 0, 2, 10, 0, 0, 3, 0, 0, 0, 0, 0, 3, 0, 5, 0, 0, 0, 1, 0, 0, 0, 64, 4, -49, 40, -60, 4, -48, 19, 36, 16, -110, 0, 80, 0, 0, 17, 1, 0, 2, 0, 3, 32, 31, 0, 0 };
-    private static final byte sample2[] = {
+    private static final byte[] sample2 = {
             // Header
             0, 5, 0, 3, 4, -48, 19, 36, 88, 71, -44, 73, 0, 0, 0, 0, 0, 0, 17, -22, 0, 0, 0, 0,
             // Record 1
@@ -61,13 +60,13 @@ public class TestParseNetflowv5 {
 
         runner.assertTransferCount(ParseNetflowv5.REL_SUCCESS, 1);
         runner.assertTransferCount(ParseNetflowv5.REL_ORIGINAL, 1);
-        final MockFlowFile mff = runner.getFlowFilesForRelationship(ParseNetflowv5.REL_SUCCESS).get(0);
+        final MockFlowFile mff = runner.getFlowFilesForRelationship(ParseNetflowv5.REL_SUCCESS).getFirst();
         mff.assertAttributeEquals("netflowv5.record.dPkts", "1");
         mff.assertAttributeEquals("netflowv5.record.dOctets", "64");
     }
 
     @Test
-    public void testSuccessfulParseToAttributesMultipleRecords() throws IOException {
+    public void testSuccessfulParseToAttributesMultipleRecords() {
         final TestRunner runner = TestRunners.newTestRunner(new ParseNetflowv5());
         runner.setProperty(ParseNetflowv5.FIELDS_DESTINATION, ParseNetflowv5.DESTINATION_ATTRIBUTES);
         runner.enqueue(sample2);
@@ -94,7 +93,7 @@ public class TestParseNetflowv5 {
 
         runner.assertTransferCount(ParseNetflowv5.REL_SUCCESS, 1);
         runner.assertTransferCount(ParseNetflowv5.REL_ORIGINAL, 1);
-        final MockFlowFile mff = runner.getFlowFilesForRelationship(ParseNetflowv5.REL_SUCCESS).get(0);
+        final MockFlowFile mff = runner.getFlowFilesForRelationship(ParseNetflowv5.REL_SUCCESS).getFirst();
 
         byte[] rawJson = mff.toByteArray();
         JsonNode record = new ObjectMapper().readTree(rawJson).get("record");
@@ -137,7 +136,7 @@ public class TestParseNetflowv5 {
     }
 
     @Test
-    public void testReadUDPPort() throws JsonProcessingException, IOException {
+    public void testReadUDPPort() throws IOException {
         final TestRunner runner = TestRunners.newTestRunner(new ParseNetflowv5());
         runner.setProperty(ParseNetflowv5.FIELDS_DESTINATION, ParseNetflowv5.DESTINATION_CONTENT);
         final Map<String, String> attributes = new HashMap<>();
@@ -147,7 +146,7 @@ public class TestParseNetflowv5 {
 
         runner.assertTransferCount(ParseNetflowv5.REL_SUCCESS, 1);
         runner.assertTransferCount(ParseNetflowv5.REL_ORIGINAL, 1);
-        final MockFlowFile mff = runner.getFlowFilesForRelationship(ParseNetflowv5.REL_SUCCESS).get(0);
+        final MockFlowFile mff = runner.getFlowFilesForRelationship(ParseNetflowv5.REL_SUCCESS).getFirst();
 
         byte[] rawJson = mff.toByteArray();
         JsonNode results = new ObjectMapper().readTree(rawJson);

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/DecryptContentPGP.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/DecryptContentPGP.java
@@ -67,7 +67,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -127,9 +126,12 @@ public class DecryptContentPGP extends AbstractProcessor {
             .identifiesControllerService(PGPPrivateKeyService.class)
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = new HashSet<>(Arrays.asList(SUCCESS, FAILURE));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = Arrays.asList(
+    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
             DECRYPTION_STRATEGY,
             PASSPHRASE,
             PRIVATE_KEY_SERVICE

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/EncryptContentPGP.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/EncryptContentPGP.java
@@ -65,10 +65,8 @@ import java.io.OutputStream;
 import java.io.PushbackInputStream;
 import java.security.SecureRandom;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -150,9 +148,12 @@ public class EncryptContentPGP extends AbstractProcessor {
     /** Disable Compression as recommended in OpenPGP refreshed specification */
     private static final CompressionAlgorithm COMPRESSION_DISABLED = CompressionAlgorithm.UNCOMPRESSED;
 
-    private static final Set<Relationship> RELATIONSHIPS = new HashSet<>(Arrays.asList(SUCCESS, FAILURE));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = Arrays.asList(
+    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
             SYMMETRIC_KEY_ALGORITHM,
             FILE_ENCODING,
             PASSPHRASE,

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/SignContentPGP.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/SignContentPGP.java
@@ -55,7 +55,6 @@ import java.io.OutputStream;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -139,9 +138,12 @@ public class SignContentPGP extends AbstractProcessor {
             .required(true)
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = new HashSet<>(Arrays.asList(SUCCESS, FAILURE));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = Arrays.asList(
+    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
             FILE_ENCODING,
             HASH_ALGORITHM,
             SIGNING_STRATEGY,

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/VerifyContentPGP.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/VerifyContentPGP.java
@@ -49,10 +49,7 @@ import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentVerifierBuilderProv
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -97,9 +94,12 @@ public class VerifyContentPGP extends AbstractProcessor {
             .required(true)
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = new HashSet<>(Arrays.asList(SUCCESS, FAILURE));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = Collections.singletonList(
+    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
             PUBLIC_KEY_SERVICE
     );
 

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/EncryptContentPGPTest.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/EncryptContentPGPTest.java
@@ -267,7 +267,7 @@ public class EncryptContentPGPTest {
 
     private void assertSuccess(final PGPPrivateKey privateKey, final DecryptionStrategy decryptionStrategy, final byte[] expected) throws IOException, PGPException {
         runner.assertAllFlowFilesTransferred(EncryptContentPGP.SUCCESS);
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(EncryptContentPGP.SUCCESS).iterator().next();
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(EncryptContentPGP.SUCCESS).getFirst();
         assertAttributesFound(DEFAULT_SYMMETRIC_KEY_ALGORITHM, flowFile);
 
         final PGPEncryptedDataList encryptedDataList = getEncryptedDataList(flowFile);
@@ -283,7 +283,7 @@ public class EncryptContentPGPTest {
 
     private void assertSuccess(final SymmetricKeyAlgorithm symmetricKeyAlgorithm, final char[] passphrase) throws IOException, PGPException {
         runner.assertAllFlowFilesTransferred(EncryptContentPGP.SUCCESS);
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(EncryptContentPGP.SUCCESS).iterator().next();
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(EncryptContentPGP.SUCCESS).getFirst();
         assertAttributesFound(symmetricKeyAlgorithm, flowFile);
 
         final PGPEncryptedDataList encryptedDataList = getEncryptedDataList(flowFile);
@@ -353,8 +353,7 @@ public class EncryptContentPGPTest {
             if (object instanceof PGPLiteralData) {
                 literalData = (PGPLiteralData) object;
                 break;
-            } else if (object instanceof PGPCompressedData) {
-                final PGPCompressedData compressedData = (PGPCompressedData) object;
+            } else if (object instanceof PGPCompressedData compressedData) {
                 final PGPObjectFactory compressedObjectFactory = new JcaPGPObjectFactory(compressedData.getDataStream());
                 literalData = getLiteralData(compressedObjectFactory);
                 break;

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/VerifyContentPGPTest.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/VerifyContentPGPTest.java
@@ -106,7 +106,7 @@ public class VerifyContentPGPTest {
         runner.run();
 
         assertFailureErrorLogged();
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(VerifyContentPGP.FAILURE).iterator().next();
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(VerifyContentPGP.FAILURE).getFirst();
         flowFile.assertContentEquals(DATA);
     }
 
@@ -121,7 +121,7 @@ public class VerifyContentPGPTest {
         runner.run();
 
         assertFailureErrorLogged();
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(VerifyContentPGP.FAILURE).iterator().next();
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(VerifyContentPGP.FAILURE).getFirst();
         flowFile.assertContentEquals(signed);
         assertFlowFileAttributesFound(flowFile);
     }
@@ -158,7 +158,7 @@ public class VerifyContentPGPTest {
 
     private MockFlowFile assertSuccess() throws PGPException {
         runner.assertAllFlowFilesTransferred(VerifyContentPGP.SUCCESS);
-        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(VerifyContentPGP.SUCCESS).iterator().next();
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(VerifyContentPGP.SUCCESS).getFirst();
         assertFlowFileAttributesFound(flowFile);
         return flowFile;
     }

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/processors/excel/SplitExcel.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/processors/excel/SplitExcel.java
@@ -109,8 +109,17 @@ public class SplitExcel extends AbstractProcessor {
             .description("The individual Excel 'segments' of the original Excel FlowFile will be routed to this relationship.")
             .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(PROTECTION_TYPE, PASSWORD);
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_ORIGINAL, REL_FAILURE, REL_SPLIT);
+    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+            PROTECTION_TYPE,
+            PASSWORD
+    );
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_ORIGINAL,
+            REL_FAILURE,
+            REL_SPLIT
+    );
+
     private static final CellCopyPolicy CELL_COPY_POLICY = new CellCopyPolicy.Builder()
             .cellFormula(false) // NOTE: setting to false allows for copying the evaluated formula value.
             .cellStyle(false) // NOTE: setting to false avoids exceeding the maximum number of cell styles (64000) in a .xlsx Workbook.

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/processor/TestPutRedisHashRecord.java
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/processor/TestPutRedisHashRecord.java
@@ -46,14 +46,13 @@ import static org.mockito.Mockito.when;
 class TestPutRedisHashRecord {
 
     private TestRunner runner;
-    private PutRedisHashRecord processor;
     private MockRecordParser parser;
 
     private MockRedisConnectionPoolService connectionPoolService;
 
     @BeforeEach
     public void setup() throws Exception {
-        processor = new PutRedisHashRecord();
+        PutRedisHashRecord processor = new PutRedisHashRecord();
         runner = TestRunners.newTestRunner(processor);
         parser = new MockRecordParser();
         runner.addControllerService("parser", parser);
@@ -91,7 +90,7 @@ class TestPutRedisHashRecord {
         runner.assertAllFlowFilesTransferred(PutRedisHashRecord.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(PutRedisHashRecord.REL_SUCCESS);
         assertEquals(1, result.size());
-        MockFlowFile ff = result.get(0);
+        MockFlowFile ff = result.getFirst();
         ff.assertAttributeEquals(PutRedisHashRecord.SUCCESS_RECORD_COUNT, "3");
         // Verify the content is untouched
         ff.assertContentEquals("hello");
@@ -116,7 +115,7 @@ class TestPutRedisHashRecord {
         runner.assertAllFlowFilesTransferred(PutRedisHashRecord.REL_FAILURE, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(PutRedisHashRecord.REL_FAILURE);
         assertEquals(1, result.size());
-        MockFlowFile ff = result.get(0);
+        MockFlowFile ff = result.getFirst();
         ff.assertAttributeEquals(PutRedisHashRecord.SUCCESS_RECORD_COUNT, "1");
         // Verify the content is untouched
         ff.assertContentEquals("hello");
@@ -140,7 +139,7 @@ class TestPutRedisHashRecord {
         runner.assertAllFlowFilesTransferred(PutRedisHashRecord.REL_FAILURE, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(PutRedisHashRecord.REL_FAILURE);
         assertEquals(1, result.size());
-        MockFlowFile ff = result.get(0);
+        MockFlowFile ff = result.getFirst();
         ff.assertAttributeEquals(PutRedisHashRecord.SUCCESS_RECORD_COUNT, "0");
         // Verify the content is untouched
         ff.assertContentEquals("hello");
@@ -164,7 +163,7 @@ class TestPutRedisHashRecord {
         runner.assertAllFlowFilesTransferred(PutRedisHashRecord.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(PutRedisHashRecord.REL_SUCCESS);
         assertEquals(1, result.size());
-        MockFlowFile ff = result.get(0);
+        MockFlowFile ff = result.getFirst();
         // Both records are transferred successfully, but the null value was not put into Redis
         ff.assertAttributeEquals(PutRedisHashRecord.SUCCESS_RECORD_COUNT, "2");
         // Verify the content is untouched

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/PutSalesforceObject.java
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/PutSalesforceObject.java
@@ -50,9 +50,6 @@ import org.apache.nifi.serialization.record.RecordSchema;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -94,18 +91,18 @@ public class PutSalesforceObject extends AbstractProcessor {
             .description("For FlowFiles created as a result of an execution error.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             SALESFORCE_INSTANCE_URL,
             API_VERSION,
             READ_TIMEOUT,
             TOKEN_PROVIDER,
             RECORD_READER_FACTORY
-    ));
+    );
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
-    )));
+    );
 
     private volatile SalesforceRestClient salesforceRestClient;
     private volatile int maxRecordCount;

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/QuerySalesforceObject.java
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/QuerySalesforceObject.java
@@ -85,7 +85,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -96,6 +95,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.nifi.processors.salesforce.util.CommonSalesforceProperties.API_VERSION;
 import static org.apache.nifi.processors.salesforce.util.CommonSalesforceProperties.READ_TIMEOUT;
@@ -307,7 +307,7 @@ public class QuerySalesforceObject extends AbstractProcessor {
         salesforceRestService = new SalesforceRestClient(salesforceConfiguration);
     }
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.of(
             SALESFORCE_INSTANCE_URL,
             API_VERSION,
             QUERY_TYPE,
@@ -323,11 +323,13 @@ public class QuerySalesforceObject extends AbstractProcessor {
             READ_TIMEOUT,
             CREATE_ZERO_RECORD_FILES,
             TOKEN_PROVIDER
-    ));
+    ).toList();
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            REL_SUCCESS, REL_FAILURE, REL_ORIGINAL
-    )));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_ORIGINAL
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/QuerySalesforceObject.java
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/QuerySalesforceObject.java
@@ -95,7 +95,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.apache.nifi.processors.salesforce.util.CommonSalesforceProperties.API_VERSION;
 import static org.apache.nifi.processors.salesforce.util.CommonSalesforceProperties.READ_TIMEOUT;
@@ -307,7 +306,7 @@ public class QuerySalesforceObject extends AbstractProcessor {
         salesforceRestService = new SalesforceRestClient(salesforceConfiguration);
     }
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             SALESFORCE_INSTANCE_URL,
             API_VERSION,
             QUERY_TYPE,
@@ -323,7 +322,7 @@ public class QuerySalesforceObject extends AbstractProcessor {
             READ_TIMEOUT,
             CREATE_ZERO_RECORD_FILES,
             TOKEN_PROVIDER
-    ).toList();
+    );
 
     private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ExecuteScript.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ExecuteScript.java
@@ -59,7 +59,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -93,6 +92,11 @@ public class ExecuteScript extends AbstractSessionFactoryProcessor implements Se
     public static final Relationship REL_SUCCESS = ScriptingComponentUtils.REL_SUCCESS;
     public static final Relationship REL_FAILURE = ScriptingComponentUtils.REL_FAILURE;
 
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
+
     private volatile String scriptToRun = null;
     volatile ScriptingComponentHelper scriptingComponentHelper = new ScriptingComponentHelper();
 
@@ -104,10 +108,7 @@ public class ExecuteScript extends AbstractSessionFactoryProcessor implements Se
      */
     @Override
     public Set<Relationship> getRelationships() {
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_FAILURE);
-        return Collections.unmodifiableSet(relationships);
+        return RELATIONSHIPS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedFilterRecord.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedFilterRecord.java
@@ -21,7 +21,6 @@ import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.processor.Relationship;
 
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -58,13 +57,11 @@ public class ScriptedFilterRecord extends ScriptedRouterProcessor<Boolean> {
             .description("In case of any issue during processing the incoming FlowFile, the incoming FlowFile will be routed to this relationship.")
             .build();
 
-    private static Set<Relationship> RELATIONSHIPS = new HashSet<>();
-
-    static {
-        RELATIONSHIPS.add(RELATIONSHIP_ORIGINAL);
-        RELATIONSHIPS.add(RELATIONSHIP_FAILURE);
-        RELATIONSHIPS.add(RELATIONSHIP_SUCCESS);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            RELATIONSHIP_ORIGINAL,
+            RELATIONSHIP_FAILURE,
+            RELATIONSHIP_SUCCESS
+    );
 
     public ScriptedFilterRecord() {
         super(Boolean.class);

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedPartitionRecord.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedPartitionRecord.java
@@ -51,7 +51,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -95,13 +94,11 @@ public class ScriptedPartitionRecord extends ScriptedRecordProcessor {
                     + "the unchanged FlowFile will be routed to this relationship")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = new HashSet<>();
-
-    static {
-        RELATIONSHIPS.add(RELATIONSHIP_ORIGINAL);
-        RELATIONSHIPS.add(RELATIONSHIP_SUCCESS);
-        RELATIONSHIPS.add(RELATIONSHIP_FAILURE);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            RELATIONSHIP_ORIGINAL,
+            RELATIONSHIP_SUCCESS,
+            RELATIONSHIP_FAILURE
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -121,7 +118,7 @@ public class ScriptedPartitionRecord extends ScriptedRecordProcessor {
         }
 
         final ScriptRunner scriptRunner = pollScriptRunner();
-        boolean success = false;
+        boolean success;
 
         try {
             final ScriptEvaluator evaluator;

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedRecordProcessor.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedRecordProcessor.java
@@ -43,7 +43,6 @@ import javax.script.SimpleBindings;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -81,7 +80,7 @@ abstract class ScriptedRecordProcessor extends AbstractProcessor implements Sear
             .required(true)
             .build();
 
-    protected static final List<PropertyDescriptor> DESCRIPTORS = Arrays.asList(
+    protected static final List<PropertyDescriptor> DESCRIPTORS = List.of(
             RECORD_READER,
             RECORD_WRITER,
             LANGUAGE,

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedTransformRecord.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedTransformRecord.java
@@ -48,9 +48,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -88,12 +86,14 @@ public class ScriptedTransformRecord extends ScriptedRecordProcessor {
         .description("Any FlowFile that cannot be transformed will be routed to this Relationship")
         .build();
 
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
+
     @Override
     public Set<Relationship> getRelationships() {
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_FAILURE);
-        return Collections.unmodifiableSet(relationships);
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedValidateRecord.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedValidateRecord.java
@@ -21,7 +21,6 @@ import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.processor.Relationship;
 
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -65,14 +64,12 @@ public class ScriptedValidateRecord extends ScriptedRouterProcessor<Boolean> {
             .description("In case of any issue during processing the incoming flow file, the incoming FlowFile will be routed to this relationship.")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = new HashSet<>();
-
-    static {
-        RELATIONSHIPS.add(RELATIONSHIP_VALID);
-        RELATIONSHIPS.add(RELATIONSHIP_INVALID);
-        RELATIONSHIPS.add(RELATIONSHIP_ORIGINAL);
-        RELATIONSHIPS.add(RELATIONSHIP_FAILURE);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            RELATIONSHIP_VALID,
+            RELATIONSHIP_INVALID,
+            RELATIONSHIP_ORIGINAL,
+            RELATIONSHIP_FAILURE
+    );
 
     public ScriptedValidateRecord() {
         super(Boolean.class);

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/BaseScriptTest.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/BaseScriptTest.java
@@ -49,7 +49,7 @@ public abstract class BaseScriptTest {
         FileUtils.copyDirectory(new File("src/test/resources"), new File("target/test/resources"));
     }
 
-    public void setupExecuteScript() throws Exception {
+    public void setupExecuteScript() {
         final ExecuteScript executeScript = new AccessibleExecuteScript();
         // Need to do something to initialize the properties, like retrieve the list of properties
         assertNotNull(executeScript.getSupportedPropertyDescriptors());
@@ -57,7 +57,7 @@ public abstract class BaseScriptTest {
         scriptingComponent = (AccessibleScriptingComponentHelper) executeScript;
     }
 
-    public void setupInvokeScriptProcessor() throws Exception {
+    public void setupInvokeScriptProcessor() {
         final InvokeScriptedProcessor invokeScriptedProcessor = new AccessibleInvokeScriptedProcessor();
         // Need to do something to initialize the properties, like retrieve the list of properties
         assertNotNull(invokeScriptedProcessor.getSupportedPropertyDescriptors());

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/ExecuteScriptGroovyTest.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/ExecuteScriptGroovyTest.java
@@ -47,7 +47,7 @@ class ExecuteScriptGroovyTest extends BaseScriptTest {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS).getFirst();
         flowFile.assertAttributeExists("time-updated");
         flowFile.assertAttributeExists("thread");
         assertTrue(SINGLE_POOL_THREAD_PATTERN.matcher(flowFile.getAttribute("thread")).find());
@@ -95,7 +95,7 @@ class ExecuteScriptGroovyTest extends BaseScriptTest {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS).getFirst();
         flowFile.assertAttributeExists("greeting");
         flowFile.assertAttributeEquals("greeting", "hello");
         runner.clearTransferState();
@@ -105,7 +105,7 @@ class ExecuteScriptGroovyTest extends BaseScriptTest {
         runner.run();
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
-        flowFile = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS).get(0);
+        flowFile = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS).getFirst();
         flowFile.assertAttributeExists("greeting");
         flowFile.assertAttributeEquals("greeting", "good-bye");
     }

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteClojure.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteClojure.java
@@ -29,9 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestExecuteClojure extends BaseScriptTest {
 
-    public final String TEST_CSV_DATA = "gender,title,first,last\n"
-            + "female,miss,marlene,shaw\n"
-            + "male,mr,todd,graham";
+    public final String TEST_CSV_DATA = """
+            gender,title,first,last
+            female,miss,marlene,shaw
+            male,mr,todd,graham""";
 
     @BeforeEach
     public void setup() throws Exception {
@@ -41,10 +42,9 @@ public class TestExecuteClojure extends BaseScriptTest {
     /**
      * Tests a script file that has provides the body of an onTrigger() function.
      *
-     * @throws Exception Any error encountered while testing
      */
     @Test
-    public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptFile() throws Exception {
+    public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptFile() {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Clojure");
         runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "clojure/test_onTrigger.clj");
@@ -56,16 +56,15 @@ public class TestExecuteClojure extends BaseScriptTest {
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS);
-        result.get(0).assertAttributeEquals("from-content", "test content");
+        result.getFirst().assertAttributeEquals("from-content", "test content");
     }
 
     /**
      * Tests a script file that has provides the body of an onTrigger() function.
      *
-     * @throws Exception Any error encountered while testing
      */
     @Test
-    public void testNoIncomingFlowFile() throws Exception {
+    public void testNoIncomingFlowFile() {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Clojure");
         runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "clojure/test_onTrigger.clj");
@@ -81,10 +80,9 @@ public class TestExecuteClojure extends BaseScriptTest {
     /**
      * Tests a script file that creates and transfers a new flow file.
      *
-     * @throws Exception Any error encountered while testing
      */
     @Test
-    public void testCreateNewFlowFileWithScriptFile() throws Exception {
+    public void testCreateNewFlowFileWithScriptFile() {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Clojure");
         runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "clojure/test_onTrigger_newFlowFile.clj");
@@ -98,17 +96,16 @@ public class TestExecuteClojure extends BaseScriptTest {
         assertEquals(1, runner.getRemovedCount());
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS);
-        result.get(0).assertAttributeEquals("selected.columns", "title,first");
-        result.get(0).assertAttributeEquals("filename", "split_cols.txt");
+        result.getFirst().assertAttributeEquals("selected.columns", "title,first");
+        result.getFirst().assertAttributeEquals("filename", "split_cols.txt");
     }
 
     /**
      * Tests a script file that uses dynamic properties defined on the processor.
      *
-     * @throws Exception Any error encountered while testing
      */
     @Test
-    public void testDynamicProperties() throws Exception {
+    public void testDynamicProperties() {
         runner.setValidateExpressionUsage(true);
         runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Clojure");
         runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "clojure/test_dynamicProperties.clj");
@@ -120,6 +117,6 @@ public class TestExecuteClojure extends BaseScriptTest {
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS);
-        result.get(0).assertAttributeEquals("from-content", "testValue");
+        result.getFirst().assertAttributeEquals("from-content", "testValue");
     }
 }

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteGroovy.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestExecuteGroovy.java
@@ -32,9 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestExecuteGroovy extends BaseScriptTest {
 
-    private final String TEST_CSV_DATA = "gender,title,first,last\n"
-            + "female,miss,marlene,shaw\n"
-            + "male,mr,todd,graham";
+    private final String TEST_CSV_DATA = """
+            gender,title,first,last
+            female,miss,marlene,shaw
+            male,mr,todd,graham""";
 
     @BeforeEach
     public void setup() throws Exception {
@@ -44,10 +45,9 @@ public class TestExecuteGroovy extends BaseScriptTest {
     /**
      * Tests a script file that has provides the body of an onTrigger() function.
      *
-     * @throws Exception Any error encountered while testing
      */
     @Test
-    public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptFile() throws Exception {
+    public void testReadFlowFileContentAndStoreInFlowFileAttributeWithScriptFile() {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
         runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
@@ -59,16 +59,15 @@ public class TestExecuteGroovy extends BaseScriptTest {
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS);
-        result.get(0).assertAttributeEquals("from-content", "test content");
+        result.getFirst().assertAttributeEquals("from-content", "test content");
     }
 
     /**
      * Tests a script file that has provides the body of an onTrigger() function.
      *
-     * @throws Exception Any error encountered while testing
      */
     @Test
-    public void testNoIncomingFlowFile() throws Exception {
+    public void testNoIncomingFlowFile() {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(scriptingComponent.getScriptingComponentHelper().SCRIPT_ENGINE, "Groovy");
         runner.setProperty(ScriptingComponentUtils.SCRIPT_FILE, TEST_RESOURCE_LOCATION + "groovy/test_onTrigger.groovy");
@@ -114,7 +113,7 @@ public class TestExecuteGroovy extends BaseScriptTest {
         assertEquals(1, runner.getRemovedCount());
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS);
-        result.get(0).assertAttributeEquals("filename", "split_cols.txt");
+        result.getFirst().assertAttributeEquals("filename", "split_cols.txt");
     }
 
     /**
@@ -134,7 +133,7 @@ public class TestExecuteGroovy extends BaseScriptTest {
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS);
-        result.get(0).assertAttributeEquals("filename", "newfile");
+        result.getFirst().assertAttributeEquals("filename", "newfile");
     }
 
     /**
@@ -154,7 +153,7 @@ public class TestExecuteGroovy extends BaseScriptTest {
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS);
-        result.get(0).assertAttributeEquals("from-content", "testValue");
+        result.getFirst().assertAttributeEquals("from-content", "testValue");
     }
 
     /**
@@ -174,7 +173,7 @@ public class TestExecuteGroovy extends BaseScriptTest {
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS);
-        MockFlowFile resultFile = result.get(0);
+        MockFlowFile resultFile = result.getFirst();
         resultFile.assertAttributeEquals("selected.columns", "first,last");
         resultFile.assertContentEquals("Marlene Shaw\nTodd Graham\n");
     }
@@ -199,7 +198,7 @@ public class TestExecuteGroovy extends BaseScriptTest {
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS);
-        result.get(0).assertAttributeEquals("from-content", "test content");
+        result.getFirst().assertAttributeEquals("from-content", "test content");
     }
 
     /**
@@ -220,7 +219,7 @@ public class TestExecuteGroovy extends BaseScriptTest {
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS);
-        result.get(0).assertAttributeEquals("from-content", "test content");
+        result.getFirst().assertAttributeEquals("from-content", "test content");
     }
 
     /**
@@ -259,7 +258,7 @@ public class TestExecuteGroovy extends BaseScriptTest {
 
         runner.assertAllFlowFilesTransferred(ExecuteScript.REL_SUCCESS, 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteScript.REL_SUCCESS);
-        result.get(0).assertAttributeEquals("from-content", "test content");
+        result.getFirst().assertAttributeEquals("from-content", "test content");
     }
 
     /**

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeGroovy.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestInvokeGroovy.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestInvokeGroovy extends BaseScriptTest {
     @BeforeEach
-    public void setup() throws Exception {
+    public void setup() {
         super.setupInvokeScriptProcessor();
     }
 
@@ -67,7 +67,7 @@ public class TestInvokeGroovy extends BaseScriptTest {
 
         runner.assertAllFlowFilesTransferred("test", 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship("test");
-        result.get(0).assertAttributeEquals("from-content", "test content");
+        result.getFirst().assertAttributeEquals("from-content", "test content");
     }
 
     /**
@@ -92,7 +92,7 @@ public class TestInvokeGroovy extends BaseScriptTest {
 
         List<PropertyDescriptor> descriptors = processor.getSupportedPropertyDescriptors();
         assertNotNull(descriptors);
-        assertTrue(descriptors.size() > 0);
+        assertFalse(descriptors.isEmpty());
         boolean found = false;
         for (PropertyDescriptor descriptor : descriptors) {
             if (descriptor.getName().equals("test-attribute")) {
@@ -124,7 +124,7 @@ public class TestInvokeGroovy extends BaseScriptTest {
 
         Set<Relationship> relationships = processor.getRelationships();
         assertNotNull(relationships);
-        assertTrue(relationships.size() > 0);
+        assertFalse(relationships.isEmpty());
         boolean found = false;
         for (Relationship relationship : relationships) {
             if (relationship.getName().equals("test")) {
@@ -202,7 +202,7 @@ public class TestInvokeGroovy extends BaseScriptTest {
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship("success");
         assertEquals(1, result.size());
         final String expectedOutput = new String(Hex.encodeHex(MessageDigestUtils.getDigest("testbla bla".getBytes())));
-        final MockFlowFile outputFlowFile = result.get(0);
+        final MockFlowFile outputFlowFile = result.getFirst();
         outputFlowFile.assertContentEquals(expectedOutput);
         outputFlowFile.assertAttributeEquals("outAttr", expectedOutput);
     }
@@ -237,7 +237,7 @@ public class TestInvokeGroovy extends BaseScriptTest {
         runner.assertAllFlowFilesTransferred("success", 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship("success");
         assertEquals(1, result.size());
-        MockFlowFile ff = result.get(0);
+        MockFlowFile ff = result.getFirst();
         ff.assertContentEquals("48\n47\n14\n");
     }
 

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedFilterRecord.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedFilterRecord.java
@@ -100,7 +100,7 @@ public class TestScriptedFilterRecord extends TestScriptedRouterProcessor {
 
     private void thenMatchingFlowFileContains(final Object[]... records) {
         testRunner.assertTransferCount(ScriptedFilterRecord.RELATIONSHIP_SUCCESS, 1);
-        final MockFlowFile resultFlowFile = testRunner.getFlowFilesForRelationship(ScriptedFilterRecord.RELATIONSHIP_SUCCESS).get(0);
+        final MockFlowFile resultFlowFile = testRunner.getFlowFilesForRelationship(ScriptedFilterRecord.RELATIONSHIP_SUCCESS).getFirst();
         assertEquals(givenExpectedFlowFile(records), resultFlowFile.getContent());
         assertEquals("text/plain", resultFlowFile.getAttribute("mime.type"));
 

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedRouterProcessor.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedRouterProcessor.java
@@ -78,13 +78,13 @@ abstract class TestScriptedRouterProcessor {
     protected void thenIncomingFlowFileIsRoutedToOriginal() {
         testRunner.assertTransferCount(getOriginalRelationship(), 1);
         testRunner.assertTransferCount(getFailedRelationship(), 0);
-        assertEquals(incomingFlowFileContent, testRunner.getFlowFilesForRelationship(getOriginalRelationship()).get(0).getContent());
+        assertEquals(incomingFlowFileContent, testRunner.getFlowFilesForRelationship(getOriginalRelationship()).getFirst().getContent());
     }
 
     protected void thenIncomingFlowFileIsRoutedToFailed() {
         testRunner.assertTransferCount(getOriginalRelationship(), 0);
         testRunner.assertTransferCount(getFailedRelationship(), 1);
-        assertEquals(incomingFlowFileContent, testRunner.getFlowFilesForRelationship(getFailedRelationship()).get(0).getContent());
+        assertEquals(incomingFlowFileContent, testRunner.getFlowFilesForRelationship(getFailedRelationship()).getFirst().getContent());
     }
 
     /**

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedTransformRecord.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedTransformRecord.java
@@ -72,7 +72,7 @@ public class TestScriptedTransformRecord {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ScriptedTransformRecord.REL_SUCCESS, 1);
 
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).getFirst();
         out.assertAttributeEquals("record.count", "3");
         assertEquals(3, testRunner.getCounterValue("Records Transformed").intValue());
         assertEquals(0, testRunner.getCounterValue("Records Dropped").intValue());
@@ -103,7 +103,7 @@ public class TestScriptedTransformRecord {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ScriptedTransformRecord.REL_SUCCESS, 1);
 
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).getFirst();
         out.assertAttributeEquals("record.count", "3");
         assertEquals(3, testRunner.getCounterValue("Records Transformed").intValue());
         assertEquals(0, testRunner.getCounterValue("Records Dropped").intValue());
@@ -128,7 +128,7 @@ public class TestScriptedTransformRecord {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ScriptedTransformRecord.REL_SUCCESS, 1);
 
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).getFirst();
         out.assertAttributeEquals("record.count", "0");
         assertEquals(0, testRunner.getCounterValue("Records Transformed").intValue());
         assertEquals(0, testRunner.getCounterValue("Records Dropped").intValue());
@@ -152,7 +152,7 @@ public class TestScriptedTransformRecord {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ScriptedTransformRecord.REL_SUCCESS, 1);
 
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).getFirst();
         out.assertAttributeEquals("record.count", "0");
         assertEquals(0, testRunner.getCounterValue("Records Transformed").intValue());
         assertEquals(3, testRunner.getCounterValue("Records Dropped").intValue());
@@ -179,7 +179,7 @@ public class TestScriptedTransformRecord {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ScriptedTransformRecord.REL_SUCCESS, 1);
 
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).getFirst();
         out.assertAttributeEquals("record.count", "9");
         assertEquals(3, testRunner.getCounterValue("Records Transformed").intValue());
         assertEquals(0, testRunner.getCounterValue("Records Dropped").intValue());
@@ -212,7 +212,7 @@ public class TestScriptedTransformRecord {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ScriptedTransformRecord.REL_SUCCESS, 1);
 
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).getFirst();
         out.assertAttributeEquals("record.count", "6");
         assertEquals(3, testRunner.getCounterValue("Records Transformed").intValue());
         assertEquals(0, testRunner.getCounterValue("Records Dropped").intValue());
@@ -243,7 +243,7 @@ public class TestScriptedTransformRecord {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ScriptedTransformRecord.REL_FAILURE, 1);
 
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_FAILURE).get(0);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_FAILURE).getFirst();
         out.assertAttributeNotExists("record.count");
         assertNull(testRunner.getCounterValue("Records Transformed"));
         assertNull(testRunner.getCounterValue("Records Dropped"));
@@ -272,7 +272,7 @@ public class TestScriptedTransformRecord {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ScriptedTransformRecord.REL_SUCCESS, 1);
 
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).getFirst();
         out.assertAttributeEquals("record.count", "3");
         assertEquals(3, testRunner.getCounterValue("Records Transformed").intValue());
         assertEquals(0, testRunner.getCounterValue("Records Dropped").intValue());
@@ -303,7 +303,7 @@ public class TestScriptedTransformRecord {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ScriptedTransformRecord.REL_SUCCESS, 1);
 
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).getFirst();
         out.assertAttributeEquals("record.count", "2");
         assertEquals(2, testRunner.getCounterValue("Records Transformed").intValue());
         assertEquals(2, testRunner.getCounterValue("Records Dropped").intValue());
@@ -333,7 +333,7 @@ public class TestScriptedTransformRecord {
 
         assertEquals(1, recordWriter.getRecordsWritten().size());
 
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_FAILURE).get(0);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_FAILURE).getFirst();
         out.assertAttributeNotExists("record.count");
         assertNull(testRunner.getCounterValue("Records Transformed"));
         assertNull(testRunner.getCounterValue("Records Dropped"));
@@ -358,7 +358,7 @@ public class TestScriptedTransformRecord {
 
         assertEquals(2, recordWriter.getRecordsWritten().size());
 
-        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_FAILURE).get(0);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_FAILURE).getFirst();
         out.assertAttributeNotExists("record.count");
         assertNull(testRunner.getCounterValue("Records Transformed"));
         assertNull(testRunner.getCounterValue("Records Dropped"));
@@ -394,7 +394,7 @@ public class TestScriptedTransformRecord {
 
         testRunner.assertAllFlowFilesTransferred(ScriptedTransformRecord.REL_SUCCESS, 1);
 
-        final MockFlowFile output = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).get(0);
+        final MockFlowFile output = testRunner.getFlowFilesForRelationship(ScriptedTransformRecord.REL_SUCCESS).getFirst();
         output.assertAttributeEquals("record.count", "2");
 
         final List<Record> outputRecords = recordWriter.getRecordsWritten();

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedValidateRecord.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/java/org/apache/nifi/processors/script/TestScriptedValidateRecord.java
@@ -32,7 +32,7 @@ public class TestScriptedValidateRecord extends TestScriptedRouterProcessor {
     private static final Object[] INVALID_RECORD_2 = new Object[] {2, "ipsum"};
 
     @Test
-    public void testIncomingFlowFileContainsValidRecordsOnly() throws Exception {
+    public void testIncomingFlowFileContainsValidRecordsOnly() {
         // given
         recordReader.addRecord(VALID_RECORD_1);
         recordReader.addRecord(VALID_RECORD_2);
@@ -105,14 +105,14 @@ public class TestScriptedValidateRecord extends TestScriptedRouterProcessor {
 
     private void thenValidFlowFileContains(final Object[]... records) {
         testRunner.assertTransferCount(ScriptedValidateRecord.RELATIONSHIP_VALID, 1);
-        final MockFlowFile resultFlowFile = testRunner.getFlowFilesForRelationship(ScriptedValidateRecord.RELATIONSHIP_VALID).get(0);
+        final MockFlowFile resultFlowFile = testRunner.getFlowFilesForRelationship(ScriptedValidateRecord.RELATIONSHIP_VALID).getFirst();
         assertEquals(givenExpectedFlowFile(records), resultFlowFile.getContent());
         assertEquals("text/plain", resultFlowFile.getAttribute("mime.type"));
     }
 
     private void thenInvalidFlowFileContains(final Object[]... records) {
         testRunner.assertTransferCount(ScriptedValidateRecord.RELATIONSHIP_INVALID, 1);
-        final MockFlowFile resultFlowFile = testRunner.getFlowFilesForRelationship(ScriptedValidateRecord.RELATIONSHIP_INVALID).get(0);
+        final MockFlowFile resultFlowFile = testRunner.getFlowFilesForRelationship(ScriptedValidateRecord.RELATIONSHIP_INVALID).getFirst();
         assertEquals(givenExpectedFlowFile(records), resultFlowFile.getContent());
         assertEquals("text/plain", resultFlowFile.getAttribute("mime.type"));
     }

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ConsumeSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ConsumeSlack.java
@@ -193,7 +193,9 @@ public class ConsumeSlack extends AbstractProcessor implements VerifiableProcess
             INCLUDE_MESSAGE_BLOCKS,
             INCLUDE_NULL_FIELDS);
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     private RateLimit rateLimit;
     private final Queue<ConsumeChannel> channels = new LinkedBlockingQueue<>();

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ConsumeSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ConsumeSlack.java
@@ -68,7 +68,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -185,6 +184,16 @@ public class ConsumeSlack extends AbstractProcessor implements VerifiableProcess
         .description("Slack messages that are successfully received will be routed to this relationship")
         .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(CHANNEL_IDS,
+            ACCESS_TOKEN,
+            REPLY_MONITOR_WINDOW,
+            REPLY_MONITOR_FREQUENCY,
+            BATCH_SIZE,
+            RESOLVE_USERNAMES,
+            INCLUDE_MESSAGE_BLOCKS,
+            INCLUDE_NULL_FIELDS);
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
 
     private RateLimit rateLimit;
     private final Queue<ConsumeChannel> channels = new LinkedBlockingQueue<>();
@@ -193,13 +202,12 @@ public class ConsumeSlack extends AbstractProcessor implements VerifiableProcess
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return Arrays.asList(CHANNEL_IDS, ACCESS_TOKEN, REPLY_MONITOR_WINDOW, REPLY_MONITOR_FREQUENCY,
-            BATCH_SIZE, RESOLVE_USERNAMES, INCLUDE_MESSAGE_BLOCKS, INCLUDE_NULL_FIELDS);
+        return PROPERTIES;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return Collections.singleton(REL_SUCCESS);
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ListenSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ListenSlack.java
@@ -149,7 +149,9 @@ public class ListenSlack extends AbstractProcessor {
             RESOLVE_USER_DETAILS
     );
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     private final TransferQueue<EventWrapper> eventTransferQueue = new LinkedTransferQueue<>();
     private volatile SocketModeApp socketModeApp;

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ListenSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ListenSlack.java
@@ -60,8 +60,6 @@ import org.apache.nifi.processors.slack.consume.UserDetailsLookup;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -86,10 +84,10 @@ import java.util.regex.Pattern;
     "See Usage / Additional Details for more information about how to configure this Processor and enable it to retrieve messages and commands from Slack.")
 public class ListenSlack extends AbstractProcessor {
 
-    private static final ObjectMapper objectMapper;
+    private static final ObjectMapper OBJECT_MAPPER;
     static {
-        objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
+        OBJECT_MAPPER = new ObjectMapper();
+        OBJECT_MAPPER.registerModule(new JavaTimeModule());
     }
 
     static final AllowableValue RECEIVE_MESSAGE_EVENTS = new AllowableValue("Receive Message Events", "Receive Message Events",
@@ -126,7 +124,7 @@ public class ListenSlack extends AbstractProcessor {
         .allowableValues(RECEIVE_MENTION_EVENTS, RECEIVE_MESSAGE_EVENTS, RECEIVE_COMMANDS, RECEIVE_JOINED_CHANNEL_EVENTS)
         .build();
 
-    final PropertyDescriptor RESOLVE_USER_DETAILS = new PropertyDescriptor.Builder()
+    static final PropertyDescriptor RESOLVE_USER_DETAILS = new PropertyDescriptor.Builder()
         .name("Resolve User Details")
         .description("Specifies whether the Processor should lookup details about the Slack User who sent the received message. " +
             "If true, the output JSON will contain an additional field named 'userDetails'. " +
@@ -144,6 +142,15 @@ public class ListenSlack extends AbstractProcessor {
         .description("All FlowFiles that are created will be sent to this Relationship.")
         .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            APP_TOKEN,
+            BOT_TOKEN,
+            EVENT_TYPE,
+            RESOLVE_USER_DETAILS
+    );
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+
     private final TransferQueue<EventWrapper> eventTransferQueue = new LinkedTransferQueue<>();
     private volatile SocketModeApp socketModeApp;
     private volatile UserDetailsLookup userDetailsLookup;
@@ -151,16 +158,12 @@ public class ListenSlack extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return Arrays.asList(
-            APP_TOKEN,
-            BOT_TOKEN,
-            EVENT_TYPE,
-            RESOLVE_USER_DETAILS);
+        return PROPERTIES;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return Collections.singleton(REL_SUCCESS);
+        return RELATIONSHIPS;
     }
 
 
@@ -247,20 +250,20 @@ public class ListenSlack extends AbstractProcessor {
 
         FlowFile flowFile = session.create();
         try (final OutputStream out = session.write(flowFile);
-             final JsonGenerator generator = objectMapper.createGenerator(out)) {
+             final JsonGenerator generator = OBJECT_MAPPER.createGenerator(out)) {
 
             // If we need to resolve user details, we need a way to inject it into the JSON. Since we have an object model at this point,
             // we serialize it to a string, then deserialize it back into a JsonNode, and then inject it into the JSON.
             if (context.getProperty(RESOLVE_USER_DETAILS).asBoolean()) {
-                final String stringRepresentation = objectMapper.writeValueAsString(messageEvent);
-                final JsonNode jsonNode = objectMapper.readTree(stringRepresentation);
+                final String stringRepresentation = OBJECT_MAPPER.writeValueAsString(messageEvent);
+                final JsonNode jsonNode = OBJECT_MAPPER.readTree(stringRepresentation);
                 if (jsonNode.hasNonNull("user")) {
                     final String userId = jsonNode.get("user").asText();
                     final User userDetails = userDetailsLookup.getUserDetails(userId);
                     if (userDetails != null) {
                         final ObjectNode objectNode = (ObjectNode) jsonNode;
-                        final String userDetailsJson = objectMapper.writeValueAsString(userDetails);
-                        final JsonNode userDetailsNode = objectMapper.readTree(userDetailsJson);
+                        final String userDetailsJson = OBJECT_MAPPER.writeValueAsString(userDetails);
+                        final JsonNode userDetailsNode = OBJECT_MAPPER.readTree(userDetailsJson);
                         objectNode.set("userDetails", userDetailsNode);
                     }
                 }

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/TestConsumeSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/test/java/org/apache/nifi/processors/slack/TestConsumeSlack.java
@@ -104,7 +104,7 @@ public class TestConsumeSlack {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ConsumeSlack.REL_SUCCESS, 1);
 
-        final MockFlowFile outFlowFile1 = testRunner.getFlowFilesForRelationship(ConsumeSlack.REL_SUCCESS).get(0);
+        final MockFlowFile outFlowFile1 = testRunner.getFlowFilesForRelationship(ConsumeSlack.REL_SUCCESS).getFirst();
         final String outputContent = outFlowFile1.getContent();
 
         final Message[] outputMessages = objectMapper.readValue(outputContent, Message[].class);
@@ -128,7 +128,7 @@ public class TestConsumeSlack {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ConsumeSlack.REL_SUCCESS, 1);
 
-        final MockFlowFile outFlowFile1 = testRunner.getFlowFilesForRelationship(ConsumeSlack.REL_SUCCESS).get(0);
+        final MockFlowFile outFlowFile1 = testRunner.getFlowFilesForRelationship(ConsumeSlack.REL_SUCCESS).getFirst();
         final String outputContent = outFlowFile1.getContent();
         final Message[] outputMessages = objectMapper.readValue(outputContent, Message[].class);
         final Message[] expectedMessages = new Message[] {message1, message2, message3, message4};
@@ -235,7 +235,7 @@ public class TestConsumeSlack {
         testRunner.assertAllFlowFilesTransferred(ConsumeSlack.REL_SUCCESS, 1);
 
         // Verify the results
-        final MockFlowFile outFlowFile1 = testRunner.getFlowFilesForRelationship(ConsumeSlack.REL_SUCCESS).get(0);
+        final MockFlowFile outFlowFile1 = testRunner.getFlowFilesForRelationship(ConsumeSlack.REL_SUCCESS).getFirst();
         final String outputContent = outFlowFile1.getContent();
         final Message[] outputMessages = objectMapper.readValue(outputContent, Message[].class);
         final Message[] expectedMessages = new Message[] {message1, message2, replies.get(0), replies.get(1), replies.get(2), message3};
@@ -316,7 +316,7 @@ public class TestConsumeSlack {
 
         // Verify output of first FlowFile
         final List<MockFlowFile> outputFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeSlack.REL_SUCCESS);
-        final String firstOutputContent = outputFlowFiles.get(0).getContent();
+        final String firstOutputContent = outputFlowFiles.getFirst().getContent();
         final Message[] firstOutputMessages = objectMapper.readValue(firstOutputContent, Message[].class);
         final Message[] expectedFirstMessages = new Message[] {message1, message2, replies.get(0), replies.get(1), replies.get(2)};
         assertArrayEquals(expectedFirstMessages, firstOutputMessages);
@@ -339,7 +339,7 @@ public class TestConsumeSlack {
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(ConsumeSlack.REL_SUCCESS, 1);
 
-        final MockFlowFile outFlowFile1 = testRunner.getFlowFilesForRelationship(ConsumeSlack.REL_SUCCESS).get(0);
+        final MockFlowFile outFlowFile1 = testRunner.getFlowFilesForRelationship(ConsumeSlack.REL_SUCCESS).getFirst();
         final String outputContent = outFlowFile1.getContent();
 
         final Message[] outputMessages = objectMapper.readValue(outputContent, Message[].class);
@@ -426,7 +426,7 @@ public class TestConsumeSlack {
 
         // Verify output of first FlowFile
         final List<MockFlowFile> outputFlowFiles = testRunner.getFlowFilesForRelationship(ConsumeSlack.REL_SUCCESS);
-        final String firstOutputContent = outputFlowFiles.get(0).getContent();
+        final String firstOutputContent = outputFlowFiles.getFirst().getContent();
         final Message[] firstOutputMessages = objectMapper.readValue(firstOutputContent, Message[].class);
         final Message[] expectedFirstMessages = new Message[] {message1, message2};
         assertArrayEquals(expectedFirstMessages, firstOutputMessages);
@@ -651,6 +651,6 @@ public class TestConsumeSlack {
     private enum CursorExpectation {
         EXPECT_CURSOR,
         EXPECT_NO_CURSOR,
-        NO_EXPECTATION;
+        NO_EXPECTATION
     }
 }

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/FetchSmb.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/FetchSmb.java
@@ -35,14 +35,11 @@ import org.apache.nifi.services.smb.SmbClientProviderService;
 import org.apache.nifi.services.smb.SmbClientService;
 import org.apache.nifi.services.smb.SmbException;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableSet;
 import static org.apache.nifi.expression.ExpressionLanguageScope.FLOWFILE_ATTRIBUTES;
 import static org.apache.nifi.processor.util.StandardValidators.ATTRIBUTE_EXPRESSION_LANGUAGE_VALIDATOR;
 
@@ -116,12 +113,12 @@ public class FetchSmb extends AbstractProcessor {
                     .description("A FlowFile will be routed here when failed to fetch its content.")
                     .build();
 
-    public static final Set<Relationship> RELATIONSHIPS = unmodifiableSet(new HashSet<>(asList(
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
-    )));
+    );
 
-    private static final List<PropertyDescriptor> PROPERTIES = asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             SMB_CLIENT_PROVIDER_SERVICE,
             REMOTE_FILE,
             COMPLETION_STRATEGY,

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/GetSmbFile.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/GetSmbFile.java
@@ -51,7 +51,6 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -219,8 +218,30 @@ public class GetSmbFile extends AbstractProcessor {
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder().name("success").description("All files are routed to success").build();
 
-    private List<PropertyDescriptor> descriptors;
-    private Set<Relationship> relationships;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        HOSTNAME,
+        SHARE,
+        DIRECTORY,
+        DOMAIN,
+        USERNAME,
+        PASSWORD,
+        SHARE_ACCESS,
+        FILE_FILTER,
+        PATH_FILTER,
+        BATCH_SIZE,
+        KEEP_SOURCE_FILE,
+        RECURSE,
+        POLLING_INTERVAL,
+        IGNORE_HIDDEN_FILES,
+        SMB_DIALECT,
+        USE_ENCRYPTION,
+        ENABLE_DFS,
+        TIMEOUT
+    );
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS
+    );
 
 
     private final BlockingQueue<String> fileQueue = new LinkedBlockingQueue<>();
@@ -240,41 +261,13 @@ public class GetSmbFile extends AbstractProcessor {
     private Set<SMB2ShareAccess> sharedAccess;
 
     @Override
-    protected void init(final ProcessorInitializationContext context) {
-        final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(HOSTNAME);
-        descriptors.add(SHARE);
-        descriptors.add(DIRECTORY);
-        descriptors.add(DOMAIN);
-        descriptors.add(USERNAME);
-        descriptors.add(PASSWORD);
-        descriptors.add(SHARE_ACCESS);
-        descriptors.add(FILE_FILTER);
-        descriptors.add(PATH_FILTER);
-        descriptors.add(BATCH_SIZE);
-        descriptors.add(KEEP_SOURCE_FILE);
-        descriptors.add(RECURSE);
-        descriptors.add(POLLING_INTERVAL);
-        descriptors.add(IGNORE_HIDDEN_FILES);
-        descriptors.add(SMB_DIALECT);
-        descriptors.add(USE_ENCRYPTION);
-        descriptors.add(ENABLE_DFS);
-        descriptors.add(TIMEOUT);
-        this.descriptors = Collections.unmodifiableList(descriptors);
-
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        this.relationships = Collections.unmodifiableSet(relationships);
-    }
-
-    @Override
     public Set<Relationship> getRelationships() {
-        return this.relationships;
+        return this.RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return descriptors;
+        return PROPERTIES;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/ListSmb.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/ListSmb.java
@@ -189,7 +189,7 @@ public class ListSmb extends AbstractListProcessor<SmbListableEntity> {
             .addValidator(new MustNotContainDirectorySeparatorsValidator())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             SMB_CLIENT_PROVIDER_SERVICE,
             SMB_LISTING_STRATEGY,
             DIRECTORY,
@@ -203,7 +203,7 @@ public class ListSmb extends AbstractListProcessor<SmbListableEntity> {
             ListedEntityTracker.TRACKING_STATE_CACHE,
             ListedEntityTracker.TRACKING_TIME_WINDOW,
             ListedEntityTracker.INITIAL_LISTING_TARGET
-    ).toList();
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/ListSmb.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/ListSmb.java
@@ -20,7 +20,6 @@ import static java.time.ZoneOffset.UTC;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.nifi.components.state.Scope.CLUSTER;
@@ -190,7 +189,7 @@ public class ListSmb extends AbstractListProcessor<SmbListableEntity> {
             .addValidator(new MustNotContainDirectorySeparatorsValidator())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = unmodifiableList(asList(
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.of(
             SMB_CLIENT_PROVIDER_SERVICE,
             SMB_LISTING_STRATEGY,
             DIRECTORY,
@@ -204,7 +203,7 @@ public class ListSmb extends AbstractListProcessor<SmbListableEntity> {
             ListedEntityTracker.TRACKING_STATE_CACHE,
             ListedEntityTracker.TRACKING_TIME_WINDOW,
             ListedEntityTracker.INITIAL_LISTING_TARGET
-    ));
+    ).toList();
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/FetchSmbIT.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/FetchSmbIT.java
@@ -73,7 +73,7 @@ class FetchSmbIT extends SambaTestContainers {
     }
 
     @Test
-    void tryToFetchNonExistingFileEmitsFailure() throws Exception {
+    void tryToFetchNonExistingFileEmitsFailure() {
         testRunner.setProperty(REMOTE_FILE, "${attribute_to_find_using_EL}");
 
         final Map<String, String> attributes = new HashMap<>();
@@ -227,7 +227,7 @@ class FetchSmbIT extends SambaTestContainers {
 
     private void assertSuccessFlowFile() {
         testRunner.assertTransferCount(REL_SUCCESS, 1);
-        assertEquals(TEST_CONTENT, testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0).getContent());
+        assertEquals(TEST_CONTENT, testRunner.getFlowFilesForRelationship(REL_SUCCESS).getFirst().getContent());
     }
 
     private void assertWarning() {

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/GetSNMP.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/GetSNMP.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * Performs an SNMP Get operation based on processor or incoming FlowFile attributes.
@@ -118,7 +117,7 @@ public class GetSNMP extends AbstractSNMPProcessor {
             .description("All FlowFiles that cannot received from the SNMP agent are routed to this relationship.")
             .build();
 
-    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.of(
+    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             AGENT_HOST,
             AGENT_PORT,
             BasicProperties.SNMP_VERSION,
@@ -134,7 +133,7 @@ public class GetSNMP extends AbstractSNMPProcessor {
             OID,
             TEXTUAL_OID,
             SNMP_STRATEGY
-    ).toList();
+    );
 
     private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/GetSNMP.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/GetSNMP.java
@@ -41,13 +41,12 @@ import org.apache.nifi.snmp.validators.OIDValidator;
 import org.snmp4j.Target;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Performs an SNMP Get operation based on processor or incoming FlowFile attributes.
@@ -119,7 +118,7 @@ public class GetSNMP extends AbstractSNMPProcessor {
             .description("All FlowFiles that cannot received from the SNMP agent are routed to this relationship.")
             .build();
 
-    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
+    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.of(
             AGENT_HOST,
             AGENT_PORT,
             BasicProperties.SNMP_VERSION,
@@ -135,12 +134,12 @@ public class GetSNMP extends AbstractSNMPProcessor {
             OID,
             TEXTUAL_OID,
             SNMP_STRATEGY
-    ));
+    ).toList();
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
-    )));
+    );
 
     private volatile GetSNMPHandler snmpHandler;
 

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/ListenTrapSNMP.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/ListenTrapSNMP.java
@@ -49,9 +49,6 @@ import org.apache.nifi.snmp.utils.UsmReader;
 import org.snmp4j.security.UsmUser;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -135,7 +132,7 @@ public class ListenTrapSNMP extends AbstractSessionFactoryProcessor implements V
             .description("All FlowFiles that cannot received from the SNMP agent are routed to this relationship")
             .build();
 
-    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
+    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SNMP_MANAGER_PORT,
             BasicProperties.SNMP_VERSION,
             BasicProperties.SNMP_COMMUNITY,
@@ -144,12 +141,12 @@ public class ListenTrapSNMP extends AbstractSessionFactoryProcessor implements V
             SNMP_USM_USERS_JSON_FILE_PATH,
             SNMP_USM_USERS_JSON,
             SNMP_USM_SECURITY_NAMES
-    ));
+    );
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
-    )));
+    );
 
     private volatile SNMPTrapReceiverHandler snmpTrapReceiverHandler;
     private volatile List<UsmUser> usmUsers;

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SendTrapSNMP.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SendTrapSNMP.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * Sends data to an SNMP manager which, upon each invocation of
@@ -88,7 +87,7 @@ public class SendTrapSNMP extends AbstractSNMPProcessor {
             .description("All FlowFiles that cannot received from the SNMP agent are routed to this relationship")
             .build();
 
-    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.of(
+    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SNMP_MANAGER_HOST,
             SNMP_MANAGER_PORT,
             BasicProperties.SNMP_VERSION,
@@ -106,7 +105,7 @@ public class SendTrapSNMP extends AbstractSNMPProcessor {
             V1TrapProperties.GENERIC_TRAP_TYPE,
             V1TrapProperties.SPECIFIC_TRAP_TYPE,
             V2TrapProperties.TRAP_OID_VALUE
-    ).toList();
+    );
 
     private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SendTrapSNMP.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SendTrapSNMP.java
@@ -41,14 +41,12 @@ import org.snmp4j.mp.SnmpConstants;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Sends data to an SNMP manager which, upon each invocation of
@@ -90,7 +88,7 @@ public class SendTrapSNMP extends AbstractSNMPProcessor {
             .description("All FlowFiles that cannot received from the SNMP agent are routed to this relationship")
             .build();
 
-    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
+    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.of(
             SNMP_MANAGER_HOST,
             SNMP_MANAGER_PORT,
             BasicProperties.SNMP_VERSION,
@@ -108,11 +106,12 @@ public class SendTrapSNMP extends AbstractSNMPProcessor {
             V1TrapProperties.GENERIC_TRAP_TYPE,
             V1TrapProperties.SPECIFIC_TRAP_TYPE,
             V2TrapProperties.TRAP_OID_VALUE
-    ));
+    ).toList();
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            REL_SUCCESS, REL_FAILURE
-    )));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     private volatile SendTrapSNMPHandler snmpHandler;
 

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SetSNMP.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SetSNMP.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * Performs an SNMP Set operation based on attributes of incoming FlowFile.
@@ -75,7 +74,7 @@ public class SetSNMP extends AbstractSNMPProcessor {
             .description("All FlowFiles that failed during the SNMP Set care routed to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             AGENT_HOST,
             AGENT_PORT,
             BasicProperties.SNMP_VERSION,
@@ -88,7 +87,7 @@ public class SetSNMP extends AbstractSNMPProcessor {
             V3SecurityProperties.SNMP_PRIVACY_PASSWORD,
             BasicProperties.SNMP_RETRIES,
             BasicProperties.SNMP_TIMEOUT
-    ).toList();
+    );
 
     private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SetSNMP.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/main/java/org/apache/nifi/snmp/processors/SetSNMP.java
@@ -36,12 +36,10 @@ import org.apache.nifi.snmp.utils.SNMPUtils;
 import org.snmp4j.Target;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Performs an SNMP Set operation based on attributes of incoming FlowFile.
@@ -77,7 +75,7 @@ public class SetSNMP extends AbstractSNMPProcessor {
             .description("All FlowFiles that failed during the SNMP Set care routed to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.of(
             AGENT_HOST,
             AGENT_PORT,
             BasicProperties.SNMP_VERSION,
@@ -90,12 +88,12 @@ public class SetSNMP extends AbstractSNMPProcessor {
             V3SecurityProperties.SNMP_PRIVACY_PASSWORD,
             BasicProperties.SNMP_RETRIES,
             BasicProperties.SNMP_TIMEOUT
-    ));
+    ).toList();
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
-    )));
+    );
 
     private volatile SetSNMPHandler snmpHandler;
 

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -70,7 +71,7 @@ class SNMPTrapReceiverTest {
 
         snmpTrapReceiver.processPdu(mockEvent);
 
-        final LogMessage logMessage = mockComponentLog.getErrorMessages().get(0);
+        final LogMessage logMessage = mockComponentLog.getErrorMessages().getFirst();
 
         assertEquals(String.format("%s Request timed out or parameters are incorrect.", MOCK_COMPONENT_ID), logMessage.getMsg());
     }
@@ -83,7 +84,7 @@ class SNMPTrapReceiverTest {
         when(mockEvent.getPDU()).thenReturn(mockPdu);
         snmpTrapReceiver.processPdu(mockEvent);
 
-        final LogMessage logMessage = mockComponentLog.getErrorMessages().get(0);
+        final LogMessage logMessage = mockComponentLog.getErrorMessages().getFirst();
 
         assertEquals(String.format("%s Request timed out or parameters are incorrect.", MOCK_COMPONENT_ID), logMessage.getMsg());
     }
@@ -110,7 +111,7 @@ class SNMPTrapReceiverTest {
         snmpTrapReceiver.processPdu(mockEvent);
 
         final List<MockFlowFile> flowFiles = mockProcessSession.getFlowFilesForRelationship(ListenTrapSNMP.REL_SUCCESS);
-        final FlowFile flowFile = flowFiles.get(0);
+        final FlowFile flowFile = flowFiles.getFirst();
 
         assertEquals("1.3.6.1.2.1.1.1.0", flowFile.getAttribute("snmp$enterprise"));
         assertEquals(String.valueOf(4), flowFile.getAttribute("snmp$specificTrapType"));
@@ -140,7 +141,7 @@ class SNMPTrapReceiverTest {
         snmpTrapReceiver.processPdu(mockEvent);
 
         final List<MockFlowFile> flowFiles = mockProcessSession.getFlowFilesForRelationship(ListenTrapSNMP.REL_SUCCESS);
-        final FlowFile flowFile = flowFiles.get(0);
+        final FlowFile flowFile = flowFiles.getFirst();
 
         assertEquals(String.valueOf(123), flowFile.getAttribute("snmp$errorIndex"));
         assertEquals("test error status text", flowFile.getAttribute("snmp$errorStatusText"));
@@ -168,9 +169,9 @@ class SNMPTrapReceiverTest {
         final List<MockFlowFile> flowFiles = mockProcessSession.getFlowFilesForRelationship(ListenTrapSNMP.REL_FAILURE);
 
         assertFalse(flowFiles.isEmpty());
-        final FlowFile flowFile = flowFiles.get(0);
+        final FlowFile flowFile = flowFiles.getFirst();
 
         assertEquals(String.valueOf(PDU.badValue), flowFile.getAttribute("snmp$errorStatus"));
-        assertEquals(null, flowFile.getAttribute("snmp$peerAddress"));
+        assertNull(flowFile.getAttribute("snmp$peerAddress"));
     }
 }

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/AbstractSNMPProcessorTest.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/AbstractSNMPProcessorTest.java
@@ -68,7 +68,7 @@ class AbstractSNMPProcessorTest {
 
         getSNMP.handleResponse(mockProcessContext, mockProcessSession, mockFlowFile, mockResponse, GetSNMP.REL_SUCCESS, GetSNMP.REL_FAILURE, "provenanceAddress", true);
 
-        final String actualLogMessage = getTestRunner.getLogger().getErrorMessages().get(0).getMsg();
+        final String actualLogMessage = getTestRunner.getLogger().getErrorMessages().getFirst().getMsg();
         final String expectedLogMessage = String.format("SNMP request failed, response error: %s", errorStatus);
         assertTrue(actualLogMessage.contains(expectedLogMessage));
     }
@@ -85,7 +85,7 @@ class AbstractSNMPProcessorTest {
         getSNMP.handleResponse(mockProcessContext, mockProcessSession, mockFlowFile, mockResponse, GetSNMP.REL_SUCCESS, GetSNMP.REL_FAILURE, "provenanceAddress", true);
 
 
-        final String actualLogMessage = getTestRunner.getLogger().getErrorMessages().get(0).getMsg();
+        final String actualLogMessage = getTestRunner.getLogger().getErrorMessages().getFirst().getMsg();
         final String expectedLogMessage = "SNMP request failed, response error: OID not found.";
         assertTrue(actualLogMessage.contains(expectedLogMessage));
     }
@@ -100,7 +100,7 @@ class AbstractSNMPProcessorTest {
         getSNMP.handleResponse(mockProcessContext, mockProcessSession, mockFlowFile, mockResponse, GetSNMP.REL_SUCCESS, GetSNMP.REL_FAILURE, "provenanceAddress", true);
 
 
-        final String actualLogMessage = getTestRunner.getLogger().getErrorMessages().get(0).getMsg();
+        final String actualLogMessage = getTestRunner.getLogger().getErrorMessages().getFirst().getMsg();
         final String expectedLogMessage = "Empty SNMP response: no variable binding found.";
         assertTrue(actualLogMessage.contains(expectedLogMessage));
     }
@@ -119,7 +119,7 @@ class AbstractSNMPProcessorTest {
         getSNMP.handleResponse(mockProcessContext, mockProcessSession, mockFlowFile, mockResponse, GetSNMP.REL_SUCCESS, GetSNMP.REL_FAILURE, "provenanceAddress", true);
         final List<MockFlowFile> flowFilesForRelationship = mockProcessSession.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS);
 
-        assertEquals("testOIDValue", flowFilesForRelationship.get(0).getAttribute(TEST_OID));
+        assertEquals("testOIDValue", flowFilesForRelationship.getFirst().getAttribute(TEST_OID));
     }
 
     @Test
@@ -134,7 +134,7 @@ class AbstractSNMPProcessorTest {
         getSNMP.handleResponse(mockProcessContext, mockProcessSession, mockFlowFile, mockResponse, GetSNMP.REL_SUCCESS, GetSNMP.REL_FAILURE, "provenanceAddress", true);
 
 
-        final String actualLogMessage = getTestRunner.getLogger().getErrorMessages().get(0).getMsg();
+        final String actualLogMessage = getTestRunner.getLogger().getErrorMessages().getFirst().getMsg();
         final String expectedLogMessage = String.format("SNMP request failed, response error: Report-PDU returned, but no error message found. " +
                 "Please, check the OID %s in an online OID repository.", TEST_OID);
 
@@ -153,7 +153,7 @@ class AbstractSNMPProcessorTest {
         getSNMP.handleResponse(mockProcessContext, mockProcessSession, mockFlowFile, mockResponse, GetSNMP.REL_SUCCESS, GetSNMP.REL_FAILURE, "provenanceAddress", true);
 
 
-        final String actualLogMessage = getTestRunner.getLogger().getErrorMessages().get(0).getMsg();
+        final String actualLogMessage = getTestRunner.getLogger().getErrorMessages().getFirst().getMsg();
         final String expectedLogMessage = String.format("SNMP request failed, response error: Report-PDU returned. %s: usmStatsUnsupportedSecLevels", UNSUPPORTED_SECURITY_LEVEL);
 
         assertTrue(actualLogMessage.contains(expectedLogMessage));

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/GetSNMPIT.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/GetSNMPIT.java
@@ -85,7 +85,7 @@ class GetSNMPIT {
         try {
             final TestRunner runner = testRunnerFactory.createSnmpGetTestRunner(testAgent.getPort(), READ_ONLY_OID_1, GET);
             runner.run();
-            final MockFlowFile successFF = runner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).get(0);
+            final MockFlowFile successFF = runner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).getFirst();
 
             assertNotNull(successFF);
             assertEquals(READ_ONLY_OID_VALUE_1, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_1 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
@@ -104,7 +104,7 @@ class GetSNMPIT {
         try {
             final TestRunner runner = testRunnerFactory.createSnmpGetTestRunner(testAgent.getPort(), WALK_OID, WALK);
             runner.run();
-            final MockFlowFile successFF = runner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).get(0);
+            final MockFlowFile successFF = runner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).getFirst();
             assertNotNull(successFF);
 
             assertEquals(READ_ONLY_OID_VALUE_1, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + READ_ONLY_OID_1 + SNMPUtils.SNMP_PROP_DELIMITER + "4"));
@@ -129,12 +129,12 @@ class GetSNMPIT {
             runner.run();
 
             if (testAgent == v1TestAgent) {
-                final MockFlowFile failureFF = runner.getFlowFilesForRelationship(GetSNMP.REL_FAILURE).get(0);
+                final MockFlowFile failureFF = runner.getFlowFilesForRelationship(GetSNMP.REL_FAILURE).getFirst();
                 assertNotNull(failureFF);
                 assertEquals(StringUtils.EMPTY, failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + NOT_FOUND_OID));
                 assertEquals("No such name", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + "errorStatusText"));
             } else {
-                final MockFlowFile failureFF = runner.getFlowFilesForRelationship(GetSNMP.REL_FAILURE).get(0);
+                final MockFlowFile failureFF = runner.getFlowFilesForRelationship(GetSNMP.REL_FAILURE).getFirst();
                 assertNotNull(failureFF);
                 assertEquals("noSuchObject", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + NOT_FOUND_OID + SNMPUtils.SNMP_PROP_DELIMITER + "128"));
                 assertEquals("Success", failureFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + "errorStatusText"));

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/SetSNMPIT.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/SetSNMPIT.java
@@ -77,7 +77,7 @@ class SetSNMPIT {
         try {
             final TestRunner runner = testRunnerFactory.createSnmpSetTestRunner(testAgent.getPort(), TEST_OID, TEST_OID_VALUE);
             runner.run();
-            final MockFlowFile successFF = runner.getFlowFilesForRelationship(SetSNMP.REL_SUCCESS).get(0);
+            final MockFlowFile successFF = runner.getFlowFilesForRelationship(SetSNMP.REL_SUCCESS).getFirst();
 
             assertNotNull(successFF);
             assertEquals(TEST_OID_VALUE, successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + TEST_OID + SNMPUtils.SNMP_PROP_DELIMITER + "4"));

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/TrapSNMPIT.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/processors/TrapSNMPIT.java
@@ -56,7 +56,7 @@ class TrapSNMPIT {
 
         Thread.sleep(50);
 
-        final MockFlowFile successFF = listenTrapTestRunner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).get(0);
+        final MockFlowFile successFF = listenTrapTestRunner.getFlowFilesForRelationship(GetSNMP.REL_SUCCESS).getFirst();
 
         assertNotNull(successFF);
         assertEquals("Success", successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + "errorStatusText"));
@@ -97,7 +97,7 @@ class TrapSNMPIT {
             }
         }
 
-        final MockFlowFile successFF = successFlowFiles.get(0);
+        final MockFlowFile successFF = successFlowFiles.getFirst();
 
         assertNotNull(successFF);
         assertEquals("Success", successFF.getAttribute(SNMPUtils.SNMP_PROP_PREFIX + "errorStatusText"));

--- a/nifi-extension-bundles/nifi-social-media-bundle/nifi-twitter-processors/src/main/java/org/apache/nifi/processors/twitter/ConsumeTwitter.java
+++ b/nifi-extension-bundles/nifi-social-media-bundle/nifi-twitter-processors/src/main/java/org/apache/nifi/processors/twitter/ConsumeTwitter.java
@@ -49,7 +49,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
 @PrimaryNodeOnly
 @SupportsBatching
@@ -248,7 +247,7 @@ public class ConsumeTwitter extends AbstractProcessor {
             .description("FlowFiles containing an array of one or more Tweets")
             .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = Stream.of(
+    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
         ENDPOINT,
         BASE_PATH,
         BEARER_TOKEN,
@@ -266,7 +265,7 @@ public class ConsumeTwitter extends AbstractProcessor {
         POLL_FIELDS,
         PLACE_FIELDS,
         EXPANSIONS
-    ).toList();
+    );
 
     private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
 

--- a/nifi-extension-bundles/nifi-social-media-bundle/nifi-twitter-processors/src/main/java/org/apache/nifi/processors/twitter/ConsumeTwitter.java
+++ b/nifi-extension-bundles/nifi-social-media-bundle/nifi-twitter-processors/src/main/java/org/apache/nifi/processors/twitter/ConsumeTwitter.java
@@ -35,7 +35,6 @@ import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -43,9 +42,6 @@ import org.apache.nifi.processor.util.StandardValidators;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.List;
-import java.util.HashSet;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.UUID;
@@ -53,6 +49,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 @PrimaryNodeOnly
 @SupportsBatching
@@ -251,8 +248,27 @@ public class ConsumeTwitter extends AbstractProcessor {
             .description("FlowFiles containing an array of one or more Tweets")
             .build();
 
-    private List<PropertyDescriptor> descriptors;
-    private Set<Relationship> relationships;
+    private static final List<PropertyDescriptor> DESCRIPTORS = Stream.of(
+        ENDPOINT,
+        BASE_PATH,
+        BEARER_TOKEN,
+        QUEUE_SIZE,
+        BATCH_SIZE,
+        BACKOFF_ATTEMPTS,
+        BACKOFF_TIME,
+        MAXIMUM_BACKOFF_TIME,
+        CONNECT_TIMEOUT,
+        READ_TIMEOUT,
+        BACKFILL_MINUTES,
+        TWEET_FIELDS,
+        USER_FIELDS,
+        MEDIA_FIELDS,
+        POLL_FIELDS,
+        PLACE_FIELDS,
+        EXPANSIONS
+    ).toList();
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
 
     private TweetStreamService tweetStreamService;
 
@@ -261,41 +277,13 @@ public class ConsumeTwitter extends AbstractProcessor {
     private final AtomicBoolean streamStarted = new AtomicBoolean(false);
 
     @Override
-    protected void init(ProcessorInitializationContext context) {
-        final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(ENDPOINT);
-        descriptors.add(BASE_PATH);
-        descriptors.add(BEARER_TOKEN);
-        descriptors.add(QUEUE_SIZE);
-        descriptors.add(BATCH_SIZE);
-        descriptors.add(BACKOFF_ATTEMPTS);
-        descriptors.add(BACKOFF_TIME);
-        descriptors.add(MAXIMUM_BACKOFF_TIME);
-        descriptors.add(CONNECT_TIMEOUT);
-        descriptors.add(READ_TIMEOUT);
-        descriptors.add(BACKFILL_MINUTES);
-        descriptors.add(TWEET_FIELDS);
-        descriptors.add(USER_FIELDS);
-        descriptors.add(MEDIA_FIELDS);
-        descriptors.add(POLL_FIELDS);
-        descriptors.add(PLACE_FIELDS);
-        descriptors.add(EXPANSIONS);
-
-        this.descriptors = Collections.unmodifiableList(descriptors);
-
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        this.relationships = Collections.unmodifiableSet(relationships);
-    }
-
-    @Override
     public Set<Relationship> getRelationships() {
-        return this.relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return this.descriptors;
+        return DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/QuerySplunkIndexingStatus.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/QuerySplunkIndexingStatus.java
@@ -39,15 +39,14 @@ import org.apache.nifi.processor.util.StandardValidators;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
 import org.apache.nifi.scheduling.SchedulingStrategy;
 
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
@@ -89,12 +88,12 @@ public class QuerySplunkIndexingStatus extends SplunkAPICall {
                     "FlowFiles are timing out or unknown by the Splunk server will transferred to \"undetermined\" relationship.")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             RELATIONSHIP_ACKNOWLEDGED,
             RELATIONSHIP_UNACKNOWLEDGED,
             RELATIONSHIP_UNDETERMINED,
             RELATIONSHIP_FAILURE
-    )));
+    );
 
     static final PropertyDescriptor TTL = new PropertyDescriptor.Builder()
             .name("ttl")
@@ -118,17 +117,20 @@ public class QuerySplunkIndexingStatus extends SplunkAPICall {
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            SplunkAPICall.PROPERTIES.stream(),
+            Stream.of(
+                    TTL,
+                    MAX_QUERY_SIZE
+            )
+    ).toList();
+
     private volatile Integer maxQuerySize;
     private volatile Integer ttl;
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> result = new ArrayList<>();
-        final List<PropertyDescriptor> common = super.getSupportedPropertyDescriptors();
-        result.addAll(common);
-        result.add(TTL);
-        result.add(MAX_QUERY_SIZE);
-        return result;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestGetSplunk.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestGetSplunk.java
@@ -111,7 +111,7 @@ public class TestGetSplunk {
         final List<MockFlowFile> mockFlowFiles = runner.getFlowFilesForRelationship(GetSplunk.REL_SUCCESS);
         assertEquals(1, mockFlowFiles.size());
 
-        final MockFlowFile mockFlowFile = mockFlowFiles.get(0);
+        final MockFlowFile mockFlowFile = mockFlowFiles.getFirst();
         mockFlowFile.assertContentEquals(resultContent);
         mockFlowFile.assertAttributeEquals(GetSplunk.QUERY_ATTR, query);
         mockFlowFile.assertAttributeEquals(GetSplunk.EARLIEST_TIME_ATTR, providedEarliest);
@@ -120,8 +120,8 @@ public class TestGetSplunk {
 
         final List<ProvenanceEventRecord> events = runner.getProvenanceEvents();
         assertEquals(1, events.size());
-        assertEquals(ProvenanceEventType.RECEIVE, events.get(0).getEventType());
-        assertEquals("https://localhost:8089", events.get(0).getTransitUri());
+        assertEquals(ProvenanceEventType.RECEIVE, events.getFirst().getEventType());
+        assertEquals("https://localhost:8089", events.getFirst().getTransitUri());
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-processors/src/test/java/org/apache/nifi/processors/stateful/analysis/AttributeRollingWindowIT.java
+++ b/nifi-extension-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-processors/src/test/java/org/apache/nifi/processors/stateful/analysis/AttributeRollingWindowIT.java
@@ -97,7 +97,7 @@ public class AttributeRollingWindowIT {
         runner.assertQueueEmpty();
 
         runner.assertAllFlowFilesTransferred(AttributeRollingWindow.REL_FAILED_SET_STATE, 1);
-        MockFlowFile mockFlowFile = runner.getFlowFilesForRelationship(REL_FAILED_SET_STATE).get(0);
+        MockFlowFile mockFlowFile = runner.getFlowFilesForRelationship(REL_FAILED_SET_STATE).getFirst();
         mockFlowFile.assertAttributeNotExists(ROLLING_WINDOW_VALUE_KEY);
         mockFlowFile.assertAttributeNotExists(ROLLING_WINDOW_COUNT_KEY);
         mockFlowFile.assertAttributeNotExists(ROLLING_WINDOW_MEAN_KEY);
@@ -124,7 +124,7 @@ public class AttributeRollingWindowIT {
         runner.enqueue("1".getBytes(), attributes);
         runner.run(1);
         runner.assertAllFlowFilesTransferred(AttributeRollingWindow.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
         runner.clearTransferState();
         flowFile.assertAttributeEquals(ROLLING_WINDOW_VALUE_KEY, "1.0");
         flowFile.assertAttributeEquals(ROLLING_WINDOW_COUNT_KEY, "1");
@@ -135,7 +135,7 @@ public class AttributeRollingWindowIT {
         runner.enqueue("2".getBytes(), attributes);
         runner.run(1);
         runner.assertAllFlowFilesTransferred(AttributeRollingWindow.REL_SUCCESS, 1);
-         flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+         flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
         runner.clearTransferState();
         flowFile.assertAttributeEquals(ROLLING_WINDOW_VALUE_KEY, "2.0");
         flowFile.assertAttributeEquals(ROLLING_WINDOW_COUNT_KEY, "2");
@@ -148,7 +148,7 @@ public class AttributeRollingWindowIT {
         runner.enqueue("2".getBytes(), attributes);
         runner.run(1);
         runner.assertAllFlowFilesTransferred(AttributeRollingWindow.REL_SUCCESS, 1);
-        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
         runner.clearTransferState();
         flowFile.assertAttributeEquals(ROLLING_WINDOW_VALUE_KEY, "1.0");
         flowFile.assertAttributeEquals(ROLLING_WINDOW_COUNT_KEY, "1");
@@ -174,7 +174,7 @@ public class AttributeRollingWindowIT {
             runner.enqueue(String.valueOf(i).getBytes(), attributes);
             runner.run();
 
-            flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+            flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
             runner.clearTransferState();
             Double value = (double) i;
             Double mean = value / i;
@@ -196,7 +196,7 @@ public class AttributeRollingWindowIT {
 
             runner.run();
 
-            flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+            flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
             runner.clearTransferState();
             Double value = (double) i;
             Double mean = value / i;
@@ -229,7 +229,7 @@ public class AttributeRollingWindowIT {
             runner.enqueue(new byte[]{}, attributes);
             runner.run();
 
-            flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+            flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
             runner.clearTransferState();
             sum += i;
             double mean = sum / i;
@@ -267,7 +267,7 @@ public class AttributeRollingWindowIT {
         runner.enqueue("1".getBytes(), attributes);
         runner.run(1);
         runner.assertAllFlowFilesTransferred(AttributeRollingWindow.REL_SUCCESS, 1);
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
         runner.clearTransferState();
         flowFile.assertAttributeEquals(ROLLING_WINDOW_VALUE_KEY, "2.0");
         flowFile.assertAttributeEquals(ROLLING_WINDOW_COUNT_KEY, "1");
@@ -278,7 +278,7 @@ public class AttributeRollingWindowIT {
         runner.enqueue("2".getBytes(), attributes);
         runner.run(1);
         runner.assertAllFlowFilesTransferred(AttributeRollingWindow.REL_SUCCESS, 1);
-        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
         runner.clearTransferState();
         flowFile.assertAttributeEquals(ROLLING_WINDOW_VALUE_KEY, "4.0");
         flowFile.assertAttributeEquals(ROLLING_WINDOW_COUNT_KEY, "2");
@@ -290,7 +290,7 @@ public class AttributeRollingWindowIT {
         runner.enqueue("2".getBytes(), attributes);
         runner.run(1);
         runner.assertAllFlowFilesTransferred(AttributeRollingWindow.REL_SUCCESS, 1);
-        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
         runner.clearTransferState();
         flowFile.assertAttributeEquals(ROLLING_WINDOW_VALUE_KEY, "6.0");
         flowFile.assertAttributeEquals(ROLLING_WINDOW_COUNT_KEY, "3");
@@ -300,7 +300,7 @@ public class AttributeRollingWindowIT {
         runner.enqueue("2".getBytes(), attributes);
         runner.run(1);
         runner.assertAllFlowFilesTransferred(AttributeRollingWindow.REL_SUCCESS, 1);
-        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
         runner.clearTransferState();
         flowFile.assertAttributeEquals(ROLLING_WINDOW_VALUE_KEY, "8.0");
         flowFile.assertAttributeEquals(ROLLING_WINDOW_COUNT_KEY, "4");
@@ -311,7 +311,7 @@ public class AttributeRollingWindowIT {
         runner.enqueue("2".getBytes(), attributes);
         runner.run(1);
         runner.assertAllFlowFilesTransferred(AttributeRollingWindow.REL_SUCCESS, 1);
-        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
         runner.clearTransferState();
         flowFile.assertAttributeEquals(ROLLING_WINDOW_VALUE_KEY, "6.0");
         flowFile.assertAttributeEquals(ROLLING_WINDOW_COUNT_KEY, "3");
@@ -320,7 +320,7 @@ public class AttributeRollingWindowIT {
         runner.enqueue("2".getBytes(), attributes);
         runner.run(1);
         runner.assertAllFlowFilesTransferred(AttributeRollingWindow.REL_SUCCESS, 1);
-        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).get(0);
+        flowFile = runner.getFlowFilesForRelationship(AttributeRollingWindow.REL_SUCCESS).getFirst();
         runner.clearTransferState();
         flowFile.assertAttributeEquals(ROLLING_WINDOW_VALUE_KEY, "8.0");
         flowFile.assertAttributeEquals(ROLLING_WINDOW_COUNT_KEY, "4");

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/AbstractWebSocketGatewayProcessor.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/AbstractWebSocketGatewayProcessor.java
@@ -42,7 +42,6 @@ import org.apache.nifi.websocket.WebSocketSessionInfo;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -96,13 +95,15 @@ public abstract class AbstractWebSocketGatewayProcessor extends AbstractSessionF
             .autoTerminateDefault(true)
             .build();
 
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_CONNECTED,
+            REL_DISCONNECTED,
+            REL_MESSAGE_TEXT,
+            REL_MESSAGE_BINARY
+    );
+
     static Set<Relationship> getAbstractRelationships() {
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_CONNECTED);
-        relationships.add(REL_DISCONNECTED);
-        relationships.add(REL_MESSAGE_TEXT);
-        relationships.add(REL_MESSAGE_BINARY);
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
@@ -148,10 +149,9 @@ public abstract class AbstractWebSocketGatewayProcessor extends AbstractSessionF
     // @OnScheduled can not report error messages well on bulletin since it's an async method.
     // So, let's do it in onTrigger().
     public void onWebSocketServiceReady(final WebSocketService webSocketService, final ProcessContext context) throws IOException {
-        if (webSocketService instanceof WebSocketClientService) {
+        if (webSocketService instanceof WebSocketClientService webSocketClientService) {
             // If it's a ws client, then connect to the remote here.
             // Otherwise, ws server is already started at WebSocketServerService
-            WebSocketClientService webSocketClientService = (WebSocketClientService) webSocketService;
             if (context.hasIncomingConnection()) {
                 final ProcessSession session = processSessionFactory.createSession();
                 final FlowFile flowFile = session.get();

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ConnectWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ConnectWebSocket.java
@@ -31,10 +31,10 @@ import org.apache.nifi.websocket.WebSocketClientService;
 import org.apache.nifi.websocket.WebSocketService;
 import org.apache.nifi.websocket.WebSocketSessionInfo;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.nifi.processors.websocket.WebSocketProcessorAttributes.ATTR_WS_CS_ID;
 import static org.apache.nifi.processors.websocket.WebSocketProcessorAttributes.ATTR_WS_ENDPOINT_ID;
@@ -79,29 +79,24 @@ public class ConnectWebSocket extends AbstractWebSocketGatewayProcessor {
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> descriptors;
-    private static final Set<Relationship> relationships;
+    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+            PROP_WEBSOCKET_CLIENT_SERVICE,
+            PROP_WEBSOCKET_CLIENT_ID
+    );
 
-    static {
-        final List<PropertyDescriptor> innerDescriptorsList = new ArrayList<>();
-        innerDescriptorsList.add(PROP_WEBSOCKET_CLIENT_SERVICE);
-        innerDescriptorsList.add(PROP_WEBSOCKET_CLIENT_ID);
-        descriptors = Collections.unmodifiableList(innerDescriptorsList);
-
-        final Set<Relationship> innerRelationshipsSet = getAbstractRelationships();
-        innerRelationshipsSet.add(REL_SUCCESS);
-        innerRelationshipsSet.add(REL_FAILURE);
-        relationships = Collections.unmodifiableSet(innerRelationshipsSet);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = Stream.concat(
+            getAbstractRelationships().stream(),
+            Stream.of(REL_SUCCESS, REL_FAILURE)
+            ).collect(Collectors.toUnmodifiableSet());
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return descriptors;
+        return DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ConnectWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ConnectWebSocket.java
@@ -79,7 +79,7 @@ public class ConnectWebSocket extends AbstractWebSocketGatewayProcessor {
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             PROP_WEBSOCKET_CLIENT_SERVICE,
             PROP_WEBSOCKET_CLIENT_ID
     );
@@ -96,7 +96,7 @@ public class ConnectWebSocket extends AbstractWebSocketGatewayProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ListenWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ListenWebSocket.java
@@ -83,7 +83,7 @@ public class ListenWebSocket extends AbstractWebSocketGatewayProcessor {
             })
             .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             PROP_WEBSOCKET_SERVER_SERVICE,
             PROP_SERVER_URL_PATH
     );
@@ -97,7 +97,7 @@ public class ListenWebSocket extends AbstractWebSocketGatewayProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ListenWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ListenWebSocket.java
@@ -33,8 +33,6 @@ import org.apache.nifi.websocket.WebSocketService;
 import org.apache.nifi.websocket.WebSocketSessionInfo;
 
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -85,27 +83,21 @@ public class ListenWebSocket extends AbstractWebSocketGatewayProcessor {
             })
             .build();
 
-    private static final List<PropertyDescriptor> descriptors;
-    private static final Set<Relationship> relationships;
+    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+            PROP_WEBSOCKET_SERVER_SERVICE,
+            PROP_SERVER_URL_PATH
+    );
 
-    static {
-        final List<PropertyDescriptor> innerDescriptorsList = new ArrayList<>();
-        innerDescriptorsList.add(PROP_WEBSOCKET_SERVER_SERVICE);
-        innerDescriptorsList.add(PROP_SERVER_URL_PATH);
-        descriptors = Collections.unmodifiableList(innerDescriptorsList);
-
-        final Set<Relationship> innerRelationshipsSet = getAbstractRelationships();
-        relationships = Collections.unmodifiableSet(innerRelationshipsSet);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = getAbstractRelationships();
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return descriptors;
+        return DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/PutWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/PutWebSocket.java
@@ -28,10 +28,7 @@ import static org.apache.nifi.websocket.WebSocketMessage.CHARSET_NAME;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -128,31 +125,26 @@ public class PutWebSocket extends AbstractProcessor {
             .description("FlowFiles that failed to send to the destination are transferred to this relationship.")
             .build();
 
-    private static final List<PropertyDescriptor> descriptors;
-    private static final Set<Relationship> relationships;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            PROP_WS_SESSION_ID,
+            PROP_WS_CONTROLLER_SERVICE_ID,
+            PROP_WS_CONTROLLER_SERVICE_ENDPOINT,
+            PROP_WS_MESSAGE_TYPE
+    );
 
-    static {
-        final List<PropertyDescriptor> innerDescriptorsList = new ArrayList<>();
-        innerDescriptorsList.add(PROP_WS_SESSION_ID);
-        innerDescriptorsList.add(PROP_WS_CONTROLLER_SERVICE_ID);
-        innerDescriptorsList.add(PROP_WS_CONTROLLER_SERVICE_ENDPOINT);
-        innerDescriptorsList.add(PROP_WS_MESSAGE_TYPE);
-        descriptors = Collections.unmodifiableList(innerDescriptorsList);
-
-        final Set<Relationship> innerRelationshipsSet = new HashSet<>();
-        innerRelationshipsSet.add(REL_SUCCESS);
-        innerRelationshipsSet.add(REL_FAILURE);
-        relationships = Collections.unmodifiableSet(innerRelationshipsSet);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return descriptors;
+        return PROPERTIES;
     }
 
     @Override
@@ -207,9 +199,7 @@ public class PutWebSocket extends AbstractProcessor {
         attrs.put(ATTR_WS_ENDPOINT_ID, webSocketServiceEndpoint);
         attrs.put(ATTR_WS_MESSAGE_TYPE, messageTypeStr);
 
-        processSession.read(flowfile, in -> {
-            StreamUtils.fillBuffer(in, messageContent, true);
-        });
+        processSession.read(flowfile, in -> StreamUtils.fillBuffer(in, messageContent, true));
 
         try {
 
@@ -244,10 +234,9 @@ public class PutWebSocket extends AbstractProcessor {
 
     }
 
-    private FlowFile transferToFailure(final ProcessSession processSession, FlowFile flowfile, final String value) {
+    private void transferToFailure(final ProcessSession processSession, FlowFile flowfile, final String value) {
         flowfile = processSession.putAttribute(flowfile, ATTR_WS_FAILURE_DETAIL, value);
         processSession.transfer(flowfile, REL_FAILURE);
-        return flowfile;
     }
 
 }

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/test/java/org/apache/nifi/processors/websocket/TestConnectWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/test/java/org/apache/nifi/processors/websocket/TestConnectWebSocket.java
@@ -111,9 +111,7 @@ class TestConnectWebSocket extends TestListenWebSocket {
 
         List<MockFlowFile> textFlowFiles = transferredFlowFiles.get(AbstractWebSocketGatewayProcessor.REL_MESSAGE_TEXT);
         assertEquals(2, textFlowFiles.size());
-        textFlowFiles.forEach(ff -> {
-            assertFlowFile(webSocketSession, serviceId, endpointId, ff, WebSocketMessage.Type.TEXT);
-        });
+        textFlowFiles.forEach(ff -> assertFlowFile(webSocketSession, serviceId, endpointId, ff, WebSocketMessage.Type.TEXT));
 
         List<MockFlowFile> binaryFlowFiles = transferredFlowFiles.get(AbstractWebSocketGatewayProcessor.REL_MESSAGE_BINARY);
         assertEquals(3, binaryFlowFiles.size());

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/test/java/org/apache/nifi/processors/websocket/TestPutWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/test/java/org/apache/nifi/processors/websocket/TestPutWebSocket.java
@@ -132,7 +132,7 @@ public class TestPutWebSocket {
 
         final List<MockFlowFile> failedFlowFiles = runner.getFlowFilesForRelationship(PutWebSocket.REL_FAILURE);
         assertEquals(1, failedFlowFiles.size());
-        final MockFlowFile failedFlowFile = failedFlowFiles.iterator().next();
+        final MockFlowFile failedFlowFile = failedFlowFiles.getFirst();
         assertNotNull(failedFlowFile.getAttribute(ATTR_WS_FAILURE_DETAIL));
 
         final List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();
@@ -168,7 +168,7 @@ public class TestPutWebSocket {
 
         final List<MockFlowFile> failedFlowFiles = runner.getFlowFilesForRelationship(PutWebSocket.REL_FAILURE);
         assertEquals(1, failedFlowFiles.size());
-        final MockFlowFile failedFlowFile = failedFlowFiles.iterator().next();
+        final MockFlowFile failedFlowFile = failedFlowFiles.getFirst();
         assertNotNull(failedFlowFile.getAttribute(ATTR_WS_FAILURE_DETAIL));
 
         final List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();
@@ -210,7 +210,7 @@ public class TestPutWebSocket {
 
         final List<MockFlowFile> failedFlowFiles = runner.getFlowFilesForRelationship(PutWebSocket.REL_FAILURE);
         assertEquals(1, failedFlowFiles.size());
-        final MockFlowFile failedFlowFile = failedFlowFiles.iterator().next();
+        final MockFlowFile failedFlowFile = failedFlowFiles.getFirst();
         assertNotNull(failedFlowFile.getAttribute(ATTR_WS_FAILURE_DETAIL));
 
         final List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();

--- a/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/main/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLog.java
+++ b/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/main/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLog.java
@@ -49,10 +49,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -126,15 +123,19 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
             .addValidator(StandardValidators.createTimePeriodValidator(0, TimeUnit.MILLISECONDS, Long.MAX_VALUE, TimeUnit.MILLISECONDS))
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.unmodifiableList(
-            Arrays.asList(CHANNEL, QUERY, MAX_BUFFER_SIZE, MAX_EVENT_QUEUE_SIZE, INACTIVE_DURATION_TO_RECONNECT));
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            CHANNEL,
+            QUERY,
+            MAX_BUFFER_SIZE,
+            MAX_EVENT_QUEUE_SIZE,
+            INACTIVE_DURATION_TO_RECONNECT);
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
             .description("Relationship for successfully consumed events.")
             .build();
 
-    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(REL_SUCCESS)));
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
     public static final String APPLICATION_XML = "application/xml";
     public static final String UNABLE_TO_SUBSCRIBE = "Unable to subscribe with provided parameters, received the following error code: ";
     public static final String PROCESSOR_ALREADY_SUBSCRIBED = "Processor already subscribed to Event Log, expected cleanup to unsubscribe.";

--- a/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/main/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLog.java
+++ b/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/main/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLog.java
@@ -135,7 +135,10 @@ public class ConsumeWindowsEventLog extends AbstractSessionFactoryProcessor {
             .description("Relationship for successfully consumed events.")
             .build();
 
-    public static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
+
     public static final String APPLICATION_XML = "application/xml";
     public static final String UNABLE_TO_SUBSCRIBE = "Unable to subscribe with provided parameters, received the following error code: ";
     public static final String PROCESSOR_ALREADY_SUBSCRIBED = "Processor already subscribed to Event Log, expected cleanup to unsubscribe.";

--- a/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/test/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLogTest.java
+++ b/nifi-extension-bundles/nifi-windows-event-log-bundle/nifi-windows-event-log-processors/src/test/java/org/apache/nifi/processors/windows/event/log/ConsumeWindowsEventLogTest.java
@@ -117,7 +117,7 @@ public class ConsumeWindowsEventLogTest {
         }).start();
 
         // Wait until the thread has really started
-        while (testRunner.getFlowFilesForRelationship(ConsumeWindowsEventLog.REL_SUCCESS).size() == 0) {
+        while (testRunner.getFlowFilesForRelationship(ConsumeWindowsEventLog.REL_SUCCESS).isEmpty()) {
             testRunner.run(1, false, false);
         }
 
@@ -169,7 +169,7 @@ public class ConsumeWindowsEventLogTest {
 
         testRunner.run(1, false, true);
 
-        WinNT.HANDLE handle = mockEventHandles(wEvtApi, kernel32, Arrays.asList("test")).get(0);
+        WinNT.HANDLE handle = mockEventHandles(wEvtApi, kernel32, List.of("test")).getFirst();
         List<EventSubscribeXmlRenderingCallback> renderingCallbacks = getRenderingCallbacks(2);
         EventSubscribeXmlRenderingCallback subscribeRenderingCallback = renderingCallbacks.get(0);
         EventSubscribeXmlRenderingCallback renderingCallback = renderingCallbacks.get(1);
@@ -209,7 +209,7 @@ public class ConsumeWindowsEventLogTest {
     public void testScheduleQueueStopThrowsException() throws Throwable {
         ReflectionUtils.invokeMethodsWithAnnotation(OnScheduled.class, evtSubscribe, testRunner.getProcessContext());
 
-        WinNT.HANDLE handle = mockEventHandles(wEvtApi, kernel32, Arrays.asList("test")).get(0);
+        WinNT.HANDLE handle = mockEventHandles(wEvtApi, kernel32, List.of("test")).getFirst();
         getRenderingCallback().onEvent(WEvtApi.EvtSubscribeNotifyAction.DELIVER, null, handle);
 
         assertThrows(ProcessException.class, () -> {
@@ -222,7 +222,7 @@ public class ConsumeWindowsEventLogTest {
     }
 
     public EventSubscribeXmlRenderingCallback getRenderingCallback() {
-        return getRenderingCallbacks(1).get(0);
+        return getRenderingCallbacks(1).getFirst();
     }
 
     public List<EventSubscribeXmlRenderingCallback> getRenderingCallbacks(int times) {

--- a/nifi-extension-bundles/nifi-workday-bundle/nifi-workday-processors/src/main/java/org/apache/nifi/processors/workday/GetWorkdayReport.java
+++ b/nifi-extension-bundles/nifi-workday-bundle/nifi-workday-processors/src/main/java/org/apache/nifi/processors/workday/GetWorkdayReport.java
@@ -26,11 +26,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -164,15 +162,20 @@ public class GetWorkdayReport extends AbstractProcessor {
         .description("Response FlowFiles transferred when receiving HTTP responses with a status code between 200 and 299.")
         .build();
 
-    protected static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(ORIGINAL, SUCCESS, FAILURE)));
-    protected static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
-        REPORT_URL,
-        WORKDAY_USERNAME,
-        WORKDAY_PASSWORD,
-        WEB_CLIENT_SERVICE,
-        RECORD_READER_FACTORY,
-        RECORD_WRITER_FACTORY
-    ));
+    protected static final Set<Relationship> RELATIONSHIPS = Set.of(
+            ORIGINAL,
+            SUCCESS,
+            FAILURE
+    );
+
+    protected static final List<PropertyDescriptor> PROPERTIES = List.of(
+            REPORT_URL,
+            WORKDAY_USERNAME,
+            WORKDAY_PASSWORD,
+            WEB_CLIENT_SERVICE,
+            RECORD_READER_FACTORY,
+            RECORD_WRITER_FACTORY
+    );
 
     private final AtomicReference<WebClientService> webClientReference = new AtomicReference<>();
     private final AtomicReference<RecordReaderFactory> recordReaderFactoryReference = new AtomicReference<>();


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14082](https://issues.apache.org/jira/browse/NIFI-14082)
This PR focuses on a uniform manner of creating the list of PropertyDescriptor objects and Set of relationships each processor may have. In addition Intellij suggestions were made more or less to the various unit tests which exercised the changed processors and in some cases to the processors themselves.
Where  possible renamed all list of PropertyDescriptor to PROPERTIES and the set of RelationShip to RELATIONSHIPS ensured they were both `private static final` and ensured all properties and relationships are on individual lines for increased readability.
All processors should now either use `List.of` or `Stream.concat` (where concatenation is needed between multiple lists) for declaring their list of property descriptor and `Set.of` when declaring their relationships.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
