### PR TITLE
NIFI-14110 Support to limit content size in PackageFlowFile

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/FlowFileFilters.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/processor/util/FlowFileFilters.java
@@ -43,22 +43,20 @@ public class FlowFileFilters {
 
             @Override
             public FlowFileFilterResult filter(final FlowFile flowFile) {
-                if (count == 0) {
-                    count++;
-                    size += flowFile.getSize();
+                count += 1;
+                size += flowFile.getSize();
 
+                if (count == 1) {
+                    // first FlowFile is always accepted
                     return FlowFileFilterResult.ACCEPT_AND_CONTINUE;
                 }
 
-                if ((size + flowFile.getSize() > maxBytes) || (count + 1 > maxCount)) {
+                if (size > maxBytes || count > maxCount) {
                     return FlowFileFilterResult.REJECT_AND_TERMINATE;
                 }
 
-                count++;
-                size += flowFile.getSize();
                 return FlowFileFilterResult.ACCEPT_AND_CONTINUE;
             }
-
         };
     }
 

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/processor/util/FlowFileFiltersTest.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/processor/util/FlowFileFiltersTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processor.util;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.DataUnit;
+import org.apache.nifi.processor.FlowFileFilter;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.apache.nifi.processor.FlowFileFilter.FlowFileFilterResult.ACCEPT_AND_CONTINUE;
+import static org.apache.nifi.processor.FlowFileFilter.FlowFileFilterResult.REJECT_AND_TERMINATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FlowFileFiltersTest {
+
+    @Nested
+    class SizeBasedFilter {
+        @Test
+        void acceptsOnlyFirstFlowFileWhenMaxCountIs0() {
+            final FlowFileFilter filter = FlowFileFilters.newSizeBasedFilter(1, DataUnit.MB, 0);
+
+            assertEquals(ACCEPT_AND_CONTINUE, filter.filter(emptyFlowFile()));
+            assertEquals(REJECT_AND_TERMINATE, filter.filter(emptyFlowFile()));
+        }
+
+        @Test
+        void rejectsFlowFilesOnceTheMaxCountWasReached() {
+            final FlowFileFilter filter = FlowFileFilters.newSizeBasedFilter(1, DataUnit.MB, 3);
+
+            assertEquals(ACCEPT_AND_CONTINUE, filter.filter(emptyFlowFile()));
+            assertEquals(ACCEPT_AND_CONTINUE, filter.filter(emptyFlowFile()));
+            assertEquals(ACCEPT_AND_CONTINUE, filter.filter(emptyFlowFile()));
+
+            assertEquals(REJECT_AND_TERMINATE, filter.filter(emptyFlowFile()));
+        }
+
+        @Test
+        void acceptsOnlyFirstFlowFileWhenItsContentSizeExceedsTheMaxSize() {
+            final FlowFileFilter filter = FlowFileFilters.newSizeBasedFilter(10, DataUnit.B, 10_000);
+
+            assertEquals(ACCEPT_AND_CONTINUE, filter.filter(flowFileOfSize(20)));
+            assertEquals(REJECT_AND_TERMINATE, filter.filter(emptyFlowFile()));
+        }
+
+        @Test
+        void rejectsFlowFilesOnceMaxSizeWasReached() {
+            final FlowFileFilter filter = FlowFileFilters.newSizeBasedFilter(30, DataUnit.B, 10_000);
+
+            assertEquals(ACCEPT_AND_CONTINUE, filter.filter(flowFileOfSize(5)));
+            assertEquals(ACCEPT_AND_CONTINUE, filter.filter(flowFileOfSize(10)));
+            assertEquals(ACCEPT_AND_CONTINUE, filter.filter(flowFileOfSize(15)));
+
+            // empty content FlowFiles are still accepted
+            assertEquals(ACCEPT_AND_CONTINUE, filter.filter(emptyFlowFile()));
+
+            assertEquals(REJECT_AND_TERMINATE, filter.filter(flowFileOfSize(1)));
+            // empty content FlowFiles are no longer accepted
+            assertEquals(REJECT_AND_TERMINATE, filter.filter(emptyFlowFile()));
+        }
+
+        private FlowFile emptyFlowFile() {
+            return flowFileOfSize(0);
+        }
+
+        private FlowFile flowFileOfSize(final long byteSize)  {
+            final int id = claimFlowFileId();
+
+            return new FlowFile() {
+                @Override
+                public long getId() {
+                    return id;
+                }
+
+                @Override
+                public long getEntryDate() {
+                    return 0;
+                }
+
+                @Override
+                public long getLineageStartDate() {
+                    return 0;
+                }
+
+                @Override
+                public long getLineageStartIndex() {
+                    return 0;
+                }
+
+                @Override
+                public Long getLastQueueDate() {
+                    return 0L;
+                }
+
+                @Override
+                public long getQueueDateIndex() {
+                    return 0;
+                }
+
+                @Override
+                public boolean isPenalized() {
+                    return false;
+                }
+
+                @Override
+                public String getAttribute(String key) {
+                    return null;
+                }
+
+                @Override
+                public long getSize() {
+                    return byteSize;
+                }
+
+                @Override
+                public Map<String, String> getAttributes() {
+                    return Map.of();
+                }
+
+                @Override
+                public int compareTo(FlowFile o) {
+                    return 0;
+                }
+            };
+        }
+    }
+
+    private int flowFileId = 0;
+
+    private int claimFlowFileId() {
+        return flowFileId++;
+    }
+}

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PackageFlowFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PackageFlowFile.java
@@ -32,10 +32,13 @@ import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.flowfile.attributes.StandardFlowFileMediaType;
 import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.DataUnit;
+import org.apache.nifi.processor.FlowFileFilter;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.FlowFileFilters;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.FlowFilePackager;
 import org.apache.nifi.util.FlowFilePackagerV3;
@@ -69,8 +72,7 @@ import java.util.Set;
         configurations = {
             @ProcessorConfiguration(
                 processorClass = PackageFlowFile.class,
-                configuration = """
-                    "Maximum Batch Size" > 1 can help improve performance by batching many flowfiles together into 1 larger file that is transmitted by InvokeHTTP.
+                configuration = PackageFlowFile.BATCHING_BEHAVIOUR_DESCRIPTION + """
 
                     Connect the success relationship of PackageFlowFile to the input of InvokeHTTP.
                 """
@@ -100,8 +102,7 @@ import java.util.Set;
         configurations = {
             @ProcessorConfiguration(
                 processorClass = PackageFlowFile.class,
-                configuration = """
-                    "Maximum Batch Size" > 1 can improve storage efficiency by batching many FlowFiles together into 1 larger file that is stored.
+                configuration = PackageFlowFile.BATCHING_BEHAVIOUR_DESCRIPTION + """
 
                     Connect the success relationship to the input of any NiFi egress processor for offline storage.
                 """
@@ -120,18 +121,36 @@ import java.util.Set;
 })
 public class PackageFlowFile extends AbstractProcessor {
 
+    public static final String BATCHING_BEHAVIOUR_DESCRIPTION = """
+                "Maximum Batch Size" > 1 can improve storage or transmission efficiency by batching many FlowFiles together into 1 larger file.
+                "Maximum Batch Content Size" can be used to enforce a soft upper limit on the overall package size.
+
+                Note, that the Batch properties only restrict the maximum amount of FlowFiles to incorporate into a single package.
+                In case less FlowFiles are queued than the properties allow for,
+                the processor will not wait for the limits to be reached but create smaller packages instead.
+            """;
+
     public static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
             .name("max-batch-size")
             .displayName("Maximum Batch Size")
-            .description("Maximum number of FlowFiles to package into one output FlowFile using a best effort, non guaranteed approach."
-                    + " Multiple input queues can produce unexpected batching behavior.")
+            .description("Maximum number of FlowFiles to package into one output FlowFile.")
             .required(true)
             .defaultValue("1")
             .addValidator(StandardValidators.createLongValidator(1, 10_000, true))
             .build();
 
+    public static final PropertyDescriptor BATCH_CONTENT_SIZE = new PropertyDescriptor.Builder()
+            .name("Maximum Batch Content Size")
+            .description("Maximum combined content size of FlowFiles to package into one output FlowFile. " +
+                    "Note, that FlowFiles whose content exceeds this limit are packaged separately.")
+            .required(true)
+            .defaultValue("1 GB")
+            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
+            .build();
+
     private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
-            BATCH_SIZE
+            BATCH_SIZE,
+            BATCH_CONTENT_SIZE
     );
 
     static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -160,7 +179,13 @@ public class PackageFlowFile extends AbstractProcessor {
 
     @Override
     public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
-        final List<FlowFile> flowFiles = session.get(context.getProperty(BATCH_SIZE).asInteger());
+        final FlowFileFilter filter = FlowFileFilters.newSizeBasedFilter(
+                context.getProperty(BATCH_CONTENT_SIZE).asDataSize(DataUnit.B),
+                DataUnit.B,
+                context.getProperty(BATCH_SIZE).asInteger()
+        );
+
+        final List<FlowFile> flowFiles = session.get(filter);
         if (flowFiles.isEmpty()) {
             return;
         }


### PR DESCRIPTION
Due to using a different API to retrieve the FlowFiles the behaviour when working with multiple queues is no longer unspecified.

I had an circular dependency problem when depending on `nifi-mock` from `nifi-utils`, which is why I use an anonymous implementation of `FlowFile` inside the tests instead of `MockFlowFile`.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14110](https://issues.apache.org/jira/browse/NIFI-14110)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
