### PR TITLE
NIFI-14116 Add PMD Rule UnnecessaryVarargsArrayCreation

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
@@ -1118,7 +1118,7 @@ public abstract class AbstractComponentNode implements ComponentNode {
         if (!matchesApiByBundleCoordinates) {
             final Class<? extends ControllerService> controllerServiceImplClass = controllerServiceNode.getControllerServiceImplementation().getClass();
             logger.debug("Comparing methods from service api '{}' against service implementation '{}'",
-                    new Object[]{controllerServiceApiClass.getCanonicalName(), controllerServiceImplClass.getCanonicalName()});
+                    controllerServiceApiClass.getCanonicalName(), controllerServiceImplClass.getCanonicalName());
 
             final ControllerServiceApiMatcher controllerServiceApiMatcher = new ControllerServiceApiMatcher();
             final boolean matchesApi = controllerServiceApiMatcher.matches(controllerServiceApiClass, controllerServiceImplClass);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ControllerServiceApiMatcher.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/ControllerServiceApiMatcher.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 
 public class ControllerServiceApiMatcher {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(ControllerServiceApiMatcher.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ControllerServiceApiMatcher.class);
 
     /**
      * Determines if all of the methods from the API class are present in the implementation class.
@@ -60,8 +60,7 @@ public class ControllerServiceApiMatcher {
 
             if (!foundMatchingImplMethod) {
                 if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("{} does not implement the API method [{}] from {}",
-                            new Object[]{serviceImplementation.getCanonicalName(), apiMethod.toString(), serviceApi.getCanonicalName()});
+                    LOGGER.debug("{} does not implement the API method [{}] from {}", serviceImplementation.getCanonicalName(), apiMethod, serviceApi.getCanonicalName());
                 }
                 return false;
             }

--- a/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/RemoteResourceManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/main/java/org/apache/nifi/remote/RemoteResourceManager.java
@@ -59,7 +59,7 @@ public class RemoteResourceManager {
             final Class<? extends FlowFileCodec> previousValue = codecMap.put(codecName, clazz);
             if (previousValue != null) {
                 logger.warn("Multiple FlowFileCodec's found with name {}; choosing to use {} in place of {}",
-                        new Object[]{codecName, clazz.getName(), previousValue.getName()});
+                        codecName, clazz.getName(), previousValue.getName());
             }
         }
 

--- a/nifi-mock/src/main/java/org/apache/nifi/util/CapturingLogger.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/CapturingLogger.java
@@ -224,6 +224,7 @@ public class CapturingLogger implements Logger {
         this.info(format, arg, null);
     }
 
+    @SuppressWarnings("PMD.UnnecessaryVarargsArrayCreation")
     @Override
     public void info(String format, Object arg1, Object arg2) {
         this.info(format, new Object[] {arg1, arg2});
@@ -294,6 +295,7 @@ public class CapturingLogger implements Logger {
         this.warn(format, arg, null);
     }
 
+    @SuppressWarnings("PMD.UnnecessaryVarargsArrayCreation")
     @Override
     public void warn(String format, Object arg1, Object arg2) {
         this.warn(format, new Object[] {arg1, arg2});

--- a/nifi-mock/src/main/java/org/apache/nifi/util/ReflectionUtils.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/ReflectionUtils.java
@@ -98,7 +98,7 @@ public class ReflectionUtils {
                 final Class<?>[] argumentTypes = method.getParameterTypes();
                 if (argumentTypes.length > args.length) {
                     LOG.error("Unable to invoke method {} on {} because method expects {} parameters but only {} were given",
-                        new Object[]{method.getName(), instance, argumentTypes.length, args.length});
+                        method.getName(), instance, argumentTypes.length, args.length);
                     return false;
                 }
 
@@ -106,7 +106,7 @@ public class ReflectionUtils {
                     final Class<?> argType = argumentTypes[i];
                     if (!argType.isAssignableFrom(args[i].getClass())) {
                         LOG.error("Unable to invoke method {} on {} because method parameter {} is expected to be of type {} but argument passed was of type {}",
-                            new Object[]{method.getName(), instance, i, argType, args[i].getClass()});
+                            method.getName(), instance, i, argType, args[i].getClass());
                         return false;
                     }
                 }
@@ -122,7 +122,6 @@ public class ReflectionUtils {
                     }
                 } catch (final IllegalAccessException | IllegalArgumentException | InvocationTargetException t) {
                     LOG.error("Unable to invoke method {} on {}", method.getName(), instance, t);
-                    LOG.error("", t);
                     return false;
                 }
             }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
@@ -102,8 +102,7 @@ public class GitFlowPersistenceProvider implements MetadataAwareFlowPersistenceP
             logger.info("Loading remote repository [{}]", remoteRepo);
             flowMetaData.loadGitRepository(flowStorageDir);
             flowMetaData.startPushThread();
-            logger.info("Configured GitFlowPersistenceProvider with Flow Storage Directory {}",
-                    new Object[] {flowStorageDir.getAbsolutePath()});
+            logger.info("Configured GitFlowPersistenceProvider with Flow Storage Directory {}", flowStorageDir.getAbsolutePath());
         } catch (IOException | GitAPIException e) {
             throw new ProviderCreationException("Failed to load a git repository " + flowStorageDir, e);
         }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseUserGroupProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/database/DatabaseUserGroupProvider.java
@@ -123,7 +123,7 @@ public class DatabaseUserGroupProvider implements ConfigurableUserGroupProvider 
     public User addUser(final User user) throws AuthorizationAccessException {
         Objects.requireNonNull(user);
         final String sql = "INSERT INTO UGP_USER(IDENTIFIER, IDENTITY) VALUES (?, ?)";
-        jdbcTemplate.update(sql, new Object[] {user.getIdentifier(), user.getIdentity()});
+        jdbcTemplate.update(sql, user.getIdentifier(), user.getIdentity());
         return user;
     }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-utils/src/main/java/org/apache/nifi/registry/util/FormatUtils.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-utils/src/main/java/org/apache/nifi/registry/util/FormatUtils.java
@@ -236,7 +236,7 @@ public class FormatUtils {
     protected static List<Object> makeWholeNumberTime(double decimal, TimeUnit timeUnit) {
         // If the value is already a whole number, return it and the current time unit
         if (decimal == Math.rint(decimal)) {
-            return Arrays.asList(new Object[]{(long) decimal, timeUnit});
+            return Arrays.asList((long) decimal, timeUnit);
         } else if (TimeUnit.NANOSECONDS == timeUnit) {
             // The time unit is as small as possible
             if (decimal < 1.0) {
@@ -244,7 +244,7 @@ public class FormatUtils {
             } else {
                 decimal = Math.rint(decimal);
             }
-            return Arrays.asList(new Object[]{(long) decimal, timeUnit});
+            return Arrays.asList((long) decimal, timeUnit);
         } else {
             // Determine the next time unit and the respective multiplier
             TimeUnit smallerTimeUnit = getSmallerTimeUnit(timeUnit);

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/ParamProviderResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/ParamProviderResult.java
@@ -59,7 +59,7 @@ public class ParamProviderResult extends AbstractWritableResult<ParameterProvide
                 .column("Property Value", 20, 80, false)
                 .build();
         if (parameterProviderDTO.getProperties() != null && !parameterProviderDTO.getProperties().isEmpty()) {
-            parameterProviderDTO.getProperties().forEach((name, value) -> propertiesTable.addRow(new String[] {name, value}));
+            parameterProviderDTO.getProperties().forEach((name, value) -> propertiesTable.addRow(name, value));
         }
         final Table fetchedParametersTable = new Table.Builder()
                 .column("Parameter Group", 20, 60, false)
@@ -70,12 +70,12 @@ public class ParamProviderResult extends AbstractWritableResult<ParameterProvide
         if (!sortedParameterNameGroups.isEmpty()) {
             sortedParameterNameGroups.forEach(group -> {
                 group.getParameterSensitivities().keySet().stream().sorted()
-                        .forEach(param -> fetchedParametersTable.addRow(new String[] {
+                        .forEach(param -> fetchedParametersTable.addRow(
                                 group.getGroupName(),
                                 getParameterContextId(group.getParameterContextName()),
                                 group.getParameterContextName(),
                                 param
-                        }));
+                        ));
             });
         }
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/ParamProvidersResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/nifi/ParamProvidersResult.java
@@ -52,7 +52,7 @@ public class ParamProvidersResult extends AbstractWritableResult<ParameterProvid
                 .build();
         for (int i = 0; i < parameterProviders.getParameterProviders().size(); i++) {
             final ParameterProviderEntity parameterProvider = parameterProviderEntities.get(i);
-            table.addRow(new String[] {String.valueOf(i), parameterProvider.getId(), parameterProvider.getComponent().getName(), parameterProvider.getComponent().getType()});
+            table.addRow(String.valueOf(i), parameterProvider.getId(), parameterProvider.getComponent().getName(), parameterProvider.getComponent().getType());
         }
         final TableWriter tableWriter = new DynamicTableWriter();
         tableWriter.write(table, output);

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -37,6 +37,7 @@ under the License.
 
     <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation" />
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
+    <rule ref="category/java/bestpractices.xml/UnnecessaryVarargsArrayCreation" />
 
     <rule ref="category/java/codestyle.xml/AvoidDollarSigns" />
     <rule ref="category/java/codestyle.xml/ExtendsObject" />


### PR DESCRIPTION
# Summary

[NIFI-14116](https://issues.apache.org/jira/browse/NIFI-14116) Adds the `UnnecessaryVarargsArrayCreation` rule to the standard PMD configuration.

This rule detects unnecessary array creation where variable arguments can be used. This is particularly useful for log statements. Changes build on work to standardize code conventions across the repository, and include changes to bring remaining references in line with rule requirements.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
