### PR TITLE
NIFI-14103 Correct thread safety for Proxied Entity Encoder

### DIFF
--- a/nifi-commons/nifi-security-proxied-entity/src/main/java/org/apache/nifi/security/proxied/entity/StandardProxiedEntityEncoder.java
+++ b/nifi-commons/nifi-security-proxied-entity/src/main/java/org/apache/nifi/security/proxied/entity/StandardProxiedEntityEncoder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.security.proxied.entity;
 
+import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -34,7 +35,7 @@ public class StandardProxiedEntityEncoder implements ProxiedEntityEncoder {
 
     private static final String ESCAPED_LT = "\\\\<";
 
-    private static final CharsetEncoder headerValueCharsetEncoder = StandardCharsets.US_ASCII.newEncoder();
+    private static final Charset headerValueCharset = StandardCharsets.US_ASCII;
 
     private static final Base64.Encoder headerValueEncoder = Base64.getEncoder();
 
@@ -73,7 +74,9 @@ public class StandardProxiedEntityEncoder implements ProxiedEntityEncoder {
         } else {
             final String escaped = identity.replaceAll(LT, ESCAPED_LT).replaceAll(GT, ESCAPED_GT);
 
-            if (headerValueCharsetEncoder.canEncode(escaped)) {
+            // Create method-local CharsetEncoder for thread-safe state handling
+            final CharsetEncoder charsetEncoder = headerValueCharset.newEncoder();
+            if (charsetEncoder.canEncode(escaped)) {
                 // Strings limited to US-ASCII characters can be transmitted as HTTP header values without encoding
                 sanitized = escaped;
             } else {


### PR DESCRIPTION
# Summary

[NIFI-14103](https://issues.apache.org/jira/browse/NIFI-14103) Corrects the thread safety of `StandardProxiedEntityEncoder` by creating a new instance of `CharsetEncoder` for each method invocation. This change matches historical implementation approaches prior to the creation of `StandardProxiedEntityEncoder`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
