### PR TITLE
NIFI-14098 Correct runtime-manifest dependency on assembly packaging

### DIFF
--- a/nifi-manifest/nifi-runtime-manifest/pom.xml
+++ b/nifi-manifest/nifi-runtime-manifest/pom.xml
@@ -90,11 +90,15 @@
                         </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <ignoredUnusedDeclaredDependencies combine.children="append">
-                        <ignoredUnusedDeclaredDependency>org.apache.nifi:nifi-assembly</ignoredUnusedDeclaredDependency>
-                    </ignoredUnusedDeclaredDependencies>
-                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.nifi</groupId>
+                        <artifactId>nifi-assembly</artifactId>
+                        <version>${project.version}</version>
+                        <classifier>manifests</classifier>
+                        <type>zip</type>
+                    </dependency>
+                </dependencies>
             </plugin>
             <!-- Execute the runtime manifest generator -->
             <plugin>


### PR DESCRIPTION
# Summary

[NIFI-14098](https://issues.apache.org/jira/browse/NIFI-14098) Corrects the dependencies in `nifi-runtime-manifest` on the `nifi-assembly` package by introducing plugin-scoped dependencies, required for unpacking.

This change resolves dependency resolution issues when running a clean install with a new version of the project.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
