### PR TITLE
NIFI-14105: Fixing issue in EditProcessGroup dialog when there is no …

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/create-process-group/create-process-group.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/create-process-group/create-process-group.component.ts
@@ -23,7 +23,6 @@ import { CanvasState } from '../../../../../state';
 import { createProcessGroup, uploadProcessGroup } from '../../../../../state/flow/flow.actions';
 import { selectSaving } from '../../../../../state/flow/flow.selectors';
 import { AsyncPipe } from '@angular/common';
-import { ErrorBanner } from '../../../../../../../ui/common/error-banner/error-banner.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -42,7 +41,6 @@ import { ContextErrorBanner } from '../../../../../../../ui/common/context-error
     standalone: true,
     imports: [
         AsyncPipe,
-        ErrorBanner,
         MatButtonModule,
         MatDialogModule,
         MatFormFieldModule,
@@ -84,7 +82,7 @@ export class CreateProcessGroup extends CloseOnEscapeDialog {
         });
 
         dialogRequest.parameterContexts.forEach((parameterContext) => {
-            if (parameterContext.permissions.canRead) {
+            if (parameterContext.permissions.canRead && parameterContext.component) {
                 this.parameterContextsOptions.push({
                     text: parameterContext.component.name,
                     value: parameterContext.id,

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/edit-process-group/edit-process-group.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/edit-process-group/edit-process-group.component.html
@@ -33,7 +33,7 @@
                             <mat-form-field>
                                 <mat-label>Parameter Context</mat-label>
                                 <mat-select formControlName="parameterContext">
-                                    @for (option of parameterContextsOptions; track option) {
+                                    @for (option of parameterContextsOptions; track option.value) {
                                         @if (option.description) {
                                             <mat-option
                                                 [value]="option.value"

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/edit-process-group/edit-process-group.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/edit-process-group/edit-process-group.component.ts
@@ -59,18 +59,27 @@ import { ContextErrorBanner } from '../../../../../../../ui/common/context-error
 })
 export class EditProcessGroup extends TabbedDialog {
     @Input() set parameterContexts(parameterContexts: ParameterContextEntity[]) {
+        this.initializeParameterContextOptions();
+
         parameterContexts.forEach((parameterContext) => {
-            if (parameterContext.permissions.canRead) {
+            if (parameterContext.permissions.canRead && parameterContext.component) {
                 this.parameterContextsOptions.push({
                     text: parameterContext.component.name,
                     value: parameterContext.id,
                     description: parameterContext.component.description
                 });
             } else {
+                let disabled: boolean;
+                if (this.request.entity.component.parameterContext) {
+                    disabled = this.request.entity.component.parameterContext.id !== parameterContext.id;
+                } else {
+                    disabled = true;
+                }
+
                 this.parameterContextsOptions.push({
                     text: parameterContext.id,
                     value: parameterContext.id,
-                    disabled: this.request.entity.component.parameterContext.id !== parameterContext.id
+                    disabled
                 });
             }
         });
@@ -167,10 +176,7 @@ export class EditProcessGroup extends TabbedDialog {
 
         this.readonly = !request.entity.permissions.canWrite;
 
-        this.parameterContextsOptions.push({
-            text: 'No parameter context',
-            value: null
-        });
+        this.initializeParameterContextOptions();
 
         this.editProcessGroupForm = this.formBuilder.group({
             name: new FormControl(request.entity.component.name, Validators.required),
@@ -201,6 +207,15 @@ export class EditProcessGroup extends TabbedDialog {
         this.initialStatelessFlowTimeout = request.entity.component.statelessFlowTimeout;
 
         this.executionEngineChanged(request.entity.component.executionEngine);
+    }
+
+    private initializeParameterContextOptions(): void {
+        this.parameterContextsOptions = [
+            {
+                text: 'No parameter context',
+                value: null
+            }
+        ];
     }
 
     executionEngineChanged(value: string): void {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/group-components/group-components.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/process-group/group-components/group-components.component.ts
@@ -73,7 +73,7 @@ export class GroupComponents {
         });
 
         dialogRequest.parameterContexts.forEach((parameterContext) => {
-            if (parameterContext.permissions.canRead) {
+            if (parameterContext.permissions.canRead && parameterContext.component) {
                 this.parameterContextsOptions.push({
                     text: parameterContext.component.name,
                     value: parameterContext.id,

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/state/parameter-context-listing/parameter-context-listing.effects.ts
@@ -534,11 +534,14 @@ export class ParameterContextListingEffects {
                 ofType(ParameterContextListingActions.promptParameterContextDeletion),
                 map((action) => action.request),
                 tap((request) => {
+                    // @ts-ignore - component will be defined since the user has permissions to delete the context, but it is optional as defined by the type
+                    const name = request.parameterContext.component.name;
+
                     const dialogReference = this.dialog.open(YesNoDialog, {
                         ...SMALL_DIALOG,
                         data: {
                             title: 'Delete Parameter Context',
-                            message: `Delete parameter context ${request.parameterContext.component.name}?`
+                            message: `Delete parameter context ${name}?`
                         }
                     });
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/edit-parameter-context/edit-parameter-context.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/edit-parameter-context/edit-parameter-context.component.ts
@@ -32,6 +32,7 @@ import { Client } from '../../../../../service/client.service';
 import { ParameterTable } from '../parameter-table/parameter-table.component';
 import {
     EditParameterResponse,
+    ParameterContext,
     ParameterContextEntity,
     ParameterContextUpdateRequestEntity,
     ParameterEntity,
@@ -104,20 +105,23 @@ export class EditParameterContext extends TabbedDialog {
             this.isNew = false;
             this.readonly = !request.parameterContext.permissions.canWrite;
 
+            // @ts-ignore - component will be defined since the user has permissions to edit the context, but it is optional as defined by the type
+            const parameterContext: ParameterContext = request.parameterContext.component;
+
             this.editParameterContextForm = this.formBuilder.group({
-                name: new FormControl(request.parameterContext.component.name, Validators.required),
-                description: new FormControl(request.parameterContext.component.description),
+                name: new FormControl(parameterContext.name, Validators.required),
+                description: new FormControl(parameterContext.description),
                 parameters: new FormControl({
-                    value: request.parameterContext.component.parameters,
+                    value: parameterContext.parameters,
                     disabled: this.readonly
                 }),
                 inheritedParameterContexts: new FormControl({
-                    value: request.parameterContext.component.inheritedParameterContexts,
+                    value: parameterContext.inheritedParameterContexts,
                     disabled: this.readonly
                 })
             });
-            if (request.parameterContext.component.parameterProviderConfiguration) {
-                this.parameterProvider = request.parameterContext.component.parameterProviderConfiguration.component;
+            if (parameterContext.parameterProviderConfiguration) {
+                this.parameterProvider = parameterContext.parameterProviderConfiguration.component;
             }
         } else {
             this.isNew = true;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-inheritance/parameter-context-inheritance.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-inheritance/parameter-context-inheritance.component.ts
@@ -113,7 +113,7 @@ export class ParameterContextInheritance implements ControlValueAccessor {
     }
 
     hasDescription(entity: ParameterContextEntity): boolean {
-        return !this.nifiCommon.isBlank(entity.component.description);
+        return !this.nifiCommon.isBlank(entity.component?.description);
     }
 
     removeSelected(entity: ParameterContextEntity, i: number): void {
@@ -172,12 +172,15 @@ export class ParameterContextInheritance implements ControlValueAccessor {
 
     private serializeInheritedParameterContexts(): ParameterContextReferenceEntity[] {
         return this.selectedParameterContexts.map((parameterContext) => {
+            // @ts-ignore - component will be defined since the user has permissions to inherit from the context, but it is optional as defined by the type
+            const name = parameterContext.component.name;
+
             return {
                 permissions: parameterContext.permissions,
                 id: parameterContext.id,
                 component: {
-                    id: parameterContext.component.id,
-                    name: parameterContext.component.name
+                    id: parameterContext.id,
+                    name
                 }
             };
         });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-table/parameter-context-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-context-table/parameter-context-table.component.ts
@@ -63,11 +63,11 @@ export class ParameterContextTable {
     }
 
     formatName(entity: ParameterContextEntity): string {
-        return this.canRead(entity) ? entity.component.name : entity.id;
+        return this.canRead(entity) && entity.component ? entity.component.name : entity.id;
     }
 
     formatProvider(entity: ParameterContextEntity): string {
-        if (!this.canRead(entity)) {
+        if (!this.canRead(entity) || !entity.component) {
             return '';
         }
         const paramProvider = entity.component.parameterProviderConfiguration;
@@ -78,7 +78,7 @@ export class ParameterContextTable {
     }
 
     formatDescription(entity: ParameterContextEntity): string {
-        return this.canRead(entity) ? entity.component.description : '';
+        return this.canRead(entity) && entity.component ? entity.component.description : '';
     }
 
     editClicked(entity: ParameterContextEntity): void {
@@ -105,14 +105,14 @@ export class ParameterContextTable {
     }
 
     canGoToParameterProvider(entity: ParameterContextEntity): boolean {
-        if (!this.canRead(entity)) {
+        if (!this.canRead(entity) || !entity.component) {
             return false;
         }
         return !!entity.component.parameterProviderConfiguration;
     }
 
     getParameterProviderLink(entity: ParameterContextEntity): string[] {
-        if (!entity.component.parameterProviderConfiguration) {
+        if (!this.canRead(entity) || !entity.component || !entity.component.parameterProviderConfiguration) {
             return [];
         }
         return ['/settings', 'parameter-providers', entity.component.parameterProviderConfiguration.id];

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.ts
@@ -20,8 +20,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
-import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { CdkConnectedOverlay, CdkOverlayOrigin } from '@angular/cdk/overlay';
+import { NgTemplateOutlet } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { EditParameterResponse, ParameterEntity } from '../../../../../state/shared';
 import { NifiTooltipDirective, NiFiCommon, TextTip, Parameter } from '@nifi/shared';
@@ -51,10 +50,7 @@ export interface ParameterItem {
         MatTableModule,
         MatSortModule,
         NgTemplateOutlet,
-        CdkOverlayOrigin,
-        CdkConnectedOverlay,
         RouterLink,
-        AsyncPipe,
         NifiTooltipDirective,
         ParameterReferences,
         MatMenu,

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/shared/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/shared/index.ts
@@ -281,7 +281,7 @@ export interface ParameterContextEntity {
     permissions: Permissions;
     id: string;
     uri: string;
-    component: ParameterContext;
+    component?: ParameterContext;
 }
 
 export interface ParameterContext {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/property-table/property-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/property-table/property-table.component.ts
@@ -235,7 +235,7 @@ export class PropertyTable implements AfterViewInit, ControlValueAccessor {
                 // the dependent value contains parameter reference, if the user can view
                 // the parameter context resolve the parameter value to see if it
                 // satisfies the dependent values
-                if (this.parameterContext?.permissions.canRead) {
+                if (this.parameterContext?.permissions.canRead && this.parameterContext.component) {
                     const referencedParameter = this.parameterContext.component.parameters
                         .map((parameterEntity) => parameterEntity.parameter)
                         .find((parameter: Parameter) => dependentValue == `#{${parameter.name}}`);
@@ -328,7 +328,7 @@ export class PropertyTable implements AfterViewInit, ControlValueAccessor {
         if (!this.supportsParameters || !this.parameterContext) {
             return null;
         }
-        if (this.parameterContext.permissions.canRead) {
+        if (this.parameterContext.permissions.canRead && this.parameterContext.component) {
             return this.parameterContext.component.parameters
                 .map((parameterEntity) => parameterEntity.parameter)
                 .filter((parameter: Parameter) => parameter.sensitive == propertyItem.descriptor.sensitive);


### PR DESCRIPTION
…selected Parameter Context and the user lacks permissions to an available Parameter Context.

- Marked the component in the ParameterContextEntity as optional.
- Updated usage to account for possible undefined component.