### PR TITLE
NIFI-14115 Set Standard HTTP Headers for Framework Responses

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/ServerProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/ServerProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.server;
+
+import org.apache.nifi.util.NiFiProperties;
+import org.eclipse.jetty.server.Server;
+
+/**
+ * Abstraction for configuring Server instances based on application properties
+ */
+interface ServerProvider {
+    /**
+     * Get Server configured using application properties
+     *
+     * @param properties Application properties
+     * @return Server
+     */
+    Server getServer(NiFiProperties properties);
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/StandardServerProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/StandardServerProvider.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.server;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.util.NiFiProperties;
+import org.apache.nifi.web.server.connector.FrameworkServerConnectorFactory;
+import org.apache.nifi.web.server.handler.HeaderWriterHandler;
+import org.apache.nifi.web.server.log.RequestLogProvider;
+import org.apache.nifi.web.server.log.StandardRequestLogProvider;
+import org.eclipse.jetty.rewrite.handler.RedirectPatternRule;
+import org.eclipse.jetty.rewrite.handler.RewriteHandler;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+import javax.net.ssl.SSLContext;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Standard implementation of Server Provider with default Handlers
+ */
+class StandardServerProvider implements ServerProvider {
+    private static final String ALL_PATHS_PATTERN = "/*";
+
+    private static final String FRONTEND_CONTEXT_PATH = "/nifi";
+
+    private final SSLContext sslContext;
+
+    StandardServerProvider(final SSLContext sslContext) {
+        this.sslContext = sslContext;
+    }
+
+    @Override
+    public Server getServer(final NiFiProperties properties) {
+        Objects.requireNonNull(properties, "Properties required");
+
+        final QueuedThreadPool threadPool = new QueuedThreadPool(properties.getWebThreads());
+        threadPool.setName("NiFi Web Server");
+        final Server server = new Server(threadPool);
+        addConnectors(server, properties, sslContext);
+
+        final Handler standardHandler = getStandardHandler(properties);
+        server.setHandler(standardHandler);
+
+        final RewriteHandler defaultRewriteHandler = new RewriteHandler();
+        final RedirectPatternRule redirectDefault = new RedirectPatternRule(ALL_PATHS_PATTERN, FRONTEND_CONTEXT_PATH);
+        defaultRewriteHandler.addRule(redirectDefault);
+        server.setDefaultHandler(defaultRewriteHandler);
+
+        final String requestLogFormat = properties.getProperty(NiFiProperties.WEB_REQUEST_LOG_FORMAT);
+        final RequestLogProvider requestLogProvider = new StandardRequestLogProvider(requestLogFormat);
+        final RequestLog requestLog = requestLogProvider.getRequestLog();
+        server.setRequestLog(requestLog);
+
+        return server;
+    }
+
+    private void addConnectors(final Server server, final NiFiProperties properties, final SSLContext sslContext) {
+        final FrameworkServerConnectorFactory serverConnectorFactory = new FrameworkServerConnectorFactory(server, properties);
+        if (properties.isHTTPSConfigured()) {
+            serverConnectorFactory.setSslContext(sslContext);
+        }
+
+        final Map<String, String> interfaces = properties.isHTTPSConfigured() ? properties.getHttpsNetworkInterfaces() : properties.getHttpNetworkInterfaces();
+        final Set<String> interfaceNames = interfaces.values().stream().filter(StringUtils::isNotBlank).collect(Collectors.toSet());
+        // Add Server Connectors based on configured Network Interface Names
+        if (interfaceNames.isEmpty()) {
+            final ServerConnector serverConnector = serverConnectorFactory.getServerConnector();
+            final String host = properties.isHTTPSConfigured() ? properties.getProperty(NiFiProperties.WEB_HTTPS_HOST) : properties.getProperty(NiFiProperties.WEB_HTTP_HOST);
+            if (StringUtils.isNotBlank(host)) {
+                serverConnector.setHost(host);
+            }
+            server.addConnector(serverConnector);
+        } else {
+            interfaceNames.stream()
+                    // Map interface name properties to Network Interfaces
+                    .map(interfaceName -> {
+                        try {
+                            return NetworkInterface.getByName(interfaceName);
+                        } catch (final SocketException e) {
+                            throw new UncheckedIOException(String.format("Network Interface [%s] not found", interfaceName), e);
+                        }
+                    })
+                    // Map Network Interfaces to host addresses
+                    .filter(Objects::nonNull)
+                    .flatMap(networkInterface -> Collections.list(networkInterface.getInetAddresses()).stream())
+                    .map(InetAddress::getHostAddress)
+                    // Map host addresses to Server Connectors
+                    .map(host -> {
+                        final ServerConnector serverConnector = serverConnectorFactory.getServerConnector();
+                        serverConnector.setHost(host);
+                        return serverConnector;
+                    })
+                    .forEach(server::addConnector);
+        }
+    }
+
+    private Handler getStandardHandler(final NiFiProperties properties) {
+        // Standard Handler supporting an ordered sequence of Handlers invoked until completion
+        final Handler.Collection standardHandler = new Handler.Sequence();
+
+        // Set Handler for standard response headers
+        standardHandler.addHandler(new HeaderWriterHandler());
+
+        // Validate Host Header when running with HTTPS enabled
+        if (properties.isHTTPSConfigured()) {
+            final HostHeaderHandler hostHeaderHandler = new HostHeaderHandler(properties);
+            standardHandler.addHandler(hostHeaderHandler);
+        }
+
+        return standardHandler;
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/filter/StandardRequestFilterProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/filter/StandardRequestFilterProvider.java
@@ -24,17 +24,9 @@ import org.apache.nifi.web.security.requests.ContentLengthFilter;
 import org.apache.nifi.web.server.log.RequestAuthenticationFilter;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.ee10.servlets.DoSFilter;
-import org.springframework.security.web.header.HeaderWriter;
-import org.springframework.security.web.header.HeaderWriterFilter;
-import org.springframework.security.web.header.writers.ContentSecurityPolicyHeaderWriter;
-import org.springframework.security.web.header.writers.HstsHeaderWriter;
-import org.springframework.security.web.header.writers.XContentTypeOptionsHeaderWriter;
-import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter;
-import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
 
 import jakarta.servlet.Filter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -44,8 +36,6 @@ import java.util.concurrent.TimeUnit;
  */
 public class StandardRequestFilterProvider implements RequestFilterProvider {
     private static final int MAX_CONTENT_SIZE_DISABLED = 0;
-
-    private static final String STANDARD_CONTENT_POLICY = "frame-ancestors 'self'";
 
     /**
      * Get Filters using provided NiFi Properties
@@ -62,8 +52,6 @@ public class StandardRequestFilterProvider implements RequestFilterProvider {
         if (properties.isHTTPSConfigured()) {
             filters.add(getFilterHolder(RequestAuthenticationFilter.class));
         }
-
-        filters.add(getHeaderWriterFilter());
 
         final int maxContentSize = getMaxContentSize(properties);
         if (maxContentSize > MAX_CONTENT_SIZE_DISABLED) {
@@ -91,21 +79,6 @@ public class StandardRequestFilterProvider implements RequestFilterProvider {
 
         filter.setName(DoSFilter.class.getSimpleName());
         return filter;
-    }
-
-    private FilterHolder getHeaderWriterFilter() {
-        final List<HeaderWriter> headerWriters = Arrays.asList(
-                new ContentSecurityPolicyHeaderWriter(STANDARD_CONTENT_POLICY),
-                new HstsHeaderWriter(),
-                new XContentTypeOptionsHeaderWriter(),
-                new XFrameOptionsHeaderWriter(XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN),
-                new XXssProtectionHeaderWriter()
-        );
-
-        final HeaderWriterFilter headerWriterFilter = new HeaderWriterFilter(headerWriters);
-        final FilterHolder filterHolder = new FilterHolder(headerWriterFilter);
-        filterHolder.setName(HeaderWriterFilter.class.getSimpleName());
-        return filterHolder;
     }
 
     private FilterHolder getFilterHolder(final Class<? extends Filter> filterClass) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/handler/HeaderWriterHandler.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/handler/HeaderWriterHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.server.handler;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Handler;
+
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+
+/**
+ * HTTP Response Header Writer Handler applies standard headers to HTTP responses
+ */
+public class HeaderWriterHandler extends Handler.Wrapper {
+    private static final String CONTENT_SECURITY_POLICY_HEADER = "Content-Security-Policy";
+    private static final String CONTENT_SECURITY_POLICY = "frame-ancestors 'self'";
+
+    private static final String FRAME_OPTIONS_HEADER = "X-Frame-Options";
+    private static final String FRAME_OPTIONS = "SAMEORIGIN";
+
+    private static final String STRICT_TRANSPORT_SECURITY_HEADER = "Strict-Transport-Security";
+    private static final String STRICT_TRANSPORT_SECURITY = "max-age=31540000";
+
+    private static final String XSS_PROTECTION_HEADER = "X-XSS-Protection";
+    private static final String XSS_PROTECTION = "1; mode=block";
+
+    /**
+     * Handle requests and set HTTP response headers
+     *
+     * @param request Jetty Request
+     * @param response Jetty Response
+     * @param callback Jetty Callback
+     * @return Handled status
+     * @throws Exception Thrown on failures from subsequent handlers
+     */
+    @Override
+    public boolean handle(final Request request, final Response response, final Callback callback) throws Exception {
+        final HttpFields.Mutable responseHeaders = response.getHeaders();
+        responseHeaders.put(CONTENT_SECURITY_POLICY_HEADER, CONTENT_SECURITY_POLICY);
+        responseHeaders.put(FRAME_OPTIONS_HEADER, FRAME_OPTIONS);
+        responseHeaders.put(XSS_PROTECTION_HEADER, XSS_PROTECTION);
+
+        if (request.isSecure()) {
+            responseHeaders.put(STRICT_TRANSPORT_SECURITY_HEADER, STRICT_TRANSPORT_SECURITY);
+        }
+
+        return super.handle(request, response, callback);
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.server;
+
+import org.apache.nifi.jetty.configuration.connector.ApplicationLayerProtocol;
+import org.apache.nifi.util.NiFiProperties;
+import org.apache.nifi.web.server.handler.HeaderWriterHandler;
+import org.eclipse.jetty.rewrite.handler.RewriteHandler;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.Server;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardServerProviderTest {
+
+    private static final String RANDOM_PORT = "0";
+
+    private static final String SSL_PROTOCOL = "ssl";
+
+    private static final String CONTENT_SECURITY_POLICY_HEADER = "Content-Security-Policy";
+
+    private static final String FRAME_OPTIONS_HEADER = "X-Frame-Options";
+
+    private static final String XSS_PROTECTION_HEADER = "X-XSS-Protection";
+
+    @Test
+    void testGetServer() {
+        final Properties applicationProperties = new Properties();
+        applicationProperties.setProperty(NiFiProperties.WEB_HTTP_PORT, RANDOM_PORT);
+        final NiFiProperties properties = NiFiProperties.createBasicNiFiProperties(null, applicationProperties);
+
+        final StandardServerProvider provider = new StandardServerProvider(null);
+
+        final Server server = provider.getServer(properties);
+
+        assertStandardConfigurationFound(server);
+        assertHttpConnectorFound(server);
+    }
+
+    @Test
+    void testGetServerHttps() throws NoSuchAlgorithmException {
+        final Properties applicationProperties = new Properties();
+        applicationProperties.setProperty(NiFiProperties.WEB_HTTPS_PORT, RANDOM_PORT);
+        final NiFiProperties properties = NiFiProperties.createBasicNiFiProperties(null, applicationProperties);
+
+        final SSLContext sslContext = SSLContext.getDefault();
+        final StandardServerProvider provider = new StandardServerProvider(sslContext);
+
+        final Server server = provider.getServer(properties);
+
+        assertStandardConfigurationFound(server);
+        assertHttpsConnectorFound(server);
+    }
+
+    @Test
+    void testGetServerStart() throws Exception {
+        final Properties applicationProperties = new Properties();
+        applicationProperties.setProperty(NiFiProperties.WEB_HTTP_PORT, RANDOM_PORT);
+        final NiFiProperties properties = NiFiProperties.createBasicNiFiProperties(null, applicationProperties);
+
+        final StandardServerProvider provider = new StandardServerProvider(null);
+
+        final Server server = provider.getServer(properties);
+
+        assertStandardConfigurationFound(server);
+        assertHttpConnectorFound(server);
+
+        try {
+            server.start();
+
+            final URI serverUri = server.getURI();
+
+            final HttpHeaders responseHeaders = getResponseHeaders(serverUri);
+
+            assertHeaderFound(responseHeaders, CONTENT_SECURITY_POLICY_HEADER);
+            assertHeaderFound(responseHeaders, FRAME_OPTIONS_HEADER);
+            assertHeaderFound(responseHeaders, XSS_PROTECTION_HEADER);
+        } finally {
+            server.stop();
+        }
+    }
+
+    HttpHeaders getResponseHeaders(final URI serverUri) throws IOException, InterruptedException {
+        try (HttpClient httpClient = HttpClient.newHttpClient()) {
+            final HttpRequest httpRequest = HttpRequest.newBuilder(serverUri).build();
+            final HttpResponse<Void> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.discarding());
+            return response.headers();
+        }
+    }
+
+    void assertHeaderFound(final HttpHeaders headers, final String headerName) {
+        final Optional<String> header = headers.firstValue(headerName);
+        assertTrue(header.isPresent());
+    }
+
+    void assertHttpConnectorFound(final Server server) {
+        final Connector[] connectors = server.getConnectors();
+        assertNotNull(connectors);
+        final Connector connector = connectors[0];
+        final List<String> protocols = connector.getProtocols();
+        assertEquals(ApplicationLayerProtocol.HTTP_1_1.getProtocol(), protocols.getFirst());
+    }
+
+    void assertHttpsConnectorFound(final Server server) {
+        final Connector[] connectors = server.getConnectors();
+        assertNotNull(connectors);
+        final Connector connector = connectors[0];
+        final List<String> protocols = connector.getProtocols();
+        assertEquals(SSL_PROTOCOL, protocols.getFirst());
+    }
+
+    void assertStandardConfigurationFound(final Server server) {
+        assertNotNull(server);
+        assertHandlersFound(server);
+
+        final RequestLog requestLog = server.getRequestLog();
+        assertNotNull(requestLog);
+    }
+
+    void assertHandlersFound(final Server server) {
+        final Handler serverHandler = server.getHandler();
+        assertInstanceOf(Handler.Collection.class, serverHandler);
+
+        Handler defaultHandler = server.getDefaultHandler();
+        assertInstanceOf(RewriteHandler.class, defaultHandler);
+
+        final Handler.Collection handlerCollection = (Handler.Collection) serverHandler;
+        final HeaderWriterHandler headerWriterHandler = handlerCollection.getDescendant(HeaderWriterHandler.class);
+        assertNotNull(headerWriterHandler);
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/StandardServerProviderTest.java
@@ -25,7 +25,6 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 
 import javax.net.ssl.SSLContext;
 import java.security.NoSuchAlgorithmException;
@@ -72,7 +71,6 @@ class StandardServerProviderTest {
         assertHttpsConnectorFound(server);
     }
 
-    @Timeout(10)
     @Test
     void testGetServerStart() throws Exception {
         final Properties applicationProperties = new Properties();

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/filter/RestApiRequestFilterProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/filter/RestApiRequestFilterProviderTest.java
@@ -21,7 +21,6 @@ import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.ee10.servlets.DoSFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.web.header.HeaderWriterFilter;
 
 import jakarta.servlet.Filter;
 import java.util.Collections;
@@ -56,7 +55,6 @@ public class RestApiRequestFilterProviderTest {
         assertNotNull(filters);
         assertFalse(filters.isEmpty());
 
-        assertFilterClassFound(filters, HeaderWriterFilter.class);
         assertFilterClassFound(filters, DataTransferExcludedDoSFilter.class);
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/filter/StandardRequestFilterProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/test/java/org/apache/nifi/web/server/filter/StandardRequestFilterProviderTest.java
@@ -22,7 +22,6 @@ import org.apache.nifi.web.server.log.RequestAuthenticationFilter;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.web.header.HeaderWriterFilter;
 
 import jakarta.servlet.Filter;
 import java.util.Collections;
@@ -81,7 +80,7 @@ public class StandardRequestFilterProviderTest {
 
         assertFilterClassFound(filters, RequestAuthenticationFilter.class);
 
-        final FilterHolder firstFilterHolder = filters.get(0);
+        final FilterHolder firstFilterHolder = filters.getFirst();
         final Class<? extends Filter> firstFilterClass = firstFilterHolder.getHeldClass();
         assertEquals(RequestAuthenticationFilter.class, firstFilterClass);
     }
@@ -90,7 +89,6 @@ public class StandardRequestFilterProviderTest {
         assertNotNull(filters);
         assertFalse(filters.isEmpty());
 
-        assertFilterClassFound(filters, HeaderWriterFilter.class);
         assertFilterClassFound(filters, DataTransferExcludedDoSFilter.class);
     }
 


### PR DESCRIPTION
# Summary

[NIFI-14115](https://issues.apache.org/jira/browse/NIFI-14115) Adjusts the framework Jetty Server configuration to set standard HTTP headers for all responses, regardless of web application.

The current implementation uses the Spring Security `HeaderWriterFilter` and applies standard Servlet Filters to configured web applications. This covers both framework REST API and custom extensions, but does not include requests to the root web server path.

The updated implementation replaces the Servlet Filter approach with a `HeaderWriterHandler` to set the same response headers using a Jetty `Handler` class. The change introduces a new `StandardServerProvider` to decouple Jetty `Server` instance initialization from lifecycle operations. The `StandardServerProvider` includes decoupled tests for basic operation, including returning expected response headers.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
