### PR TITLE
NIFI-14109 Refactored remaining processors and control services to be uniform when creating properties and relationships.

### DIFF
--- a/nifi-extension-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/main/java/org/apache/nifi/processors/airtable/QueryAirtableTable.java
+++ b/nifi-extension-bundles/nifi-airtable-bundle/nifi-airtable-processors/src/main/java/org/apache/nifi/processors/airtable/QueryAirtableTable.java
@@ -194,7 +194,7 @@ public class QueryAirtableTable extends AbstractProcessor {
             .description("For FlowFiles created as a result of a successful query.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             API_URL,
             PAT,
             BASE_ID,
@@ -217,7 +217,7 @@ public class QueryAirtableTable extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -139,7 +139,7 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .build();
 
-    protected static final List<PropertyDescriptor> PARENT_PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BROKERS,
             HOST, PORT,
             V_HOST,
@@ -147,8 +147,11 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
             PASSWORD,
             AMQP_VERSION,
             SSL_CONTEXT_SERVICE,
-            USE_CERT_AUTHENTICATION
-    );
+            USE_CERT_AUTHENTICATION);
+
+    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
 
     private BlockingQueue<AMQPResource<T>> resourceQueue;
 

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessor.java
@@ -139,23 +139,16 @@ abstract class AbstractAMQPProcessor<T extends AMQPWorker> extends AbstractProce
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> propertyDescriptors;
-
-    static {
-        propertyDescriptors = List.of(
-                BROKERS,
-                HOST, PORT,
-                V_HOST,
-                USER,
-                PASSWORD,
-                AMQP_VERSION,
-                SSL_CONTEXT_SERVICE,
-                USE_CERT_AUTHENTICATION);
-    }
-
-    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
-        return propertyDescriptors;
-    }
+    protected static final List<PropertyDescriptor> PARENT_PROPERTIES = List.of(
+            BROKERS,
+            HOST, PORT,
+            V_HOST,
+            USER,
+            PASSWORD,
+            AMQP_VERSION,
+            SSL_CONTEXT_SERVICE,
+            USE_CERT_AUTHENTICATION
+    );
 
     private BlockingQueue<AMQPResource<T>> resourceQueue;
 

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -162,7 +162,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         .description("All FlowFiles that are received from the AMQP queue are routed to this relationship")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
           Stream.of(
               QUEUE,
               AUTO_ACKNOWLEDGE,
@@ -172,7 +172,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
               HEADER_KEY_PREFIX,
               HEADER_SEPARATOR,
               REMOVE_CURLY_BRACES
-          ), PARENT_PROPERTIES.stream()
+          ), getCommonPropertyDescriptors().stream()
     ).toList();
 
     private static final Set<Relationship> RELATIONSHIPS = Set.of(
@@ -315,7 +315,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/ConsumeAMQP.java
@@ -40,13 +40,12 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Tags({"amqp", "rabbit", "get", "message", "receive", "consume"})
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
@@ -163,28 +162,24 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
         .description("All FlowFiles that are received from the AMQP queue are routed to this relationship")
         .build();
 
-    private static final List<PropertyDescriptor> propertyDescriptors;
-    private static final Set<Relationship> relationships;
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+          Stream.of(
+              QUEUE,
+              AUTO_ACKNOWLEDGE,
+              BATCH_SIZE,
+              PREFETCH_COUNT,
+              HEADER_FORMAT,
+              HEADER_KEY_PREFIX,
+              HEADER_SEPARATOR,
+              REMOVE_CURLY_BRACES
+          ), PARENT_PROPERTIES.stream()
+    ).toList();
 
-    private static final ObjectMapper objectMapper;
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
-    static {
-        List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(QUEUE);
-        properties.add(AUTO_ACKNOWLEDGE);
-        properties.add(BATCH_SIZE);
-        properties.add(PREFETCH_COUNT);
-        properties.add(HEADER_FORMAT);
-        properties.add(HEADER_KEY_PREFIX);
-        properties.add(HEADER_SEPARATOR);
-        properties.add(REMOVE_CURLY_BRACES);
-        properties.addAll(getCommonPropertyDescriptors());
-        propertyDescriptors = Collections.unmodifiableList(properties);
-
-        relationships = Set.of(REL_SUCCESS);
-
-        objectMapper = new ObjectMapper();
-    }
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     /**
      * Will construct a {@link FlowFile} containing the body of the consumed AMQP message (if {@link GetResponse} returned by {@link AMQPConsumer} is
@@ -303,7 +298,7 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
     }
 
     private static String convertMapToJSONString(Map<String, Object> headers) throws JsonProcessingException {
-        return objectMapper.writeValueAsString(headers);
+        return OBJECT_MAPPER.writeValueAsString(headers);
     }
 
     @Override
@@ -320,12 +315,12 @@ public class ConsumeAMQP extends AbstractAMQPProcessor<AMQPConsumer> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     public enum OutputHeaderFormat implements DescribedValue {

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -132,7 +132,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
             .description("All FlowFiles that cannot be routed to the AMQP destination are routed to this relationship")
             .build();
 
-    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
             Stream.of(
                     EXCHANGE,
                     ROUTING_KEY,
@@ -140,7 +140,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
                     HEADERS_PATTERN,
                     HEADER_SEPARATOR
             ),
-            PARENT_PROPERTIES.stream()
+            getCommonPropertyDescriptors().stream()
     ).toList();
 
     private final static Set<Relationship> RELATIONSHIPS = Set.of(
@@ -203,7 +203,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/main/java/org/apache/nifi/amqp/processors/PublishAMQP.java
@@ -140,7 +140,7 @@ public class PublishAMQP extends AbstractAMQPProcessor<AMQPPublisher> {
                     HEADERS_PATTERN,
                     HEADER_SEPARATOR
             ),
-            getCommonPropertyDescriptors().stream()
+            PARENT_PROPERTIES.stream()
     ).toList();
 
     private final static Set<Relationship> RELATIONSHIPS = Set.of(

--- a/nifi-extension-bundles/nifi-apicurio-bundle/nifi-apicurio-schema-registry-service/src/main/java/org/apache/nifi/apicurio/schemaregistry/ApicurioSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-apicurio-bundle/nifi-apicurio-schema-registry-service/src/main/java/org/apache/nifi/apicurio/schemaregistry/ApicurioSchemaRegistry.java
@@ -94,7 +94,7 @@ public class ApicurioSchemaRegistry extends AbstractControllerService implements
             .identifiesControllerService(WebClientServiceProvider.class)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SCHEMA_REGISTRY_URL,
             SCHEMA_GROUP_ID,
             CACHE_SIZE,
@@ -105,7 +105,7 @@ public class ApicurioSchemaRegistry extends AbstractControllerService implements
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private volatile SchemaRegistryClient client;

--- a/nifi-extension-bundles/nifi-asana-bundle/nifi-asana-processors/src/main/java/org/apache/nifi/processors/asana/GetAsanaObject.java
+++ b/nifi-extension-bundles/nifi-asana-bundle/nifi-asana-processors/src/main/java/org/apache/nifi/processors/asana/GetAsanaObject.java
@@ -190,7 +190,7 @@ public class GetAsanaObject extends AbstractProcessor {
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .build();
 
-    protected static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PROP_ASANA_CLIENT_SERVICE,
             PROP_DISTRIBUTED_CACHE_SERVICE,
             PROP_ASANA_OBJECT_TYPE,
@@ -236,7 +236,7 @@ public class GetAsanaObject extends AbstractProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-asana-bundle/nifi-asana-services/src/main/java/org/apache/nifi/controller/asana/StandardAsanaClientProviderService.java
+++ b/nifi-extension-bundles/nifi-asana-bundle/nifi-asana-services/src/main/java/org/apache/nifi/controller/asana/StandardAsanaClientProviderService.java
@@ -71,7 +71,7 @@ public class StandardAsanaClientProviderService extends AbstractControllerServic
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .build();
 
-    protected static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             PROP_ASANA_API_BASE_URL,
             PROP_ASANA_PERSONAL_ACCESS_TOKEN,
             PROP_ASANA_WORKSPACE_NAME
@@ -83,7 +83,7 @@ public class StandardAsanaClientProviderService extends AbstractControllerServic
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-asana-bundle/nifi-asana-services/src/main/java/org/apache/nifi/controller/asana/StandardAsanaClientProviderService.java
+++ b/nifi-extension-bundles/nifi-asana-bundle/nifi-asana-services/src/main/java/org/apache/nifi/controller/asana/StandardAsanaClientProviderService.java
@@ -71,7 +71,7 @@ public class StandardAsanaClientProviderService extends AbstractControllerServic
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PROP_ASANA_API_BASE_URL,
             PROP_ASANA_PERSONAL_ACCESS_TOKEN,
             PROP_ASANA_WORKSPACE_NAME
@@ -83,7 +83,7 @@ public class StandardAsanaClientProviderService extends AbstractControllerServic
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/main/java/org/apache/nifi/processors/avro/ExtractAvroMetadata.java
+++ b/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/main/java/org/apache/nifi/processors/avro/ExtractAvroMetadata.java
@@ -113,7 +113,7 @@ public class ExtractAvroMetadata extends AbstractProcessor {
     static final String SCHEMA_FINGERPRINT_ATTR = "schema.fingerprint";
     static final String ITEM_COUNT_ATTR = "item.count";
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FINGERPRINT_ALGORITHM,
             METADATA_KEYS,
             COUNT_ITEMS
@@ -131,7 +131,7 @@ public class ExtractAvroMetadata extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/main/java/org/apache/nifi/processors/avro/SplitAvro.java
+++ b/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/main/java/org/apache/nifi/processors/avro/SplitAvro.java
@@ -150,7 +150,7 @@ public class SplitAvro extends AbstractProcessor {
             "avro.codec"
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SPLIT_STRATEGY,
             OUTPUT_SIZE,
             OUTPUT_STRATEGY,
@@ -170,7 +170,7 @@ public class SplitAvro extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/ml/AbstractAwsMachineLearningJobStarter.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/ml/AbstractAwsMachineLearningJobStarter.java
@@ -76,7 +76,7 @@ public abstract class AbstractAwsMachineLearningJobStarter<
         config.renameProperty("aws-region", REGION.getName());
     }
 
-    protected static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             MANDATORY_AWS_CREDENTIALS_PROVIDER_SERVICE,
             REGION,
             TIMEOUT,
@@ -95,6 +95,10 @@ public abstract class AbstractAwsMachineLearningJobStarter<
             REL_FAILURE
     );
 
+    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
     @Override
     public Set<Relationship> getRelationships() {
         return RELATIONSHIPS;
@@ -102,7 +106,7 @@ public abstract class AbstractAwsMachineLearningJobStarter<
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/ml/AbstractAwsMachineLearningJobStatusProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/ml/AbstractAwsMachineLearningJobStatusProcessor.java
@@ -79,7 +79,7 @@ public abstract class AbstractAwsMachineLearningJobStatusProcessor<
             .autoTerminateDefault(true)
             .build();
     public static final String FAILURE_REASON_ATTRIBUTE = "failure.reason";
-    protected static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             TASK_ID,
             MANDATORY_AWS_CREDENTIALS_PROVIDER_SERVICE,
             REGION,
@@ -91,6 +91,10 @@ public abstract class AbstractAwsMachineLearningJobStatusProcessor<
             .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
             .findAndAddModules()
             .build();
+
+    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
 
     @Override
     public void migrateProperties(final PropertyConfiguration config) {
@@ -112,7 +116,7 @@ public abstract class AbstractAwsMachineLearningJobStatusProcessor<
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     protected FlowFile writeToFlowFile(final ProcessSession session, final FlowFile flowFile, final AwsResponse response) {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-parameter-providers/src/main/java/org/apache/nifi/parameter/aws/AwsSecretsManagerParameterProvider.java
@@ -165,7 +165,7 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
 
     private static final String DEFAULT_USER_AGENT = "NiFi";
     private static final Protocol DEFAULT_PROTOCOL = Protocol.HTTPS;
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SECRET_LISTING_STRATEGY,
             SECRET_NAME_PATTERN,
             SECRET_NAMES,
@@ -179,7 +179,7 @@ public class AwsSecretsManagerParameterProvider extends AbstractParameterProvide
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/cloudwatch/PutCloudWatchMetric.java
@@ -184,7 +184,7 @@ public class PutCloudWatchMetric extends AbstractAwsSyncProcessor<CloudWatchClie
             .addValidator(DOUBLE_VALIDATOR)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         NAMESPACE,
         METRIC_NAME,
         REGION,
@@ -210,7 +210,7 @@ public class PutCloudWatchMetric extends AbstractAwsSyncProcessor<CloudWatchClie
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/service/AWSCredentialsProviderControllerService.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/service/AWSCredentialsProviderControllerService.java
@@ -264,7 +264,7 @@ public class AWSCredentialsProviderControllerService extends AbstractControllerS
         .build();
 
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         USE_DEFAULT_CREDENTIALS,
         ACCESS_KEY_ID,
         SECRET_KEY,
@@ -304,7 +304,7 @@ public class AWSCredentialsProviderControllerService extends AbstractControllerS
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/DeleteDynamoDB.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/DeleteDynamoDB.java
@@ -70,7 +70,7 @@ import java.util.Map;
     })
 public class DeleteDynamoDB extends AbstractDynamoDBProcessor {
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         TABLE,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -88,7 +88,7 @@ public class DeleteDynamoDB extends AbstractDynamoDBProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/GetDynamoDB.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/GetDynamoDB.java
@@ -83,7 +83,7 @@ public class GetDynamoDB extends AbstractDynamoDBProcessor {
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         TABLE,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -117,7 +117,7 @@ public class GetDynamoDB extends AbstractDynamoDBProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/PutDynamoDB.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/PutDynamoDB.java
@@ -77,7 +77,7 @@ import java.util.Map;
 @SystemResourceConsideration(resource = SystemResource.MEMORY)
 public class PutDynamoDB extends AbstractDynamoDBProcessor {
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         TABLE,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -99,7 +99,7 @@ public class PutDynamoDB extends AbstractDynamoDBProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/PutDynamoDBRecord.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/dynamodb/PutDynamoDBRecord.java
@@ -172,7 +172,7 @@ public class PutDynamoDBRecord extends AbstractDynamoDBProcessor {
             .description("Defines the name of the sort key field in the DynamoDB table. Sort key is also known as range key.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         TABLE,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -190,7 +190,7 @@ public class PutDynamoDBRecord extends AbstractDynamoDBProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/firehose/PutKinesisFirehose.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/firehose/PutKinesisFirehose.java
@@ -87,7 +87,7 @@ public class PutKinesisFirehose extends AbstractAwsSyncProcessor<FirehoseClient,
             .sensitive(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         KINESIS_FIREHOSE_DELIVERY_STREAM_NAME,
         BATCH_SIZE,
         REGION,
@@ -101,7 +101,7 @@ public class PutKinesisFirehose extends AbstractAwsSyncProcessor<FirehoseClient,
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -315,7 +315,7 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
                     " the contents of the message will be routed to this Relationship as its own individual FlowFile.")
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             // Kinesis Stream specific properties
             KINESIS_STREAM_NAME,
             APPLICATION_NAME,
@@ -388,7 +388,7 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/PutKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/PutKinesisStream.java
@@ -113,7 +113,7 @@ public class PutKinesisStream extends AbstractAwsSyncProcessor<KinesisClient, Ki
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         KINESIS_STREAM_NAME,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -129,7 +129,7 @@ public class PutKinesisStream extends AbstractAwsSyncProcessor<KinesisClient, Ki
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/lambda/PutLambda.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/lambda/PutLambda.java
@@ -98,7 +98,7 @@ public class PutLambda extends AbstractAwsSyncProcessor<LambdaClient, LambdaClie
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             AWS_LAMBDA_FUNCTION_NAME,
             AWS_LAMBDA_FUNCTION_QUALIFIER,
             REGION,
@@ -111,7 +111,7 @@ public class PutLambda extends AbstractAwsSyncProcessor<LambdaClient, LambdaClie
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ml/textract/GetAwsTextractJobStatus.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ml/textract/GetAwsTextractJobStatus.java
@@ -68,14 +68,14 @@ public class GetAwsTextractJobStatus extends AbstractAwsMachineLearningJobStatus
             .defaultValue(String.format("${%s}", TEXTRACT_TYPE_ATTRIBUTE))
             .addValidator(TEXTRACT_TYPE_VALIDATOR)
             .build();
-    private static final List<PropertyDescriptor> TEXTRACT_PROPERTIES = Stream.concat(
-            PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(TEXTRACT_TYPE)
     ).toList();
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return TEXTRACT_PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ml/textract/StartAwsTextractJob.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ml/textract/StartAwsTextractJob.java
@@ -63,14 +63,14 @@ public class StartAwsTextractJob extends AbstractAwsMachineLearningJobStarter<
             .allowableValues(TextractType.TEXTRACT_TYPES)
             .defaultValue(DOCUMENT_ANALYSIS.getType())
             .build();
-    private static final List<PropertyDescriptor> TEXTRACT_PROPERTIES = Stream.concat(
-            PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(TEXTRACT_TYPE)
     ).toList();
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return TEXTRACT_PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/CopyS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/CopyS3Object.java
@@ -86,7 +86,7 @@ public class CopyS3Object extends AbstractS3Processor {
             .defaultValue("${filename}-1")
             .build();
 
-    static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SOURCE_BUCKET,
             SOURCE_KEY,
             DESTINATION_BUCKET,
@@ -111,7 +111,7 @@ public class CopyS3Object extends AbstractS3Processor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/DeleteS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/DeleteS3Object.java
@@ -62,7 +62,7 @@ public class DeleteS3Object extends AbstractS3Processor {
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BUCKET_WITH_DEFAULT_VALUE,
             KEY,
             AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -80,11 +80,12 @@ public class DeleteS3Object extends AbstractS3Processor {
             SIGNER_OVERRIDE,
             S3_CUSTOM_SIGNER_CLASS_NAME,
             S3_CUSTOM_SIGNER_MODULE_LOCATION,
-        PROXY_CONFIGURATION_SERVICE);
+            PROXY_CONFIGURATION_SERVICE
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
@@ -271,7 +271,7 @@ public class FetchS3Object extends AbstractS3Processor {
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         BUCKET_WITH_DEFAULT_VALUE,
         KEY,
         S3_REGION,
@@ -291,7 +291,7 @@ public class FetchS3Object extends AbstractS3Processor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/GetS3ObjectMetadata.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/GetS3ObjectMetadata.java
@@ -86,7 +86,7 @@ public class GetS3ObjectMetadata extends AbstractS3Processor {
             .dependsOn(METADATA_TARGET, TARGET_ATTRIBUTES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             METADATA_TARGET,
             ATTRIBUTE_INCLUDE_PATTERN,
             BUCKET_WITH_DEFAULT_VALUE,
@@ -133,7 +133,7 @@ public class GetS3ObjectMetadata extends AbstractS3Processor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/ListS3.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/ListS3.java
@@ -290,7 +290,7 @@ public class ListS3 extends AbstractS3Processor implements VerifiableProcessor {
         .build();
 
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         BUCKET_WITHOUT_DEFAULT_VALUE,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -321,7 +321,7 @@ public class ListS3 extends AbstractS3Processor implements VerifiableProcessor {
             REL_SUCCESS
     );
 
-    private static final Set<PropertyDescriptor> TRACKING_RESET_PROPERTIES = Set.of(
+    private static final Set<PropertyDescriptor> TRACKING_RESET_PROPERTY_DESCRIPTORS = Set.of(
             BUCKET_WITHOUT_DEFAULT_VALUE,
             REGION,
             PREFIX,
@@ -350,7 +350,7 @@ public class ListS3 extends AbstractS3Processor implements VerifiableProcessor {
 
     @Override
     public void onPropertyModified(final PropertyDescriptor descriptor, final String oldValue, final String newValue) {
-        if (isConfigurationRestored() && TRACKING_RESET_PROPERTIES.contains(descriptor)) {
+        if (isConfigurationRestored() && TRACKING_RESET_PROPERTY_DESCRIPTORS.contains(descriptor)) {
             resetTracking = true;
         }
     }
@@ -421,7 +421,7 @@ public class ListS3 extends AbstractS3Processor implements VerifiableProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -264,7 +264,7 @@ public class PutS3Object extends AbstractS3Processor {
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BUCKET_WITH_DEFAULT_VALUE,
             KEY,
             S3_REGION,
@@ -300,7 +300,8 @@ public class PutS3Object extends AbstractS3Processor {
             MULTIPART_TEMP_DIR,
             USE_CHUNKED_ENCODING,
             USE_PATH_STYLE_ACCESS,
-        PROXY_CONFIGURATION_SERVICE);
+            PROXY_CONFIGURATION_SERVICE
+    );
 
     final static String S3_BUCKET_KEY = "s3.bucket";
     final static String S3_OBJECT_KEY = "s3.key";
@@ -331,7 +332,7 @@ public class PutS3Object extends AbstractS3Processor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/TagS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/TagS3Object.java
@@ -105,7 +105,7 @@ public class TagS3Object extends AbstractS3Processor {
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BUCKET_WITH_DEFAULT_VALUE,
             KEY,
             S3_REGION,
@@ -120,11 +120,12 @@ public class TagS3Object extends AbstractS3Processor {
             SIGNER_OVERRIDE,
             S3_CUSTOM_SIGNER_CLASS_NAME,
             S3_CUSTOM_SIGNER_MODULE_LOCATION,
-        PROXY_CONFIGURATION_SERVICE);
+            PROXY_CONFIGURATION_SERVICE
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/encryption/StandardS3EncryptionService.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/encryption/StandardS3EncryptionService.java
@@ -109,7 +109,7 @@ public class StandardS3EncryptionService extends AbstractControllerService imple
             .defaultValue(RegionUtilV1.createAllowableValue(Regions.DEFAULT_REGION).getValue())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
        ENCRYPTION_STRATEGY,
        ENCRYPTION_VALUE,
        KMS_REGION
@@ -194,7 +194,7 @@ public class StandardS3EncryptionService extends AbstractControllerService imple
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/encryption/StandardS3EncryptionService.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/encryption/StandardS3EncryptionService.java
@@ -45,7 +45,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -109,6 +108,12 @@ public class StandardS3EncryptionService extends AbstractControllerService imple
             .allowableValues(RegionUtilV1.getAvailableRegions())
             .defaultValue(RegionUtilV1.createAllowableValue(Regions.DEFAULT_REGION).getValue())
             .build();
+
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+       ENCRYPTION_STRATEGY,
+       ENCRYPTION_VALUE,
+       KMS_REGION
+    );
 
     private String keyValue = "";
     private String kmsRegion = "";
@@ -189,11 +194,7 @@ public class StandardS3EncryptionService extends AbstractControllerService imple
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(ENCRYPTION_STRATEGY);
-        properties.add(ENCRYPTION_VALUE);
-        properties.add(KMS_REGION);
-        return Collections.unmodifiableList(properties);
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/service/S3FileResourceService.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/service/S3FileResourceService.java
@@ -78,7 +78,7 @@ public class S3FileResourceService extends AbstractControllerService implements 
             .fromPropertyDescriptor(RegionUtilV1.S3_REGION)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BUCKET_WITH_DEFAULT_VALUE,
             KEY,
             S3_REGION,
@@ -90,7 +90,7 @@ public class S3FileResourceService extends AbstractControllerService implements 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sns/PutSNS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sns/PutSNS.java
@@ -122,7 +122,7 @@ public class PutSNS extends AbstractAwsSyncProcessor<SnsClient, SnsClientBuilder
             .build();
 
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ARN,
             ARN_TYPE,
             SUBJECT,
@@ -135,13 +135,14 @@ public class PutSNS extends AbstractAwsSyncProcessor<SnsClient, SnsClientBuilder
             USE_JSON_STRUCTURE,
             CHARACTER_ENCODING,
             MESSAGEGROUPID,
-            MESSAGEDEDUPLICATIONID);
+            MESSAGEDEDUPLICATIONID
+    );
 
     public static final int MAX_SIZE = 256 * 1024;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/DeleteSQS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/DeleteSQS.java
@@ -63,7 +63,7 @@ public class DeleteSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuil
             .defaultValue("${sqs.receipt.handle}")
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         QUEUE_URL,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -71,11 +71,12 @@ public class DeleteSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuil
         RECEIPT_HANDLE,
         TIMEOUT,
         ENDPOINT_OVERRIDE,
-        PROXY_CONFIGURATION_SERVICE);
+        PROXY_CONFIGURATION_SERVICE
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/GetSQS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/GetSQS.java
@@ -116,7 +116,7 @@ public class GetSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
             .addValidator(StandardValidators.createTimePeriodValidator(0, TimeUnit.SECONDS, 20, TimeUnit.SECONDS))  // 20 seconds is the maximum allowed by SQS
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         QUEUE_URL,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -128,11 +128,12 @@ public class GetSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
         CHARSET,
         VISIBILITY_TIMEOUT,
         RECEIVE_MSG_WAIT_TIME,
-        PROXY_CONFIGURATION_SERVICE);
+        PROXY_CONFIGURATION_SERVICE
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/PutSQS.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/sqs/PutSQS.java
@@ -102,7 +102,7 @@ public class PutSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         QUEUE_URL,
         REGION,
         AWS_CREDENTIALS_PROVIDER_SERVICE,
@@ -112,13 +112,14 @@ public class PutSQS extends AbstractAwsSyncProcessor<SqsClient, SqsClientBuilder
         ENDPOINT_OVERRIDE,
         PROXY_CONFIGURATION_SERVICE,
         MESSAGEGROUPID,
-        MESSAGEDEDUPLICATIONID);
+        MESSAGEDEDUPLICATIONID
+    );
 
     private volatile List<PropertyDescriptor> userDefinedProperties = Collections.emptyList();
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/credentials/provider/service/MockAWSProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/credentials/provider/service/MockAWSProcessor.java
@@ -48,7 +48,7 @@ import static org.apache.nifi.processors.aws.credentials.provider.service.AWSCre
  */
 public class MockAWSProcessor extends AbstractAWSCredentialsProviderProcessor<AmazonS3Client> {
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             USE_DEFAULT_CREDENTIALS,
             PROFILE_NAME,
             USE_ANONYMOUS_CREDENTIALS,
@@ -66,7 +66,7 @@ public class MockAWSProcessor extends AbstractAWSCredentialsProviderProcessor<Am
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/AmazonGlueSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/AmazonGlueSchemaRegistry.java
@@ -53,7 +53,6 @@ import java.net.Proxy;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
@@ -137,7 +136,7 @@ public class AmazonGlueSchemaRegistry extends AbstractControllerService implemen
 
     private static final PropertyDescriptor PROXY_CONFIGURATION_SERVICE = ProxyConfiguration.createProxyConfigPropertyDescriptor(PROXY_SPECS);
 
-    private static final List<PropertyDescriptor> PROPERTIES = new ArrayList<>(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             SCHEMA_REGISTRY_NAME,
             REGION,
             COMMUNICATIONS_TIMEOUT,
@@ -146,7 +145,7 @@ public class AmazonGlueSchemaRegistry extends AbstractControllerService implemen
             AWS_CREDENTIALS_PROVIDER_SERVICE,
             PROXY_CONFIGURATION_SERVICE,
             SSL_CONTEXT_SERVICE
-    ));
+    );
 
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/AmazonGlueSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/AmazonGlueSchemaRegistry.java
@@ -136,7 +136,7 @@ public class AmazonGlueSchemaRegistry extends AbstractControllerService implemen
 
     private static final PropertyDescriptor PROXY_CONFIGURATION_SERVICE = ProxyConfiguration.createProxyConfigPropertyDescriptor(PROXY_SPECS);
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SCHEMA_REGISTRY_NAME,
             REGION,
             COMMUNICATIONS_TIMEOUT,
@@ -150,7 +150,7 @@ public class AmazonGlueSchemaRegistry extends AbstractControllerService implemen
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private volatile SchemaRegistryClient client;

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-parameter-providers/src/main/java/org/apache/nifi/parameter/azure/AzureKeyVaultSecretsParameterProvider.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-parameter-providers/src/main/java/org/apache/nifi/parameter/azure/AzureKeyVaultSecretsParameterProvider.java
@@ -75,7 +75,7 @@ public class AzureKeyVaultSecretsParameterProvider extends AbstractParameterProv
 
     static final String GROUP_NAME_TAG = "group-name";
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             AZURE_CREDENTIALS_SERVICE,
             KEY_VAULT_URI,
             GROUP_NAME_PATTERN
@@ -83,7 +83,7 @@ public class AzureKeyVaultSecretsParameterProvider extends AbstractParameterProv
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/AbstractAzureCosmosDBProcessor.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/AbstractAzureCosmosDBProcessor.java
@@ -87,7 +87,7 @@ public abstract class AbstractAzureCosmosDBProcessor extends AbstractProcessor {
         .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
         .build();
 
-    static final List<PropertyDescriptor> descriptors = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CONNECTION_SERVICE,
             AzureCosmosDBUtils.URI,
             AzureCosmosDBUtils.DB_ACCESS_KEY,
@@ -100,6 +100,10 @@ public abstract class AbstractAzureCosmosDBProcessor extends AbstractProcessor {
     private CosmosClient cosmosClient;
     private CosmosContainer container;
     private AzureCosmosDBConnectionService connectionService;
+
+    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
 
     @OnScheduled
     public void onScheduled(final ProcessContext context) throws CosmosException {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/PutAzureCosmosDBRecord.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/cosmos/document/PutAzureCosmosDBRecord.java
@@ -97,9 +97,13 @@ public class PutAzureCosmosDBRecord extends AbstractAzureCosmosDBProcessor {
             REL_FAILURE
     );
 
-    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            descriptors.stream(),
-            Stream.of(RECORD_READER_FACTORY, INSERT_BATCH_SIZE, CONFLICT_HANDLE_STRATEGY)
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
+            Stream.of(
+                    RECORD_READER_FACTORY,
+                    INSERT_BATCH_SIZE,
+                    CONFLICT_HANDLE_STRATEGY
+            )
     ).toList();
 
     @Override
@@ -109,7 +113,7 @@ public class PutAzureCosmosDBRecord extends AbstractAzureCosmosDBProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     protected void bulkInsert(final List<Map<String, Object>> records) throws CosmosException {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/PutAzureDataExplorer.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/PutAzureDataExplorer.java
@@ -161,7 +161,7 @@ public class PutAzureDataExplorer extends AbstractProcessor {
             .defaultValue("5 s")
             .build();
 
-    private static final List<PropertyDescriptor> descriptors = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             INGEST_SERVICE,
             DATABASE_NAME,
             TABLE_NAME,
@@ -189,7 +189,7 @@ public class PutAzureDataExplorer extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return descriptors;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/QueryAzureDataExplorer.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/data/explorer/QueryAzureDataExplorer.java
@@ -95,7 +95,7 @@ public class QueryAzureDataExplorer extends AbstractProcessor {
             FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             KUSTO_QUERY_SERVICE,
             DATABASE_NAME,
             QUERY
@@ -110,7 +110,7 @@ public class QueryAzureDataExplorer extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/ConsumeAzureEventHub.java
@@ -312,7 +312,7 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
             REL_PARSE_FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             NAMESPACE,
             EVENT_HUB_NAME,
             SERVICE_BUS_ENDPOINT,
@@ -347,7 +347,7 @@ public class ConsumeAzureEventHub extends AbstractSessionFactoryProcessor implem
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/GetAzureEventHub.java
@@ -159,7 +159,7 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
             .description("Any FlowFile that is successfully received from the event hub will be transferred to this Relationship.")
             .build();
 
-    private final static List<PropertyDescriptor> PROPERTIES = List.of(
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             NAMESPACE,
             EVENT_HUB_NAME,
             SERVICE_BUS_ENDPOINT,
@@ -199,7 +199,7 @@ public class GetAzureEventHub extends AbstractProcessor implements AzureEventHub
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/eventhub/PutAzureEventHub.java
@@ -119,7 +119,7 @@ public class PutAzureEventHub extends AbstractProcessor implements AzureEventHub
             .description("Any FlowFile that could not be sent to the event hub will be transferred to this Relationship.")
             .build();
 
-    private final static List<PropertyDescriptor> PROPERTIES = List.of(
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             NAMESPACE,
             EVENT_HUB_NAME,
             SERVICE_BUS_ENDPOINT,
@@ -146,7 +146,7 @@ public class PutAzureEventHub extends AbstractProcessor implements AzureEventHub
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/CopyAzureBlobStorage_v12.java
@@ -167,7 +167,7 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             .required(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SOURCE_STORAGE_CREDENTIALS_SERVICE,
             SOURCE_CONTAINER_NAME,
             SOURCE_BLOB_NAME,
@@ -181,7 +181,7 @@ public class CopyAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureBlobStorage_v12.java
@@ -73,7 +73,7 @@ public class DeleteAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BLOB_STORAGE_CREDENTIALS_SERVICE,
             CONTAINER,
             BLOB_NAME,
@@ -83,7 +83,7 @@ public class DeleteAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/DeleteAzureDataLakeStorage.java
@@ -69,7 +69,7 @@ public class DeleteAzureDataLakeStorage extends AbstractAzureDataLakeStorageProc
             .dependsOn(FILESYSTEM_OBJECT_TYPE, FS_TYPE_FILE)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ADLS_CREDENTIALS_SERVICE,
             FILESYSTEM,
             FILESYSTEM_OBJECT_TYPE,
@@ -114,6 +114,6 @@ public class DeleteAzureDataLakeStorage extends AbstractAzureDataLakeStorageProc
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 }

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureBlobStorage_v12.java
@@ -140,7 +140,7 @@ public class FetchAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 im
             .required(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BLOB_STORAGE_CREDENTIALS_SERVICE,
             CONTAINER,
             BLOB_NAME,
@@ -161,7 +161,7 @@ public class FetchAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 im
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/FetchAzureDataLakeStorage.java
@@ -125,7 +125,7 @@ public class FetchAzureDataLakeStorage extends AbstractAzureDataLakeStorageProce
             .defaultValue("0")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ADLS_CREDENTIALS_SERVICE,
             FILESYSTEM,
             DIRECTORY,
@@ -138,7 +138,7 @@ public class FetchAzureDataLakeStorage extends AbstractAzureDataLakeStorageProce
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureBlobStorage_v12.java
@@ -134,7 +134,7 @@ public class ListAzureBlobStorage_v12 extends AbstractListAzureProcessor<BlobInf
             .dependsOn(LISTING_STRATEGY, BY_ENTITIES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BLOB_STORAGE_CREDENTIALS_SERVICE,
             CONTAINER,
             BLOB_NAME_PREFIX,
@@ -154,7 +154,7 @@ public class ListAzureBlobStorage_v12 extends AbstractListAzureProcessor<BlobInf
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/ListAzureDataLakeStorage.java
@@ -141,7 +141,7 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
             .defaultValue(Boolean.FALSE.toString())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ADLS_CREDENTIALS_SERVICE,
             FILESYSTEM,
             DIRECTORY,
@@ -178,7 +178,7 @@ public class ListAzureDataLakeStorage extends AbstractListAzureProcessor<ADLSFil
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/MoveAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/MoveAzureDataLakeStorage.java
@@ -130,7 +130,7 @@ public class MoveAzureDataLakeStorage extends AbstractAzureDataLakeStorageProces
             .addValidator(new DirectoryValidator("Destination Directory"))
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ADLS_CREDENTIALS_SERVICE,
             SOURCE_FILESYSTEM,
             SOURCE_DIRECTORY,
@@ -143,7 +143,7 @@ public class MoveAzureDataLakeStorage extends AbstractAzureDataLakeStorageProces
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureBlobStorage_v12.java
@@ -104,7 +104,7 @@ import static org.apache.nifi.processors.transfer.ResourceTransferUtils.getFileR
         @WritesAttribute(attribute = ATTR_NAME_IGNORED, description = ATTR_DESCRIPTION_IGNORED)})
 public class PutAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 implements ClientSideEncryptionSupport {
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BLOB_STORAGE_CREDENTIALS_SERVICE,
             AzureStorageUtils.CONTAINER,
             AzureStorageUtils.CREATE_CONTAINER,
@@ -127,7 +127,7 @@ public class PutAzureBlobStorage_v12 extends AbstractAzureBlobProcessor_v12 impl
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/PutAzureDataLakeStorage.java
@@ -124,7 +124,7 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
             .dependsOn(WRITING_STRATEGY, WritingStrategy.WRITE_AND_RENAME)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ADLS_CREDENTIALS_SERVICE,
             FILESYSTEM,
             DIRECTORY,
@@ -139,7 +139,7 @@ public class PutAzureDataLakeStorage extends AbstractAzureDataLakeStorageProcess
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/GetAzureQueueStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/GetAzureQueueStorage_v12.java
@@ -96,7 +96,7 @@ public class GetAzureQueueStorage_v12 extends AbstractAzureQueueStorage_v12 {
             .build();
 
     private static final ProxySpec[] PROXY_SPECS = {ProxySpec.HTTP, ProxySpec.SOCKS};
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             QUEUE_NAME,
             ENDPOINT_SUFFIX,
             STORAGE_CREDENTIALS_SERVICE,
@@ -115,7 +115,7 @@ public class GetAzureQueueStorage_v12 extends AbstractAzureQueueStorage_v12 {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/PutAzureQueueStorage_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/processors/azure/storage/queue/PutAzureQueueStorage_v12.java
@@ -65,7 +65,7 @@ public class PutAzureQueueStorage_v12 extends AbstractAzureQueueStorage_v12 {
             .build();
 
     private static final ProxySpec[] PROXY_SPECS = {ProxySpec.HTTP, ProxySpec.SOCKS};
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             QUEUE_NAME,
             ENDPOINT_SUFFIX,
             STORAGE_CREDENTIALS_SERVICE,
@@ -80,7 +80,7 @@ public class PutAzureQueueStorage_v12 extends AbstractAzureQueueStorage_v12 {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/StandardAzureCredentialsControllerService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/StandardAzureCredentialsControllerService.java
@@ -68,7 +68,7 @@ public class StandardAzureCredentialsControllerService extends AbstractControlle
             .dependsOn(CREDENTIAL_CONFIGURATION_STRATEGY, MANAGED_IDENTITY)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CREDENTIAL_CONFIGURATION_STRATEGY,
             MANAGED_IDENTITY_CLIENT_ID
     );
@@ -77,7 +77,7 @@ public class StandardAzureCredentialsControllerService extends AbstractControlle
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/StandardAzureCredentialsControllerService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/StandardAzureCredentialsControllerService.java
@@ -69,7 +69,8 @@ public class StandardAzureCredentialsControllerService extends AbstractControlle
             .build();
 
     private static final List<PropertyDescriptor> PROPERTIES = List.of(
-            CREDENTIAL_CONFIGURATION_STRATEGY, MANAGED_IDENTITY_CLIENT_ID
+            CREDENTIAL_CONFIGURATION_STRATEGY,
+            MANAGED_IDENTITY_CLIENT_ID
     );
 
     private TokenCredential credentials;

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/cosmos/document/AzureCosmosDBClientService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/cosmos/document/AzureCosmosDBClientService.java
@@ -83,7 +83,7 @@ public class AzureCosmosDBClientService extends AbstractControllerService implem
                                 .buildClient();
     }
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             AzureCosmosDBUtils.URI,
             AzureCosmosDBUtils.DB_ACCESS_KEY,
             AzureCosmosDBUtils.CONSISTENCY
@@ -91,7 +91,7 @@ public class AzureCosmosDBClientService extends AbstractControllerService implem
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/cosmos/document/AzureCosmosDBClientService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/cosmos/document/AzureCosmosDBClientService.java
@@ -83,7 +83,7 @@ public class AzureCosmosDBClientService extends AbstractControllerService implem
                                 .buildClient();
     }
 
-    static List<PropertyDescriptor> descriptors = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             AzureCosmosDBUtils.URI,
             AzureCosmosDBUtils.DB_ACCESS_KEY,
             AzureCosmosDBUtils.CONSISTENCY
@@ -91,7 +91,7 @@ public class AzureCosmosDBClientService extends AbstractControllerService implem
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return descriptors;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoIngestService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoIngestService.java
@@ -105,7 +105,7 @@ public class StandardKustoIngestService extends AbstractControllerService implem
             .addValidator(StandardValidators.URL_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             AUTHENTICATION_STRATEGY,
             APPLICATION_CLIENT_ID,
             APPLICATION_KEY,
@@ -127,7 +127,7 @@ public class StandardKustoIngestService extends AbstractControllerService implem
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoIngestService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoIngestService.java
@@ -105,7 +105,7 @@ public class StandardKustoIngestService extends AbstractControllerService implem
             .addValidator(StandardValidators.URL_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             AUTHENTICATION_STRATEGY,
             APPLICATION_CLIENT_ID,
             APPLICATION_KEY,
@@ -127,7 +127,7 @@ public class StandardKustoIngestService extends AbstractControllerService implem
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoQueryService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoQueryService.java
@@ -83,7 +83,7 @@ public class StandardKustoQueryService extends AbstractControllerService impleme
             .dependsOn(AUTHENTICATION_STRATEGY, KustoAuthenticationStrategy.APPLICATION_CREDENTIALS)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             CLUSTER_URI,
             AUTHENTICATION_STRATEGY,
             APPLICATION_CLIENT_ID,
@@ -95,7 +95,7 @@ public class StandardKustoQueryService extends AbstractControllerService impleme
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     public static final Pair<String, String> NIFI_SOURCE = Pair.of("processor", "nifi-source");

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoQueryService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoQueryService.java
@@ -83,7 +83,7 @@ public class StandardKustoQueryService extends AbstractControllerService impleme
             .dependsOn(AUTHENTICATION_STRATEGY, KustoAuthenticationStrategy.APPLICATION_CREDENTIALS)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CLUSTER_URI,
             AUTHENTICATION_STRATEGY,
             APPLICATION_CLIENT_ID,
@@ -95,7 +95,7 @@ public class StandardKustoQueryService extends AbstractControllerService impleme
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     public static final Pair<String, String> NIFI_SOURCE = Pair.of("processor", "nifi-source");

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/eventhub/AzureEventHubRecordSink.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/eventhub/AzureEventHubRecordSink.java
@@ -125,7 +125,7 @@ public class AzureEventHubRecordSink extends AbstractControllerService implement
             .required(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             SERVICE_BUS_ENDPOINT,
             EVENT_HUB_NAMESPACE,
             EVENT_HUB_NAME,
@@ -143,7 +143,7 @@ public class AzureEventHubRecordSink extends AbstractControllerService implement
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     protected EventHubProducerClient createEventHubClient(final String namespace,

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/eventhub/AzureEventHubRecordSink.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/eventhub/AzureEventHubRecordSink.java
@@ -125,7 +125,7 @@ public class AzureEventHubRecordSink extends AbstractControllerService implement
             .required(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SERVICE_BUS_ENDPOINT,
             EVENT_HUB_NAMESPACE,
             EVENT_HUB_NAME,
@@ -143,7 +143,7 @@ public class AzureEventHubRecordSink extends AbstractControllerService implement
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     protected EventHubProducerClient createEventHubClient(final String namespace,

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/ADLSCredentialsControllerService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/ADLSCredentialsControllerService.java
@@ -77,7 +77,7 @@ public class ADLSCredentialsControllerService extends AbstractControllerService 
             .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL, AzureStorageCredentialsType.MANAGED_IDENTITY)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ACCOUNT_NAME,
             ENDPOINT_SUFFIX,
             CREDENTIALS_TYPE,
@@ -94,7 +94,7 @@ public class ADLSCredentialsControllerService extends AbstractControllerService 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureBlobStorageFileResourceService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureBlobStorageFileResourceService.java
@@ -72,7 +72,7 @@ public class AzureBlobStorageFileResourceService extends AbstractControllerServi
             .defaultValue(String.format("${%s}", ATTR_NAME_BLOBNAME))
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BLOB_STORAGE_CREDENTIALS_SERVICE,
             CONTAINER,
             BLOB_NAME
@@ -83,7 +83,7 @@ public class AzureBlobStorageFileResourceService extends AbstractControllerServi
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureDataLakeStorageFileResourceService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureDataLakeStorageFileResourceService.java
@@ -76,7 +76,7 @@ public class AzureDataLakeStorageFileResourceService extends AbstractControllerS
             .defaultValue(String.format("${%s}", ATTR_NAME_DIRECTORY))
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ADLS_CREDENTIALS_SERVICE,
             FILESYSTEM,
             DIRECTORY,
@@ -88,7 +88,7 @@ public class AzureDataLakeStorageFileResourceService extends AbstractControllerS
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureStorageCredentialsControllerService_v12.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/storage/AzureStorageCredentialsControllerService_v12.java
@@ -57,7 +57,7 @@ public class AzureStorageCredentialsControllerService_v12 extends AbstractContro
             .dependsOn(CREDENTIALS_TYPE, AzureStorageCredentialsType.SERVICE_PRINCIPAL, AzureStorageCredentialsType.MANAGED_IDENTITY)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ACCOUNT_NAME,
             ENDPOINT_SUFFIX,
             CREDENTIALS_TYPE,
@@ -74,7 +74,7 @@ public class AzureStorageCredentialsControllerService_v12 extends AbstractContro
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AbstractAzureLogAnalyticsReportingTask.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AbstractAzureLogAnalyticsReportingTask.java
@@ -89,7 +89,7 @@ public abstract class AbstractAzureLogAnalyticsReportingTask extends AbstractRep
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT).build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             LOG_ANALYTICS_WORKSPACE_ID,
             LOG_ANALYTICS_WORKSPACE_KEY,
             APPLICATION_ID,
@@ -114,7 +114,7 @@ public abstract class AbstractAzureLogAnalyticsReportingTask extends AbstractRep
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AzureLogAnalyticsProvenanceReportingTask.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AzureLogAnalyticsProvenanceReportingTask.java
@@ -167,7 +167,7 @@ public class AzureLogAnalyticsProvenanceReportingTask extends AbstractAzureLogAn
                         .description("Specifies how many records to send in a single batch, at most.").required(true)
                         .defaultValue("1000").addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR).build();
 
-        private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
                 LOG_ANALYTICS_WORKSPACE_ID,
                 LOG_ANALYTICS_CUSTOM_LOG_NAME,
                 LOG_ANALYTICS_WORKSPACE_KEY,
@@ -194,7 +194,7 @@ public class AzureLogAnalyticsProvenanceReportingTask extends AbstractAzureLogAn
 
         @Override
         protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-                return PROPERTIES;
+                return PROPERTY_DESCRIPTORS;
         }
 
         public void CreateConsumer(final ReportingContext context) {

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AzureLogAnalyticsReportingTask.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-reporting-task/src/main/java/org/apache/nifi/reporting/azure/loganalytics/AzureLogAnalyticsReportingTask.java
@@ -58,7 +58,7 @@ public class AzureLogAnalyticsReportingTask extends AbstractAzureLogAnalyticsRep
             .defaultValue("nifimetrics").addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT).build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SEND_JVM_METRICS,
             LOG_ANALYTICS_WORKSPACE_ID,
             LOG_ANALYTICS_CUSTOM_LOG_NAME,
@@ -72,7 +72,7 @@ public class AzureLogAnalyticsReportingTask extends AbstractAzureLogAnalyticsRep
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/FetchBoxFile.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/FetchBoxFile.java
@@ -99,7 +99,7 @@ public class FetchBoxFile extends AbstractProcessor {
             REL_FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BoxClientService.BOX_CLIENT_SERVICE,
             FILE_ID
     );
@@ -108,7 +108,7 @@ public class FetchBoxFile extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ListBoxFile.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ListBoxFile.java
@@ -128,7 +128,7 @@ public class ListBoxFile extends AbstractListProcessor<BoxFileInfo> {
         .dependsOn(LISTING_STRATEGY, BY_ENTITIES)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         BoxClientService.BOX_CLIENT_SERVICE,
         FOLDER_ID,
         RECURSIVE_SEARCH,
@@ -144,7 +144,7 @@ public class ListBoxFile extends AbstractListProcessor<BoxFileInfo> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/PutBoxFile.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/PutBoxFile.java
@@ -160,7 +160,7 @@ public class PutBoxFile extends AbstractProcessor {
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BoxClientService.BOX_CLIENT_SERVICE,
             FOLDER_ID,
             SUBFOLDER_NAME,
@@ -199,7 +199,7 @@ public class PutBoxFile extends AbstractProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-services/src/main/java/org/apache/nifi/box/controllerservices/JsonConfigBasedBoxClientService.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-services/src/main/java/org/apache/nifi/box/controllerservices/JsonConfigBasedBoxClientService.java
@@ -87,7 +87,7 @@ public class JsonConfigBasedBoxClientService extends AbstractControllerService i
 
     private static final ProxySpec[] PROXY_SPECS = {ProxySpec.HTTP, ProxySpec.HTTP_AUTH};
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         ACCOUNT_ID,
         APP_CONFIG_FILE,
         APP_CONFIG_JSON,
@@ -98,7 +98,7 @@ public class JsonConfigBasedBoxClientService extends AbstractControllerService i
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
@@ -451,7 +451,7 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
                     SSL_MODE_VERIFY_IDENTITY)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             HOSTS,
             DRIVER_NAME,
             DRIVER_LOCATION,
@@ -515,7 +515,7 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/DecryptContentAge.java
+++ b/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/DecryptContentAge.java
@@ -120,7 +120,7 @@ public class DecryptContentAge extends AbstractProcessor implements VerifiablePr
             FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PRIVATE_KEY_SOURCE,
             PRIVATE_KEY_IDENTITIES,
             PRIVATE_KEY_IDENTITY_RESOURCES
@@ -163,7 +163,7 @@ public class DecryptContentAge extends AbstractProcessor implements VerifiablePr
      */
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/EncryptContentAge.java
+++ b/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/EncryptContentAge.java
@@ -127,7 +127,7 @@ public class EncryptContentAge extends AbstractProcessor implements VerifiablePr
             FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FILE_ENCODING,
             PUBLIC_KEY_SOURCE,
             PUBLIC_KEY_RECIPIENTS,
@@ -164,7 +164,7 @@ public class EncryptContentAge extends AbstractProcessor implements VerifiablePr
      */
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/VerifyContentMAC.java
+++ b/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/src/main/java/org/apache/nifi/processors/cipher/VerifyContentMAC.java
@@ -133,7 +133,7 @@ public class VerifyContentMAC extends AbstractProcessor {
     protected static final String MAC_ALGORITHM_ATTRIBUTE = "mac.algorithm";
     protected static final String MAC_ENCODING_ATTRIBUTE = "mac.encoding";
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
                     MAC_ALGORITHM,
                     MAC_ENCODING,
                     MAC,
@@ -198,7 +198,7 @@ public class VerifyContentMAC extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-compress-bundle/nifi-compress-processors/src/main/java/org/apache/nifi/processors/compress/ModifyCompression.java
+++ b/nifi-extension-bundles/nifi-compress-bundle/nifi-compress-processors/src/main/java/org/apache/nifi/processors/compress/ModifyCompression.java
@@ -149,14 +149,17 @@ public class ModifyCompression extends AbstractProcessor {
             .description("FlowFiles will be transferred to the failure relationship on compression modification errors")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             INPUT_COMPRESSION_STRATEGY,
             OUTPUT_COMPRESSION_STRATEGY,
             OUTPUT_COMPRESSION_LEVEL,
             OUTPUT_FILENAME_STRATEGY
     );
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     private static final Map<String, CompressionStrategy> compressionFormatMimeTypeMap;
 
@@ -184,7 +187,7 @@ public class ModifyCompression extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
@@ -148,7 +148,7 @@ public class ConfluentSchemaRegistry extends AbstractControllerService implement
             .sensitive(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         SCHEMA_REGISTRY_URLS,
         SSL_CONTEXT,
         TIMEOUT,
@@ -164,7 +164,7 @@ public class ConfluentSchemaRegistry extends AbstractControllerService implement
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private static final Validator REQUEST_HEADER_VALIDATOR = (subject, value, context) -> new ValidationResult.Builder()

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
@@ -148,21 +148,23 @@ public class ConfluentSchemaRegistry extends AbstractControllerService implement
             .sensitive(true)
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        SCHEMA_REGISTRY_URLS,
+        SSL_CONTEXT,
+        TIMEOUT,
+        CACHE_SIZE,
+        CACHE_EXPIRATION,
+        AUTHENTICATION_TYPE,
+        USERNAME,
+        PASSWORD
+    );
+
     private volatile SchemaRegistryClient client;
 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(SCHEMA_REGISTRY_URLS);
-        properties.add(SSL_CONTEXT);
-        properties.add(TIMEOUT);
-        properties.add(CACHE_SIZE);
-        properties.add(CACHE_EXPIRATION);
-        properties.add(AUTHENTICATION_TYPE);
-        properties.add(USERNAME);
-        properties.add(PASSWORD);
-        return properties;
+        return PROPERTIES;
     }
 
     private static final Validator REQUEST_HEADER_VALIDATOR = (subject, value, context) -> new ValidationResult.Builder()

--- a/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/FetchDropbox.java
+++ b/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/FetchDropbox.java
@@ -105,7 +105,7 @@ public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
             REL_FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CREDENTIAL_SERVICE,
             FILE,
             ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxySpec.HTTP_AUTH)
@@ -120,7 +120,7 @@ public class FetchDropbox extends AbstractProcessor implements DropboxTrait {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
+++ b/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/ListDropbox.java
@@ -143,7 +143,7 @@ public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implemen
             .dependsOn(LISTING_STRATEGY, BY_ENTITIES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CREDENTIAL_SERVICE,
             FOLDER,
             RECURSIVE_SEARCH,
@@ -165,7 +165,7 @@ public class ListDropbox extends AbstractListProcessor<DropboxFileInfo> implemen
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/PutDropbox.java
+++ b/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-processors/src/main/java/org/apache/nifi/processors/dropbox/PutDropbox.java
@@ -52,10 +52,7 @@ import com.dropbox.core.v2.files.UploadUploader;
 import com.dropbox.core.v2.files.WriteMode;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -165,7 +162,7 @@ public class PutDropbox extends AbstractProcessor implements DropboxTrait {
             .required(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CREDENTIAL_SERVICE,
             FOLDER,
             FILE_NAME,
@@ -173,16 +170,12 @@ public class PutDropbox extends AbstractProcessor implements DropboxTrait {
             CHUNKED_UPLOAD_THRESHOLD,
             CHUNKED_UPLOAD_SIZE,
             ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxySpec.HTTP_AUTH)
-    ));
+    );
 
-    private static final Set<Relationship> RELATIONSHIPS;
-
-    static {
-        final Set<Relationship> rels = new HashSet<>();
-        rels.add(REL_SUCCESS);
-        rels.add(REL_FAILURE);
-        RELATIONSHIPS = Collections.unmodifiableSet(rels);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS,
+        REL_FAILURE
+    );
 
     private volatile DbxClientV2 dropboxApiClient;
 
@@ -193,7 +186,7 @@ public class PutDropbox extends AbstractProcessor implements DropboxTrait {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-services/src/main/java/org/apache/nifi/services/dropbox/StandardDropboxCredentialService.java
+++ b/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-services/src/main/java/org/apache/nifi/services/dropbox/StandardDropboxCredentialService.java
@@ -75,7 +75,7 @@ public class StandardDropboxCredentialService extends AbstractControllerService 
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             APP_KEY,
             APP_SECRET,
             ACCESS_TOKEN,
@@ -86,7 +86,7 @@ public class StandardDropboxCredentialService extends AbstractControllerService 
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-services/src/main/java/org/apache/nifi/services/dropbox/StandardDropboxCredentialService.java
+++ b/nifi-extension-bundles/nifi-dropbox-bundle/nifi-dropbox-services/src/main/java/org/apache/nifi/services/dropbox/StandardDropboxCredentialService.java
@@ -16,8 +16,6 @@
  */
 package org.apache.nifi.services.dropbox;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -77,16 +75,12 @@ public class StandardDropboxCredentialService extends AbstractControllerService 
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES;
-
-    static {
-        final List<PropertyDescriptor> props = new ArrayList<>();
-        props.add(APP_KEY);
-        props.add(APP_SECRET);
-        props.add(ACCESS_TOKEN);
-        props.add(REFRESH_TOKEN);
-        PROPERTIES = Collections.unmodifiableList(props);
-    }
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            APP_KEY,
+            APP_SECRET,
+            ACCESS_TOKEN,
+            REFRESH_TOKEN
+    );
 
     private DropboxCredentialDetails credential;
 

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -102,10 +102,30 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
 
     private ObjectMapper mapper;
 
-    private static final List<PropertyDescriptor> properties = List.of(HTTP_HOSTS, PATH_PREFIX, AUTHORIZATION_SCHEME, USERNAME, PASSWORD, API_KEY_ID, API_KEY,
-            PROP_SSL_CONTEXT_SERVICE, PROXY_CONFIGURATION_SERVICE, CONNECT_TIMEOUT, SOCKET_TIMEOUT, CHARSET,
-            SUPPRESS_NULLS, COMPRESSION, SEND_META_HEADER, STRICT_DEPRECATION, NODE_SELECTOR, SNIFF_CLUSTER_NODES,
-            SNIFFER_INTERVAL, SNIFFER_REQUEST_TIMEOUT, SNIFF_ON_FAILURE, SNIFFER_FAILURE_DELAY);
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            HTTP_HOSTS,
+            PATH_PREFIX,
+            AUTHORIZATION_SCHEME,
+            USERNAME,
+            PASSWORD,
+            API_KEY_ID,
+            API_KEY,
+            PROP_SSL_CONTEXT_SERVICE,
+            PROXY_CONFIGURATION_SERVICE,
+            CONNECT_TIMEOUT,
+            SOCKET_TIMEOUT,
+            CHARSET,
+            SUPPRESS_NULLS,
+            COMPRESSION,
+            SEND_META_HEADER,
+            STRICT_DEPRECATION,
+            NODE_SELECTOR,
+            SNIFF_CLUSTER_NODES,
+            SNIFFER_INTERVAL,
+            SNIFFER_REQUEST_TIMEOUT,
+            SNIFF_ON_FAILURE,
+            SNIFFER_FAILURE_DELAY
+    );
 
     private RestClient client;
 
@@ -117,7 +137,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -102,7 +102,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
 
     private ObjectMapper mapper;
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             HTTP_HOSTS,
             PATH_PREFIX,
             AUTHORIZATION_SCHEME,
@@ -137,7 +137,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchStringLookupService.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchStringLookupService.java
@@ -30,7 +30,6 @@ import org.apache.nifi.lookup.StringLookupService;
 import org.apache.nifi.processor.util.StandardValidators;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -64,7 +63,13 @@ public class ElasticSearchStringLookupService extends AbstractControllerService 
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
-    private static final List<PropertyDescriptor> DESCRIPTORS = Arrays.asList(CLIENT_SERVICE, INDEX, TYPE);
+
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            CLIENT_SERVICE,
+            INDEX,
+            TYPE
+    );
+
     private static final ObjectMapper mapper = new ObjectMapper();
     public static final String ID = "es_document_id";
     private ElasticSearchClientService esClient;
@@ -73,7 +78,7 @@ public class ElasticSearchStringLookupService extends AbstractControllerService 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchStringLookupService.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchStringLookupService.java
@@ -64,7 +64,7 @@ public class ElasticSearchStringLookupService extends AbstractControllerService 
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CLIENT_SERVICE,
             INDEX,
             TYPE
@@ -78,7 +78,7 @@ public class ElasticSearchStringLookupService extends AbstractControllerService 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/AbstractEmailProcessor.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/AbstractEmailProcessor.java
@@ -165,7 +165,7 @@ abstract class AbstractEmailProcessor<T extends AbstractMailReceiver> extends Ab
      * Will ensure that list of PropertyDescriptors is build only once, since
      * all other lifecycle methods are invoked multiple times.
      */
-    final static List<PropertyDescriptor> SHARED_DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             HOST,
             PORT,
             AUTHORIZATION_MODE,
@@ -194,6 +194,10 @@ abstract class AbstractEmailProcessor<T extends AbstractMailReceiver> extends Ab
 
     protected volatile Optional<OAuth2AccessTokenProvider> oauth2AccessTokenProviderOptional;
     protected volatile AccessToken oauth2AccessDetails;
+
+    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
 
     @OnScheduled
     public void onScheduled(final ProcessContext context) {

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeIMAP.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumeIMAP.java
@@ -51,8 +51,8 @@ public class ConsumeIMAP extends AbstractEmailProcessor<ImapMailReceiver> {
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .build();
 
-    static final List<PropertyDescriptor> DESCRIPTORS = Stream.concat(
-            SHARED_DESCRIPTORS.stream(),
+    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                     SHOULD_MARK_READ,
                     USE_SSL
@@ -75,6 +75,6 @@ public class ConsumeIMAP extends AbstractEmailProcessor<ImapMailReceiver> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 }

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumePOP3.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ConsumePOP3.java
@@ -46,6 +46,6 @@ public class ConsumePOP3 extends AbstractEmailProcessor<Pop3MailReceiver> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return SHARED_DESCRIPTORS;
+        return getCommonPropertyDescriptors();
     }
 }

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailAttachments.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailAttachments.java
@@ -83,7 +83,10 @@ public class ExtractEmailAttachments extends AbstractProcessor {
 
     private static final String ATTACHMENT_DISPOSITION = "attachment";
 
-    private static final Set<Relationship> relationships = Set.of(REL_ATTACHMENTS, REL_ORIGINAL, REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_ATTACHMENTS,
+            REL_ORIGINAL,
+            REL_FAILURE);
 
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) {
@@ -171,7 +174,7 @@ public class ExtractEmailAttachments extends AbstractProcessor {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     private void parseAttachments(final List<DataSource> attachments, final MimePart parentPart, final int depth) throws MessagingException, IOException {

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailHeaders.java
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/src/main/java/org/apache/nifi/processors/email/ExtractEmailHeaders.java
@@ -127,12 +127,12 @@ public class ExtractEmailHeaders extends AbstractProcessor {
 
     private static final String ATTACHMENT_DISPOSITION = "attachment";
 
-    private static final Set<Relationship> relationships = Set.of(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CAPTURED_HEADERS,
             STRICT_PARSING
     );
@@ -221,12 +221,12 @@ public class ExtractEmailHeaders extends AbstractProcessor {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private static void putAddressListInAttributes(

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/AbstractEnrichIP.java
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/AbstractEnrichIP.java
@@ -95,7 +95,7 @@ public abstract class AbstractEnrichIP extends AbstractProcessor {
             REL_NOT_FOUND
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             GEO_DATABASE_FILE,
             IP_ADDRESS_ATTRIBUTE,
             LOG_LEVEL
@@ -117,7 +117,7 @@ public abstract class AbstractEnrichIP extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/GeoEnrichIPRecord.java
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/src/main/java/org/apache/nifi/processors/GeoEnrichIPRecord.java
@@ -154,7 +154,7 @@ public class GeoEnrichIPRecord extends AbstractEnrichIP {
             REL_NOT_FOUND
     );
 
-    public static final List<PropertyDescriptor> GEO_PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> GEO_PROPERTY_DESCRIPTORS = List.of(
             GEO_CITY,
             GEO_LATITUDE,
             GEO_LONGITUDE,
@@ -163,7 +163,7 @@ public class GeoEnrichIPRecord extends AbstractEnrichIP {
             GEO_POSTAL_CODE
     );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             GEO_DATABASE_FILE,
             READER,
             WRITER,
@@ -185,7 +185,7 @@ public class GeoEnrichIPRecord extends AbstractEnrichIP {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     protected volatile RecordReaderFactory readerFactory;
@@ -234,9 +234,9 @@ public class GeoEnrichIPRecord extends AbstractEnrichIP {
         try (InputStream is = session.read(input);
              OutputStream os = session.write(output);
              OutputStream osNotFound = splitOutput ? session.write(notFound) : null) {
-            RecordPathCache cache = new RecordPathCache(GEO_PROPERTIES.size() + 1);
+            RecordPathCache cache = new RecordPathCache(GEO_PROPERTY_DESCRIPTORS.size() + 1);
             Map<PropertyDescriptor, RecordPath> paths = new HashMap<>();
-            for (PropertyDescriptor descriptor : GEO_PROPERTIES) {
+            for (PropertyDescriptor descriptor : GEO_PROPERTY_DESCRIPTORS) {
                 if (!context.getProperty(descriptor).isSet()) {
                     continue;
                 }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventBatchingProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventBatchingProcessor.java
@@ -43,7 +43,7 @@ import static org.apache.nifi.processor.util.listen.ListenerProperties.NETWORK_I
  */
 public abstract class AbstractListenEventBatchingProcessor<E extends Event> extends AbstractListenEventProcessor<E> {
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             NETWORK_INTF_NAME,
             PORT,
             RECV_BUFFER_SIZE,
@@ -60,7 +60,7 @@ public abstract class AbstractListenEventBatchingProcessor<E extends Event> exte
     @Override
     protected void init(final ProcessorInitializationContext context) {
         this.descriptors = Stream.concat(
-                PROPERTIES.stream(),
+                PROPERTY_DESCRIPTORS.stream(),
                 getAdditionalProperties().stream()
         ).toList();
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventProcessor.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.charset.Charset;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -45,6 +44,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 
 import static org.apache.nifi.processor.util.listen.ListenerProperties.NETWORK_INTF_NAME;
 
@@ -109,6 +109,15 @@ public abstract class AbstractListenEventProcessor<E extends Event> extends Abst
 
     public static final int POLL_TIMEOUT_MS = 20;
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        NETWORK_INTF_NAME,
+        PORT,
+        RECV_BUFFER_SIZE,
+        MAX_MESSAGE_QUEUE_SIZE,
+        MAX_SOCKET_BUFFER_SIZE,
+        CHARSET
+    );
+
     protected Set<Relationship> relationships;
     protected List<PropertyDescriptor> descriptors;
 
@@ -124,15 +133,10 @@ public abstract class AbstractListenEventProcessor<E extends Event> extends Abst
 
     @Override
     protected void init(final ProcessorInitializationContext context) {
-        final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(NETWORK_INTF_NAME);
-        descriptors.add(PORT);
-        descriptors.add(RECV_BUFFER_SIZE);
-        descriptors.add(MAX_MESSAGE_QUEUE_SIZE);
-        descriptors.add(MAX_SOCKET_BUFFER_SIZE);
-        descriptors.add(CHARSET);
-        descriptors.addAll(getAdditionalProperties());
-        this.descriptors = Collections.unmodifiableList(descriptors);
+        this.descriptors = Stream.concat(
+                PROPERTIES.stream(),
+                getAdditionalProperties().stream()
+        ).toList();
 
         final Set<Relationship> relationships = new HashSet<>();
         relationships.add(REL_SUCCESS);

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-event-listen/src/main/java/org/apache/nifi/processor/util/listen/AbstractListenEventProcessor.java
@@ -109,7 +109,7 @@ public abstract class AbstractListenEventProcessor<E extends Event> extends Abst
 
     public static final int POLL_TIMEOUT_MS = 20;
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         NETWORK_INTF_NAME,
         PORT,
         RECV_BUFFER_SIZE,
@@ -134,7 +134,7 @@ public abstract class AbstractListenEventProcessor<E extends Event> extends Abst
     @Override
     protected void init(final ProcessorInitializationContext context) {
         this.descriptors = Stream.concat(
-                PROPERTIES.stream(),
+                PROPERTY_DESCRIPTORS.stream(),
                 getAdditionalProperties().stream()
         ).toList();
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/FetchFileTransfer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/FetchFileTransfer.java
@@ -40,7 +40,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -142,6 +141,22 @@ public abstract class FetchFileTransfer extends AbstractProcessor {
         .description("Any FlowFile that could not be fetched from the remote server due to insufficient permissions will be transferred to this Relationship.")
         .build();
 
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        HOSTNAME,
+        UNDEFAULTED_PORT,
+        REMOTE_FILENAME,
+        COMPLETION_STRATEGY,
+        MOVE_DESTINATION_DIR,
+        MOVE_CREATE_DIRECTORY
+    );
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS,
+        REL_NOT_FOUND,
+        REL_PERMISSION_DENIED,
+        REL_COMMS_FAILURE
+    );
+
     private final Map<Tuple<String, Integer>, BlockingQueue<FileTransferIdleWrapper>> fileTransferMap = new HashMap<>();
     private final long IDLE_CONNECTION_MILLIS = TimeUnit.SECONDS.toMillis(10L); // amount of time to wait before closing an idle connection
     private volatile long lastClearTime = System.currentTimeMillis();
@@ -149,12 +164,7 @@ public abstract class FetchFileTransfer extends AbstractProcessor {
 
     @Override
     public Set<Relationship> getRelationships() {
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_NOT_FOUND);
-        relationships.add(REL_PERMISSION_DENIED);
-        relationships.add(REL_COMMS_FAILURE);
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @OnScheduled
@@ -203,14 +213,7 @@ public abstract class FetchFileTransfer extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(HOSTNAME);
-        properties.add(UNDEFAULTED_PORT);
-        properties.add(REMOTE_FILENAME);
-        properties.add(COMPLETION_STRATEGY);
-        properties.add(MOVE_DESTINATION_DIR);
-        properties.add(MOVE_CREATE_DIRECTORY);
-        return properties;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/GetFileTransfer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/GetFileTransfer.java
@@ -59,7 +59,10 @@ public abstract class GetFileTransfer extends AbstractProcessor {
             .name("success")
             .description("All FlowFiles that are received are routed to success")
             .build();
-    private final Set<Relationship> relationships;
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS
+    );
 
     public static final String FILE_LAST_MODIFY_TIME_ATTRIBUTE = "file.lastModifiedTime";
     public static final String FILE_OWNER_ATTRIBUTE = "file.owner";
@@ -81,15 +84,9 @@ public abstract class GetFileTransfer extends AbstractProcessor {
     private final Lock sharableTransferLock = transferLock.readLock();
     private final Lock mutuallyExclusiveTransferLock = transferLock.writeLock();
 
-    public GetFileTransfer() {
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        this.relationships = Collections.unmodifiableSet(relationships);
-    }
-
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     protected abstract FileTransfer getFileTransfer(final ProcessContext context);

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/PutFileTransfer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/PutFileTransfer.java
@@ -32,8 +32,6 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -58,20 +56,19 @@ public abstract class PutFileTransfer<T extends FileTransfer> extends AbstractPr
             .description("FlowFiles that were rejected by the destination system")
             .build();
 
-    private final Set<Relationship> relationships;
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_REJECT
+    );
 
     public PutFileTransfer() {
         super();
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_FAILURE);
-        relationships.add(REL_REJECT);
-        this.relationships = Collections.unmodifiableSet(relationships);
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     protected abstract T getFileTransfer(final ProcessContext context);

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
@@ -141,7 +141,7 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
     private static final Object RESOURCES_LOCK = new Object();
     private static final HdfsResources EMPTY_HDFS_RESOURCES = new HdfsResources(null, null, null, null);
 
-    protected static final List<PropertyDescriptor> PARENT_PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             HADOOP_CONFIGURATION_RESOURCES,
             KERBEROS_USER_SERVICE,
             ADDITIONAL_CLASSPATH_RESOURCES
@@ -153,6 +153,10 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
 
     // Holder of cached Configuration information so validation does not reload the same config over and over
     private final AtomicReference<ValidationResources> validationResourceHolder = new AtomicReference<>();
+
+    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
 
     @Override
     protected void init(ProcessorInitializationContext context) {
@@ -170,7 +174,7 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PARENT_PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-hadoop-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractHadoopProcessor.java
@@ -141,7 +141,11 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
     private static final Object RESOURCES_LOCK = new Object();
     private static final HdfsResources EMPTY_HDFS_RESOURCES = new HdfsResources(null, null, null, null);
 
-    protected List<PropertyDescriptor> properties;
+    protected static final List<PropertyDescriptor> PARENT_PROPERTIES = List.of(
+            HADOOP_CONFIGURATION_RESOURCES,
+            KERBEROS_USER_SERVICE,
+            ADDITIONAL_CLASSPATH_RESOURCES
+    );
 
     // variables shared by all threads of this processor
     // Hadoop Configuration, Filesystem, and UserGroupInformation (optional)
@@ -153,12 +157,6 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
     @Override
     protected void init(ProcessorInitializationContext context) {
         hdfsResources.set(EMPTY_HDFS_RESOURCES);
-
-        properties = List.of(
-                HADOOP_CONFIGURATION_RESOURCES,
-                KERBEROS_USER_SERVICE,
-                ADDITIONAL_CLASSPATH_RESOURCES
-        );
     }
 
     @Override
@@ -172,7 +170,7 @@ public abstract class AbstractHadoopProcessor extends AbstractProcessor implemen
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PARENT_PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-listed-entity/src/main/java/org/apache/nifi/processor/util/list/AbstractListProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-listed-entity/src/main/java/org/apache/nifi/processor/util/list/AbstractListProcessor.java
@@ -56,7 +56,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -233,6 +232,10 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
             .identifiesControllerService(RecordSetWriterFactory.class)
             .build();
 
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS
+    );
+
     /**
      * Represents the timestamp of an entity which was the latest one within those listed at the previous cycle.
      * It does not necessary mean it has been processed as well.
@@ -286,9 +289,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
 
     @Override
     public Set<Relationship> getRelationships() {
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        return relationships;
+       return RELATIONSHIPS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractFetchHDFSRecord.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractFetchHDFSRecord.java
@@ -114,7 +114,7 @@ public abstract class AbstractFetchHDFSRecord extends AbstractHadoopProcessor {
                 REL_FAILURE
         );
 
-        final List<PropertyDescriptor> props = new ArrayList<>(PARENT_PROPERTIES);
+        final List<PropertyDescriptor> props = new ArrayList<>(getCommonPropertyDescriptors());
         props.add(FILENAME);
         props.add(RECORD_WRITER);
         props.addAll(getAdditionalProperties());

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractFetchHDFSRecord.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractFetchHDFSRecord.java
@@ -50,7 +50,6 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -109,13 +108,13 @@ public abstract class AbstractFetchHDFSRecord extends AbstractHadoopProcessor {
     protected final void init(final ProcessorInitializationContext context) {
         super.init(context);
 
-        final Set<Relationship> rels = new HashSet<>();
-        rels.add(REL_SUCCESS);
-        rels.add(REL_RETRY);
-        rels.add(REL_FAILURE);
-        this.fetchHdfsRecordRelationships = Collections.unmodifiableSet(rels);
+        this.fetchHdfsRecordRelationships = Set.of(
+                REL_SUCCESS,
+                REL_RETRY,
+                REL_FAILURE
+        );
 
-        final List<PropertyDescriptor> props = new ArrayList<>(properties);
+        final List<PropertyDescriptor> props = new ArrayList<>(PARENT_PROPERTIES);
         props.add(FILENAME);
         props.add(RECORD_WRITER);
         props.addAll(getAdditionalProperties());

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractPutHDFSRecord.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractPutHDFSRecord.java
@@ -152,7 +152,7 @@ public abstract class AbstractPutHDFSRecord extends AbstractHadoopProcessor {
                 REL_FAILURE
         );
 
-        final List<PropertyDescriptor> props = new ArrayList<>(PARENT_PROPERTIES);
+        final List<PropertyDescriptor> props = new ArrayList<>(getCommonPropertyDescriptors());
         props.add(RECORD_READER);
 
         props.add(new PropertyDescriptor.Builder()

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractPutHDFSRecord.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-hadoop-record-utils/src/main/java/org/apache/nifi/processors/hadoop/AbstractPutHDFSRecord.java
@@ -55,7 +55,6 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -147,14 +146,13 @@ public abstract class AbstractPutHDFSRecord extends AbstractHadoopProcessor {
     @Override
     protected final void init(final ProcessorInitializationContext context) {
         super.init(context);
+        this.putHdfsRecordRelationships = Set.of(
+                REL_SUCCESS,
+                REL_RETRY,
+                REL_FAILURE
+        );
 
-        final Set<Relationship> rels = new HashSet<>();
-        rels.add(REL_SUCCESS);
-        rels.add(REL_RETRY);
-        rels.add(REL_FAILURE);
-        this.putHdfsRecordRelationships = Collections.unmodifiableSet(rels);
-
-        final List<PropertyDescriptor> props = new ArrayList<>(properties);
+        final List<PropertyDescriptor> props = new ArrayList<>(PARENT_PROPERTIES);
         props.add(RECORD_READER);
 
         props.add(new PropertyDescriptor.Builder()

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-parameter-providers/src/main/java/org/apache/nifi/parameter/gcp/GcpSecretManagerParameterProvider.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-parameter-providers/src/main/java/org/apache/nifi/parameter/gcp/GcpSecretManagerParameterProvider.java
@@ -41,8 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,15 +89,15 @@ public class GcpSecretManagerParameterProvider extends AbstractParameterProvider
 
     private static final String GROUP_NAME_LABEL = "group-name";
     private static final String SECRETS_PATH = "secrets/";
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             GROUP_NAME_PATTERN,
             PROJECT_ID,
             GCP_CREDENTIALS_PROVIDER_SERVICE
-    ));
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/service/GCPCredentialsControllerService.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/service/GCPCredentialsControllerService.java
@@ -41,7 +41,6 @@ import org.apache.nifi.proxy.ProxyConfiguration;
 import org.apache.nifi.reporting.InitializationException;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -75,26 +74,22 @@ import static org.apache.nifi.processors.gcp.credentials.factory.CredentialPrope
 )
 public class GCPCredentialsControllerService extends AbstractControllerService implements GCPCredentialsService, VerifiableControllerService {
 
-    private static final List<PropertyDescriptor> properties;
-
-    static {
-        final List<PropertyDescriptor> props = new ArrayList<>();
-        props.add(USE_APPLICATION_DEFAULT_CREDENTIALS);
-        props.add(USE_COMPUTE_ENGINE_CREDENTIALS);
-        props.add(SERVICE_ACCOUNT_JSON_FILE);
-        props.add(SERVICE_ACCOUNT_JSON);
-        props.add(ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxyAwareTransportFactory.PROXY_SPECS));
-        props.add(DELEGATION_STRATEGY);
-        props.add(DELEGATION_USER);
-        properties = Collections.unmodifiableList(props);
-    }
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            USE_APPLICATION_DEFAULT_CREDENTIALS,
+            USE_COMPUTE_ENGINE_CREDENTIALS,
+            SERVICE_ACCOUNT_JSON_FILE,
+            SERVICE_ACCOUNT_JSON,
+            ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxyAwareTransportFactory.PROXY_SPECS),
+            DELEGATION_STRATEGY,
+            DELEGATION_USER
+    );
 
     private volatile GoogleCredentials googleCredentials;
     protected final CredentialsFactory credentialsProviderFactory = new CredentialsFactory();
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTY_DESCRIPTORS;
     }
 
     public GoogleCredentials getGoogleCredentials() throws ProcessException {

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -230,7 +230,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
             .description("A FlowFile will be routed here for each File for which fetch was attempted but failed.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         GoogleUtils.GCP_CREDENTIALS_PROVIDER_SERVICE,
         FILE_ID,
         ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxyAwareTransportFactory.PROXY_SPECS),
@@ -240,7 +240,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
         GOOGLE_DRAWING_EXPORT_TYPE
     );
 
-    public static final Set<Relationship> RELATIONSHIPS = Set.of(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
     );
@@ -249,7 +249,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/ListGoogleDrive.java
@@ -148,7 +148,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
             .dependsOn(LISTING_STRATEGY, BY_ENTITIES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             GoogleUtils.GCP_CREDENTIALS_PROVIDER_SERVICE,
             FOLDER_ID,
             RECURSIVE_SEARCH,
@@ -165,7 +165,7 @@ public class ListGoogleDrive extends AbstractListProcessor<GoogleDriveFileInfo> 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
@@ -158,7 +158,7 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
             .required(false)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             GCP_CREDENTIALS_PROVIDER_SERVICE,
             FOLDER_ID,
             FILE_NAME,
@@ -196,7 +196,7 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/ConsumeGCPubSub.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/ConsumeGCPubSub.java
@@ -95,7 +95,7 @@ public class ConsumeGCPubSub extends AbstractGCPubSubWithProxyProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             GCP_CREDENTIALS_PROVIDER_SERVICE,
             PROJECT_ID,
             SUBSCRIPTION,
@@ -115,7 +115,7 @@ public class ConsumeGCPubSub extends AbstractGCPubSubWithProxyProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PublishGCPubSub.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/pubsub/PublishGCPubSub.java
@@ -173,7 +173,7 @@ public class PublishGCPubSub extends AbstractGCPubSubWithProxyProcessor {
             .description("FlowFiles are routed to this relationship if the Google Cloud Pub/Sub operation fails but attempting the operation again may succeed.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             GCP_CREDENTIALS_PROVIDER_SERVICE,
             PROJECT_ID,
             TOPIC_NAME,
@@ -199,7 +199,7 @@ public class PublishGCPubSub extends AbstractGCPubSubWithProxyProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/GCSFileResourceService.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/GCSFileResourceService.java
@@ -44,7 +44,6 @@ import org.apache.nifi.processors.gcp.util.GoogleUtils;
 
 import java.io.IOException;
 import java.nio.channels.Channels;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -89,7 +88,7 @@ public class GCSFileResourceService extends AbstractControllerService implements
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             BUCKET,
             KEY,
             GoogleUtils.GCP_CREDENTIALS_PROVIDER_SERVICE

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/GCSFileResourceService.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/GCSFileResourceService.java
@@ -88,7 +88,7 @@ public class GCSFileResourceService extends AbstractControllerService implements
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BUCKET,
             KEY,
             GoogleUtils.GCP_CREDENTIALS_PROVIDER_SERVICE
@@ -98,7 +98,7 @@ public class GCSFileResourceService extends AbstractControllerService implements
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractGcpVisionProcessor.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractGcpVisionProcessor.java
@@ -42,20 +42,24 @@ public abstract class AbstractGcpVisionProcessor extends AbstractProcessor  {
     public static final Relationship REL_FAILURE = new Relationship.Builder().name("failure")
             .description("FlowFiles are routed to failure relationship").build();
 
-    protected static final Set<Relationship> RELATIONSHIPS = Set.of(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
     );
 
-    protected static final List<PropertyDescriptor> COMMON_PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             GCP_CREDENTIALS_PROVIDER_SERVICE
     );
 
     private ImageAnnotatorClient vision;
 
+    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return COMMON_PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractGetGcpVisionAnnotateOperationStatus.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/AbstractGetGcpVisionAnnotateOperationStatus.java
@@ -57,12 +57,12 @@ abstract public class AbstractGetGcpVisionAnnotateOperationStatus extends Abstra
             .description("Upon successful completion, the original FlowFile will be routed to this relationship.")
             .autoTerminateDefault(true)
             .build();
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            COMMON_PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(OPERATION_KEY)
     ).toList();
 
-    private static final Set<Relationship> COMMON_RELATIONSHIPS = Set.of(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             REL_ORIGINAL,
             REL_SUCCESS,
             REL_FAILURE,
@@ -71,12 +71,12 @@ abstract public class AbstractGetGcpVisionAnnotateOperationStatus extends Abstra
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return COMMON_RELATIONSHIPS;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateFilesOperation.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateFilesOperation.java
@@ -69,7 +69,7 @@ public class StartGcpVisionAnnotateFilesOperation extends AbstractStartGcpVision
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             JSON_PAYLOAD,
             GCP_CREDENTIALS_PROVIDER_SERVICE,
             OUTPUT_BUCKET,
@@ -78,7 +78,7 @@ public class StartGcpVisionAnnotateFilesOperation extends AbstractStartGcpVision
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateImagesOperation.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateImagesOperation.java
@@ -68,7 +68,8 @@ public class StartGcpVisionAnnotateImagesOperation extends AbstractStartGcpVisio
                     }""")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             JSON_PAYLOAD,
             GCP_CREDENTIALS_PROVIDER_SERVICE,
             OUTPUT_BUCKET,
@@ -77,7 +78,7 @@ public class StartGcpVisionAnnotateImagesOperation extends AbstractStartGcpVisio
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-geohash-bundle/nifi-geohash-processors/src/main/java/org/apache/nifi/processors/geohash/GeohashRecord.java
+++ b/nifi-extension-bundles/nifi-geohash-bundle/nifi-geohash-processors/src/main/java/org/apache/nifi/processors/geohash/GeohashRecord.java
@@ -223,7 +223,7 @@ public class GeohashRecord extends AbstractProcessor {
             REL_FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             MODE,
             RECORD_READER,
             RECORD_WRITER,
@@ -255,7 +255,7 @@ public class GeohashRecord extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-geohash-bundle/nifi-geohash-processors/src/main/java/org/apache/nifi/processors/geohash/GeohashRecord.java
+++ b/nifi-extension-bundles/nifi-geohash-bundle/nifi-geohash-processors/src/main/java/org/apache/nifi/processors/geohash/GeohashRecord.java
@@ -31,7 +31,6 @@ import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.record.path.FieldValue;
@@ -56,10 +55,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Optional;
@@ -226,28 +223,23 @@ public class GeohashRecord extends AbstractProcessor {
             REL_FAILURE
     );
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            MODE,
+            RECORD_READER,
+            RECORD_WRITER,
+            ROUTING_STRATEGY,
+            LATITUDE_RECORD_PATH,
+            LONGITUDE_RECORD_PATH,
+            GEOHASH_RECORD_PATH,
+            GEOHASH_FORMAT,
+            GEOHASH_LEVEL
+    );
+
     private RoutingStrategyExecutor routingStrategyExecutor;
     private static boolean isSplit;
     private static Integer enrichedCount, unenrichedCount;
 
     private final RecordPathCache cache = new RecordPathCache(100);
-
-    private List<PropertyDescriptor> descriptors;
-
-    @Override
-    protected void init(final ProcessorInitializationContext context) {
-        descriptors = new ArrayList<>();
-        descriptors.add(MODE);
-        descriptors.add(RECORD_READER);
-        descriptors.add(RECORD_WRITER);
-        descriptors.add(ROUTING_STRATEGY);
-        descriptors.add(LATITUDE_RECORD_PATH);
-        descriptors.add(LONGITUDE_RECORD_PATH);
-        descriptors.add(GEOHASH_RECORD_PATH);
-        descriptors.add(GEOHASH_FORMAT);
-        descriptors.add(GEOHASH_LEVEL);
-        descriptors = Collections.unmodifiableList(descriptors);
-    }
 
     @Override
     public void onPropertyModified(final PropertyDescriptor descriptor, final String oldValue, final String newValue) {
@@ -263,7 +255,7 @@ public class GeohashRecord extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return descriptors;
+        return PROPERTIES;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-processors/src/main/java/org/apache/nifi/processors/graph/ExecuteGraphQuery.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-processors/src/main/java/org/apache/nifi/processors/graph/ExecuteGraphQuery.java
@@ -36,9 +36,6 @@ import org.apache.nifi.util.StringUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,35 +61,29 @@ import java.util.Set;
     })
 public class ExecuteGraphQuery extends AbstractGraphExecutor {
 
-    private static final Set<Relationship> relationships;
-    private static final List<PropertyDescriptor> propertyDescriptors;
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS,
+        REL_ORIGINAL,
+        REL_FAILURE
+    );
+
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        CLIENT_SERVICE,
+        QUERY
+    );
 
     public static final String EXECUTION_TIME = "query.took";
-
-    static {
-        final Set<Relationship> tempRelationships = new HashSet<>();
-        tempRelationships.add(REL_SUCCESS);
-        tempRelationships.add(REL_ORIGINAL);
-        tempRelationships.add(REL_FAILURE);
-        relationships = Collections.unmodifiableSet(tempRelationships);
-
-        final List<PropertyDescriptor> tempDescriptors = new ArrayList<>();
-        tempDescriptors.add(CLIENT_SERVICE);
-        tempDescriptors.add(QUERY);
-
-        propertyDescriptors = Collections.unmodifiableList(tempDescriptors);
-    }
 
     protected ObjectMapper mapper = new ObjectMapper();
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private volatile GraphClientService clientService;

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-processors/src/main/java/org/apache/nifi/processors/graph/ExecuteGraphQueryRecord.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-processors/src/main/java/org/apache/nifi/processors/graph/ExecuteGraphQueryRecord.java
@@ -51,9 +51,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -120,10 +118,6 @@ public class ExecuteGraphQueryRecord extends  AbstractGraphExecutor {
                 .dynamic(true).addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build();
     }
 
-    public static final List<PropertyDescriptor> DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
-            CLIENT_SERVICE, READER_SERVICE, WRITER_SERVICE, SUBMISSION_SCRIPT
-    ));
-
     public static final Relationship SUCCESS = new Relationship.Builder().name("original")
                                                     .description("Original flow files that successfully interacted with " +
                                                             "graph server.")
@@ -136,9 +130,18 @@ public class ExecuteGraphQueryRecord extends  AbstractGraphExecutor {
                                                     .autoTerminateDefault(true)
                                                     .build();
 
-    public static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            SUCCESS, FAILURE, GRAPH
-    )));
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            CLIENT_SERVICE,
+            READER_SERVICE,
+            WRITER_SERVICE,
+            SUBMISSION_SCRIPT
+    );
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE,
+            GRAPH
+    );
 
     public static final String RECORD_COUNT = "record.count";
     public static final String GRAPH_OPERATION_TIME = "graph.operations.took";
@@ -151,7 +154,7 @@ public class ExecuteGraphQueryRecord extends  AbstractGraphExecutor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private GraphClientService clientService;

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/src/main/java/org/apache/nifi/graph/Neo4JCypherClientService.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/src/main/java/org/apache/nifi/graph/Neo4JCypherClientService.java
@@ -43,7 +43,6 @@ import org.neo4j.driver.summary.SummaryCounters;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -156,21 +155,17 @@ public class Neo4JCypherClientService extends AbstractControllerService implemen
     protected String password;
     protected String connectionUrl;
 
-    private static final List<PropertyDescriptor> DESCRIPTORS;
-    static {
-        List<PropertyDescriptor> _temp = new ArrayList<>();
-        _temp.add(CONNECTION_URL);
-        _temp.add(USERNAME);
-        _temp.add(PASSWORD);
-        _temp.add(CONNECTION_TIMEOUT);
-        _temp.add(MAX_CONNECTION_POOL_SIZE);
-        _temp.add(MAX_CONNECTION_ACQUISITION_TIMEOUT);
-        _temp.add(IDLE_TIME_BEFORE_CONNECTION_TEST);
-        _temp.add(MAX_CONNECTION_LIFETIME);
-        _temp.add(SSL_TRUST_STORE_FILE);
-
-        DESCRIPTORS = Collections.unmodifiableList(_temp);
-    }
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            CONNECTION_URL,
+            USERNAME,
+            PASSWORD,
+            CONNECTION_TIMEOUT,
+            MAX_CONNECTION_POOL_SIZE,
+            MAX_CONNECTION_ACQUISITION_TIMEOUT,
+            IDLE_TIME_BEFORE_CONNECTION_TEST,
+            MAX_CONNECTION_LIFETIME,
+            SSL_TRUST_STORE_FILE
+    );
 
     @Override
     protected Collection<ValidationResult> customValidate(ValidationContext validationContext) {
@@ -191,7 +186,7 @@ public class Neo4JCypherClientService extends AbstractControllerService implemen
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     protected Driver getDriver(ConfigurationContext context) {

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/src/main/java/org/apache/nifi/graph/Neo4JCypherClientService.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/src/main/java/org/apache/nifi/graph/Neo4JCypherClientService.java
@@ -155,7 +155,7 @@ public class Neo4JCypherClientService extends AbstractControllerService implemen
     protected String password;
     protected String connectionUrl;
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CONNECTION_URL,
             USERNAME,
             PASSWORD,
@@ -186,7 +186,7 @@ public class Neo4JCypherClientService extends AbstractControllerService implemen
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     protected Driver getDriver(ConfigurationContext context) {

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/src/main/java/org/apache/nifi/graph/TinkerpopClientService.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/src/main/java/org/apache/nifi/graph/TinkerpopClientService.java
@@ -217,7 +217,7 @@ public class TinkerpopClientService extends AbstractControllerService implements
             .identifiesControllerService(SSLContextProvider.class)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SUBMISSION_TYPE,
             CONNECTION_SETTINGS,
             REMOTE_OBJECTS_FILE,
@@ -296,7 +296,7 @@ public class TinkerpopClientService extends AbstractControllerService implements
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/src/main/java/org/apache/nifi/graph/TinkerpopClientService.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/src/main/java/org/apache/nifi/graph/TinkerpopClientService.java
@@ -57,9 +57,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -219,7 +217,7 @@ public class TinkerpopClientService extends AbstractControllerService implements
             .identifiesControllerService(SSLContextProvider.class)
             .build();
 
-    public static final List<PropertyDescriptor> DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
+    public static final List<PropertyDescriptor> PROPERTIES = List.of(
             SUBMISSION_TYPE,
             CONNECTION_SETTINGS,
             REMOTE_OBJECTS_FILE,
@@ -232,7 +230,7 @@ public class TinkerpopClientService extends AbstractControllerService implements
             USER_NAME,
             PASSWORD,
             SSL_CONTEXT_SERVICE
-    ));
+    );
 
     private GroovyShell groovyShell;
     private Map<String, Script> compiledCode;
@@ -298,7 +296,7 @@ public class TinkerpopClientService extends AbstractControllerService implements
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
@@ -136,7 +136,7 @@ public class ExecuteGroovyScript extends AbstractProcessor {
 
     public static final Relationship REL_FAILURE = new Relationship.Builder().name("failure").description("FlowFiles that failed to be processed").build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SCRIPT_FILE,
             SCRIPT_BODY,
             FAIL_STRATEGY,
@@ -165,7 +165,7 @@ public class ExecuteGroovyScript extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private File asFile(String f) {

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/CreateHadoopSequenceFile.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/CreateHadoopSequenceFile.java
@@ -98,8 +98,8 @@ public class CreateHadoopSequenceFile extends AbstractHadoopProcessor {
             RELATIONSHIP_FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            PARENT_PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                 COMPRESSION_TYPE,
                 COMPRESSION_CODEC
@@ -113,7 +113,7 @@ public class CreateHadoopSequenceFile extends AbstractHadoopProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/CreateHadoopSequenceFile.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/CreateHadoopSequenceFile.java
@@ -36,12 +36,10 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processors.hadoop.util.SequenceFileWriter;
 import org.apache.nifi.util.StopWatch;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 /**
  * <p>
@@ -83,14 +81,7 @@ public class CreateHadoopSequenceFile extends AbstractHadoopProcessor {
             .name("failure")
             .description("Incoming files that failed to generate a Sequence File are sent to this relationship")
             .build();
-    private static final Set<Relationship> relationships;
 
-    static {
-        Set<Relationship> rels = new HashSet<>();
-        rels.add(RELATIONSHIP_SUCCESS);
-        rels.add(RELATIONSHIP_FAILURE);
-        relationships = Collections.unmodifiableSet(rels);
-    }
     // Optional Properties.
     static final PropertyDescriptor COMPRESSION_TYPE = new PropertyDescriptor.Builder()
             .displayName("Compression type")
@@ -102,17 +93,27 @@ public class CreateHadoopSequenceFile extends AbstractHadoopProcessor {
     // Default Values.
     public static final String DEFAULT_COMPRESSION_TYPE = "NONE";
 
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            RELATIONSHIP_SUCCESS,
+            RELATIONSHIP_FAILURE
+    );
+
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            PARENT_PROPERTIES.stream(),
+            Stream.of(
+                COMPRESSION_TYPE,
+                COMPRESSION_CODEC
+            )
+    ).toList();
+
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        List<PropertyDescriptor> someProps = new ArrayList<>(properties);
-        someProps.add(COMPRESSION_TYPE);
-        someProps.add(COMPRESSION_CODEC);
-        return  someProps;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
@@ -112,8 +112,8 @@ public class DeleteHDFS extends AbstractHadoopProcessor {
             REL_FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            PARENT_PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                 FILE_OR_DIRECTORY,
                 RECURSIVE
@@ -122,7 +122,7 @@ public class DeleteHDFS extends AbstractHadoopProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/DeleteHDFS.java
@@ -43,14 +43,12 @@ import org.apache.nifi.processors.hadoop.util.GSSExceptionRollbackYieldSessionHa
 
 import java.io.IOException;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 @InputRequirement(InputRequirement.Requirement.INPUT_ALLOWED)
 @Tags({"hadoop", "HCFS", "HDFS", "delete", "remove", "filesystem"})
@@ -109,26 +107,27 @@ public class DeleteHDFS extends AbstractHadoopProcessor {
     protected final Pattern GLOB_PATTERN = Pattern.compile("\\[|\\]|\\*|\\?|\\^|\\{|\\}|\\\\c");
     protected final Matcher GLOB_MATCHER = GLOB_PATTERN.matcher("");
 
-    private static final Set<Relationship> relationships;
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
-    static {
-        final Set<Relationship> relationshipSet = new HashSet<>();
-        relationshipSet.add(REL_SUCCESS);
-        relationshipSet.add(REL_FAILURE);
-        relationships = Collections.unmodifiableSet(relationshipSet);
-    }
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            PARENT_PROPERTIES.stream(),
+            Stream.of(
+                FILE_OR_DIRECTORY,
+                RECURSIVE
+            )
+    ).toList();
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        List<PropertyDescriptor> props = new ArrayList<>(properties);
-        props.add(FILE_OR_DIRECTORY);
-        props.add(RECURSIVE);
-        return props;
+        return PROPERTIES;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/FetchHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/FetchHDFS.java
@@ -53,11 +53,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
@@ -101,21 +100,28 @@ public class FetchHDFS extends AbstractHadoopProcessor {
                 + "This generally indicates that the Fetch should be tried again.")
         .build();
 
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_COMMS_FAILURE
+    );
+
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            PARENT_PROPERTIES.stream(),
+            Stream.of(
+                FILENAME,
+                COMPRESSION_CODEC
+            )
+    ).toList();
+
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> props = new ArrayList<>(properties);
-        props.add(FILENAME);
-        props.add(COMPRESSION_CODEC);
-        return props;
+        return PROPERTIES;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_FAILURE);
-        relationships.add(REL_COMMS_FAILURE);
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/FetchHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/FetchHDFS.java
@@ -106,8 +106,8 @@ public class FetchHDFS extends AbstractHadoopProcessor {
             REL_COMMS_FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            PARENT_PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                 FILENAME,
                 COMPRESSION_CODEC
@@ -116,7 +116,7 @@ public class FetchHDFS extends AbstractHadoopProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFS.java
@@ -57,7 +57,6 @@ import java.io.InputStream;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -68,6 +67,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 @TriggerWhenEmpty
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
@@ -178,11 +178,27 @@ public class GetHDFS extends AbstractHadoopProcessor {
     .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
     .build();
 
-    private static final Set<Relationship> relationships;
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
-    static {
-        relationships = Collections.singleton(REL_SUCCESS);
-    }
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            PARENT_PROPERTIES.stream(),
+            Stream.of(
+                    DIRECTORY,
+                    RECURSE_SUBDIRS,
+                    KEEP_SOURCE_FILE,
+                    FILE_FILTER_REGEX,
+                    FILTER_MATCH_NAME_ONLY,
+                    IGNORE_DOTTED_FILES,
+                    MIN_AGE,
+                    MAX_AGE,
+                    POLLING_INTERVAL,
+                    BATCH_SIZE,
+                    BUFFER_SIZE,
+                    COMPRESSION_CODEC
+            )
+    ).toList();
 
     protected ProcessorConfiguration processorConfig;
     private final AtomicLong logEmptyListing = new AtomicLong(2L);
@@ -196,25 +212,12 @@ public class GetHDFS extends AbstractHadoopProcessor {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        List<PropertyDescriptor> props = new ArrayList<>(properties);
-        props.add(DIRECTORY);
-        props.add(RECURSE_SUBDIRS);
-        props.add(KEEP_SOURCE_FILE);
-        props.add(FILE_FILTER_REGEX);
-        props.add(FILTER_MATCH_NAME_ONLY);
-        props.add(IGNORE_DOTTED_FILES);
-        props.add(MIN_AGE);
-        props.add(MAX_AGE);
-        props.add(POLLING_INTERVAL);
-        props.add(BATCH_SIZE);
-        props.add(BUFFER_SIZE);
-        props.add(COMPRESSION_CODEC);
-        return props;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFS.java
@@ -182,8 +182,8 @@ public class GetHDFS extends AbstractHadoopProcessor {
             REL_SUCCESS
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            PARENT_PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                     DIRECTORY,
                     RECURSE_SUBDIRS,
@@ -217,7 +217,7 @@ public class GetHDFS extends AbstractHadoopProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSFileInfo.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSFileInfo.java
@@ -21,12 +21,12 @@ import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -230,6 +230,29 @@ public class GetHDFSFileInfo extends AbstractHadoopProcessor {
             .description("All failed attempts to access HDFS will be routed to this relationship")
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            PARENT_PROPERTIES.stream(),
+            Stream.of(
+                FULL_PATH,
+                RECURSE_SUBDIRS,
+                DIR_FILTER,
+                FILE_FILTER,
+                FILE_EXCLUDE_FILTER,
+                IGNORE_DOTTED_DIRS,
+                IGNORE_DOTTED_FILES,
+                GROUPING,
+                BATCH_SIZE,
+                DESTINATION
+            )
+    ).toList();
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_NOT_FOUND,
+            REL_ORIGINAL,
+            REL_FAILURE
+    );
+
     @Override
     protected void init(final ProcessorInitializationContext context) {
         super.init(context);
@@ -237,28 +260,12 @@ public class GetHDFSFileInfo extends AbstractHadoopProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> props = new ArrayList<>(properties);
-        props.add(FULL_PATH);
-        props.add(RECURSE_SUBDIRS);
-        props.add(DIR_FILTER);
-        props.add(FILE_FILTER);
-        props.add(FILE_EXCLUDE_FILTER);
-        props.add(IGNORE_DOTTED_DIRS);
-        props.add(IGNORE_DOTTED_FILES);
-        props.add(GROUPING);
-        props.add(BATCH_SIZE);
-        props.add(DESTINATION);
-        return props;
+        return PROPERTIES;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_NOT_FOUND);
-        relationships.add(REL_ORIGINAL);
-        relationships.add(REL_FAILURE);
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSFileInfo.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/GetHDFSFileInfo.java
@@ -230,8 +230,8 @@ public class GetHDFSFileInfo extends AbstractHadoopProcessor {
             .description("All failed attempts to access HDFS will be routed to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            PARENT_PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                 FULL_PATH,
                 RECURSE_SUBDIRS,
@@ -260,7 +260,7 @@ public class GetHDFSFileInfo extends AbstractHadoopProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/ListHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/ListHDFS.java
@@ -160,8 +160,8 @@ public class ListHDFS extends AbstractHadoopProcessor {
     public static final String LATEST_TIMESTAMP_KEY = "latest.timestamp";
     public static final String LATEST_FILES_KEY = "latest.file.%d";
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            PARENT_PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                 DIRECTORY,
                 RECURSE_SUBDIRS,
@@ -189,7 +189,7 @@ public class ListHDFS extends AbstractHadoopProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-       return PROPERTIES;
+       return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/ListHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/ListHDFS.java
@@ -52,9 +52,7 @@ import org.apache.nifi.serialization.RecordSetWriterFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -162,9 +160,23 @@ public class ListHDFS extends AbstractHadoopProcessor {
     public static final String LATEST_TIMESTAMP_KEY = "latest.timestamp";
     public static final String LATEST_FILES_KEY = "latest.file.%d";
 
-    private static final List<PropertyDescriptor> LIST_HDFS_PROPERTIES = Arrays.asList(
-            DIRECTORY, RECURSE_SUBDIRS, RECORD_WRITER, FILE_FILTER, FILE_FILTER_MODE, MINIMUM_FILE_AGE, MAXIMUM_FILE_AGE);
-    private static final Set<Relationship> RELATIONSHIPS = Collections.singleton(REL_SUCCESS);
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            PARENT_PROPERTIES.stream(),
+            Stream.of(
+                DIRECTORY,
+                RECURSE_SUBDIRS,
+                RECORD_WRITER,
+                FILE_FILTER,
+                FILE_FILTER_MODE,
+                MINIMUM_FILE_AGE,
+                MAXIMUM_FILE_AGE
+            )
+    ).toList();
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
+
     private Pattern fileFilterRegexPattern;
     private volatile boolean resetState = false;
 
@@ -177,9 +189,7 @@ public class ListHDFS extends AbstractHadoopProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> props = new ArrayList<>(properties);
-        props.addAll(LIST_HDFS_PROPERTIES);
-        return props;
+       return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/MoveHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/MoveHDFS.java
@@ -188,8 +188,8 @@ public class MoveHDFS extends AbstractHadoopProcessor {
             REL_FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            PARENT_PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                 CONFLICT_RESOLUTION,
                 INPUT_DIRECTORY_OR_FILE,
@@ -220,7 +220,7 @@ public class MoveHDFS extends AbstractHadoopProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
@@ -239,8 +239,8 @@ public class PutHDFS extends AbstractHadoopProcessor {
             REL_FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            PARENT_PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                     new PropertyDescriptor.Builder()
                             .fromPropertyDescriptor(DIRECTORY)
@@ -269,7 +269,7 @@ public class PutHDFS extends AbstractHadoopProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/PutHDFS.java
@@ -75,13 +75,13 @@ import java.security.PrivilegedAction;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.io.InputStream;
+import java.util.stream.Stream;
+
 import org.apache.nifi.processors.transfer.ResourceTransferSource;
 import static org.apache.nifi.processors.transfer.ResourceTransferProperties.FILE_RESOURCE_SERVICE;
 import static org.apache.nifi.processors.transfer.ResourceTransferProperties.RESOURCE_TRANSFER_SOURCE;
@@ -234,41 +234,42 @@ public class PutHDFS extends AbstractHadoopProcessor {
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .build();
 
-    private static final Set<Relationship> relationships;
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
-    static {
-        final Set<Relationship> rels = new HashSet<>();
-        rels.add(REL_SUCCESS);
-        rels.add(REL_FAILURE);
-        relationships = Collections.unmodifiableSet(rels);
-    }
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            PARENT_PROPERTIES.stream(),
+            Stream.of(
+                    new PropertyDescriptor.Builder()
+                            .fromPropertyDescriptor(DIRECTORY)
+                            .description("The parent HDFS directory to which files should be written. The directory will be created if it doesn't exist.")
+                            .build(),
+                    CONFLICT_RESOLUTION,
+                    APPEND_MODE,
+                    WRITING_STRATEGY,
+                    BLOCK_SIZE,
+                    BUFFER_SIZE,
+                    REPLICATION_FACTOR,
+                    UMASK,
+                    REMOTE_OWNER,
+                    REMOTE_GROUP,
+                    COMPRESSION_CODEC,
+                    IGNORE_LOCALITY,
+                    RESOURCE_TRANSFER_SOURCE,
+                    FILE_RESOURCE_SERVICE
+            )
+    ).toList();
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        List<PropertyDescriptor> props = new ArrayList<>(properties);
-        props.add(new PropertyDescriptor.Builder()
-                .fromPropertyDescriptor(DIRECTORY)
-                .description("The parent HDFS directory to which files should be written. The directory will be created if it doesn't exist.")
-                .build());
-        props.add(CONFLICT_RESOLUTION);
-        props.add(APPEND_MODE);
-        props.add(WRITING_STRATEGY);
-        props.add(BLOCK_SIZE);
-        props.add(BUFFER_SIZE);
-        props.add(REPLICATION_FACTOR);
-        props.add(UMASK);
-        props.add(REMOTE_OWNER);
-        props.add(REMOTE_GROUP);
-        props.add(COMPRESSION_CODEC);
-        props.add(IGNORE_LOCALITY);
-        props.add(RESOURCE_TRANSFER_SOURCE);
-        props.add(FILE_RESOURCE_SERVICE);
-        return props;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/inotify/GetHDFSEvents.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/inotify/GetHDFSEvents.java
@@ -136,8 +136,8 @@ public class GetHDFSEvents extends AbstractHadoopProcessor {
             .description("A flow file with updated information about a specific event will be sent to this relationship.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            PARENT_PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                     POLL_DURATION,
                     HDFS_PATH_TO_WATCH,
@@ -158,7 +158,7 @@ public class GetHDFSEvents extends AbstractHadoopProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/inotify/GetHDFSEvents.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/inotify/GetHDFSEvents.java
@@ -53,14 +53,13 @@ import org.apache.nifi.processors.hadoop.PutHDFS;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 @TriggerSerially
 @TriggerWhenEmpty
@@ -137,7 +136,21 @@ public class GetHDFSEvents extends AbstractHadoopProcessor {
             .description("A flow file with updated information about a specific event will be sent to this relationship.")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Collections.singletonList(REL_SUCCESS)));
+    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+            PARENT_PROPERTIES.stream(),
+            Stream.of(
+                    POLL_DURATION,
+                    HDFS_PATH_TO_WATCH,
+                    IGNORE_HIDDEN_FILES,
+                    EVENT_TYPES,
+                    NUMBER_OF_RETRIES_FOR_POLL
+            )
+    ).toList();
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
+
     private static final String LAST_TX_ID = "last.tx.id";
     private volatile long lastTxId = -1L;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -145,13 +158,7 @@ public class GetHDFSEvents extends AbstractHadoopProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        List<PropertyDescriptor> props = new ArrayList<>(properties);
-        props.add(POLL_DURATION);
-        props.add(HDFS_PATH_TO_WATCH);
-        props.add(IGNORE_HIDDEN_FILES);
-        props.add(EVENT_TYPES);
-        props.add(NUMBER_OF_RETRIES_FOR_POLL);
-        return Collections.unmodifiableList(props);
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hashicorp-vault-bundle/nifi-hashicorp-vault-client-service/src/main/java/org/apache/nifi/vault/hashicorp/StandardHashiCorpVaultClientService.java
+++ b/nifi-extension-bundles/nifi-hashicorp-vault-bundle/nifi-hashicorp-vault-client-service/src/main/java/org/apache/nifi/vault/hashicorp/StandardHashiCorpVaultClientService.java
@@ -56,7 +56,7 @@ import java.util.Map;
 )
 public class StandardHashiCorpVaultClientService extends AbstractControllerService implements HashiCorpVaultClientService {
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         CONFIGURATION_STRATEGY,
         VAULT_URI,
         VAULT_AUTHENTICATION,
@@ -81,7 +81,7 @@ public class StandardHashiCorpVaultClientService extends AbstractControllerServi
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hashicorp-vault-bundle/nifi-hashicorp-vault-client-service/src/main/java/org/apache/nifi/vault/hashicorp/StandardHashiCorpVaultClientService.java
+++ b/nifi-extension-bundles/nifi-hashicorp-vault-bundle/nifi-hashicorp-vault-client-service/src/main/java/org/apache/nifi/vault/hashicorp/StandardHashiCorpVaultClientService.java
@@ -38,8 +38,6 @@ import org.springframework.core.env.PropertySource;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -58,15 +56,15 @@ import java.util.Map;
 )
 public class StandardHashiCorpVaultClientService extends AbstractControllerService implements HashiCorpVaultClientService {
 
-    private static List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
-            CONFIGURATION_STRATEGY,
-            VAULT_URI,
-            VAULT_AUTHENTICATION,
-            SSL_CONTEXT_SERVICE,
-            VAULT_PROPERTIES_FILES,
-            CONNECTION_TIMEOUT,
-            READ_TIMEOUT
-    ));
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        CONFIGURATION_STRATEGY,
+        VAULT_URI,
+        VAULT_AUTHENTICATION,
+        SSL_CONTEXT_SERVICE,
+        VAULT_PROPERTIES_FILES,
+        CONNECTION_TIMEOUT,
+        READ_TIMEOUT
+    );
 
     private HashiCorpVaultCommunicationService communicationService;
 

--- a/nifi-extension-bundles/nifi-hashicorp-vault-bundle/nifi-hashicorp-vault-parameter-provider/src/main/java/org/apache/nifi/vault/hashicorp/HashiCorpVaultParameterProvider.java
+++ b/nifi-extension-bundles/nifi-hashicorp-vault-bundle/nifi-hashicorp-vault-parameter-provider/src/main/java/org/apache/nifi/vault/hashicorp/HashiCorpVaultParameterProvider.java
@@ -32,8 +32,6 @@ import org.apache.nifi.parameter.VerifiableParameterProvider;
 import org.apache.nifi.processor.util.StandardValidators;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -81,17 +79,18 @@ public class HashiCorpVaultParameterProvider extends AbstractParameterProvider i
             .defaultValue(".*")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             VAULT_CLIENT_SERVICE,
             KV_PATH,
             KV_VERSION,
-            SECRET_NAME_PATTERN));
+            SECRET_NAME_PATTERN
+    );
 
     private HashiCorpVaultCommunicationService vaultCommunicationService;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/src/main/java/org/apache/nifi/hazelcast/services/cacheclient/HazelcastMapCacheClient.java
+++ b/nifi-extension-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/src/main/java/org/apache/nifi/hazelcast/services/cacheclient/HazelcastMapCacheClient.java
@@ -84,7 +84,7 @@ public class HazelcastMapCacheClient extends AbstractControllerService implement
             .build();
 
     private static final long STARTING_REVISION = 1;
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         HAZELCAST_CACHE_MANAGER,
         HAZELCAST_CACHE_NAME,
         HAZELCAST_ENTRY_TTL
@@ -192,7 +192,7 @@ public class HazelcastMapCacheClient extends AbstractControllerService implement
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private <S> String serializeCacheEntryKey(final S key, final Serializer<S> serializer) throws IOException {

--- a/nifi-extension-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/src/main/java/org/apache/nifi/hazelcast/services/cacheclient/HazelcastMapCacheClient.java
+++ b/nifi-extension-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/src/main/java/org/apache/nifi/hazelcast/services/cacheclient/HazelcastMapCacheClient.java
@@ -36,9 +36,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -86,15 +84,11 @@ public class HazelcastMapCacheClient extends AbstractControllerService implement
             .build();
 
     private static final long STARTING_REVISION = 1;
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS;
-
-    static {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(HAZELCAST_CACHE_MANAGER);
-        properties.add(HAZELCAST_CACHE_NAME);
-        properties.add(HAZELCAST_ENTRY_TTL);
-        PROPERTY_DESCRIPTORS = Collections.unmodifiableList(properties);
-    }
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        HAZELCAST_CACHE_MANAGER,
+        HAZELCAST_CACHE_NAME,
+        HAZELCAST_ENTRY_TTL
+    );
 
     private volatile HazelcastCache cache = null;
 
@@ -198,7 +192,7 @@ public class HazelcastMapCacheClient extends AbstractControllerService implement
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     private <S> String serializeCacheEntryKey(final S key, final Serializer<S> serializer) throws IOException {

--- a/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
+++ b/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/ExtractHL7Attributes.java
@@ -137,7 +137,7 @@ public class ExtractHL7Attributes extends AbstractProcessor {
             .description("A FlowFile is routed to this relationship if it cannot be mapped to FlowFile Attributes. This would happen if the FlowFile does not contain valid HL7 data")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CHARACTER_SET,
             USE_SEGMENT_NAMES,
             PARSE_SEGMENT_FIELDS,
@@ -152,7 +152,7 @@ public class ExtractHL7Attributes extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/RouteHL7.java
+++ b/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/src/main/java/org/apache/nifi/processors/hl7/RouteHL7.java
@@ -90,7 +90,7 @@ public class RouteHL7 extends AbstractProcessor {
             .description("The original FlowFile that comes into this processor will be routed to this relationship, unless it is routed to 'failure'")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CHARACTER_SET
     );
 
@@ -114,7 +114,7 @@ public class RouteHL7 extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-hubspot-bundle/nifi-hubspot-processors/src/main/java/org/apache/nifi/processors/hubspot/GetHubSpot.java
+++ b/nifi-extension-bundles/nifi-hubspot-bundle/nifi-hubspot-processors/src/main/java/org/apache/nifi/processors/hubspot/GetHubSpot.java
@@ -182,7 +182,7 @@ public class GetHubSpot extends AbstractProcessor {
     private volatile WebClientServiceProvider webClientServiceProvider;
     private volatile boolean isObjectTypeModified;
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             OBJECT_TYPE,
             ACCESS_TOKEN,
             RESULT_LIMIT,
@@ -198,7 +198,7 @@ public class GetHubSpot extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-iotdb-bundle/nifi-iotdb-processors/src/main/java/org/apache/nifi/processors/AbstractIoTDB.java
+++ b/nifi-extension-bundles/nifi-iotdb-bundle/nifi-iotdb-processors/src/main/java/org/apache/nifi/processors/AbstractIoTDB.java
@@ -19,11 +19,9 @@ package org.apache.nifi.processors;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -111,19 +109,19 @@ public abstract class AbstractIoTDB extends AbstractProcessor {
             .description("Processing failed")
             .build();
 
-    private static final List<PropertyDescriptor> descriptors = new ArrayList<>();
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        IOTDB_HOST,
+        IOTDB_PORT,
+        USERNAME,
+        PASSWORD
+    );
 
-    private static final Set<Relationship> relationships = new LinkedHashSet<>();
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS,
+        REL_FAILURE
+    );
 
     static {
-        descriptors.add(IOTDB_HOST);
-        descriptors.add(IOTDB_PORT);
-        descriptors.add(USERNAME);
-        descriptors.add(PASSWORD);
-
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_FAILURE);
-
         typeMap.put(RecordFieldType.STRING, TSDataType.TEXT);
         typeMap.put(RecordFieldType.BOOLEAN, TSDataType.BOOLEAN);
         typeMap.put(RecordFieldType.INT, TSDataType.INT32);
@@ -149,7 +147,7 @@ public abstract class AbstractIoTDB extends AbstractProcessor {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @OnScheduled
@@ -184,7 +182,7 @@ public abstract class AbstractIoTDB extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return Collections.unmodifiableList(descriptors);
+        return PROPERTY_DESCRIPTORS;
     }
 
     protected TSDataType getType(RecordFieldType type) {

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProperties.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProperties.java
@@ -99,7 +99,7 @@ public class JndiJmsConnectionFactoryProperties {
             .sensitive(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             JndiJmsConnectionFactoryProperties.JNDI_INITIAL_CONTEXT_FACTORY,
             JndiJmsConnectionFactoryProperties.JNDI_PROVIDER_URL,
             JndiJmsConnectionFactoryProperties.JNDI_CONNECTION_FACTORY_NAME,
@@ -109,7 +109,7 @@ public class JndiJmsConnectionFactoryProperties {
     );
 
     public static List<PropertyDescriptor> getPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     public static PropertyDescriptor getDynamicPropertyDescriptor(final String propertyDescriptorName) {

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProperties.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryProperties.java
@@ -99,7 +99,7 @@ public class JndiJmsConnectionFactoryProperties {
             .sensitive(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             JndiJmsConnectionFactoryProperties.JNDI_INITIAL_CONTEXT_FACTORY,
             JndiJmsConnectionFactoryProperties.JNDI_PROVIDER_URL,
             JndiJmsConnectionFactoryProperties.JNDI_CONNECTION_FACTORY_NAME,
@@ -109,7 +109,7 @@ public class JndiJmsConnectionFactoryProperties {
     );
 
     public static List<PropertyDescriptor> getPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     public static PropertyDescriptor getDynamicPropertyDescriptor(final String propertyDescriptorName) {

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/processors/PublishJMS.java
@@ -161,12 +161,12 @@ public class PublishJMS extends AbstractJMSProcessor<JMSPublisher> {
             .description("All FlowFiles that cannot be sent to JMS destination are routed to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> COMMON_PROPERTIES = Stream.concat(
+    private static final List<PropertyDescriptor> COMMON_PROPERTY_DESCRIPTORS = Stream.concat(
             JNDI_JMS_CF_PROPERTIES.stream(),
             JMS_CF_PROPERTIES.stream()
     ).toList();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
             Stream.of(
                     CF_SERVICE,
                     DESTINATION,
@@ -181,8 +181,9 @@ public class PublishJMS extends AbstractJMSProcessor<JMSPublisher> {
                     MAX_BATCH_SIZE,
                     RECORD_READER,
                     RECORD_WRITER),
-            COMMON_PROPERTIES.stream()
+            COMMON_PROPERTY_DESCRIPTORS.stream()
     ).toList();
+
     private final static Set<Relationship> RELATIONSHIPS = Set.of(
             REL_SUCCESS,
             REL_FAILURE
@@ -294,7 +295,7 @@ public class PublishJMS extends AbstractJMSProcessor<JMSPublisher> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/AbstractJoltTransform.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/AbstractJoltTransform.java
@@ -99,8 +99,13 @@ public abstract class AbstractJoltTransform extends AbstractProcessor {
             .required(true)
             .build();
 
-    static final List<PropertyDescriptor> PROPERTIES = List.of(JOLT_TRANSFORM, JOLT_SPEC, CUSTOM_CLASS,
-            MODULES, TRANSFORM_CACHE_SIZE);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            JOLT_TRANSFORM,
+            JOLT_SPEC,
+            CUSTOM_CLASS,
+            MODULES,
+            TRANSFORM_CACHE_SIZE
+    );
 
     /**
      * It is a cache for transform objects. It keeps values indexed by jolt specification string.
@@ -108,6 +113,10 @@ public abstract class AbstractJoltTransform extends AbstractProcessor {
      * when there is no jolt-record-spec specified).
      */
     private Cache<Optional<String>, JoltTransform> transformCache;
+
+    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
 
     @OnScheduled
     public void setup(final ProcessContext context) {

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/JoltTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/JoltTransformJSON.java
@@ -87,8 +87,8 @@ public class JoltTransformJSON extends AbstractJoltTransform {
             .description("If a FlowFile fails processing for any reason (for example, the FlowFile is not valid JSON), it will be routed to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            AbstractJoltTransform.PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                     PRETTY_PRINT,
                     MAX_STRING_LENGTH
@@ -110,7 +110,7 @@ public class JoltTransformJSON extends AbstractJoltTransform {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/JoltTransformRecord.java
+++ b/nifi-extension-bundles/nifi-jolt-bundle/nifi-jolt-processors/src/main/java/org/apache/nifi/processors/jolt/JoltTransformRecord.java
@@ -106,8 +106,8 @@ public class JoltTransformRecord extends AbstractJoltTransform {
             .description("The original FlowFile that was transformed. If the FlowFile fails processing, nothing will be sent to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            AbstractJoltTransform.PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                     RECORD_READER,
                     RECORD_WRITER
@@ -127,7 +127,7 @@ public class JoltTransformRecord extends AbstractJoltTransform {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/main/java/org/apache/nifi/processors/jslt/JSLTTransformJSON.java
+++ b/nifi-extension-bundles/nifi-jslt-bundle/nifi-jslt-processors/src/main/java/org/apache/nifi/processors/jslt/JSLTTransformJSON.java
@@ -148,7 +148,7 @@ public class JSLTTransformJSON extends AbstractProcessor {
             .description("If a FlowFile fails processing for any reason (for example, the FlowFile is not valid JSON), it will be routed to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             JSLT_TRANSFORM,
             TRANSFORMATION_STRATEGY,
             PRETTY_PRINT,
@@ -172,7 +172,7 @@ public class JSLTTransformJSON extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-service/src/main/java/org/apache/nifi/kafka/service/Kafka3ConnectionService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-service/src/main/java/org/apache/nifi/kafka/service/Kafka3ConnectionService.java
@@ -214,7 +214,7 @@ public class Kafka3ConnectionService extends AbstractControllerService implement
             .defaultValue("5 sec")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BOOTSTRAP_SERVERS,
             SECURITY_PROTOCOL,
             SASL_MECHANISM,
@@ -246,7 +246,7 @@ public class Kafka3ConnectionService extends AbstractControllerService implement
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-service/src/main/java/org/apache/nifi/kafka/service/Kafka3ConnectionService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-service/src/main/java/org/apache/nifi/kafka/service/Kafka3ConnectionService.java
@@ -214,7 +214,7 @@ public class Kafka3ConnectionService extends AbstractControllerService implement
             .defaultValue("5 sec")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             BOOTSTRAP_SERVERS,
             SECURITY_PROTOCOL,
             SASL_MECHANISM,
@@ -246,7 +246,7 @@ public class Kafka3ConnectionService extends AbstractControllerService implement
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/ConsumeKafka.java
@@ -276,7 +276,7 @@ public class ConsumeKafka extends AbstractProcessor implements VerifiableProcess
             .description("If configured to use a Record Reader, a Kafka message that cannot be parsed using the configured Record Reader will be routed to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CONNECTION_SERVICE,
             GROUP_ID,
             TOPIC_FORMAT,
@@ -313,7 +313,7 @@ public class ConsumeKafka extends AbstractProcessor implements VerifiableProcess
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/PublishKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/PublishKafka.java
@@ -299,7 +299,7 @@ public class PublishKafka extends AbstractProcessor implements KafkaPublishCompo
             .description("Any FlowFile that cannot be sent to Kafka will be routed to this Relationship")
             .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CONNECTION_SERVICE,
             TOPIC_NAME,
             FAILURE_STRATEGY,
@@ -323,14 +323,17 @@ public class PublishKafka extends AbstractProcessor implements KafkaPublishCompo
             RECORD_METADATA_STRATEGY
     );
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     private final Queue<KafkaProducerService> producerServices = new LinkedBlockingQueue<>();
 
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/document/ExtractDocumentText.java
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/document/ExtractDocumentText.java
@@ -32,10 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -53,7 +50,11 @@ public class ExtractDocumentText extends AbstractProcessor {
     public static final Relationship REL_FAILURE = new Relationship.Builder().name("failure")
             .description("Content extraction failed").build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(REL_ORIGINAL, REL_EXTRACTED, REL_FAILURE)));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_ORIGINAL,
+            REL_EXTRACTED,
+            REL_FAILURE
+    );
 
     @Override
     public Set<Relationship> getRelationships() {

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ExtractImageMetadata.java
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ExtractImageMetadata.java
@@ -16,10 +16,7 @@
  */
 package org.apache.nifi.processors.image;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,7 +34,6 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -79,30 +75,23 @@ public class ExtractImageMetadata extends AbstractProcessor {
         .description("Any FlowFile that fails to have image metadata extracted will be routed to failure")
         .build();
 
-    private Set<Relationship> relationships;
-    private List<PropertyDescriptor> properties;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            MAX_NUMBER_OF_ATTRIBUTES
+    );
 
-    @Override
-    protected void init(final ProcessorInitializationContext context) {
-
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(MAX_NUMBER_OF_ATTRIBUTES);
-        this.properties = Collections.unmodifiableList(properties);
-
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(SUCCESS);
-        relationships.add(FAILURE);
-        this.relationships = Collections.unmodifiableSet(relationships);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
-        return this.relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return this.properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ExtractImageMetadata.java
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ExtractImageMetadata.java
@@ -75,7 +75,7 @@ public class ExtractImageMetadata extends AbstractProcessor {
         .description("Any FlowFile that fails to have image metadata extracted will be routed to failure")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             MAX_NUMBER_OF_ATTRIBUTES
     );
 
@@ -91,7 +91,7 @@ public class ExtractImageMetadata extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ResizeImage.java
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/image/ResizeImage.java
@@ -25,8 +25,6 @@ import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -105,22 +103,26 @@ public class ResizeImage extends AbstractProcessor {
         .description("A FlowFile is routed to this relationship if it is not in the specified format")
         .build();
 
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        IMAGE_WIDTH,
+        IMAGE_HEIGHT,
+        SCALING_ALGORITHM,
+        KEEP_RATIO
+    );
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS,
+        REL_FAILURE
+    );
+
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(IMAGE_WIDTH);
-        properties.add(IMAGE_HEIGHT);
-        properties.add(SCALING_ALGORITHM);
-        properties.add(KEEP_RATIO);
-        return properties;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(REL_SUCCESS);
-        relationships.add(REL_FAILURE);
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/media/ExtractMediaMetadata.java
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/media/ExtractMediaMetadata.java
@@ -115,7 +115,7 @@ public class ExtractMediaMetadata extends AbstractProcessor {
             .description("Any FlowFile that fails to have media metadata extracted will be routed to failure")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         MAX_NUMBER_OF_ATTRIBUTES,
         MAX_ATTRIBUTE_LENGTH,
         METADATA_KEY_FILTER,
@@ -138,7 +138,7 @@ public class ExtractMediaMetadata extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @SuppressWarnings("unused")

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/media/ExtractMediaMetadata.java
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/src/main/java/org/apache/nifi/processors/media/ExtractMediaMetadata.java
@@ -18,10 +18,7 @@ package org.apache.nifi.processors.media;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +40,6 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -119,37 +115,30 @@ public class ExtractMediaMetadata extends AbstractProcessor {
             .description("Any FlowFile that fails to have media metadata extracted will be routed to failure")
             .build();
 
-    private Set<Relationship> relationships;
-    private List<PropertyDescriptor> properties;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        MAX_NUMBER_OF_ATTRIBUTES,
+        MAX_ATTRIBUTE_LENGTH,
+        METADATA_KEY_FILTER,
+        METADATA_KEY_PREFIX
+    );
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
 
     private final AtomicReference<Pattern> metadataKeyFilterRef = new AtomicReference<>();
 
     private volatile AutoDetectParser autoDetectParser;
 
     @Override
-    protected void init(final ProcessorInitializationContext context) {
-
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(MAX_NUMBER_OF_ATTRIBUTES);
-        properties.add(MAX_ATTRIBUTE_LENGTH);
-        properties.add(METADATA_KEY_FILTER);
-        properties.add(METADATA_KEY_PREFIX);
-        this.properties = Collections.unmodifiableList(properties);
-
-        final Set<Relationship> relationships = new HashSet<>();
-        relationships.add(SUCCESS);
-        relationships.add(FAILURE);
-        this.relationships = Collections.unmodifiableSet(relationships);
-    }
-
-    @Override
     public Set<Relationship> getRelationships() {
-        return this.relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return this.properties;
+        return PROPERTIES;
     }
 
     @SuppressWarnings("unused")

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/AbstractMongoProcessor.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/AbstractMongoProcessor.java
@@ -157,7 +157,7 @@ public abstract class AbstractMongoProcessor extends AbstractProcessor {
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
 
-    static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CLIENT_SERVICE,
             DATABASE_NAME,
             COLLECTION_NAME
@@ -197,6 +197,10 @@ public abstract class AbstractMongoProcessor extends AbstractProcessor {
     protected ObjectMapper objectMapper;
     protected MongoClient mongoClient;
     protected MongoDBClientService clientService;
+
+    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
 
     @OnScheduled
     public final void createClient(ProcessContext context) {

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/DeleteMongo.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/DeleteMongo.java
@@ -92,8 +92,8 @@ public class DeleteMongo extends AbstractMongoProcessor {
             REL_FAILURE
     );
 
-    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            AbstractMongoProcessor.DESCRIPTORS.stream(),
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                     DELETE_MODE,
                     FAIL_ON_NO_DELETE
@@ -107,7 +107,7 @@ public class DeleteMongo extends AbstractMongoProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private static final List<String> ALLOWED_DELETE_VALUES;

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongo.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongo.java
@@ -91,8 +91,8 @@ public class GetMongo extends AbstractMongoQueryProcessor {
             REL_ORIGINAL
     );
 
-    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            AbstractMongoProcessor.DESCRIPTORS.stream(),
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                     JSON_TYPE,
                     USE_PRETTY_PRINTING,
@@ -124,7 +124,7 @@ public class GetMongo extends AbstractMongoQueryProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     //Turn a list of Mongo result documents into a String representation of a JSON array

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongoRecord.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/GetMongoRecord.java
@@ -76,7 +76,7 @@ public class GetMongoRecord extends AbstractMongoQueryProcessor {
         .required(true)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CLIENT_SERVICE,
             WRITER_FACTORY,
             DATABASE_NAME,
@@ -98,7 +98,7 @@ public class GetMongoRecord extends AbstractMongoQueryProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongo.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongo.java
@@ -151,8 +151,8 @@ public class PutMongo extends AbstractMongoProcessor {
             REL_FAILURE
     );
 
-    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            AbstractMongoProcessor.DESCRIPTORS.stream(),
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                     MODE,
                     UPSERT,
@@ -171,7 +171,7 @@ public class PutMongo extends AbstractMongoProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoBulkOperations.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoBulkOperations.java
@@ -97,8 +97,8 @@ public class PutMongoBulkOperations extends AbstractMongoProcessor {
             REL_FAILURE
     );
 
-    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            AbstractMongoProcessor.DESCRIPTORS.stream(),
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(ORDERED, CHARACTER_SET)
     ).toList();
 
@@ -109,7 +109,7 @@ public class PutMongoBulkOperations extends AbstractMongoProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoRecord.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/PutMongoRecord.java
@@ -142,8 +142,8 @@ public class PutMongoRecord extends AbstractMongoProcessor {
             REL_FAILURE
     );
 
-    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            AbstractMongoProcessor.DESCRIPTORS.stream(),
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                     RECORD_READER_FACTORY,
                     INSERT_COUNT,
@@ -161,7 +161,7 @@ public class PutMongoRecord extends AbstractMongoProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/RunMongoAggregation.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/RunMongoAggregation.java
@@ -104,8 +104,8 @@ public class RunMongoAggregation extends AbstractMongoProcessor {
             REL_FAILURE
     );
 
-    private final static List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            AbstractMongoProcessor.DESCRIPTORS.stream(),
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
                     CHARSET,
                     QUERY,
@@ -125,7 +125,7 @@ public class RunMongoAggregation extends AbstractMongoProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private String buildBatch(List<Document> batch) {

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/gridfs/AbstractGridFSProcessor.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/gridfs/AbstractGridFSProcessor.java
@@ -33,9 +33,6 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.StringUtils;
 import org.bson.types.ObjectId;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -96,23 +93,25 @@ public abstract class AbstractGridFSProcessor extends AbstractProcessor {
         .description("When the operation succeeds, the flowfile is sent to this relationship.")
         .build();
 
-    static final List<PropertyDescriptor> PARENT_PROPERTIES;
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        CLIENT_SERVICE,
+        DATABASE_NAME,
+        BUCKET_NAME
+    );
 
-    static final Set<Relationship> PARENT_RELATIONSHIPS;
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS,
+        REL_FAILURE
+    );
 
     protected volatile MongoDBClientService clientService;
 
-    static {
-        List<PropertyDescriptor> _temp = new ArrayList<>();
-        _temp.add(CLIENT_SERVICE);
-        _temp.add(DATABASE_NAME);
-        _temp.add(BUCKET_NAME);
-        PARENT_PROPERTIES = Collections.unmodifiableList(_temp);
+    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
 
-        Set<Relationship> _rels = new HashSet<>();
-        _rels.add(REL_SUCCESS);
-        _rels.add(REL_FAILURE);
-        PARENT_RELATIONSHIPS = Collections.unmodifiableSet(_rels);
+    protected static Set<Relationship> getCommonRelationships() {
+        return RELATIONSHIPS;
     }
 
     protected MongoDatabase getDatabase(FlowFile input, ProcessContext context) {

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/gridfs/DeleteGridFS.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/gridfs/DeleteGridFS.java
@@ -43,10 +43,9 @@ import org.bson.Document;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 @CapabilityDescription("Deletes a file from GridFS using a file name or a query.")
 @Tags({"gridfs", "delete", "mongodb"})
@@ -71,25 +70,23 @@ public class DeleteGridFS extends AbstractGridFSProcessor {
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .build();
 
-    static final List<PropertyDescriptor> DESCRIPTORS;
-
-    static {
-        List<PropertyDescriptor> _temp = new ArrayList<>();
-        _temp.addAll(PARENT_PROPERTIES);
-        _temp.add(FILE_NAME);
-        _temp.add(QUERY);
-        _temp.add(QUERY_ATTRIBUTE);
-        DESCRIPTORS = Collections.unmodifiableList(_temp);
-    }
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
+            Stream.of(
+                FILE_NAME,
+                QUERY,
+                QUERY_ATTRIBUTE
+            )
+    ).toList();
 
     @Override
     public Set<Relationship> getRelationships() {
-        return new HashSet<>(PARENT_RELATIONSHIPS);
+        return getCommonRelationships();
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/gridfs/FetchGridFS.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/gridfs/FetchGridFS.java
@@ -43,13 +43,12 @@ import org.bson.Document;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
 @WritesAttributes(
@@ -75,27 +74,26 @@ public class FetchGridFS extends AbstractGridFSProcessor implements QueryHelper 
         .description("The original input flowfile goes to this relationship if the query does not cause an error")
         .build();
 
-    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS;
-    static final Set<Relationship> RELATIONSHIP_SET;
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
+            Stream.of(
+                FILE_NAME,
+                QUERY,
+                QUERY_ATTRIBUTE,
+                OPERATION_MODE
+            )
+    ).toList();
 
-    static {
-        List<PropertyDescriptor> _temp = new ArrayList<>();
-        _temp.addAll(PARENT_PROPERTIES);
-        _temp.add(FILE_NAME);
-        _temp.add(QUERY);
-        _temp.add(QUERY_ATTRIBUTE);
-        _temp.add(OPERATION_MODE);
-        PROPERTY_DESCRIPTORS = Collections.unmodifiableList(_temp);
-
-        Set<Relationship> _rels = new HashSet<>();
-        _rels.addAll(PARENT_RELATIONSHIPS);
-        _rels.add(REL_ORIGINAL);
-        RELATIONSHIP_SET = Collections.unmodifiableSet(_rels);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = Stream.concat(
+            getCommonRelationships().stream(),
+            Stream.of(
+                REL_ORIGINAL
+            )
+    ).collect(Collectors.toUnmodifiableSet());
 
     @Override
     public Set<Relationship> getRelationships() {
-        return RELATIONSHIP_SET;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/gridfs/PutGridFS.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/gridfs/PutGridFS.java
@@ -43,12 +43,11 @@ import org.bson.Document;
 import org.bson.types.ObjectId;
 
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
 @Tags({"mongo", "gridfs", "put", "file", "store"})
@@ -118,22 +117,23 @@ public class PutGridFS extends AbstractGridFSProcessor {
 
     static final String ID_ATTRIBUTE = "gridfs.id";
 
-    static final List<PropertyDescriptor> DESCRIPTORS;
-    static final Set<Relationship> RELATIONSHIP_SET;
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
+            Stream.of(
+                FILE_NAME,
+                PROPERTIES_PREFIX,
+                ENFORCE_UNIQUENESS,
+                HASH_ATTRIBUTE,
+                CHUNK_SIZE
+            )
+    ).toList();
 
-    static {
-        List<PropertyDescriptor> propertyDescriptors = new ArrayList<>(PARENT_PROPERTIES);
-        propertyDescriptors.add(FILE_NAME);
-        propertyDescriptors.add(PROPERTIES_PREFIX);
-        propertyDescriptors.add(ENFORCE_UNIQUENESS);
-        propertyDescriptors.add(HASH_ATTRIBUTE);
-        propertyDescriptors.add(CHUNK_SIZE);
-        DESCRIPTORS = Collections.unmodifiableList(propertyDescriptors);
-
-        Set<Relationship> relationships = new HashSet<>(PARENT_RELATIONSHIPS);
-        relationships.add(REL_DUPLICATE);
-        RELATIONSHIP_SET = Collections.unmodifiableSet(relationships);
-    }
+    private static final Set<Relationship> RELATIONSHIPS = Stream.concat(
+            getCommonRelationships().stream(),
+            Stream.of(
+                REL_DUPLICATE
+            )
+    ).collect(Collectors.toUnmodifiableSet());
 
     private String uniqueness;
     private String hashAttribute;
@@ -147,12 +147,12 @@ public class PutGridFS extends AbstractGridFSProcessor {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return RELATIONSHIP_SET;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
@@ -57,7 +57,7 @@ public class MongoDBControllerService extends AbstractControllerService implemen
         this.mongoClient = createClient(context, this.mongoClient);
     }
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         URI,
         DB_USER,
         DB_PASSWORD,
@@ -174,7 +174,7 @@ public class MongoDBControllerService extends AbstractControllerService implemen
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnDisabled

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
@@ -23,7 +23,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
-import java.util.ArrayList;
+
 import java.util.Arrays;
 import java.util.List;
 import java.net.URLEncoder;
@@ -57,16 +57,14 @@ public class MongoDBControllerService extends AbstractControllerService implemen
         this.mongoClient = createClient(context, this.mongoClient);
     }
 
-    static List<PropertyDescriptor> descriptors = new ArrayList<>();
-
-    static {
-        descriptors.add(URI);
-        descriptors.add(DB_USER);
-        descriptors.add(DB_PASSWORD);
-        descriptors.add(SSL_CONTEXT_SERVICE);
-        descriptors.add(CLIENT_AUTH);
-        descriptors.add(WRITE_CONCERN);
-    }
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        URI,
+        DB_USER,
+        DB_PASSWORD,
+        SSL_CONTEXT_SERVICE,
+        CLIENT_AUTH,
+        WRITE_CONCERN
+    );
 
     protected MongoClient mongoClient;
     private String writeConcernProperty;
@@ -176,7 +174,7 @@ public class MongoDBControllerService extends AbstractControllerService implemen
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return descriptors;
+        return PROPERTIES;
     }
 
     @OnDisabled

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/ConsumeMQTT.java
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/ConsumeMQTT.java
@@ -206,7 +206,7 @@ public class ConsumeMQTT extends AbstractMQTTProcessor {
             .autoTerminateDefault(true) // to make sure flow are still valid after upgrades
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PROP_BROKER_URI,
             PROP_MQTT_VERSION,
             PROP_USERNAME,
@@ -301,7 +301,7 @@ public class ConsumeMQTT extends AbstractMQTTProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/PublishMQTT.java
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/PublishMQTT.java
@@ -126,7 +126,7 @@ public class PublishMQTT extends AbstractMQTTProcessor {
             .description("FlowFiles that failed to send to the destination are transferred to this relationship.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PROP_BROKER_URI,
             PROP_MQTT_VERSION,
             PROP_USERNAME,
@@ -170,7 +170,7 @@ public class PublishMQTT extends AbstractMQTTProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/ParseNetflowv5.java
+++ b/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/ParseNetflowv5.java
@@ -84,7 +84,7 @@ public class ParseNetflowv5 extends AbstractProcessor {
     public static final Relationship REL_SUCCESS = new Relationship.Builder().name("success")
             .description("Any FlowFile that is successfully parsed as a netflowv5 data will be transferred to this Relationship.").build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FIELDS_DESTINATION
     );
 
@@ -101,7 +101,7 @@ public class ParseNetflowv5 extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/pcap/SplitPCAP.java
+++ b/nifi-extension-bundles/nifi-network-bundle/nifi-network-processors/src/main/java/org/apache/nifi/processors/network/pcap/SplitPCAP.java
@@ -111,7 +111,7 @@ public class SplitPCAP extends AbstractProcessor {
             .description("The individual PCAP 'segments' of the original PCAP FlowFile will be routed to this relationship.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PCAP_MAX_SIZE
     );
 
@@ -128,7 +128,7 @@ public class SplitPCAP extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/ParquetReader.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/ParquetReader.java
@@ -21,7 +21,6 @@ import static org.apache.nifi.parquet.utils.ParquetUtils.createParquetConfig;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -41,6 +40,10 @@ import org.apache.nifi.serialization.RecordReaderFactory;
         "The schema will come from the Parquet data itself.")
 public class ParquetReader extends AbstractControllerService implements RecordReaderFactory {
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            ParquetUtils.AVRO_READ_COMPATIBILITY
+    );
+
     @Override
     public RecordReader createRecordReader(final Map<String, String> variables, final InputStream in, final long inputLength, final ComponentLog logger) throws IOException {
         final Configuration conf = new Configuration();
@@ -51,8 +54,6 @@ public class ParquetReader extends AbstractControllerService implements RecordRe
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(ParquetUtils.AVRO_READ_COMPATIBILITY);
-        return properties;
+        return PROPERTIES;
     }
 }

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/ParquetReader.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/parquet/ParquetReader.java
@@ -40,7 +40,7 @@ import org.apache.nifi.serialization.RecordReaderFactory;
         "The schema will come from the Parquet data itself.")
 public class ParquetReader extends AbstractControllerService implements RecordReaderFactory {
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ParquetUtils.AVRO_READ_COMPATIBILITY
     );
 
@@ -54,6 +54,6 @@ public class ParquetReader extends AbstractControllerService implements RecordRe
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 }

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/processors/parquet/CalculateParquetOffsets.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/processors/parquet/CalculateParquetOffsets.java
@@ -17,13 +17,9 @@
 
 package org.apache.nifi.processors.parquet;
 
-import static java.util.Collections.singletonList;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -109,12 +105,14 @@ public class CalculateParquetOffsets extends AbstractProcessor {
             .description("FlowFiles, with special attributes that represent a chunk of the input file.")
             .build();
 
-    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PROP_RECORDS_PER_SPLIT,
             PROP_ZERO_CONTENT_OUTPUT
     );
 
-    static final Set<Relationship> RELATIONSHIPS = new HashSet<>(singletonList(REL_SUCCESS));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/processors/parquet/CalculateParquetRowGroupOffsets.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/processors/parquet/CalculateParquetRowGroupOffsets.java
@@ -17,12 +17,9 @@
 
 package org.apache.nifi.processors.parquet;
 
-import static java.util.Collections.singletonList;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -83,9 +80,13 @@ public class CalculateParquetRowGroupOffsets extends AbstractProcessor {
             .description("FlowFiles, with special attributes that represent a chunk of the input file.")
             .build();
 
-    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = singletonList(PROP_ZERO_CONTENT_OUTPUT);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            PROP_ZERO_CONTENT_OUTPUT
+    );
 
-    static final Set<Relationship> RELATIONSHIPS = new HashSet<>(singletonList(REL_SUCCESS));
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/processors/parquet/ConvertAvroToParquet.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/processors/parquet/ConvertAvroToParquet.java
@@ -19,7 +19,6 @@
 package org.apache.nifi.processors.parquet;
 
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
@@ -39,7 +38,6 @@ import org.apache.nifi.parquet.utils.ParquetUtils;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.parquet.avro.AvroParquetWriter;
@@ -49,8 +47,6 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,8 +70,6 @@ public class ConvertAvroToParquet extends AbstractProcessor {
     // Attributes
     public static final String RECORD_COUNT_ATTRIBUTE = "record.count";
 
-    private volatile List<PropertyDescriptor> parquetProps;
-
     // Relationships
     static final Relationship SUCCESS = new Relationship.Builder()
             .name("success")
@@ -87,33 +81,25 @@ public class ConvertAvroToParquet extends AbstractProcessor {
             .description("Avro content that could not be processed")
             .build();
 
-    static final Set<Relationship> RELATIONSHIPS
-            = ImmutableSet.<Relationship>builder()
-            .add(SUCCESS)
-            .add(FAILURE)
-            .build();
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS,
+            FAILURE
+    );
 
-    @Override
-    protected final void init(final ProcessorInitializationContext context) {
-
-
-        final List<PropertyDescriptor> props = new ArrayList<>();
-
-        props.add(ParquetUtils.COMPRESSION_TYPE);
-        props.add(ParquetUtils.ROW_GROUP_SIZE);
-        props.add(ParquetUtils.PAGE_SIZE);
-        props.add(ParquetUtils.DICTIONARY_PAGE_SIZE);
-        props.add(ParquetUtils.MAX_PADDING_SIZE);
-        props.add(ParquetUtils.ENABLE_DICTIONARY_ENCODING);
-        props.add(ParquetUtils.ENABLE_VALIDATION);
-        props.add(ParquetUtils.WRITER_VERSION);
-
-        this.parquetProps = Collections.unmodifiableList(props);
-    }
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        ParquetUtils.COMPRESSION_TYPE,
+        ParquetUtils.ROW_GROUP_SIZE,
+        ParquetUtils.PAGE_SIZE,
+        ParquetUtils.DICTIONARY_PAGE_SIZE,
+        ParquetUtils.MAX_PADDING_SIZE,
+        ParquetUtils.ENABLE_DICTIONARY_ENCODING,
+        ParquetUtils.ENABLE_VALIDATION,
+        ParquetUtils.WRITER_VERSION
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return parquetProps;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/processors/parquet/PutParquet.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/main/java/org/apache/nifi/processors/parquet/PutParquet.java
@@ -17,8 +17,6 @@
 package org.apache.nifi.processors.parquet;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -84,6 +82,19 @@ public class PutParquet extends AbstractPutHDFSRecord {
             .defaultValue("false")
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        ParquetUtils.ROW_GROUP_SIZE,
+        ParquetUtils.PAGE_SIZE,
+        ParquetUtils.DICTIONARY_PAGE_SIZE,
+        ParquetUtils.MAX_PADDING_SIZE,
+        ParquetUtils.ENABLE_DICTIONARY_ENCODING,
+        ParquetUtils.ENABLE_VALIDATION,
+        ParquetUtils.WRITER_VERSION,
+        ParquetUtils.AVRO_WRITE_OLD_LIST_STRUCTURE,
+        ParquetUtils.AVRO_ADD_LIST_ELEMENT_RECORDS,
+        REMOVE_CRC_FILES
+    );
+
     @Override
     public List<AllowableValue> getCompressionTypes(final ProcessorInitializationContext context) {
         return ParquetUtils.COMPRESSION_TYPES;
@@ -96,18 +107,7 @@ public class PutParquet extends AbstractPutHDFSRecord {
 
     @Override
     public List<PropertyDescriptor> getAdditionalProperties() {
-        final List<PropertyDescriptor> props = new ArrayList<>();
-        props.add(ParquetUtils.ROW_GROUP_SIZE);
-        props.add(ParquetUtils.PAGE_SIZE);
-        props.add(ParquetUtils.DICTIONARY_PAGE_SIZE);
-        props.add(ParquetUtils.MAX_PADDING_SIZE);
-        props.add(ParquetUtils.ENABLE_DICTIONARY_ENCODING);
-        props.add(ParquetUtils.ENABLE_VALIDATION);
-        props.add(ParquetUtils.WRITER_VERSION);
-        props.add(ParquetUtils.AVRO_WRITE_OLD_LIST_STRUCTURE);
-        props.add(ParquetUtils.AVRO_ADD_LIST_ELEMENT_RECORDS);
-        props.add(REMOVE_CRC_FILES);
-        return Collections.unmodifiableList(props);
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/DecryptContentPGP.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/DecryptContentPGP.java
@@ -131,7 +131,7 @@ public class DecryptContentPGP extends AbstractProcessor {
             FAILURE
     );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DECRYPTION_STRATEGY,
             PASSPHRASE,
             PRIVATE_KEY_SERVICE
@@ -158,7 +158,7 @@ public class DecryptContentPGP extends AbstractProcessor {
      */
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/EncryptContentPGP.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/EncryptContentPGP.java
@@ -153,7 +153,7 @@ public class EncryptContentPGP extends AbstractProcessor {
             FAILURE
     );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SYMMETRIC_KEY_ALGORITHM,
             FILE_ENCODING,
             PASSPHRASE,
@@ -178,7 +178,7 @@ public class EncryptContentPGP extends AbstractProcessor {
      */
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/SignContentPGP.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/SignContentPGP.java
@@ -143,7 +143,7 @@ public class SignContentPGP extends AbstractProcessor {
             FAILURE
     );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FILE_ENCODING,
             HASH_ALGORITHM,
             SIGNING_STRATEGY,
@@ -173,7 +173,7 @@ public class SignContentPGP extends AbstractProcessor {
      */
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/VerifyContentPGP.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/VerifyContentPGP.java
@@ -99,7 +99,7 @@ public class VerifyContentPGP extends AbstractProcessor {
             FAILURE
     );
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PUBLIC_KEY_SERVICE
     );
 
@@ -124,7 +124,7 @@ public class VerifyContentPGP extends AbstractProcessor {
      */
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPrivateKeyService.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPrivateKeyService.java
@@ -94,7 +94,7 @@ public class StandardPGPPrivateKeyService extends AbstractControllerService impl
 
     private static final Charset KEY_CHARSET = StandardCharsets.US_ASCII;
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             KEYRING_FILE,
             KEYRING,
             KEY_PASSWORD
@@ -153,7 +153,7 @@ public class StandardPGPPrivateKeyService extends AbstractControllerService impl
      */
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPrivateKeyService.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPrivateKeyService.java
@@ -52,7 +52,6 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -95,7 +94,7 @@ public class StandardPGPPrivateKeyService extends AbstractControllerService impl
 
     private static final Charset KEY_CHARSET = StandardCharsets.US_ASCII;
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             KEYRING_FILE,
             KEYRING,
             KEY_PASSWORD
@@ -154,7 +153,7 @@ public class StandardPGPPrivateKeyService extends AbstractControllerService impl
      */
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPublicKeyService.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPublicKeyService.java
@@ -83,7 +83,7 @@ public class StandardPGPPublicKeyService extends AbstractControllerService imple
 
     private static final boolean PARALLEL_DISABLED = false;
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             KEYRING_FILE,
             KEYRING
     );
@@ -134,7 +134,7 @@ public class StandardPGPPublicKeyService extends AbstractControllerService imple
      */
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPublicKeyService.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-service/src/main/java/org/apache/nifi/pgp/service/standard/StandardPGPPublicKeyService.java
@@ -48,7 +48,6 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -84,7 +83,7 @@ public class StandardPGPPublicKeyService extends AbstractControllerService imple
 
     private static final boolean PARALLEL_DISABLED = false;
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             KEYRING_FILE,
             KEYRING
     );
@@ -135,7 +134,7 @@ public class StandardPGPPublicKeyService extends AbstractControllerService imple
      */
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/processors/excel/SplitExcel.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/processors/excel/SplitExcel.java
@@ -109,7 +109,7 @@ public class SplitExcel extends AbstractProcessor {
             .description("The individual Excel 'segments' of the original Excel FlowFile will be routed to this relationship.")
             .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PROTECTION_TYPE,
             PASSWORD
     );
@@ -138,7 +138,7 @@ public class SplitExcel extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/processor/PutRedisHashRecord.java
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/processor/PutRedisHashRecord.java
@@ -123,7 +123,7 @@ public class PutRedisHashRecord extends AbstractProcessor {
             .description("FlowFiles containing Records with processing errors will be routed to this relationship")
             .build();
 
-    static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER_FACTORY,
             REDIS_CONNECTION_POOL,
             HASH_VALUE_RECORD_PATH,
@@ -138,7 +138,7 @@ public class PutRedisHashRecord extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/service/SimpleRedisDistributedMapCacheClientService.java
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/service/SimpleRedisDistributedMapCacheClientService.java
@@ -35,8 +35,6 @@ import org.springframework.data.redis.core.types.Expiration;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,13 +48,10 @@ import static org.apache.nifi.redis.util.RedisUtils.TTL;
         "This service is intended to be used when a non-atomic DistributedMapCacheClient is required.")
 public class SimpleRedisDistributedMapCacheClientService extends AbstractControllerService implements DistributedMapCacheClient {
 
-    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS;
-    static {
-        final List<PropertyDescriptor> props = new ArrayList<>();
-        props.add(REDIS_CONNECTION_POOL);
-        props.add(TTL);
-        PROPERTY_DESCRIPTORS = Collections.unmodifiableList(props);
-    }
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            REDIS_CONNECTION_POOL,
+            TTL
+    );
 
     private volatile RedisConnectionPool redisConnectionPool;
     private Long ttl;
@@ -67,7 +62,7 @@ public class SimpleRedisDistributedMapCacheClientService extends AbstractControl
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/service/SimpleRedisDistributedMapCacheClientService.java
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/main/java/org/apache/nifi/redis/service/SimpleRedisDistributedMapCacheClientService.java
@@ -48,7 +48,7 @@ import static org.apache.nifi.redis.util.RedisUtils.TTL;
         "This service is intended to be used when a non-atomic DistributedMapCacheClient is required.")
 public class SimpleRedisDistributedMapCacheClientService extends AbstractControllerService implements DistributedMapCacheClient {
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             REDIS_CONNECTION_POOL,
             TTL
     );
@@ -62,7 +62,7 @@ public class SimpleRedisDistributedMapCacheClientService extends AbstractControl
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-utils/src/main/java/org/apache/nifi/redis/util/RedisUtils.java
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-utils/src/main/java/org/apache/nifi/redis/util/RedisUtils.java
@@ -48,7 +48,6 @@ import redis.clients.jedis.JedisPoolConfig;
 import javax.net.ssl.SSLContext;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -298,34 +297,31 @@ public class RedisUtils {
             .identifiesControllerService(SSLContextProvider.class)
             .build();
 
-    public static final List<PropertyDescriptor> REDIS_CONNECTION_PROPERTY_DESCRIPTORS;
-    static {
-        final List<PropertyDescriptor> props = new ArrayList<>();
-        props.add(RedisUtils.REDIS_MODE);
-        props.add(RedisUtils.CONNECTION_STRING);
-        props.add(RedisUtils.DATABASE);
-        props.add(RedisUtils.COMMUNICATION_TIMEOUT);
-        props.add(RedisUtils.CLUSTER_MAX_REDIRECTS);
-        props.add(RedisUtils.SENTINEL_MASTER);
-        props.add(RedisUtils.USERNAME);
-        props.add(RedisUtils.PASSWORD);
-        props.add(RedisUtils.SENTINEL_USERNAME);
-        props.add(RedisUtils.SENTINEL_PASSWORD);
-        props.add(RedisUtils.SSL_CONTEXT_SERVICE);
-        props.add(RedisUtils.POOL_MAX_TOTAL);
-        props.add(RedisUtils.POOL_MAX_IDLE);
-        props.add(RedisUtils.POOL_MIN_IDLE);
-        props.add(RedisUtils.POOL_BLOCK_WHEN_EXHAUSTED);
-        props.add(RedisUtils.POOL_MAX_WAIT_TIME);
-        props.add(RedisUtils.POOL_MIN_EVICTABLE_IDLE_TIME);
-        props.add(RedisUtils.POOL_TIME_BETWEEN_EVICTION_RUNS);
-        props.add(RedisUtils.POOL_NUM_TESTS_PER_EVICTION_RUN);
-        props.add(RedisUtils.POOL_TEST_ON_CREATE);
-        props.add(RedisUtils.POOL_TEST_ON_BORROW);
-        props.add(RedisUtils.POOL_TEST_ON_RETURN);
-        props.add(RedisUtils.POOL_TEST_WHILE_IDLE);
-        REDIS_CONNECTION_PROPERTY_DESCRIPTORS = Collections.unmodifiableList(props);
-    }
+    public static final List<PropertyDescriptor> REDIS_CONNECTION_PROPERTY_DESCRIPTORS = List.of(
+        RedisUtils.REDIS_MODE,
+        RedisUtils.CONNECTION_STRING,
+        RedisUtils.DATABASE,
+        RedisUtils.COMMUNICATION_TIMEOUT,
+        RedisUtils.CLUSTER_MAX_REDIRECTS,
+        RedisUtils.SENTINEL_MASTER,
+        RedisUtils.USERNAME,
+        RedisUtils.PASSWORD,
+        RedisUtils.SENTINEL_USERNAME,
+        RedisUtils.SENTINEL_PASSWORD,
+        RedisUtils.SSL_CONTEXT_SERVICE,
+        RedisUtils.POOL_MAX_TOTAL,
+        RedisUtils.POOL_MAX_IDLE,
+        RedisUtils.POOL_MIN_IDLE,
+        RedisUtils.POOL_BLOCK_WHEN_EXHAUSTED,
+        RedisUtils.POOL_MAX_WAIT_TIME,
+        RedisUtils.POOL_MIN_EVICTABLE_IDLE_TIME,
+        RedisUtils.POOL_TIME_BETWEEN_EVICTION_RUNS,
+        RedisUtils.POOL_NUM_TESTS_PER_EVICTION_RUN,
+        RedisUtils.POOL_TEST_ON_CREATE,
+        RedisUtils.POOL_TEST_ON_BORROW,
+        RedisUtils.POOL_TEST_ON_RETURN,
+        RedisUtils.POOL_TEST_WHILE_IDLE
+    );
 
     public static RedisConfig createRedisConfig(final PropertyContext context) {
         final RedisType redisType = RedisType.fromDisplayName(context.getProperty(RedisUtils.REDIS_MODE).getValue());

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/main/java/org/apache/nifi/schemaregistry/services/AvroSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/main/java/org/apache/nifi/schemaregistry/services/AvroSchemaRegistry.java
@@ -63,7 +63,7 @@ public class AvroSchemaRegistry extends AbstractControllerService implements Sch
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             VALIDATE_FIELD_NAMES
     );
 
@@ -132,7 +132,7 @@ public class AvroSchemaRegistry extends AbstractControllerService implements Sch
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/main/java/org/apache/nifi/schemaregistry/services/AvroSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/main/java/org/apache/nifi/schemaregistry/services/AvroSchemaRegistry.java
@@ -25,19 +25,15 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.controller.AbstractControllerService;
-import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.schema.access.SchemaField;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.SchemaIdentifier;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -67,16 +63,9 @@ public class AvroSchemaRegistry extends AbstractControllerService implements Sch
             .required(true)
             .build();
 
-    private List<PropertyDescriptor> propertyDescriptors = new ArrayList<>();
-
-
-    @Override
-    protected void init(ControllerServiceInitializationContext config) throws InitializationException {
-        super.init(config);
-        List<PropertyDescriptor> _propertyDescriptors = new ArrayList<>();
-        _propertyDescriptors.add(VALIDATE_FIELD_NAMES);
-        propertyDescriptors = Collections.unmodifiableList(_propertyDescriptors);
-    }
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            VALIDATE_FIELD_NAMES
+    );
 
     @Override
     public void onPropertyModified(final PropertyDescriptor descriptor, final String oldValue, final String newValue) {
@@ -143,7 +132,7 @@ public class AvroSchemaRegistry extends AbstractControllerService implements Sch
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propertyDescriptors;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/main/java/org/apache/nifi/schemaregistry/services/StandardJsonSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/main/java/org/apache/nifi/schemaregistry/services/StandardJsonSchemaRegistry.java
@@ -58,7 +58,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
         expressionLanguageScope = ExpressionLanguageScope.NONE)
 public class StandardJsonSchemaRegistry extends AbstractControllerService implements JsonSchemaRegistry, JsonSchemaRegistryComponent {
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SCHEMA_VERSION
     );
 
@@ -143,7 +143,7 @@ public class StandardJsonSchemaRegistry extends AbstractControllerService implem
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/main/java/org/apache/nifi/schemaregistry/services/StandardJsonSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/src/main/java/org/apache/nifi/schemaregistry/services/StandardJsonSchemaRegistry.java
@@ -34,7 +34,6 @@ import org.apache.nifi.json.schema.SchemaVersion;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -59,7 +58,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
         expressionLanguageScope = ExpressionLanguageScope.NONE)
 public class StandardJsonSchemaRegistry extends AbstractControllerService implements JsonSchemaRegistry, JsonSchemaRegistryComponent {
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.singletonList(SCHEMA_VERSION);
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            SCHEMA_VERSION
+    );
 
     private final ConcurrentMap<String, JsonSchema> jsonSchemas;
     private final ConcurrentMap<SchemaVersion, JsonSchemaFactory> schemaFactories;
@@ -142,7 +143,7 @@ public class StandardJsonSchemaRegistry extends AbstractControllerService implem
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/PutSalesforceObject.java
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/PutSalesforceObject.java
@@ -91,7 +91,7 @@ public class PutSalesforceObject extends AbstractProcessor {
             .description("For FlowFiles created as a result of an execution error.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SALESFORCE_INSTANCE_URL,
             API_VERSION,
             READ_TIMEOUT,
@@ -109,7 +109,7 @@ public class PutSalesforceObject extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/QuerySalesforceObject.java
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/main/java/org/apache/nifi/processors/salesforce/QuerySalesforceObject.java
@@ -307,7 +307,7 @@ public class QuerySalesforceObject extends AbstractProcessor {
         salesforceRestService = new SalesforceRestClient(salesforceConfiguration);
     }
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SALESFORCE_INSTANCE_URL,
             API_VERSION,
             QUERY_TYPE,
@@ -333,7 +333,7 @@ public class QuerySalesforceObject extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedPartitionRecord.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedPartitionRecord.java
@@ -105,7 +105,7 @@ public class ScriptedPartitionRecord extends ScriptedRecordProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedRecordProcessor.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedRecordProcessor.java
@@ -80,7 +80,7 @@ abstract class ScriptedRecordProcessor extends AbstractProcessor implements Sear
             .required(true)
             .build();
 
-    protected static final List<PropertyDescriptor> DESCRIPTORS = List.of(
+    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER,
             RECORD_WRITER,
             LANGUAGE,

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedRouterProcessor.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedRouterProcessor.java
@@ -75,7 +75,7 @@ public abstract class ScriptedRouterProcessor<T> extends ScriptedRecordProcessor
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedTransformRecord.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/processors/script/ScriptedTransformRecord.java
@@ -98,7 +98,7 @@ public class ScriptedTransformRecord extends ScriptedRecordProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-shopify-bundle/nifi-shopify-processors/src/main/java/org/apache/nifi/processors/shopify/GetShopify.java
+++ b/nifi-extension-bundles/nifi-shopify-bundle/nifi-shopify-processors/src/main/java/org/apache/nifi/processors/shopify/GetShopify.java
@@ -197,15 +197,15 @@ public class GetShopify extends AbstractProcessor {
                     propertyMap.put(resourceType, resourceDescriptor);
                     return resourceDescriptor;
                 })
-                .collect(Collectors.toList());
-        final List<PropertyDescriptor> propertyDescriptors = new ArrayList<>(Arrays.asList(
+                .toList();
+        final List<PropertyDescriptor> propertyDescriptors = new ArrayList<>(List.of(
                 STORE_DOMAIN,
                 ACCESS_TOKEN,
                 API_VERSION,
                 OBJECT_CATEGORY
         ));
         propertyDescriptors.addAll(resourceDescriptors);
-        propertyDescriptors.addAll(Arrays.asList(
+        propertyDescriptors.addAll(List.of(
                 RESULT_LIMIT,
                 IS_INCREMENTAL,
                 INCREMENTAL_DELAY,

--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/sink/SiteToSiteReportingRecordSink.java
+++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/sink/SiteToSiteReportingRecordSink.java
@@ -18,8 +18,6 @@ package org.apache.nifi.reporting.sink;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
@@ -52,31 +50,31 @@ import org.apache.nifi.serialization.record.RecordSet;
 @CapabilityDescription("Provides a service to write records using a configured RecordSetWriter over a Site-to-Site connection.")
 public class SiteToSiteReportingRecordSink extends AbstractControllerService implements RecordSinkService {
 
-    private List<PropertyDescriptor> properties;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            RECORD_WRITER_FACTORY,
+            SiteToSiteUtils.DESTINATION_URL,
+            SiteToSiteUtils.PORT_NAME,
+            SiteToSiteUtils.SSL_CONTEXT,
+            SiteToSiteUtils.INSTANCE_URL,
+            SiteToSiteUtils.COMPRESS,
+            SiteToSiteUtils.TIMEOUT,
+            SiteToSiteUtils.BATCH_SIZE,
+            SiteToSiteUtils.TRANSPORT_PROTOCOL,
+            SiteToSiteUtils.PROXY_CONFIGURATION_SERVICE
+    );
+
     private volatile SiteToSiteClient siteToSiteClient;
     private volatile RecordSetWriterFactory writerFactory;
     private volatile StateManager stateManager;
 
     @Override
     protected void init(final ControllerServiceInitializationContext context) {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(RECORD_WRITER_FACTORY);
-        properties.add(SiteToSiteUtils.DESTINATION_URL);
-        properties.add(SiteToSiteUtils.PORT_NAME);
-        properties.add(SiteToSiteUtils.SSL_CONTEXT);
-        properties.add(SiteToSiteUtils.INSTANCE_URL);
-        properties.add(SiteToSiteUtils.COMPRESS);
-        properties.add(SiteToSiteUtils.TIMEOUT);
-        properties.add(SiteToSiteUtils.BATCH_SIZE);
-        properties.add(SiteToSiteUtils.TRANSPORT_PROTOCOL);
-        properties.add(SiteToSiteUtils.PROXY_CONFIGURATION_SERVICE);
-        this.properties = Collections.unmodifiableList(properties);
         this.stateManager = context.getStateManager();
     }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/sink/SiteToSiteReportingRecordSink.java
+++ b/nifi-extension-bundles/nifi-site-to-site-reporting-bundle/nifi-site-to-site-reporting-task/src/main/java/org/apache/nifi/reporting/sink/SiteToSiteReportingRecordSink.java
@@ -50,7 +50,7 @@ import org.apache.nifi.serialization.record.RecordSet;
 @CapabilityDescription("Provides a service to write records using a configured RecordSetWriter over a Site-to-Site connection.")
 public class SiteToSiteReportingRecordSink extends AbstractControllerService implements RecordSinkService {
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_WRITER_FACTORY,
             SiteToSiteUtils.DESTINATION_URL,
             SiteToSiteUtils.PORT_NAME,
@@ -74,7 +74,7 @@ public class SiteToSiteReportingRecordSink extends AbstractControllerService imp
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ConsumeSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ConsumeSlack.java
@@ -184,7 +184,8 @@ public class ConsumeSlack extends AbstractProcessor implements VerifiableProcess
         .description("Slack messages that are successfully received will be routed to this relationship")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(CHANNEL_IDS,
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            CHANNEL_IDS,
             ACCESS_TOKEN,
             REPLY_MONITOR_WINDOW,
             REPLY_MONITOR_FREQUENCY,
@@ -204,7 +205,7 @@ public class ConsumeSlack extends AbstractProcessor implements VerifiableProcess
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ListenSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ListenSlack.java
@@ -142,7 +142,7 @@ public class ListenSlack extends AbstractProcessor {
         .description("All FlowFiles that are created will be sent to this Relationship.")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             APP_TOKEN,
             BOT_TOKEN,
             EVENT_TYPE,
@@ -160,7 +160,7 @@ public class ListenSlack extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PublishSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/PublishSlack.java
@@ -222,7 +222,7 @@ public class PublishSlack extends AbstractProcessor {
         .required(false)
         .build();
 
-    private static final List<PropertyDescriptor> properties = List.of(ACCESS_TOKEN,
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(ACCESS_TOKEN,
         CHANNEL,
         PUBLISH_STRATEGY,
         MESSAGE_TEXT,
@@ -230,7 +230,8 @@ public class PublishSlack extends AbstractProcessor {
         SEND_CONTENT_AS_ATTACHMENT,
         MAX_FILE_SIZE,
         THREAD_TS,
-        METHODS_ENDPOINT_URL_PREFIX);
+        METHODS_ENDPOINT_URL_PREFIX
+    );
 
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -248,7 +249,7 @@ public class PublishSlack extends AbstractProcessor {
         .description("FlowFiles are routed to 'failure' if unable to be sent to Slack for any other reason")
         .build();
 
-    private static final Set<Relationship> relationships = Set.of(
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
         REL_SUCCESS,
         REL_RATE_LIMITED,
         REL_FAILURE);
@@ -261,12 +262,12 @@ public class PublishSlack extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/services/slack/SlackRecordSink.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/services/slack/SlackRecordSink.java
@@ -91,7 +91,7 @@ public class SlackRecordSink extends AbstractControllerService implements Record
             .identifiesControllerService(WebClientServiceProvider.class)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         API_URL,
         ACCESS_TOKEN,
         CHANNEL_ID,
@@ -105,7 +105,7 @@ public class SlackRecordSink extends AbstractControllerService implements Record
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/services/slack/SlackRecordSink.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/services/slack/SlackRecordSink.java
@@ -36,8 +36,6 @@ import org.apache.nifi.web.client.provider.api.WebClientServiceProvider;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -93,19 +91,21 @@ public class SlackRecordSink extends AbstractControllerService implements Record
             .identifiesControllerService(WebClientServiceProvider.class)
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        API_URL,
+        ACCESS_TOKEN,
+        CHANNEL_ID,
+        INPUT_CHARACTER_SET,
+        RECORD_WRITER_FACTORY,
+        WEB_SERVICE_CLIENT_PROVIDER
+    );
+
     private volatile RecordSetWriterFactory writerFactory;
     private SlackRestService service;
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return Collections.unmodifiableList(Arrays.asList(
-                API_URL,
-                ACCESS_TOKEN,
-                CHANNEL_ID,
-                INPUT_CHARACTER_SET,
-                RECORD_WRITER_FACTORY,
-                WEB_SERVICE_CLIENT_PROVIDER
-        ));
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/FetchSmb.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/FetchSmb.java
@@ -118,7 +118,7 @@ public class FetchSmb extends AbstractProcessor {
             REL_FAILURE
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SMB_CLIENT_PROVIDER_SERVICE,
             REMOTE_FILE,
             COMPLETION_STRATEGY,
@@ -135,7 +135,7 @@ public class FetchSmb extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/GetSmbFile.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/GetSmbFile.java
@@ -218,7 +218,7 @@ public class GetSmbFile extends AbstractProcessor {
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder().name("success").description("All files are routed to success").build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         HOSTNAME,
         SHARE,
         DIRECTORY,
@@ -262,12 +262,12 @@ public class GetSmbFile extends AbstractProcessor {
 
     @Override
     public Set<Relationship> getRelationships() {
-        return this.RELATIONSHIPS;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/ListSmb.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/ListSmb.java
@@ -189,7 +189,7 @@ public class ListSmb extends AbstractListProcessor<SmbListableEntity> {
             .addValidator(new MustNotContainDirectorySeparatorsValidator())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SMB_CLIENT_PROVIDER_SERVICE,
             SMB_LISTING_STRATEGY,
             DIRECTORY,
@@ -207,7 +207,7 @@ public class ListSmb extends AbstractListProcessor<SmbListableEntity> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/PutSmbFile.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/PutSmbFile.java
@@ -170,7 +170,7 @@ public class PutSmbFile extends AbstractProcessor {
             .description("Files that could not be written to the output network path for some reason are transferred to this relationship")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             HOSTNAME,
             SHARE,
             DIRECTORY,
@@ -202,7 +202,7 @@ public class PutSmbFile extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/PutSmbFile.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/PutSmbFile.java
@@ -48,7 +48,6 @@ import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.AbstractProcessor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -171,43 +170,39 @@ public class PutSmbFile extends AbstractProcessor {
             .description("Files that could not be written to the output network path for some reason are transferred to this relationship")
             .build();
 
-    private List<PropertyDescriptor> descriptors;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            HOSTNAME,
+            SHARE,
+            DIRECTORY,
+            DOMAIN,
+            USERNAME,
+            PASSWORD,
+            CREATE_DIRS,
+            SHARE_ACCESS,
+            CONFLICT_RESOLUTION,
+            BATCH_SIZE,
+            RENAME_SUFFIX,
+            SMB_DIALECT,
+            USE_ENCRYPTION,
+            ENABLE_DFS,
+            TIMEOUT);
 
-    private Set<Relationship> relationships;
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     private SMBClient smbClient = null; // this gets synchronized when the `connect` method is called
     private Set<SMB2ShareAccess> sharedAccess;
 
     @Override
-    protected void init(final ProcessorInitializationContext context) {
-        this.descriptors = List.of(
-                HOSTNAME,
-                SHARE,
-                DIRECTORY,
-                DOMAIN,
-                USERNAME,
-                PASSWORD,
-                CREATE_DIRS,
-                SHARE_ACCESS,
-                CONFLICT_RESOLUTION,
-                BATCH_SIZE,
-                RENAME_SUFFIX,
-                SMB_DIALECT,
-                USE_ENCRYPTION,
-                ENABLE_DFS,
-                TIMEOUT);
-
-        this.relationships = Set.of(REL_SUCCESS, REL_FAILURE);
-    }
-
-    @Override
     public Set<Relationship> getRelationships() {
-        return this.relationships;
+        return RELATIONSHIPS;
     }
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return descriptors;
+        return PROPERTIES;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-smbj-client/src/main/java/org/apache/nifi/services/smb/SmbjClientProviderService.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-smbj-client/src/main/java/org/apache/nifi/services/smb/SmbjClientProviderService.java
@@ -101,7 +101,7 @@ public class SmbjClientProviderService extends AbstractControllerService impleme
             .addValidator(NON_BLANK_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             HOSTNAME,
             PORT,
             SHARE,
@@ -122,7 +122,7 @@ public class SmbjClientProviderService extends AbstractControllerService impleme
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-smbj-client/src/main/java/org/apache/nifi/services/smb/SmbjClientProviderService.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-smbj-client/src/main/java/org/apache/nifi/services/smb/SmbjClientProviderService.java
@@ -32,10 +32,8 @@ import org.apache.nifi.controller.ConfigurationContext;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
 import java.util.List;
 
-import static java.util.Arrays.asList;
 import static org.apache.nifi.processor.util.StandardValidators.NON_BLANK_VALIDATOR;
 import static org.apache.nifi.processor.util.StandardValidators.NON_EMPTY_VALIDATOR;
 import static org.apache.nifi.processor.util.StandardValidators.PORT_VALIDATOR;
@@ -103,19 +101,18 @@ public class SmbjClientProviderService extends AbstractControllerService impleme
             .addValidator(NON_BLANK_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections
-            .unmodifiableList(asList(
-                    HOSTNAME,
-                    PORT,
-                    SHARE,
-                    USERNAME,
-                    PASSWORD,
-                    DOMAIN,
-                    SMB_DIALECT,
-                    USE_ENCRYPTION,
-                    ENABLE_DFS,
-                    TIMEOUT
-            ));
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            HOSTNAME,
+            PORT,
+            SHARE,
+            USERNAME,
+            PASSWORD,
+            DOMAIN,
+            SMB_DIALECT,
+            USE_ENCRYPTION,
+            ENABLE_DFS,
+            TIMEOUT
+    );
 
     private SMBClient smbClient;
     private AuthenticationContext authenticationContext;

--- a/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/main/java/org/apache/nifi/processors/snowflake/GetSnowflakeIngestStatus.java
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/main/java/org/apache/nifi/processors/snowflake/GetSnowflakeIngestStatus.java
@@ -79,13 +79,19 @@ public class GetSnowflakeIngestStatus extends AbstractProcessor {
             .description("For FlowFiles whose file is still not ingested. These FlowFiles should be routed back to this processor to try again later")
             .build();
 
-    static final List<PropertyDescriptor> PROPERTIES = List.of(INGEST_MANAGER_PROVIDER);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        INGEST_MANAGER_PROVIDER
+    );
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_RETRY, REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS,
+        REL_RETRY,
+        REL_FAILURE
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/main/java/org/apache/nifi/processors/snowflake/PutSnowflakeInternalStage.java
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/main/java/org/apache/nifi/processors/snowflake/PutSnowflakeInternalStage.java
@@ -113,7 +113,7 @@ public class PutSnowflakeInternalStage extends AbstractProcessor {
             .description("For FlowFiles of failed PUT operation")
             .build();
 
-    static final List<PropertyDescriptor> PROPERTIES = List.of(
+    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SNOWFLAKE_CONNECTION_PROVIDER,
             INTERNAL_STAGE_TYPE,
             DATABASE,
@@ -122,11 +122,14 @@ public class PutSnowflakeInternalStage extends AbstractProcessor {
             INTERNAL_STAGE
     );
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/main/java/org/apache/nifi/processors/snowflake/StartSnowflakeIngest.java
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-processors/src/main/java/org/apache/nifi/processors/snowflake/StartSnowflakeIngest.java
@@ -72,13 +72,18 @@ public class StartSnowflakeIngest extends AbstractProcessor {
             .description("For FlowFiles of failed ingest request")
             .build();
 
-    static final List<PropertyDescriptor> PROPERTIES = List.of(INGEST_MANAGER_PROVIDER);
+    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            INGEST_MANAGER_PROVIDER
+    );
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/main/java/org/apache/nifi/snowflake/service/SnowflakeComputingConnectionPool.java
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/main/java/org/apache/nifi/snowflake/service/SnowflakeComputingConnectionPool.java
@@ -142,7 +142,7 @@ public class SnowflakeComputingConnectionPool extends AbstractDBCPConnectionPool
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CONNECTION_URL_FORMAT,
             SNOWFLAKE_URL,
             SNOWFLAKE_ACCOUNT_LOCATOR,
@@ -169,7 +169,7 @@ public class SnowflakeComputingConnectionPool extends AbstractDBCPConnectionPool
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/main/java/org/apache/nifi/snowflake/service/StandardSnowflakeIngestManagerProviderService.java
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/nifi-snowflake-services/src/main/java/org/apache/nifi/snowflake/service/StandardSnowflakeIngestManagerProviderService.java
@@ -126,7 +126,7 @@ public class StandardSnowflakeIngestManagerProviderService extends AbstractContr
             .required(true)
             .build();
 
-    static final List<PropertyDescriptor> PROPERTIES = List.of(
+    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ACCOUNT_IDENTIFIER_FORMAT,
             HOST_URL,
             ACCOUNT_LOCATOR,
@@ -143,7 +143,7 @@ public class StandardSnowflakeIngestManagerProviderService extends AbstractContr
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private volatile String fullyQualifiedPipeName;

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/GetSplunk.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/GetSplunk.java
@@ -270,7 +270,7 @@ public class GetSplunk extends AbstractProcessor implements ClassloaderIsolation
             REL_SUCCESS
     );
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         SCHEME,
         HOSTNAME,
         PORT,
@@ -304,7 +304,7 @@ public class GetSplunk extends AbstractProcessor implements ClassloaderIsolation
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunkHTTP.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunkHTTP.java
@@ -43,15 +43,12 @@ import java.io.StringWriter;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
 @Tags({"splunk", "logs", "http"})
@@ -133,9 +130,22 @@ public class PutSplunkHTTP extends SplunkAPICall {
             .description("FlowFiles that failed to send to the destination are sent to this relationship.")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
+            Stream.of(
+                SOURCE,
+                SOURCE_TYPE,
+                HOST,
+                INDEX,
+                CONTENT_TYPE,
+                CHARSET
+            )
+    ).toList();
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
             RELATIONSHIP_SUCCESS,
-            RELATIONSHIP_FAILURE)));
+            RELATIONSHIP_FAILURE
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -144,14 +154,7 @@ public class PutSplunkHTTP extends SplunkAPICall {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> result = new ArrayList<>(super.getSupportedPropertyDescriptors());
-        result.add(SOURCE);
-        result.add(SOURCE_TYPE);
-        result.add(HOST);
-        result.add(INDEX);
-        result.add(CONTENT_TYPE);
-        result.add(CHARSET);
-        return result;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/QuerySplunkIndexingStatus.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/QuerySplunkIndexingStatus.java
@@ -117,11 +117,11 @@ public class QuerySplunkIndexingStatus extends SplunkAPICall {
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Stream.concat(
-            SplunkAPICall.PROPERTIES.stream(),
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getCommonPropertyDescriptors().stream(),
             Stream.of(
-                    TTL,
-                    MAX_QUERY_SIZE
+                TTL,
+                MAX_QUERY_SIZE
             )
     ).toList();
 
@@ -130,7 +130,7 @@ public class QuerySplunkIndexingStatus extends SplunkAPICall {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/SplunkAPICall.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/SplunkAPICall.java
@@ -35,7 +35,6 @@ import org.apache.nifi.processor.util.StandardValidators;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.List;
 
 abstract class SplunkAPICall extends AbstractProcessor {
@@ -135,7 +134,7 @@ abstract class SplunkAPICall extends AbstractProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
-    protected static final List<PropertyDescriptor> PROPERTIES = Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SCHEME,
             HOSTNAME,
             PORT,
@@ -154,9 +153,13 @@ abstract class SplunkAPICall extends AbstractProcessor {
     private volatile Service splunkService;
     private volatile String requestChannel;
 
+    protected static List<PropertyDescriptor> getCommonPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return SplunkAPICall.PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractRecordProcessor.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AbstractRecordProcessor.java
@@ -78,17 +78,24 @@ public abstract class AbstractRecordProcessor extends AbstractProcessor {
             + "the unchanged FlowFile will be routed to this relationship")
         .build();
 
-    private static final List<PropertyDescriptor> properties = List.of(RECORD_READER, RECORD_WRITER);
-    private static final Set<Relationship> relationships = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            RECORD_READER,
+            RECORD_WRITER
+    );
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override
     public Set<Relationship> getRelationships() {
-        return relationships;
+        return RELATIONSHIPS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToCSV.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToCSV.java
@@ -146,7 +146,7 @@ public class AttributesToCSV extends AbstractProcessor {
             .defaultValue("false")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ATTRIBUTES_LIST,
             ATTRIBUTES_REGEX,
             DESTINATION,
@@ -174,7 +174,7 @@ public class AttributesToCSV extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToJSON.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToJSON.java
@@ -167,7 +167,7 @@ public class AttributesToJSON extends AbstractProcessor {
             .dependsOn(DESTINATION, DESTINATION_CONTENT)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ATTRIBUTES_LIST,
             ATTRIBUTES_REGEX,
             DESTINATION,
@@ -198,7 +198,7 @@ public class AttributesToJSON extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CalculateRecordStats.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CalculateRecordStats.java
@@ -94,7 +94,7 @@ public class CalculateRecordStats extends AbstractProcessor {
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
 
-    static final List<PropertyDescriptor> PROPERTIES = List.of(
+    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER,
             LIMIT
     );
@@ -125,8 +125,9 @@ public class CalculateRecordStats extends AbstractProcessor {
             .build();
     }
 
+    @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CompressContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CompressContent.java
@@ -186,7 +186,7 @@ public class CompressContent extends AbstractProcessor {
         .defaultValue("false")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             MODE,
             COMPRESSION_FORMAT,
             COMPRESSION_LEVEL,
@@ -230,7 +230,7 @@ public class CompressContent extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ControlRate.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ControlRate.java
@@ -208,7 +208,7 @@ public class ControlRate extends AbstractProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RATE_CONTROL_CRITERIA,
             TIME_PERIOD,
             MAX_RATE,
@@ -261,7 +261,7 @@ public class ControlRate extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ConvertCharacterSet.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ConvertCharacterSet.java
@@ -90,14 +90,16 @@ public class ConvertCharacterSet extends AbstractProcessor {
             .required(true)
             .build();
 
-    private final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             INPUT_CHARSET,
             OUTPUT_CHARSET
     );
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder().name("success").description("").build();
 
-    private final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     public static final int MAX_BUFFER_SIZE = 512 * 1024;
 
@@ -108,7 +110,7 @@ public class ConvertCharacterSet extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CountText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CountText.java
@@ -151,7 +151,7 @@ public class CountText extends AbstractProcessor {
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             TEXT_LINE_COUNT_PD,
             TEXT_LINE_NONEMPTY_COUNT_PD,
             TEXT_WORD_COUNT_PD,
@@ -331,6 +331,6 @@ public class CountText extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CryptographicHashContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CryptographicHashContent.java
@@ -70,7 +70,7 @@ public class CryptographicHashContent extends AbstractProcessor {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FAIL_WHEN_EMPTY,
             HASH_ALGORITHM
     );
@@ -97,7 +97,7 @@ public class CryptographicHashContent extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeduplicateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeduplicateRecord.java
@@ -264,7 +264,7 @@ public class DeduplicateRecord extends AbstractProcessor {
             .required(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DEDUPLICATION_STRATEGY,
             DISTRIBUTED_MAP_CACHE,
             CACHE_IDENTIFIER,
@@ -312,7 +312,7 @@ public class DeduplicateRecord extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeleteFile.java
@@ -109,7 +109,7 @@ public class DeleteFile extends AbstractProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
-    private final static List<PropertyDescriptor> PROPERTIES = List.of(
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DIRECTORY_PATH,
             FILENAME
     );
@@ -121,7 +121,7 @@ public class DeleteFile extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DetectDuplicate.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DetectDuplicate.java
@@ -108,7 +108,7 @@ public class DetectDuplicate extends AbstractProcessor {
             .defaultValue("true")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CACHE_ENTRY_IDENTIFIER,
             FLOWFILE_DESCRIPTION,
             AGE_OFF_DURATION,
@@ -141,7 +141,7 @@ public class DetectDuplicate extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DuplicateFlowFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DuplicateFlowFile.java
@@ -59,14 +59,18 @@ public class DuplicateFlowFile extends AbstractProcessor {
     .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
     .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(NUM_COPIES);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        NUM_COPIES
+    );
 
     static final Relationship REL_SUCCESS = new Relationship.Builder()
     .name("success")
     .description("The original FlowFile and all copies will be sent to this relationship")
     .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -75,7 +79,7 @@ public class DuplicateFlowFile extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EncodeContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EncodeContent.java
@@ -101,7 +101,7 @@ public class EncodeContent extends AbstractProcessor {
             .dependsOn(LINE_OUTPUT_MODE, LineOutputMode.MULTIPLE_LINES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             MODE,
             ENCODING,
             LINE_OUTPUT_MODE,
@@ -134,7 +134,7 @@ public class EncodeContent extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EnforceOrder.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EnforceOrder.java
@@ -178,7 +178,7 @@ public class EnforceOrder extends AbstractProcessor {
         .expressionLanguageSupported(ExpressionLanguageScope.NONE)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             GROUP_IDENTIFIER,
             ORDER_ATTRIBUTE,
             INITIAL_ORDER,
@@ -223,7 +223,7 @@ public class EnforceOrder extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EvaluateJsonPath.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EvaluateJsonPath.java
@@ -124,7 +124,7 @@ public class EvaluateJsonPath extends AbstractJsonPathProcessor {
             .dependsOn(DESTINATION, DESTINATION_ATTRIBUTE)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DESTINATION,
             RETURN_TYPE,
             PATH_NOT_FOUND,
@@ -191,7 +191,7 @@ public class EvaluateJsonPath extends AbstractJsonPathProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EvaluateXPath.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EvaluateXPath.java
@@ -131,7 +131,7 @@ public class EvaluateXPath extends AbstractProcessor {
             .defaultValue("false")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DESTINATION,
             RETURN_TYPE,
             VALIDATE_DTD
@@ -192,7 +192,7 @@ public class EvaluateXPath extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EvaluateXQuery.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EvaluateXQuery.java
@@ -149,7 +149,7 @@ public class EvaluateXQuery extends AbstractProcessor {
             .defaultValue("false")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DESTINATION,
             XML_OUTPUT_METHOD,
             XML_OUTPUT_OMIT_XML_DECLARATION,
@@ -208,7 +208,7 @@ public class EvaluateXQuery extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteProcess.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteProcess.java
@@ -153,7 +153,7 @@ public class ExecuteProcess extends AbstractProcessor {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             COMMAND,
             COMMAND_ARGUMENTS,
             BATCH_DURATION,
@@ -184,7 +184,7 @@ public class ExecuteProcess extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteSQLRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteSQLRecord.java
@@ -150,7 +150,7 @@ public class ExecuteSQLRecord extends AbstractExecuteSQL {
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DBCP_SERVICE,
             SQL_PRE_QUERY,
             SQL_SELECT_QUERY,
@@ -174,7 +174,7 @@ public class ExecuteSQLRecord extends AbstractExecuteSQL {
 
     public ExecuteSQLRecord() {
         relationships = RELATIONSHIPS;
-        propDescriptors = PROPERTIES;
+        propDescriptors = PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteStreamCommand.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteStreamCommand.java
@@ -287,7 +287,7 @@ public class ExecuteStreamCommand extends AbstractProcessor {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             WORKING_DIR,
             EXECUTION_COMMAND,
             ARGUMENTS_STRATEGY,
@@ -328,7 +328,7 @@ public class ExecuteStreamCommand extends AbstractProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExtractGrok.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExtractGrok.java
@@ -154,7 +154,7 @@ public class ExtractGrok extends AbstractProcessor {
         .defaultValue("false")
         .build();
 
-    private final static List<PropertyDescriptor> PROPERTIES = List.of(
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             GROK_EXPRESSION,
             GROK_PATTERNS,
             DESTINATION,
@@ -191,7 +191,7 @@ public class ExtractGrok extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnStopped

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExtractRecordSchema.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExtractRecordSchema.java
@@ -77,7 +77,7 @@ public class ExtractRecordSchema extends AbstractProcessor {
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER,
             SCHEMA_CACHE_SIZE
     );
@@ -101,7 +101,7 @@ public class ExtractRecordSchema extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExtractText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExtractText.java
@@ -229,7 +229,7 @@ public class ExtractText extends AbstractProcessor {
         .defaultValue("false")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CHARACTER_SET,
             MAX_BUFFER_SIZE,
             MAX_CAPTURE_GROUP_LENGTH,
@@ -273,7 +273,7 @@ public class ExtractText extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchDistributedMapCache.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchDistributedMapCache.java
@@ -119,7 +119,7 @@ public class FetchDistributedMapCache extends AbstractProcessor {
             .defaultValue("UTF-8")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CACHE_ENTRY_IDENTIFIER,
             DISTRIBUTED_CACHE_SERVICE,
             PUT_CACHE_VALUE_IN_ATTRIBUTE,
@@ -151,7 +151,7 @@ public class FetchDistributedMapCache extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFTP.java
@@ -88,7 +88,7 @@ public class FetchFTP extends FetchFileTransfer {
     private static final PropertyDescriptor PORT =
             new PropertyDescriptor.Builder().fromPropertyDescriptor(UNDEFAULTED_PORT).defaultValue("21").build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             HOSTNAME,
             PORT,
             USERNAME,
@@ -110,7 +110,7 @@ public class FetchFTP extends FetchFileTransfer {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
@@ -176,7 +176,7 @@ public class FetchFile extends AbstractProcessor {
         .required(true)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FILENAME,
             COMPLETION_STRATEGY,
             MOVE_DESTINATION_DIR,
@@ -212,7 +212,7 @@ public class FetchFile extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchSFTP.java
@@ -97,7 +97,7 @@ public class FetchSFTP extends FetchFileTransfer {
                     MOVE_CREATE_DIRECTORY.getDisplayName(),
                     SFTPTransfer.DISABLE_DIRECTORY_LISTING.getDescription())).build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             HOSTNAME,
             PORT,
             USERNAME,
@@ -125,7 +125,7 @@ public class FetchSFTP extends FetchFileTransfer {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FilterAttribute.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FilterAttribute.java
@@ -113,7 +113,7 @@ public class FilterAttribute extends AbstractProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
-    private final static List<PropertyDescriptor> PROPERTIES = List.of(
+    private final static List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FILTER_MODE,
             MATCHING_STRATEGY,
             ATTRIBUTE_ENUMERATION,
@@ -131,7 +131,7 @@ public class FilterAttribute extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FlattenJson.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FlattenJson.java
@@ -158,7 +158,7 @@ public class FlattenJson extends AbstractProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SEPARATOR,
             FLATTEN_MODE,
             IGNORE_RESERVED_CHARACTERS,
@@ -184,7 +184,7 @@ public class FlattenJson extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ForkRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ForkRecord.java
@@ -141,7 +141,7 @@ public class ForkRecord extends AbstractProcessor {
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER,
             RECORD_WRITER,
             MODE,
@@ -169,7 +169,7 @@ public class ForkRecord extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateFlowFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateFlowFile.java
@@ -127,7 +127,7 @@ public class GenerateFlowFile extends AbstractProcessor {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FILE_SIZE,
             BATCH_SIZE,
             DATA_FORMAT,
@@ -141,13 +141,15 @@ public class GenerateFlowFile extends AbstractProcessor {
             .name("success")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS
+    );
 
     private static final char[] TEXT_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*()-_=+/?.,';:\"?<>\n\t ".toCharArray();
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateRecord.java
@@ -151,7 +151,7 @@ public class GenerateRecord extends AbstractProcessor {
             .required(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_WRITER,
             NUM_RECORDS,
             NULLABLE_FIELDS,
@@ -164,13 +164,15 @@ public class GenerateRecord extends AbstractProcessor {
             .description("FlowFiles that are successfully created will be routed to this relationship")
             .build();
 
-    static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     private volatile Faker faker = new Faker();
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateTableFetch.java
@@ -164,7 +164,7 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DBCP_SERVICE,
             DB_TYPE,
             TABLE_NAME,
@@ -190,7 +190,7 @@ public class GenerateTableFetch extends AbstractDatabaseFetchProcessor {
     );
 
     public GenerateTableFetch() {
-        propDescriptors = PROPERTIES;
+        propDescriptors = PROPERTY_DESCRIPTORS;
         relationships = RELATIONSHIPS;
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFTP.java
@@ -56,7 +56,7 @@ import java.util.List;
 @SeeAlso(PutFTP.class)
 public class GetFTP extends GetFileTransfer {
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FTPTransfer.HOSTNAME,
             FTPTransfer.PORT,
             FTPTransfer.USERNAME,
@@ -83,7 +83,7 @@ public class GetFTP extends GetFileTransfer {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFile.java
@@ -188,7 +188,7 @@ public class GetFile extends AbstractProcessor {
             .defaultValue("10")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DIRECTORY,
             FILE_FILTER,
             PATH_FILTER,
@@ -226,7 +226,7 @@ public class GetFile extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFileResource.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetFileResource.java
@@ -88,17 +88,22 @@ public class GetFileResource extends AbstractProcessor {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(FILE_RESOURCE, MIME_TYPE);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        FILE_RESOURCE,
+        MIME_TYPE
+    );
 
     public static final Relationship SUCCESS = new Relationship.Builder()
             .name("success")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        SUCCESS
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GetSFTP.java
@@ -55,7 +55,7 @@ import java.util.List;
 @SeeAlso(PutSFTP.class)
 public class GetSFTP extends GetFileTransfer {
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SFTPTransfer.HOSTNAME,
             SFTPTransfer.PORT,
             SFTPTransfer.USERNAME,
@@ -88,7 +88,7 @@ public class GetSFTP extends GetFileTransfer {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpRequest.java
@@ -319,7 +319,7 @@ public class HandleHttpRequest extends AbstractProcessor {
             .defaultValue("512 KB")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PORT,
             HOSTNAME,
             SSL_CONTEXT,
@@ -348,7 +348,9 @@ public class HandleHttpRequest extends AbstractProcessor {
             .description("All content that is received is routed to the 'success' relationship")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     private volatile Server server;
     private volatile boolean ready;
@@ -360,7 +362,7 @@ public class HandleHttpRequest extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpResponse.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/HandleHttpResponse.java
@@ -82,7 +82,7 @@ public class HandleHttpResponse extends AbstractProcessor {
             .required(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             STATUS_CODE,
             HTTP_CONTEXT_MAP,
             ATTRIBUTES_AS_HEADERS_REGEX
@@ -98,11 +98,14 @@ public class HandleHttpResponse extends AbstractProcessor {
                     + "for instance, if the connection times out or if NiFi is restarted before responding to the HTTP Request.")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS, REL_FAILURE);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE
+    );
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/IdentifyMimeType.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/IdentifyMimeType.java
@@ -131,11 +131,11 @@ public class IdentifyMimeType extends AbstractProcessor {
             .dependsOn(CONFIG_STRATEGY, REPLACE, MERGE)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
-            USE_FILENAME_IN_DETECTION,
-            CONFIG_STRATEGY,
-            MIME_CONFIG_BODY,
-            MIME_CONFIG_FILE
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        USE_FILENAME_IN_DETECTION,
+        CONFIG_STRATEGY,
+        MIME_CONFIG_BODY,
+        MIME_CONFIG_FILE
     );
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -143,7 +143,9 @@ public class IdentifyMimeType extends AbstractProcessor {
             .description("All FlowFiles are routed to success")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS
+    );
 
     private final TikaConfig config;
     private Detector detector;
@@ -205,7 +207,7 @@ public class IdentifyMimeType extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -483,7 +483,7 @@ public class InvokeHTTP extends AbstractProcessor {
 
     private static final PropertyDescriptor PROXY_CONFIGURATION_SERVICE = ProxyConfiguration.createProxyConfigPropertyDescriptor(PROXY_SPECS);
 
-    public static final List<PropertyDescriptor> PROPERTIES = List.of(
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             HTTP_METHOD,
             HTTP_URL,
             HTTP2_DISABLED,
@@ -571,7 +571,7 @@ public class InvokeHTTP extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/JoinEnrichment.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/JoinEnrichment.java
@@ -186,7 +186,7 @@ public class JoinEnrichment extends BinFiles {
         .defaultValue("10000")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ORIGINAL_RECORD_READER,
             ENRICHMENT_RECORD_READER,
             RECORD_WRITER,
@@ -231,7 +231,7 @@ public class JoinEnrichment extends BinFiles {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListDatabaseTables.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListDatabaseTables.java
@@ -227,7 +227,7 @@ public class ListDatabaseTables extends AbstractProcessor {
         .identifiesControllerService(RecordSetWriterFactory.class)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DBCP_SERVICE,
             CATALOG,
             SCHEMA_PATTERN,
@@ -248,7 +248,7 @@ public class ListDatabaseTables extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFTP.java
@@ -74,7 +74,7 @@ public class ListFTP extends ListFileTransfer {
     private static final PropertyDescriptor PORT =
             new PropertyDescriptor.Builder().fromPropertyDescriptor(UNDEFAULTED_PORT).defaultValue("21").build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FILE_TRANSFER_LISTING_STRATEGY,
             HOSTNAME,
             PORT,
@@ -103,7 +103,7 @@ public class ListFTP extends ListFileTransfer {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListFile.java
@@ -267,7 +267,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
         .defaultValue("3 mins")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DIRECTORY,
             LISTING_STRATEGY,
             RECURSE,
@@ -292,7 +292,9 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
             MAX_LISTING_TIME
     );
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     private volatile ScheduledExecutorService monitoringThreadPool;
     private volatile Future<?> monitoringFuture;
@@ -324,7 +326,7 @@ public class ListFile extends AbstractListProcessor<FileInfo> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
@@ -80,7 +80,7 @@ import java.util.stream.Collectors;
 @DefaultSchedule(strategy = SchedulingStrategy.TIMER_DRIVEN, period = "1 min")
 public class ListSFTP extends ListFileTransfer {
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FILE_TRANSFER_LISTING_STRATEGY,
             SFTPTransfer.HOSTNAME,
             SFTPTransfer.PORT,
@@ -121,7 +121,7 @@ public class ListSFTP extends ListFileTransfer {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenFTP.java
@@ -117,7 +117,7 @@ public class ListenFTP extends AbstractSessionFactoryProcessor {
             .sensitive(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BIND_ADDRESS,
             PORT,
             USERNAME,
@@ -130,7 +130,9 @@ public class ListenFTP extends AbstractSessionFactoryProcessor {
             .description("Relationship for successfully received files.")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(RELATIONSHIP_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            RELATIONSHIP_SUCCESS
+    );
 
     private volatile FtpServer ftpServer;
     private volatile CountDownLatch sessionFactorySetSignal;
@@ -138,7 +140,7 @@ public class ListenFTP extends AbstractSessionFactoryProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
@@ -298,7 +298,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
             .dependsOn(RECORD_READER)
             .build();
 
-    protected static final List<PropertyDescriptor> PROPERTIES = List.of(
+    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             BASE_PATH,
             PORT,
             HEALTH_CHECK_PORT,
@@ -324,7 +324,9 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
             .description("Relationship for successfully received FlowFiles")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(RELATIONSHIP_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            RELATIONSHIP_SUCCESS
+    );
 
     public static final String CONTEXT_ATTRIBUTE_PROCESSOR = "processor";
     public static final String CONTEXT_ATTRIBUTE_LOGGER = "logger";
@@ -377,7 +379,7 @@ public class ListenHTTP extends AbstractSessionFactoryProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnStopped

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenSyslog.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenSyslog.java
@@ -192,7 +192,7 @@ public class ListenSyslog extends AbstractSyslogProcessor {
             .dependsOn(PROTOCOL, TCP_VALUE)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PROTOCOL,
             PORT,
             NETWORK_INTF_NAME,
@@ -239,7 +239,7 @@ public class ListenSyslog extends AbstractSyslogProcessor {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenTCP.java
@@ -127,7 +127,7 @@ public class ListenTCP extends AbstractProcessor {
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ListenerProperties.NETWORK_INTF_NAME,
             ListenerProperties.PORT,
             ListenerProperties.RECV_BUFFER_SIZE,
@@ -148,7 +148,9 @@ public class ListenTCP extends AbstractProcessor {
             .description("Messages received successfully will be sent out this relationship.")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     private static final long TRACKING_LOG_INTERVAL = 60000;
     private final AtomicLong nextTrackingLog = new AtomicLong();
@@ -269,12 +271,12 @@ public class ListenTCP extends AbstractProcessor {
 
     @Override
     public final Set<Relationship> getRelationships() {
-        return this.RELATIONSHIPS;
+        return RELATIONSHIPS;
     }
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private String getMessageDemarcator(final ProcessContext context) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogAttribute.java
@@ -143,7 +143,7 @@ public class LogAttribute extends AbstractProcessor {
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             LOG_LEVEL,
             LOG_PAYLOAD,
             ATTRIBUTES_TO_LOG_CSV,
@@ -178,7 +178,7 @@ public class LogAttribute extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     protected String processFlowFile(final ComponentLog logger, final DebugLevels logLevel, final FlowFile flowFile, final ProcessSession session, final ProcessContext context) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogMessage.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LogMessage.java
@@ -75,10 +75,10 @@ public class LogMessage extends AbstractProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
-            LOG_LEVEL,
-            LOG_PREFIX,
-            LOG_MESSAGE
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        LOG_LEVEL,
+        LOG_PREFIX,
+        LOG_MESSAGE
     );
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
@@ -86,7 +86,9 @@ public class LogMessage extends AbstractProcessor {
             .description("All FlowFiles are routed to this relationship")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS
+    );
 
     enum MessageLogLevel {
         trace, debug, info, warn, error
@@ -99,7 +101,7 @@ public class LogMessage extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LookupAttribute.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LookupAttribute.java
@@ -85,7 +85,7 @@ public class LookupAttribute extends AbstractProcessor {
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             LOOKUP_SERVICE,
             INCLUDE_EMPTY_VALUES
     );
@@ -143,7 +143,7 @@ public class LookupAttribute extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LookupRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/LookupRecord.java
@@ -221,7 +221,7 @@ public class LookupRecord extends AbstractProcessor {
         .required(true)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER,
             RECORD_WRITER,
             LOOKUP_SERVICE,
@@ -272,7 +272,7 @@ public class LookupRecord extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeContent.java
@@ -424,7 +424,7 @@ public class MergeContent extends BinFiles {
         .build();
 
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             MERGE_STRATEGY,
             MERGE_FORMAT,
             AttributeStrategyUtil.ATTRIBUTE_STRATEGY,
@@ -469,7 +469,7 @@ public class MergeContent extends BinFiles {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MergeRecord.java
@@ -279,7 +279,7 @@ public class MergeRecord extends AbstractSessionFactoryProcessor {
         .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER,
             RECORD_WRITER,
             MERGE_STRATEGY,
@@ -316,7 +316,7 @@ public class MergeRecord extends AbstractSessionFactoryProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ModifyBytes.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ModifyBytes.java
@@ -52,7 +52,10 @@ public class ModifyBytes extends AbstractProcessor {
             .name("success")
             .description("Processed flowfiles.")
             .build();
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     public static final PropertyDescriptor START_OFFSET = new PropertyDescriptor.Builder()
             .name("Start Offset")
@@ -80,7 +83,8 @@ public class ModifyBytes extends AbstractProcessor {
             .allowableValues("true", "false")
             .defaultValue("false")
             .build();
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             START_OFFSET,
             END_OFFSET,
             REMOVE_ALL
@@ -93,7 +97,7 @@ public class ModifyBytes extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MonitorActivity.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/MonitorActivity.java
@@ -162,7 +162,7 @@ public class MonitorActivity extends AbstractProcessor {
             .defaultValue(REPORT_NODE_ALL.getValue())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             THRESHOLD,
             CONTINUALLY_SEND_MESSAGES,
             INACTIVITY_MESSAGE,
@@ -209,7 +209,7 @@ public class MonitorActivity extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Notify.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Notify.java
@@ -132,7 +132,7 @@ public class Notify extends AbstractProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RELEASE_SIGNAL_IDENTIFIER,
             SIGNAL_COUNTER_NAME,
             SIGNAL_COUNTER_DELTA,
@@ -158,7 +158,7 @@ public class Notify extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PackageFlowFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PackageFlowFile.java
@@ -130,7 +130,9 @@ public class PackageFlowFile extends AbstractProcessor {
             .addValidator(StandardValidators.createLongValidator(1, 10_000, true))
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(BATCH_SIZE);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            BATCH_SIZE
+    );
 
     static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
@@ -153,7 +155,7 @@ public class PackageFlowFile extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseSyslog.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseSyslog.java
@@ -74,7 +74,9 @@ public class ParseSyslog extends AbstractProcessor {
         .addValidator(StandardValidators.CHARACTER_SET_VALIDATOR)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(CHARSET);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        CHARSET
+    );
 
     static final Relationship REL_FAILURE = new Relationship.Builder()
         .name("failure")
@@ -94,7 +96,7 @@ public class ParseSyslog extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseSyslog5424.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ParseSyslog5424.java
@@ -111,7 +111,7 @@ public class ParseSyslog5424 extends AbstractProcessor {
         .defaultValue("true")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CHARSET,
             NIL_POLICY,
             INCLUDE_BODY_IN_ATTRIBUTES
@@ -137,7 +137,7 @@ public class ParseSyslog5424 extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PartitionRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PartitionRecord.java
@@ -141,7 +141,7 @@ public class PartitionRecord extends AbstractProcessor {
         .required(true)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER,
             RECORD_WRITER
     );
@@ -168,7 +168,7 @@ public class PartitionRecord extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDistributedMapCache.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDistributedMapCache.java
@@ -105,7 +105,7 @@ public class PutDistributedMapCache extends AbstractProcessor {
         .expressionLanguageSupported(ExpressionLanguageScope.NONE)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CACHE_ENTRY_IDENTIFIER,
             DISTRIBUTED_CACHE_SERVICE,
             CACHE_UPDATE_STRATEGY,
@@ -133,7 +133,7 @@ public class PutDistributedMapCache extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutEmail.java
@@ -296,7 +296,7 @@ public class PutEmail extends AbstractProcessor {
             .defaultValue(StandardCharsets.UTF_8.name())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SMTP_HOSTNAME,
             SMTP_PORT,
             AUTHORIZATION_MODE,
@@ -357,7 +357,7 @@ public class PutEmail extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFTP.java
@@ -75,7 +75,7 @@ public class PutFTP extends PutFileTransfer<FTPTransfer> {
             .fromPropertyDescriptor(FTPTransfer.REMOTE_PATH)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES).build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FTPTransfer.HOSTNAME,
             FTPTransfer.PORT,
             FTPTransfer.USERNAME,
@@ -101,7 +101,7 @@ public class PutFTP extends PutFileTransfer<FTPTransfer> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutFile.java
@@ -159,7 +159,7 @@ public class PutFile extends AbstractProcessor {
             .defaultValue("true")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DIRECTORY,
             CONFLICT_RESOLUTION,
             CREATE_DIRS,
@@ -192,7 +192,7 @@ public class PutFile extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutRecord.java
@@ -77,7 +77,7 @@ public class PutRecord extends AbstractProcessor {
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER,
             RECORD_SINK,
             INCLUDE_ZERO_RECORD_RESULTS
@@ -113,7 +113,7 @@ public class PutRecord extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSFTP.java
@@ -43,7 +43,7 @@ import java.util.List;
 @SeeAlso(GetSFTP.class)
 public class PutSFTP extends PutFileTransfer<SFTPTransfer> {
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FileTransfer.HOSTNAME,
             SFTPTransfer.PORT,
             FileTransfer.USERNAME,
@@ -77,7 +77,7 @@ public class PutSFTP extends PutFileTransfer<SFTPTransfer> {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -180,7 +180,7 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
             .defaultValue("false")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CONNECTION_POOL,
             SQL_STATEMENT,
             SUPPORT_TRANSACTIONS,
@@ -221,7 +221,7 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSyslog.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSyslog.java
@@ -149,7 +149,7 @@ public class PutSyslog extends AbstractSyslogProcessor {
             .dependsOn(PROTOCOL, TCP_VALUE)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             HOSTNAME,
             PROTOCOL,
             PORT,
@@ -195,7 +195,7 @@ public class PutSyslog extends AbstractSyslogProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTable.java
@@ -92,7 +92,7 @@ public class QueryDatabaseTable extends AbstractQueryDatabaseTable {
             .description("The name of the database table to be queried. When a custom query is used, this property is used to alias the query and appears as an attribute on the FlowFile.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DBCP_SERVICE,
             DB_TYPE,
             TABLE_NAME,
@@ -118,7 +118,7 @@ public class QueryDatabaseTable extends AbstractQueryDatabaseTable {
 
     public QueryDatabaseTable() {
         relationships = RELATIONSHIPS;
-        propDescriptors = PROPERTIES;
+        propDescriptors = PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryDatabaseTableRecord.java
@@ -191,7 +191,7 @@ public class QueryDatabaseTableRecord extends AbstractQueryDatabaseTable {
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DBCP_SERVICE,
             DB_TYPE,
             TABLE_NAME,
@@ -213,11 +213,13 @@ public class QueryDatabaseTableRecord extends AbstractQueryDatabaseTable {
             VARIABLE_REGISTRY_ONLY_DEFAULT_SCALE
     );
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS
+    );
 
     public QueryDatabaseTableRecord() {
         relationships = RELATIONSHIPS;
-        propDescriptors = PROPERTIES;
+        propDescriptors = PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/QueryRecord.java
@@ -218,7 +218,7 @@ public class QueryRecord extends AbstractProcessor {
         .required(true)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER_FACTORY,
             RECORD_WRITER_FACTORY,
             INCLUDE_ZERO_RECORD_FLOWFILES,
@@ -262,7 +262,7 @@ public class QueryRecord extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceText.java
@@ -274,7 +274,7 @@ public class ReplaceText extends AbstractProcessor {
         .required(false)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             REPLACEMENT_STRATEGY,
             SEARCH_VALUE,
             REPLACEMENT_VALUE,
@@ -306,7 +306,7 @@ public class ReplaceText extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ReplaceTextWithMapping.java
@@ -117,7 +117,7 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
             .defaultValue("1 MB")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             REGEX,
             MATCHING_GROUP_FOR_LOOKUP_KEY,
             MAPPING_FILE,
@@ -168,7 +168,7 @@ public class ReplaceTextWithMapping extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RetryFlowFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RetryFlowFile.java
@@ -140,7 +140,7 @@ public class RetryFlowFile extends AbstractProcessor {
             .defaultValue(FAIL_ON_REUSE.getValue())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RETRY_ATTRIBUTE,
             MAXIMUM_RETRIES,
             PENALIZE_RETRIED,
@@ -199,7 +199,7 @@ public class RetryFlowFile extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteOnAttribute.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteOnAttribute.java
@@ -192,7 +192,9 @@ public class RouteOnAttribute extends AbstractProcessor {
             .defaultValue(ROUTE_PROPERTY_NAME.getValue())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(ROUTE_STRATEGY);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            ROUTE_STRATEGY
+    );
 
     public static final Relationship REL_NO_MATCH = new Relationship.Builder()
             .name("unmatched")
@@ -220,7 +222,7 @@ public class RouteOnAttribute extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteOnContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteOnContent.java
@@ -91,7 +91,7 @@ public class RouteOnContent extends AbstractProcessor {
             .defaultValue("UTF-8")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             MATCH_REQUIREMENT,
             CHARACTER_SET,
             BUFFER_SIZE
@@ -106,7 +106,7 @@ public class RouteOnContent extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/RouteText.java
@@ -205,7 +205,7 @@ public class RouteText extends AbstractProcessor {
         .defaultValue("UTF-8")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ROUTE_STRATEGY,
             MATCH_STRATEGY,
             CHARACTER_SET,
@@ -264,7 +264,7 @@ public class RouteText extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SampleRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SampleRecord.java
@@ -174,7 +174,7 @@ public class SampleRecord extends AbstractProcessor {
             .dependsOn(SAMPLING_STRATEGY, PROBABILISTIC_SAMPLING, RESERVOIR_SAMPLING)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER_FACTORY,
             RECORD_WRITER_FACTORY,
             SAMPLING_STRATEGY,
@@ -214,7 +214,7 @@ public class SampleRecord extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ScanAttribute.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ScanAttribute.java
@@ -95,7 +95,7 @@ public class ScanAttribute extends AbstractProcessor {
             .addValidator(StandardValidators.createRegexValidator(0, 1, false))
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DICTIONARY_FILE,
             ATTRIBUTE_PATTERN,
             MATCHING_CRITERIA,
@@ -123,7 +123,7 @@ public class ScanAttribute extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ScanContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ScanContent.java
@@ -85,7 +85,7 @@ public class ScanContent extends AbstractProcessor {
             .defaultValue(TEXT_ENCODING)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DICTIONARY,
             DICTIONARY_ENCODING
     );
@@ -114,7 +114,7 @@ public class ScanContent extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SegmentContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SegmentContent.java
@@ -78,7 +78,9 @@ public class SegmentContent extends AbstractProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(SIZE);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            SIZE
+    );
 
     public static final Relationship REL_SEGMENTS = new Relationship.Builder()
             .name("segments")
@@ -102,7 +104,7 @@ public class SegmentContent extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitContent.java
@@ -115,7 +115,7 @@ public class SplitContent extends AbstractProcessor {
             .defaultValue(TRAILING_POSITION.getValue())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FORMAT,
             BYTE_SEQUENCE,
             KEEP_SEQUENCE,
@@ -145,7 +145,7 @@ public class SplitContent extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitJson.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitJson.java
@@ -89,7 +89,7 @@ public class SplitJson extends AbstractJsonPathProcessor {
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             ARRAY_JSON_PATH_EXPRESSION,
             NULL_VALUE_DEFAULT_REPRESENTATION,
             MAX_STRING_LENGTH
@@ -127,7 +127,7 @@ public class SplitJson extends AbstractJsonPathProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitRecord.java
@@ -96,7 +96,7 @@ public class SplitRecord extends AbstractProcessor {
         .required(true)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER,
             RECORD_WRITER,
             RECORDS_PER_SPLIT
@@ -124,7 +124,7 @@ public class SplitRecord extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitText.java
@@ -135,7 +135,7 @@ public class SplitText extends AbstractProcessor {
             .defaultValue("true")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             LINE_SPLIT_COUNT,
             FRAGMENT_MAX_SIZE,
             HEADER_LINE_COUNT,
@@ -268,7 +268,7 @@ public class SplitText extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitXml.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitXml.java
@@ -94,7 +94,9 @@ public class SplitXml extends AbstractProcessor {
             .defaultValue("1")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(SPLIT_DEPTH);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            SPLIT_DEPTH
+    );
 
     public static final Relationship REL_ORIGINAL = new Relationship.Builder()
             .name("original")
@@ -122,7 +124,7 @@ public class SplitXml extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TailFile.java
@@ -294,7 +294,7 @@ public class TailFile extends AbstractProcessor {
             .defaultValue("65536 B")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             MODE,
             FILENAME,
             ROLLING_FILENAME_PATTERN,
@@ -316,7 +316,9 @@ public class TailFile extends AbstractProcessor {
             .description("All FlowFiles are routed to this Relationship.")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(REL_SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+        REL_SUCCESS
+    );
 
     private volatile Map<String, TailFileObject> states = new HashMap<>();
     private final AtomicLong lastLookup = new AtomicLong(0L);
@@ -330,7 +332,7 @@ public class TailFile extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformXml.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/TransformXml.java
@@ -159,7 +159,7 @@ public class TransformXml extends AbstractProcessor {
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             XSLT_FILE_NAME,
             XSLT_CONTROLLER,
             XSLT_CONTROLLER_KEY,
@@ -193,7 +193,7 @@ public class TransformXml extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -206,7 +206,7 @@ public class UnpackContent extends AbstractProcessor {
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PACKAGING_FORMAT,
             ZIP_FILENAME_CHARSET,
             FILE_FILTER,
@@ -245,7 +245,7 @@ public class UnpackContent extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnStopped

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UpdateCounter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UpdateCounter.java
@@ -60,7 +60,7 @@ public class UpdateCounter extends AbstractProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             COUNTER_NAME,
             DELTA
     );
@@ -70,7 +70,9 @@ public class UpdateCounter extends AbstractProcessor {
             .description("Counter was updated/retrieved")
             .build();
 
-    private static final Set<Relationship> RELATIONSHIPS = Set.of(SUCCESS);
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            SUCCESS
+    );
 
     @Override
     public Set<Relationship> getRelationships() {
@@ -79,7 +81,7 @@ public class UpdateCounter extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateCsv.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateCsv.java
@@ -195,7 +195,7 @@ public class ValidateCsv extends AbstractProcessor {
             .defaultValue("false")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SCHEMA,
             CSV_SOURCE_ATTRIBUTE,
             HEADER,
@@ -228,7 +228,7 @@ public class ValidateCsv extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateJson.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateJson.java
@@ -170,7 +170,7 @@ public class ValidateJson extends AbstractProcessor {
             .dependsOn(SCHEMA_ACCESS_STRATEGY, JsonSchemaStrategy.SCHEMA_CONTENT_PROPERTY)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SCHEMA_ACCESS_STRATEGY,
             SCHEMA_NAME,
             SCHEMA_REGISTRY,
@@ -223,7 +223,7 @@ public class ValidateJson extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateRecord.java
@@ -191,7 +191,7 @@ public class ValidateRecord extends AbstractProcessor {
         .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RECORD_READER,
             RECORD_WRITER,
             INVALID_RECORD_WRITER,
@@ -229,7 +229,7 @@ public class ValidateRecord extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateXml.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ValidateXml.java
@@ -107,7 +107,7 @@ public class ValidateXml extends AbstractProcessor {
             .addValidator(StandardValidators.ATTRIBUTE_KEY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SCHEMA_FILE,
             XML_SOURCE_ATTRIBUTE
     );
@@ -139,7 +139,7 @@ public class ValidateXml extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Wait.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Wait.java
@@ -237,7 +237,7 @@ public class Wait extends AbstractProcessor {
         .expressionLanguageSupported(ExpressionLanguageScope.NONE)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RELEASE_SIGNAL_IDENTIFIER,
             TARGET_SIGNAL_COUNT,
             SIGNAL_COUNTER_NAME,
@@ -281,7 +281,7 @@ public class Wait extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-db-schema-registry-bundle/nifi-db-schema-registry-service/src/main/java/org/apache/nifi/db/schemaregistry/DatabaseTableSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-db-schema-registry-bundle/nifi-db-schema-registry-service/src/main/java/org/apache/nifi/db/schemaregistry/DatabaseTableSchemaRegistry.java
@@ -82,7 +82,7 @@ public class DatabaseTableSchemaRegistry extends AbstractControllerService imple
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         DBCP_SERVICE,
         CATALOG_NAME,
         SCHEMA_NAME
@@ -94,7 +94,7 @@ public class DatabaseTableSchemaRegistry extends AbstractControllerService imple
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-db-schema-registry-bundle/nifi-db-schema-registry-service/src/main/java/org/apache/nifi/db/schemaregistry/DatabaseTableSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-db-schema-registry-bundle/nifi-db-schema-registry-service/src/main/java/org/apache/nifi/db/schemaregistry/DatabaseTableSchemaRegistry.java
@@ -40,8 +40,6 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -84,11 +82,11 @@ public class DatabaseTableSchemaRegistry extends AbstractControllerService imple
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    protected List<PropertyDescriptor> propDescriptors = Collections.unmodifiableList(Arrays.asList(
-            DBCP_SERVICE,
-            CATALOG_NAME,
-            SCHEMA_NAME
-    ));
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        DBCP_SERVICE,
+        CATALOG_NAME,
+        SCHEMA_NAME
+    );
 
     private volatile DBCPService dbcpService;
     private volatile String dbCatalogName;
@@ -96,7 +94,7 @@ public class DatabaseTableSchemaRegistry extends AbstractControllerService imple
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return propDescriptors;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
@@ -20,8 +20,6 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -95,32 +93,27 @@ public class DBCPConnectionPool extends AbstractDBCPConnectionPool implements DB
      */
     protected static final String SENSITIVE_PROPERTY_PREFIX = "SENSITIVE.";
 
-    private static final List<PropertyDescriptor> PROPERTIES;
-
-    static {
-        final List<PropertyDescriptor> props = new ArrayList<>();
-        props.add(DATABASE_URL);
-        props.add(DB_DRIVERNAME);
-        props.add(DB_DRIVER_LOCATION);
-        props.add(KERBEROS_USER_SERVICE);
-        props.add(DB_USER);
-        props.add(DB_PASSWORD);
-        props.add(MAX_WAIT_TIME);
-        props.add(MAX_TOTAL_CONNECTIONS);
-        props.add(VALIDATION_QUERY);
-        props.add(MIN_IDLE);
-        props.add(MAX_IDLE);
-        props.add(MAX_CONN_LIFETIME);
-        props.add(EVICTION_RUN_PERIOD);
-        props.add(MIN_EVICTABLE_IDLE_TIME);
-        props.add(SOFT_MIN_EVICTABLE_IDLE_TIME);
-
-        PROPERTIES = Collections.unmodifiableList(props);
-    }
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        DATABASE_URL,
+        DB_DRIVERNAME,
+        DB_DRIVER_LOCATION,
+        KERBEROS_USER_SERVICE,
+        DB_USER,
+        DB_PASSWORD,
+        MAX_WAIT_TIME,
+        MAX_TOTAL_CONNECTIONS,
+        VALIDATION_QUERY,
+        MIN_IDLE,
+        MAX_IDLE,
+        MAX_CONN_LIFETIME,
+        EVICTION_RUN_PERIOD,
+        MIN_EVICTABLE_IDLE_TIME,
+        SOFT_MIN_EVICTABLE_IDLE_TIME
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/record/sink/db/DatabaseRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/record/sink/db/DatabaseRecordSink.java
@@ -160,7 +160,7 @@ public class DatabaseRecordSink extends AbstractControllerService implements Rec
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         DBCP_SERVICE,
         CATALOG_NAME,
         SCHEMA_NAME,
@@ -178,7 +178,7 @@ public class DatabaseRecordSink extends AbstractControllerService implements Rec
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/record/sink/db/DatabaseRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/record/sink/db/DatabaseRecordSink.java
@@ -25,7 +25,6 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
-import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.dbcp.DBCPService;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -48,7 +47,6 @@ import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -162,31 +160,25 @@ public class DatabaseRecordSink extends AbstractControllerService implements Rec
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
-    private List<PropertyDescriptor> properties;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        DBCP_SERVICE,
+        CATALOG_NAME,
+        SCHEMA_NAME,
+        TABLE_NAME,
+        TRANSLATE_FIELD_NAMES,
+        UNMATCHED_FIELD_BEHAVIOR,
+        UNMATCHED_COLUMN_BEHAVIOR,
+        QUOTED_IDENTIFIERS,
+        QUOTED_TABLE_IDENTIFIER,
+        QUERY_TIMEOUT
+    );
+
     private volatile ConfigurationContext context;
     private volatile DBCPService dbcpService;
 
     @Override
-    protected void init(final ControllerServiceInitializationContext context) {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(DBCP_SERVICE);
-        properties.add(CATALOG_NAME);
-        properties.add(SCHEMA_NAME);
-        properties.add(TABLE_NAME);
-        properties.add(TRANSLATE_FIELD_NAMES);
-        properties.add(UNMATCHED_FIELD_BEHAVIOR);
-        properties.add(UNMATCHED_COLUMN_BEHAVIOR);
-        properties.add(QUOTED_IDENTIFIERS);
-        properties.add(QUOTED_TABLE_IDENTIFIER);
-
-        properties.add(QUERY_TIMEOUT);
-
-        this.properties = Collections.unmodifiableList(properties);
-    }
-
-    @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/main/java/org/apache/nifi/dbcp/HikariCPConnectionPool.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/main/java/org/apache/nifi/dbcp/HikariCPConnectionPool.java
@@ -205,7 +205,7 @@ public class HikariCPConnectionPool extends AbstractControllerService implements
             .required(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         DATABASE_URL,
         DB_DRIVERNAME,
         DB_DRIVER_LOCATION,
@@ -224,7 +224,7 @@ public class HikariCPConnectionPool extends AbstractControllerService implements
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/main/java/org/apache/nifi/dbcp/HikariCPConnectionPool.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/src/main/java/org/apache/nifi/dbcp/HikariCPConnectionPool.java
@@ -50,7 +50,6 @@ import javax.security.auth.login.LoginException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -206,31 +205,26 @@ public class HikariCPConnectionPool extends AbstractControllerService implements
             .required(false)
             .build();
 
-    private static final List<PropertyDescriptor> properties;
-
-    static {
-        final List<PropertyDescriptor> props = new ArrayList<>();
-        props.add(DATABASE_URL);
-        props.add(DB_DRIVERNAME);
-        props.add(DB_DRIVER_LOCATION);
-        props.add(KERBEROS_USER_SERVICE);
-        props.add(DB_USER);
-        props.add(DB_PASSWORD);
-        props.add(MAX_WAIT_TIME);
-        props.add(MAX_TOTAL_CONNECTIONS);
-        props.add(VALIDATION_QUERY);
-        props.add(MIN_IDLE);
-        props.add(MAX_CONN_LIFETIME);
-
-        properties = Collections.unmodifiableList(props);
-    }
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        DATABASE_URL,
+        DB_DRIVERNAME,
+        DB_DRIVER_LOCATION,
+        KERBEROS_USER_SERVICE,
+        DB_USER,
+        DB_PASSWORD,
+        MAX_WAIT_TIME,
+        MAX_TOTAL_CONNECTIONS,
+        VALIDATION_QUERY,
+        MIN_IDLE,
+        MAX_CONN_LIFETIME
+    );
 
     private volatile HikariDataSource dataSource;
     private volatile KerberosUser kerberosUser;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/MapCacheClientService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/MapCacheClientService.java
@@ -36,7 +36,6 @@ import org.apache.nifi.remote.VersionNegotiatorFactory;
 import org.apache.nifi.ssl.SSLContextProvider;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -82,6 +81,13 @@ public class MapCacheClientService extends AbstractControllerService implements 
         .defaultValue("30 secs")
         .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        HOSTNAME,
+        PORT,
+        SSL_CONTEXT_SERVICE,
+        COMMUNICATIONS_TIMEOUT
+    );
+
     private volatile NettyMapCacheClient cacheClient = null;
 
     /**
@@ -91,12 +97,7 @@ public class MapCacheClientService extends AbstractControllerService implements 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(HOSTNAME);
-        descriptors.add(PORT);
-        descriptors.add(SSL_CONTEXT_SERVICE);
-        descriptors.add(COMMUNICATIONS_TIMEOUT);
-        return descriptors;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/MapCacheClientService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/MapCacheClientService.java
@@ -81,7 +81,7 @@ public class MapCacheClientService extends AbstractControllerService implements 
         .defaultValue("30 secs")
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         HOSTNAME,
         PORT,
         SSL_CONTEXT_SERVICE,
@@ -97,7 +97,7 @@ public class MapCacheClientService extends AbstractControllerService implements 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/SetCacheClientService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/SetCacheClientService.java
@@ -70,7 +70,7 @@ public class SetCacheClientService extends AbstractControllerService implements 
             .defaultValue("30 secs")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         HOSTNAME,
         PORT,
         SSL_CONTEXT_SERVICE,
@@ -86,7 +86,7 @@ public class SetCacheClientService extends AbstractControllerService implements 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-       return PROPERTIES;
+       return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/SetCacheClientService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-client-service/src/main/java/org/apache/nifi/distributed/cache/client/SetCacheClientService.java
@@ -32,7 +32,6 @@ import org.apache.nifi.remote.VersionNegotiatorFactory;
 import org.apache.nifi.ssl.SSLContextProvider;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -71,6 +70,13 @@ public class SetCacheClientService extends AbstractControllerService implements 
             .defaultValue("30 secs")
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        HOSTNAME,
+        PORT,
+        SSL_CONTEXT_SERVICE,
+        COMMUNICATIONS_TIMEOUT
+    );
+
     private volatile NettySetCacheClient cacheClient = null;
 
     /**
@@ -80,12 +86,7 @@ public class SetCacheClientService extends AbstractControllerService implements 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(HOSTNAME);
-        descriptors.add(PORT);
-        descriptors.add(SSL_CONTEXT_SERVICE);
-        descriptors.add(COMMUNICATIONS_TIMEOUT);
-        return descriptors;
+       return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-file-resource-service-bundle/nifi-file-resource-service/src/main/java/org/apache/nifi/fileresource/service/StandardFileResourceService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-file-resource-service-bundle/nifi-file-resource-service/src/main/java/org/apache/nifi/fileresource/service/StandardFileResourceService.java
@@ -39,7 +39,6 @@ import org.apache.nifi.processor.util.StandardValidators;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -66,7 +65,7 @@ public class StandardFileResourceService extends AbstractControllerService imple
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             FILE_PATH
     );
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-file-resource-service-bundle/nifi-file-resource-service/src/main/java/org/apache/nifi/fileresource/service/StandardFileResourceService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-file-resource-service-bundle/nifi-file-resource-service/src/main/java/org/apache/nifi/fileresource/service/StandardFileResourceService.java
@@ -65,7 +65,7 @@ public class StandardFileResourceService extends AbstractControllerService imple
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FILE_PATH
     );
 
@@ -73,7 +73,7 @@ public class StandardFileResourceService extends AbstractControllerService imple
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-hadoop-dbcp-service-bundle/nifi-hadoop-dbcp-service/src/main/java/org/apache/nifi/dbcp/HadoopDBCPConnectionPool.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-hadoop-dbcp-service-bundle/nifi-hadoop-dbcp-service/src/main/java/org/apache/nifi/dbcp/HadoopDBCPConnectionPool.java
@@ -35,7 +35,6 @@ import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.components.resource.ResourceCardinality;
 import org.apache.nifi.components.resource.ResourceType;
 import org.apache.nifi.controller.ConfigurationContext;
-import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.dbcp.utils.DBCPProperties;
 import org.apache.nifi.dbcp.utils.DataSourceConfiguration;
 import org.apache.nifi.expression.ExpressionLanguageScope;
@@ -49,7 +48,6 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -115,34 +113,29 @@ public class HadoopDBCPConnectionPool extends AbstractDBCPConnectionPool {
             .dynamicallyModifiesClasspath(true)
             .build();
 
-    private List<PropertyDescriptor> properties;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        DATABASE_URL,
+        DB_DRIVERNAME,
+        DB_DRIVER_LOCATION,
+        HADOOP_CONFIGURATION_RESOURCES,
+        KERBEROS_USER_SERVICE,
+        DB_USER,
+        DB_PASSWORD,
+        MAX_WAIT_TIME,
+        MAX_TOTAL_CONNECTIONS,
+        VALIDATION_QUERY,
+        MIN_IDLE,
+        MAX_IDLE,
+        MAX_CONN_LIFETIME,
+        EVICTION_RUN_PERIOD,
+        MIN_EVICTABLE_IDLE_TIME,
+        SOFT_MIN_EVICTABLE_IDLE_TIME
+    );
 
     private volatile Boolean foundHadoopDependencies;
 
     // Holder of cached Configuration information so validation does not reload the same config over and over
     private final AtomicReference<ValidationResources> validationResourceHolder = new AtomicReference<>(null);
-
-    @Override
-    protected void init(final ControllerServiceInitializationContext context) {
-        properties = Arrays.asList(
-                DATABASE_URL,
-                DB_DRIVERNAME,
-                DB_DRIVER_LOCATION,
-                HADOOP_CONFIGURATION_RESOURCES,
-                KERBEROS_USER_SERVICE,
-                DB_USER,
-                DB_PASSWORD,
-                MAX_WAIT_TIME,
-                MAX_TOTAL_CONNECTIONS,
-                VALIDATION_QUERY,
-                MIN_IDLE,
-                MAX_IDLE,
-                MAX_CONN_LIFETIME,
-                EVICTION_RUN_PERIOD,
-                MIN_EVICTABLE_IDLE_TIME,
-                SOFT_MIN_EVICTABLE_IDLE_TIME
-        );
-    }
 
     @Override
     public void migrateProperties(final PropertyConfiguration config) {
@@ -154,7 +147,7 @@ public class HadoopDBCPConnectionPool extends AbstractDBCPConnectionPool {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-hadoop-dbcp-service-bundle/nifi-hadoop-dbcp-service/src/main/java/org/apache/nifi/dbcp/HadoopDBCPConnectionPool.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-hadoop-dbcp-service-bundle/nifi-hadoop-dbcp-service/src/main/java/org/apache/nifi/dbcp/HadoopDBCPConnectionPool.java
@@ -113,7 +113,7 @@ public class HadoopDBCPConnectionPool extends AbstractDBCPConnectionPool {
             .dynamicallyModifiesClasspath(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         DATABASE_URL,
         DB_DRIVERNAME,
         DB_DRIVER_LOCATION,
@@ -147,7 +147,7 @@ public class HadoopDBCPConnectionPool extends AbstractDBCPConnectionPool {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-http-context-map-bundle/nifi-http-context-map/src/main/java/org/apache/nifi/http/StandardHttpContextMap.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-http-context-map-bundle/nifi-http-context-map/src/main/java/org/apache/nifi/http/StandardHttpContextMap.java
@@ -65,7 +65,7 @@ public class StandardHttpContextMap extends AbstractControllerService implements
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         MAX_OUTSTANDING_REQUESTS,
         REQUEST_EXPIRATION
     );
@@ -80,7 +80,7 @@ public class StandardHttpContextMap extends AbstractControllerService implements
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-http-context-map-bundle/nifi-http-context-map/src/main/java/org/apache/nifi/http/StandardHttpContextMap.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-http-context-map-bundle/nifi-http-context-map/src/main/java/org/apache/nifi/http/StandardHttpContextMap.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.http;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +65,11 @@ public class StandardHttpContextMap extends AbstractControllerService implements
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        MAX_OUTSTANDING_REQUESTS,
+        REQUEST_EXPIRATION
+    );
+
     private static final long CLEANUP_MAX_DELAY_NANOS = 5_000_000_000L;
 
     private final ConcurrentMap<String, Wrapper> wrapperMap = new ConcurrentHashMap<>();
@@ -76,10 +80,7 @@ public class StandardHttpContextMap extends AbstractControllerService implements
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>(2);
-        properties.add(MAX_OUTSTANDING_REQUESTS);
-        properties.add(REQUEST_EXPIRATION);
-        return properties;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-key-service-bundle/nifi-key-service/src/main/java/org/apache/nifi/key/service/StandardPrivateKeyService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-key-service-bundle/nifi-key-service/src/main/java/org/apache/nifi/key/service/StandardPrivateKeyService.java
@@ -79,7 +79,7 @@ public class StandardPrivateKeyService extends AbstractControllerService impleme
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             KEY_FILE,
             KEY,
             KEY_PASSWORD
@@ -141,7 +141,7 @@ public class StandardPrivateKeyService extends AbstractControllerService impleme
      */
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-standard-services/nifi-key-service-bundle/nifi-key-service/src/main/java/org/apache/nifi/key/service/StandardPrivateKeyService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-key-service-bundle/nifi-key-service/src/main/java/org/apache/nifi/key/service/StandardPrivateKeyService.java
@@ -43,7 +43,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -80,7 +79,7 @@ public class StandardPrivateKeyService extends AbstractControllerService impleme
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> DESCRIPTORS = Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             KEY_FILE,
             KEY,
             KEY_PASSWORD
@@ -142,7 +141,7 @@ public class StandardPrivateKeyService extends AbstractControllerService impleme
      */
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/DistributedMapCacheLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/DistributedMapCacheLookupService.java
@@ -79,7 +79,7 @@ public class DistributedMapCacheLookupService extends AbstractControllerService 
             .defaultValue(StandardCharsets.UTF_8.displayName())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         PROP_DISTRIBUTED_CACHE_SERVICE,
         CHARACTER_ENCODING
     );
@@ -96,7 +96,7 @@ public class DistributedMapCacheLookupService extends AbstractControllerService 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/DistributedMapCacheLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/DistributedMapCacheLookupService.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -80,6 +79,11 @@ public class DistributedMapCacheLookupService extends AbstractControllerService 
             .defaultValue(StandardCharsets.UTF_8.displayName())
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        PROP_DISTRIBUTED_CACHE_SERVICE,
+        CHARACTER_ENCODING
+    );
+
     private static Set<String> getStandardCharsetNames() {
         return STANDARD_CHARSETS.stream().map(c -> c.displayName()).collect(Collectors.toSet());
     }
@@ -92,10 +96,7 @@ public class DistributedMapCacheLookupService extends AbstractControllerService 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(PROP_DISTRIBUTED_CACHE_SERVICE);
-        descriptors.add(CHARACTER_ENCODING);
-        return descriptors;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/RestLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/RestLookupService.java
@@ -212,33 +212,29 @@ public class RestLookupService extends AbstractControllerService implements Reco
     static final String BODY_KEY = "request.body";
     static final String METHOD_KEY = "request.method";
 
-    static final List<PropertyDescriptor> DESCRIPTORS;
-    static final Set<String> KEYS;
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        URL,
+        RECORD_READER,
+        RECORD_PATH,
+        RESPONSE_HANDLING_STRATEGY,
+        SSL_CONTEXT_SERVICE,
+        AUTHENTICATION_STRATEGY,
+        OAUTH2_ACCESS_TOKEN_PROVIDER,
+        PROXY_CONFIGURATION_SERVICE,
+        PROP_BASIC_AUTH_USERNAME,
+        PROP_BASIC_AUTH_PASSWORD,
+        PROP_DIGEST_AUTH,
+        PROP_CONNECT_TIMEOUT,
+        PROP_READ_TIMEOUT
+    );
+
+    static final Set<String> KEYS = Set.of();
 
     static final List<String> VALID_VERBS = Arrays.asList("delete", "get", "post", "put");
 
-    static {
-        DESCRIPTORS = Collections.unmodifiableList(Arrays.asList(
-            URL,
-            RECORD_READER,
-            RECORD_PATH,
-            RESPONSE_HANDLING_STRATEGY,
-            SSL_CONTEXT_SERVICE,
-            AUTHENTICATION_STRATEGY,
-            OAUTH2_ACCESS_TOKEN_PROVIDER,
-            PROXY_CONFIGURATION_SERVICE,
-            PROP_BASIC_AUTH_USERNAME,
-            PROP_BASIC_AUTH_PASSWORD,
-            PROP_DIGEST_AUTH,
-            PROP_CONNECT_TIMEOUT,
-            PROP_READ_TIMEOUT
-        ));
-        KEYS = Collections.emptySet();
-    }
-
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return DESCRIPTORS;
+        return PROPERTIES;
     }
 
     private volatile ProxyConfigurationService proxyConfigurationService;

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/RestLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/RestLookupService.java
@@ -212,7 +212,7 @@ public class RestLookupService extends AbstractControllerService implements Reco
     static final String BODY_KEY = "request.body";
     static final String METHOD_KEY = "request.method";
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         URL,
         RECORD_READER,
         RECORD_PATH,
@@ -234,7 +234,7 @@ public class RestLookupService extends AbstractControllerService implements Reco
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private volatile ProxyConfigurationService proxyConfigurationService;

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/configuration2/CommonsConfigurationLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/configuration2/CommonsConfigurationLookupService.java
@@ -67,7 +67,7 @@ public abstract class CommonsConfigurationLookupService<T extends FileBasedConfi
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CONFIGURATION_FILE
     );
 
@@ -89,7 +89,7 @@ public abstract class CommonsConfigurationLookupService<T extends FileBasedConfi
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/configuration2/CommonsConfigurationLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/configuration2/CommonsConfigurationLookupService.java
@@ -30,7 +30,6 @@ import org.apache.nifi.components.resource.ResourceCardinality;
 import org.apache.nifi.components.resource.ResourceType;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
-import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.lookup.LookupFailureException;
 import org.apache.nifi.lookup.StringLookupService;
@@ -38,7 +37,6 @@ import org.apache.nifi.reporting.InitializationException;
 
 import java.io.File;
 import java.lang.reflect.ParameterizedType;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -69,9 +67,12 @@ public abstract class CommonsConfigurationLookupService<T extends FileBasedConfi
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            CONFIGURATION_FILE
+    );
+
     private final Class<T> resultClass = (Class<T>) ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
 
-    private List<PropertyDescriptor> properties;
 
     private volatile ReloadingFileBasedConfigurationBuilder<T> builder;
 
@@ -88,14 +89,7 @@ public abstract class CommonsConfigurationLookupService<T extends FileBasedConfi
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
-    }
-
-    @Override
-    protected void init(final ControllerServiceInitializationContext context) throws InitializationException {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(CONFIGURATION_FILE);
-        this.properties = Collections.unmodifiableList(properties);
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/AbstractDatabaseLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/AbstractDatabaseLookupService.java
@@ -22,17 +22,16 @@ import org.apache.nifi.dbcp.DBCPService;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.util.StandardValidators;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class AbstractDatabaseLookupService extends AbstractControllerService {
 
     static final String KEY = "key";
 
-    static final Set<String> REQUIRED_KEYS = Collections.unmodifiableSet(Stream.of(KEY).collect(Collectors.toSet()));
+    static final Set<String> REQUIRED_KEYS = Set.of(
+        KEY
+    );
 
     static final PropertyDescriptor DBCP_SERVICE = new PropertyDescriptor.Builder()
             .name("dbrecord-lookup-dbcp-service")

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
@@ -40,9 +40,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -71,19 +69,21 @@ public class DatabaseRecordLookupService extends AbstractDatabaseLookupService i
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        DBCP_SERVICE,
+        TABLE_NAME,
+        LOOKUP_KEY_COLUMN,
+        LOOKUP_VALUE_COLUMNS,
+        CACHE_SIZE,
+        CLEAR_CACHE_ON_ENABLED,
+        CACHE_EXPIRATION,
+        DEFAULT_PRECISION,
+        DEFAULT_SCALE
+    );
+
     @Override
     protected void init(final ControllerServiceInitializationContext context) {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(DBCP_SERVICE);
-        properties.add(TABLE_NAME);
-        properties.add(LOOKUP_KEY_COLUMN);
-        properties.add(LOOKUP_VALUE_COLUMNS);
-        properties.add(CACHE_SIZE);
-        properties.add(CLEAR_CACHE_ON_ENABLED);
-        properties.add(CACHE_EXPIRATION);
-        properties.add(DEFAULT_PRECISION);
-        properties.add(DEFAULT_SCALE);
-        this.properties = Collections.unmodifiableList(properties);
+        this.properties = PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/DatabaseRecordLookupService.java
@@ -69,7 +69,7 @@ public class DatabaseRecordLookupService extends AbstractDatabaseLookupService i
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         DBCP_SERVICE,
         TABLE_NAME,
         LOOKUP_KEY_COLUMN,
@@ -83,7 +83,7 @@ public class DatabaseRecordLookupService extends AbstractDatabaseLookupService i
 
     @Override
     protected void init(final ControllerServiceInitializationContext context) {
-        this.properties = PROPERTIES;
+        this.properties = PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/SimpleDatabaseLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/SimpleDatabaseLookupService.java
@@ -60,7 +60,7 @@ public class SimpleDatabaseLookupService extends AbstractDatabaseLookupService i
                     .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
                     .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         DBCP_SERVICE,
         TABLE_NAME,
         LOOKUP_KEY_COLUMN,
@@ -72,7 +72,7 @@ public class SimpleDatabaseLookupService extends AbstractDatabaseLookupService i
 
     @Override
     protected void init(final ControllerServiceInitializationContext context) {
-        this.properties = PROPERTIES;
+        this.properties = PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/SimpleDatabaseLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/db/SimpleDatabaseLookupService.java
@@ -37,8 +37,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -62,17 +60,19 @@ public class SimpleDatabaseLookupService extends AbstractDatabaseLookupService i
                     .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
                     .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        DBCP_SERVICE,
+        TABLE_NAME,
+        LOOKUP_KEY_COLUMN,
+        LOOKUP_VALUE_COLUMN,
+        CACHE_SIZE,
+        CLEAR_CACHE_ON_ENABLED,
+        CACHE_EXPIRATION
+    );
+
     @Override
     protected void init(final ControllerServiceInitializationContext context) {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(DBCP_SERVICE);
-        properties.add(TABLE_NAME);
-        properties.add(LOOKUP_KEY_COLUMN);
-        properties.add(LOOKUP_VALUE_COLUMN);
-        properties.add(CACHE_SIZE);
-        properties.add(CLEAR_CACHE_ON_ENABLED);
-        properties.add(CACHE_EXPIRATION);
-        this.properties = Collections.unmodifiableList(properties);
+        this.properties = PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/maxmind/IPLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/maxmind/IPLookupService.java
@@ -138,7 +138,7 @@ public class IPLookupService extends AbstractControllerService implements Record
         .required(true)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         GEO_DATABASE_FILE,
         LOOKUP_CITY,
         LOOKUP_ISP,
@@ -149,7 +149,7 @@ public class IPLookupService extends AbstractControllerService implements Record
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/maxmind/IPLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/maxmind/IPLookupService.java
@@ -50,7 +50,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -139,16 +138,18 @@ public class IPLookupService extends AbstractControllerService implements Record
         .required(true)
         .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        GEO_DATABASE_FILE,
+        LOOKUP_CITY,
+        LOOKUP_ISP,
+        LOOKUP_DOMAIN,
+        LOOKUP_CONNECTION_TYPE,
+        LOOKUP_ANONYMOUS_IP_INFO
+    );
+
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(GEO_DATABASE_FILE);
-        properties.add(LOOKUP_CITY);
-        properties.add(LOOKUP_ISP);
-        properties.add(LOOKUP_DOMAIN);
-        properties.add(LOOKUP_CONNECTION_TYPE);
-        properties.add(LOOKUP_ANONYMOUS_IP_INFO);
-        return properties;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
@@ -209,7 +209,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
 
     private static final ProxySpec[] PROXY_SPECS = {ProxySpec.HTTP_AUTH};
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         AUTHORIZATION_SERVER_URL,
         CLIENT_AUTHENTICATION_STRATEGY,
         GRANT_TYPE,
@@ -251,7 +251,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
@@ -55,7 +55,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -210,7 +209,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
 
     private static final ProxySpec[] PROXY_SPECS = {ProxySpec.HTTP_AUTH};
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
         AUTHORIZATION_SERVER_URL,
         CLIENT_AUTHENTICATION_STRATEGY,
         GRANT_TYPE,
@@ -226,7 +225,7 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         SSL_CONTEXT,
         HTTP_PROTOCOL_STRATEGY,
         ProxyConfiguration.createProxyConfigPropertyDescriptor(PROXY_SPECS)
-    ));
+    );
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-proxy-configuration-bundle/nifi-proxy-configuration/src/main/java/org/apache/nifi/proxy/StandardProxyConfigurationService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-proxy-configuration-bundle/nifi-proxy-configuration/src/main/java/org/apache/nifi/proxy/StandardProxyConfigurationService.java
@@ -89,18 +89,20 @@ public class StandardProxyConfigurationService extends AbstractControllerService
             .sensitive(true)
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        PROXY_TYPE,
+        SOCKS_VERSION,
+        PROXY_SERVER_HOST,
+        PROXY_SERVER_PORT,
+        PROXY_USER_NAME,
+        PROXY_USER_PASSWORD
+    );
+
     private volatile ProxyConfiguration configuration = ProxyConfiguration.DIRECT_CONFIGURATION;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(PROXY_TYPE);
-        properties.add(SOCKS_VERSION);
-        properties.add(PROXY_SERVER_HOST);
-        properties.add(PROXY_SERVER_PORT);
-        properties.add(PROXY_USER_NAME);
-        properties.add(PROXY_USER_PASSWORD);
-        return properties;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-proxy-configuration-bundle/nifi-proxy-configuration/src/main/java/org/apache/nifi/proxy/StandardProxyConfigurationService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-proxy-configuration-bundle/nifi-proxy-configuration/src/main/java/org/apache/nifi/proxy/StandardProxyConfigurationService.java
@@ -89,7 +89,7 @@ public class StandardProxyConfigurationService extends AbstractControllerService
             .sensitive(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         PROXY_TYPE,
         SOCKS_VERSION,
         PROXY_SERVER_HOST,
@@ -102,7 +102,7 @@ public class StandardProxyConfigurationService extends AbstractControllerService
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/lookup/ReaderLookup.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/lookup/ReaderLookup.java
@@ -68,13 +68,16 @@ public class ReaderLookup extends AbstractControllerService implements RecordRea
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        SERVICE_TO_USE
+    );
 
     private volatile Map<String, RecordReaderFactory> recordReaderFactoryMap;
     private volatile PropertyValue serviceToUseValue;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return Collections.singletonList(SERVICE_TO_USE);
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/lookup/ReaderLookup.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/lookup/ReaderLookup.java
@@ -68,7 +68,7 @@ public class ReaderLookup extends AbstractControllerService implements RecordRea
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         SERVICE_TO_USE
     );
 
@@ -77,7 +77,7 @@ public class ReaderLookup extends AbstractControllerService implements RecordRea
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/lookup/RecordSetWriterLookup.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/lookup/RecordSetWriterLookup.java
@@ -67,6 +67,9 @@ public class RecordSetWriterLookup extends AbstractControllerService implements 
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            SERVICE_TO_USE
+    );
 
     private volatile Map<String, RecordSetWriterFactory> recordSetWriterFactoryMap;
     private volatile PropertyValue serviceToUseValue;
@@ -82,7 +85,7 @@ public class RecordSetWriterLookup extends AbstractControllerService implements 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return Collections.singletonList(SERVICE_TO_USE);
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/lookup/RecordSetWriterLookup.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/lookup/RecordSetWriterLookup.java
@@ -67,7 +67,7 @@ public class RecordSetWriterLookup extends AbstractControllerService implements 
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             SERVICE_TO_USE
     );
 
@@ -85,7 +85,7 @@ public class RecordSetWriterLookup extends AbstractControllerService implements 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/schema/inference/VolatileSchemaCache.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/schema/inference/VolatileSchemaCache.java
@@ -59,7 +59,7 @@ public class VolatileSchemaCache extends AbstractControllerService implements Re
 
     private static final Base64.Encoder ENCODER = Base64.getEncoder().withoutPadding();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         MAX_SIZE
     );
 
@@ -67,7 +67,7 @@ public class VolatileSchemaCache extends AbstractControllerService implements Re
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/schema/inference/VolatileSchemaCache.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/schema/inference/VolatileSchemaCache.java
@@ -38,7 +38,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -60,11 +59,15 @@ public class VolatileSchemaCache extends AbstractControllerService implements Re
 
     private static final Base64.Encoder ENCODER = Base64.getEncoder().withoutPadding();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        MAX_SIZE
+    );
+
     private volatile Cache<String, RecordSchema> cache;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return Collections.singletonList(MAX_SIZE);
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/text/FreeFormTextRecordSetWriter.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/text/FreeFormTextRecordSetWriter.java
@@ -35,7 +35,6 @@ import org.apache.nifi.serialization.record.RecordSchema;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -61,15 +60,17 @@ public class FreeFormTextRecordSetWriter extends AbstractControllerService imple
         .required(true)
         .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        TEXT,
+        CHARACTER_SET
+    );
+
     private volatile PropertyValue textValue;
     private volatile Charset characterSet;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(TEXT);
-        properties.add(CHARACTER_SET);
-        return properties;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/text/FreeFormTextRecordSetWriter.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/text/FreeFormTextRecordSetWriter.java
@@ -60,7 +60,7 @@ public class FreeFormTextRecordSetWriter extends AbstractControllerService imple
         .required(true)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         TEXT,
         CHARACTER_SET
     );
@@ -70,7 +70,7 @@ public class FreeFormTextRecordSetWriter extends AbstractControllerService imple
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/EmailRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/EmailRecordSink.java
@@ -174,7 +174,7 @@ public class EmailRecordSink extends AbstractControllerService implements Record
             .defaultValue("NiFi")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             FROM,
             TO,
             CC,
@@ -212,7 +212,7 @@ public class EmailRecordSink extends AbstractControllerService implements Record
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/EmailRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/EmailRecordSink.java
@@ -47,9 +47,7 @@ import org.apache.nifi.util.StringUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -176,6 +174,23 @@ public class EmailRecordSink extends AbstractControllerService implements Record
             .defaultValue("NiFi")
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            FROM,
+            TO,
+            CC,
+            BCC,
+            SUBJECT,
+            SMTP_HOSTNAME,
+            SMTP_PORT,
+            SMTP_AUTH,
+            SMTP_USERNAME,
+            SMTP_PASSWORD,
+            SMTP_STARTTLS,
+            SMTP_SSL,
+            HEADER_XMAILER,
+            RecordSinkService.RECORD_WRITER_FACTORY
+    );
+
     private volatile RecordSetWriterFactory writerFactory;
 
     /**
@@ -197,22 +212,7 @@ public class EmailRecordSink extends AbstractControllerService implements Record
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return Collections.unmodifiableList(Arrays.asList(
-                FROM,
-                TO,
-                CC,
-                BCC,
-                SUBJECT,
-                SMTP_HOSTNAME,
-                SMTP_PORT,
-                SMTP_AUTH,
-                SMTP_USERNAME,
-                SMTP_PASSWORD,
-                SMTP_STARTTLS,
-                SMTP_SSL,
-                HEADER_XMAILER,
-                RecordSinkService.RECORD_WRITER_FACTORY
-        ));
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/HttpRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/HttpRecordSink.java
@@ -46,8 +46,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -94,20 +92,20 @@ public class HttpRecordSink extends AbstractControllerService implements RecordS
             .required(false)
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            API_URL,
+            MAX_BATCH_SIZE,
+            RECORD_WRITER_FACTORY,
+            WEB_SERVICE_CLIENT_PROVIDER,
+            OAUTH2_ACCESS_TOKEN_PROVIDER
+    );
+
     private String apiUrl;
     private int maxBatchSize;
     private volatile RecordSetWriterFactory writerFactory;
     private WebClientServiceProvider webClientServiceProvider;
     private volatile Optional<OAuth2AccessTokenProvider> oauth2AccessTokenProviderOptional;
     Map<String, String> dynamicHttpHeaders;
-
-    public static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
-            API_URL,
-            MAX_BATCH_SIZE,
-            RECORD_WRITER_FACTORY,
-            WEB_SERVICE_CLIENT_PROVIDER,
-            OAUTH2_ACCESS_TOKEN_PROVIDER
-    ));
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/HttpRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/HttpRecordSink.java
@@ -92,7 +92,7 @@ public class HttpRecordSink extends AbstractControllerService implements RecordS
             .required(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             API_URL,
             MAX_BATCH_SIZE,
             RECORD_WRITER_FACTORY,
@@ -109,7 +109,7 @@ public class HttpRecordSink extends AbstractControllerService implements RecordS
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/LoggingRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/LoggingRecordSink.java
@@ -50,7 +50,7 @@ public class LoggingRecordSink extends AbstractControllerService implements Reco
             .defaultValue(LogLevel.INFO.name())
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             RecordSinkService.RECORD_WRITER_FACTORY,
             LOG_LEVEL
     );
@@ -60,7 +60,7 @@ public class LoggingRecordSink extends AbstractControllerService implements Reco
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/LoggingRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/LoggingRecordSink.java
@@ -22,7 +22,6 @@ import org.apache.nifi.annotation.lifecycle.OnEnabled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
-import org.apache.nifi.controller.ControllerServiceInitializationContext;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.logging.LogLevel;
 import org.apache.nifi.reporting.InitializationException;
@@ -35,18 +34,12 @@ import org.apache.nifi.serialization.record.RecordSet;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 @Tags({"record", "sink", "log"})
 @CapabilityDescription("Provides a RecordSinkService that can be used to log records to the application log (nifi-app.log, e.g.) using the specified writer for formatting.")
 public class LoggingRecordSink extends AbstractControllerService implements RecordSinkService {
-
-    private List<PropertyDescriptor> properties;
-    private volatile RecordSetWriterFactory writerFactory;
-    private volatile LogLevel logLevel;
 
     public static final PropertyDescriptor LOG_LEVEL = new PropertyDescriptor.Builder()
             .name("logsink-log-level")
@@ -57,18 +50,17 @@ public class LoggingRecordSink extends AbstractControllerService implements Reco
             .defaultValue(LogLevel.INFO.name())
             .build();
 
-    @Override
-    protected void init(final ControllerServiceInitializationContext context) throws InitializationException {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(RecordSinkService.RECORD_WRITER_FACTORY);
-        properties.add(LOG_LEVEL);
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+            RecordSinkService.RECORD_WRITER_FACTORY,
+            LOG_LEVEL
+    );
 
-        this.properties = Collections.unmodifiableList(properties);
-    }
+    private volatile RecordSetWriterFactory writerFactory;
+    private volatile LogLevel logLevel;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/event/UDPEventRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/event/UDPEventRecordSink.java
@@ -78,7 +78,7 @@ public class UDPEventRecordSink extends AbstractControllerService implements Rec
             .defaultValue("2")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         HOSTNAME,
         PORT,
         RECORD_WRITER_FACTORY,
@@ -97,7 +97,7 @@ public class UDPEventRecordSink extends AbstractControllerService implements Rec
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/event/UDPEventRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/main/java/org/apache/nifi/record/sink/event/UDPEventRecordSink.java
@@ -39,8 +39,6 @@ import org.apache.nifi.serialization.record.RecordSet;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,13 +78,11 @@ public class UDPEventRecordSink extends AbstractControllerService implements Rec
             .defaultValue("2")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Collections.unmodifiableList(
-            Arrays.asList(
-                    HOSTNAME,
-                    PORT,
-                    RECORD_WRITER_FACTORY,
-                    SENDER_THREADS
-            )
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        HOSTNAME,
+        PORT,
+        RECORD_WRITER_FACTORY,
+        SENDER_THREADS
     );
 
     private static final String TRANSIT_URI_ATTRIBUTE_KEY = "record.sink.url";
@@ -101,7 +97,7 @@ public class UDPEventRecordSink extends AbstractControllerService implements Rec
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/PEMEncodedSSLContextProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/PEMEncodedSSLContextProvider.java
@@ -141,7 +141,7 @@ public class PEMEncodedSSLContextProvider extends AbstractControllerService impl
             .dependsOn(CERTIFICATE_AUTHORITIES_SOURCE, CertificateAuthoritiesSource.PROPERTIES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             TLS_PROTOCOL,
             PRIVATE_KEY_SOURCE,
             PRIVATE_KEY,
@@ -162,7 +162,7 @@ public class PEMEncodedSSLContextProvider extends AbstractControllerService impl
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/PEMEncodedSSLContextProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/PEMEncodedSSLContextProvider.java
@@ -141,7 +141,7 @@ public class PEMEncodedSSLContextProvider extends AbstractControllerService impl
             .dependsOn(CERTIFICATE_AUTHORITIES_SOURCE, CertificateAuthoritiesSource.PROPERTIES)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             TLS_PROTOCOL,
             PRIVATE_KEY_SOURCE,
             PRIVATE_KEY,
@@ -162,7 +162,7 @@ public class PEMEncodedSSLContextProvider extends AbstractControllerService impl
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
@@ -141,7 +141,7 @@ public class StandardSSLContextService extends AbstractControllerService impleme
             .sensitive(false)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             KEYSTORE,
             KEYSTORE_PASSWORD,
             KEY_PASSWORD,
@@ -185,7 +185,7 @@ public class StandardSSLContextService extends AbstractControllerService impleme
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-ssl-context-bundle/nifi-ssl-context-service/src/main/java/org/apache/nifi/ssl/StandardSSLContextService.java
@@ -141,7 +141,7 @@ public class StandardSSLContextService extends AbstractControllerService impleme
             .sensitive(false)
             .build();
 
-    private static final List<PropertyDescriptor> properties = List.of(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             KEYSTORE,
             KEYSTORE_PASSWORD,
             KEY_PASSWORD,
@@ -185,7 +185,7 @@ public class StandardSSLContextService extends AbstractControllerService impleme
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTIES;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-web-client-provider-bundle/nifi-web-client-provider-service/src/main/java/org/apache/nifi/web/client/provider/service/StandardWebClientServiceProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-web-client-provider-bundle/nifi-web-client-provider-service/src/main/java/org/apache/nifi/web/client/provider/service/StandardWebClientServiceProvider.java
@@ -98,7 +98,7 @@ public class StandardWebClientServiceProvider extends AbstractControllerService 
             .identifiesControllerService(SSLContextProvider.class)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             CONNECT_TIMEOUT,
             READ_TIMEOUT,
             WRITE_TIMEOUT,
@@ -161,7 +161,7 @@ public class StandardWebClientServiceProvider extends AbstractControllerService 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     private Duration getDuration(final ConfigurationContext context, final PropertyDescriptor propertyDescriptor) {

--- a/nifi-extension-bundles/nifi-standard-services/nifi-web-client-provider-bundle/nifi-web-client-provider-service/src/main/java/org/apache/nifi/web/client/provider/service/StandardWebClientServiceProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-web-client-provider-bundle/nifi-web-client-provider-service/src/main/java/org/apache/nifi/web/client/provider/service/StandardWebClientServiceProvider.java
@@ -43,7 +43,6 @@ import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 import java.net.Proxy;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -99,7 +98,7 @@ public class StandardWebClientServiceProvider extends AbstractControllerService 
             .identifiesControllerService(SSLContextProvider.class)
             .build();
 
-    static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Arrays.asList(
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
             CONNECT_TIMEOUT,
             READ_TIMEOUT,
             WRITE_TIMEOUT,
@@ -162,7 +161,7 @@ public class StandardWebClientServiceProvider extends AbstractControllerService 
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
+        return PROPERTIES;
     }
 
     private Duration getDuration(final ConfigurationContext context, final PropertyDescriptor propertyDescriptor) {

--- a/nifi-extension-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-processors/src/main/java/org/apache/nifi/processors/stateful/analysis/AttributeRollingWindow.java
+++ b/nifi-extension-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-processors/src/main/java/org/apache/nifi/processors/stateful/analysis/AttributeRollingWindow.java
@@ -127,7 +127,7 @@ public class AttributeRollingWindow extends AbstractProcessor {
                 REL_FAILED_SET_STATE,
                 REL_FAILURE);
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             VALUE_TO_TRACK,
             TIME_WINDOW,
             SUB_WINDOW_LENGTH
@@ -143,7 +143,7 @@ public class AttributeRollingWindow extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnScheduled

--- a/nifi-extension-bundles/nifi-update-attribute-bundle/nifi-update-attribute-processor/src/main/java/org/apache/nifi/processors/attributes/UpdateAttribute.java
+++ b/nifi-extension-bundles/nifi-update-attribute-bundle/nifi-update-attribute-processor/src/main/java/org/apache/nifi/processors/attributes/UpdateAttribute.java
@@ -231,7 +231,7 @@ public class UpdateAttribute extends AbstractProcessor implements Searchable {
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             DELETE_ATTRIBUTES,
             STORE_STATE,
             STATEFUL_VARIABLES_INIT_VALUE,
@@ -254,7 +254,7 @@ public class UpdateAttribute extends AbstractProcessor implements Searchable {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ConnectWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ConnectWebSocket.java
@@ -79,7 +79,7 @@ public class ConnectWebSocket extends AbstractWebSocketGatewayProcessor {
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PROP_WEBSOCKET_CLIENT_SERVICE,
             PROP_WEBSOCKET_CLIENT_ID
     );
@@ -96,7 +96,7 @@ public class ConnectWebSocket extends AbstractWebSocketGatewayProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ListenWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/ListenWebSocket.java
@@ -83,7 +83,7 @@ public class ListenWebSocket extends AbstractWebSocketGatewayProcessor {
             })
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PROP_WEBSOCKET_SERVER_SERVICE,
             PROP_SERVER_URL_PATH
     );
@@ -97,7 +97,7 @@ public class ListenWebSocket extends AbstractWebSocketGatewayProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/PutWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/PutWebSocket.java
@@ -125,7 +125,7 @@ public class PutWebSocket extends AbstractProcessor {
             .description("FlowFiles that failed to send to the destination are transferred to this relationship.")
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             PROP_WS_SESSION_ID,
             PROP_WS_CONTROLLER_SERVICE_ID,
             PROP_WS_CONTROLLER_SERVICE_ENDPOINT,
@@ -144,7 +144,7 @@ public class PutWebSocket extends AbstractProcessor {
 
     @Override
     public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/AbstractJettyWebSocketService.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/AbstractJettyWebSocketService.java
@@ -20,7 +20,6 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.websocket.AbstractWebSocketService;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public abstract class AbstractJettyWebSocketService extends AbstractWebSocketService {
@@ -52,11 +51,13 @@ public abstract class AbstractJettyWebSocketService extends AbstractWebSocketSer
             .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
             .build();
 
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            INPUT_BUFFER_SIZE,
+            MAX_TEXT_MESSAGE_SIZE,
+            MAX_BINARY_MESSAGE_SIZE
+    );
+
     static List<PropertyDescriptor> getAbstractPropertyDescriptors() {
-        final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(INPUT_BUFFER_SIZE);
-        descriptors.add(MAX_TEXT_MESSAGE_SIZE);
-        descriptors.add(MAX_BINARY_MESSAGE_SIZE);
-        return descriptors;
+        return PROPERTY_DESCRIPTORS;
     }
 }

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketClient.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketClient.java
@@ -66,6 +66,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
 
 @Tags({"WebSocket", "Jetty", "client"})
 @CapabilityDescription("Implementation of WebSocketClientService." +
@@ -193,24 +194,23 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
 
     private static final int INITIAL_BACKOFF_MILLIS = 100;
     private static final int MAXIMUM_BACKOFF_MILLIS = 3200;
-    private static final List<PropertyDescriptor> properties;
 
-    static {
-        final List<PropertyDescriptor> props = new ArrayList<>(getAbstractPropertyDescriptors());
-        props.add(WS_URI);
-        props.add(SSL_CONTEXT);
-        props.add(CONNECTION_TIMEOUT);
-        props.add(CONNECTION_ATTEMPT_COUNT);
-        props.add(SESSION_MAINTENANCE_INTERVAL);
-        props.add(USER_NAME);
-        props.add(USER_PASSWORD);
-        props.add(AUTH_CHARSET);
-        props.add(CUSTOM_AUTH);
-        props.add(PROXY_HOST);
-        props.add(PROXY_PORT);
-
-        properties = Collections.unmodifiableList(props);
-    }
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getAbstractPropertyDescriptors().stream(),
+            Stream.of(
+                    WS_URI,
+                    SSL_CONTEXT,
+                    CONNECTION_TIMEOUT,
+                    CONNECTION_ATTEMPT_COUNT,
+                    SESSION_MAINTENANCE_INTERVAL,
+                    USER_NAME,
+                    USER_PASSWORD,
+                    AUTH_CHARSET,
+                    CUSTOM_AUTH,
+                    PROXY_HOST,
+                    PROXY_PORT
+            )
+    ).toList();
 
     private final Map<String, SessionInfo> activeSessions = new ConcurrentHashMap<>();
     private final ReentrantLock connectionLock = new ReentrantLock();
@@ -224,7 +224,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketServer.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketServer.java
@@ -69,6 +69,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 @Tags({"WebSocket", "Jetty", "server"})
 @CapabilityDescription("Implementation of WebSocketServerService." +
@@ -165,28 +166,26 @@ public class JettyWebSocketServer extends AbstractJettyWebSocketService implemen
             .identifiesExternalResource(ResourceCardinality.SINGLE, ResourceType.FILE)
             .build();
 
-    private static final List<PropertyDescriptor> properties;
-
-    static {
-        final List<PropertyDescriptor> props = new ArrayList<>(getAbstractPropertyDescriptors());
-        props.add(LISTEN_PORT);
-        props.add(SSL_CONTEXT);
-        props.add(CLIENT_AUTH);
-        props.add(BASIC_AUTH);
-        props.add(AUTH_PATH_SPEC);
-        props.add(AUTH_ROLES);
-        props.add(LOGIN_SERVICE);
-        props.add(USERS_PROPERTIES_FILE);
-
-        properties = Collections.unmodifiableList(props);
-    }
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = Stream.concat(
+            getAbstractPropertyDescriptors().stream(),
+            Stream.of(
+                LISTEN_PORT,
+                SSL_CONTEXT,
+                CLIENT_AUTH,
+                BASIC_AUTH,
+                AUTH_PATH_SPEC,
+                AUTH_ROLES,
+                LOGIN_SERVICE,
+                USERS_PROPERTIES_FILE
+            )
+    ).toList();
 
     private Server server;
     private Integer listenPort;
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return properties;
+        return PROPERTY_DESCRIPTORS;
     }
 
 

--- a/nifi-extension-bundles/nifi-workday-bundle/nifi-workday-processors/src/main/java/org/apache/nifi/processors/workday/GetWorkdayReport.java
+++ b/nifi-extension-bundles/nifi-workday-bundle/nifi-workday-processors/src/main/java/org/apache/nifi/processors/workday/GetWorkdayReport.java
@@ -201,7 +201,7 @@ public class GetWorkdayReport extends AbstractProcessor {
             FAILURE
     );
 
-    protected static final List<PropertyDescriptor> PROPERTIES = List.of(
+    protected static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             REPORT_URL,
             AUTH_TYPE,
             OAUTH2_ACCESS_TOKEN_PROVIDER,
@@ -219,7 +219,7 @@ public class GetWorkdayReport extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-zendesk-bundle/nifi-zendesk-processors/src/main/java/org/apache/nifi/processors/zendesk/PutZendeskTicket.java
+++ b/nifi-extension-bundles/nifi-zendesk-bundle/nifi-zendesk-processors/src/main/java/org/apache/nifi/processors/zendesk/PutZendeskTicket.java
@@ -117,7 +117,7 @@ public class PutZendeskTicket extends AbstractZendesk {
             .dependsOn(RECORD_READER)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             WEB_CLIENT_SERVICE_PROVIDER,
             ZENDESK_SUBDOMAIN,
             ZENDESK_USER,
@@ -158,7 +158,7 @@ public class PutZendeskTicket extends AbstractZendesk {
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-zendesk-bundle/nifi-zendesk-services/src/main/java/org/apache/nifi/services/zendesk/ZendeskRecordSink.java
+++ b/nifi-extension-bundles/nifi-zendesk-bundle/nifi-zendesk-services/src/main/java/org/apache/nifi/services/zendesk/ZendeskRecordSink.java
@@ -102,7 +102,7 @@ public class ZendeskRecordSink extends AbstractControllerService implements Reco
             .required(true)
             .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
             WEB_CLIENT_SERVICE_PROVIDER,
             ZENDESK_SUBDOMAIN,
             ZENDESK_USER,
@@ -129,7 +129,7 @@ public class ZendeskRecordSink extends AbstractControllerService implements Reco
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/main/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProvider.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-kubernetes-bundle/nifi-framework-kubernetes-state-provider/src/main/java/org/apache/nifi/kubernetes/state/provider/KubernetesConfigMapStateProvider.java
@@ -61,7 +61,9 @@ public class KubernetesConfigMapStateProvider extends AbstractConfigurableCompon
         .required(false)
         .build();
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(CONFIG_MAP_NAME_PREFIX);
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            CONFIG_MAP_NAME_PREFIX
+    );
 
     private static final int MAX_UPDATE_ATTEMPTS = 5;
 
@@ -100,7 +102,7 @@ public class KubernetesConfigMapStateProvider extends AbstractConfigurableCompon
 
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     /**

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/ServiceA.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/ServiceA.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.controller.service.mock;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.nifi.components.PropertyDescriptor;
@@ -39,10 +38,10 @@ public class ServiceA extends AbstractControllerService {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(OTHER_SERVICE);
-        descriptors.add(OTHER_SERVICE_2);
-        return descriptors;
+        return List.of(
+                OTHER_SERVICE,
+                OTHER_SERVICE_2
+        );
     }
 
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/ServiceC.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/ServiceC.java
@@ -16,7 +16,6 @@
  */
 package org.apache.nifi.controller.service.mock;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.nifi.components.PropertyDescriptor;
@@ -45,11 +44,11 @@ public class ServiceC extends AbstractControllerService {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(REQ_SERVICE_1);
-        descriptors.add(REQ_SERVICE_2);
-        descriptors.add(OPT_SERVICE);
-        return descriptors;
+        return List.of(
+                REQ_SERVICE_1,
+                REQ_SERVICE_2,
+                OPT_SERVICE
+        );
     }
 
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/ServiceD.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/ServiceD.java
@@ -19,7 +19,6 @@ package org.apache.nifi.controller.service.mock;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.AbstractControllerService;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class ServiceD extends AbstractControllerService {
@@ -36,10 +35,10 @@ public class ServiceD extends AbstractControllerService {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> descriptors = new ArrayList<>();
-        descriptors.add(PROP_FOO1);
-        descriptors.add(PROP_FOO2);
-        return descriptors;
+        return List.of(
+                PROP_FOO1,
+                PROP_FOO2
+        );
     }
 
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/processors/DynamicPropertiesTestProcessor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/test/processors/DynamicPropertiesTestProcessor.java
@@ -30,7 +30,6 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -59,9 +58,9 @@ public class DynamicPropertiesTestProcessor extends AbstractProcessor {
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
-    public static final List<PropertyDescriptor> PROPERTIES = Collections.unmodifiableList(Arrays.asList(
-            STATIC_PROPERTY
-    ));
+    public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+        STATIC_PROPERTY
+    );
 
     private ProcessorNode processorNode;
 
@@ -88,7 +87,7 @@ public class DynamicPropertiesTestProcessor extends AbstractProcessor {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @Override

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/ClassloaderIsolationKeyProviderService.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/ClassloaderIsolationKeyProviderService.java
@@ -22,7 +22,6 @@ import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.processor.util.StandardValidators;
 
-import java.util.Collections;
 import java.util.List;
 
 public class ClassloaderIsolationKeyProviderService extends AbstractControllerService implements KeyProviderService {
@@ -36,7 +35,9 @@ public class ClassloaderIsolationKeyProviderService extends AbstractControllerSe
 
     private volatile String keyField;
 
-    private static final List<PropertyDescriptor> PROPERTIES = Collections.singletonList(KEY_FIELD);
+    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+        KEY_FIELD
+    );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/ClassloaderIsolationKeyProviderService.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/ClassloaderIsolationKeyProviderService.java
@@ -35,13 +35,13 @@ public class ClassloaderIsolationKeyProviderService extends AbstractControllerSe
 
     private volatile String keyField;
 
-    private static final List<PropertyDescriptor> PROPERTIES = List.of(
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
         KEY_FIELD
     );
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return PROPERTIES;
+        return PROPERTY_DESCRIPTORS;
     }
 
     @OnEnabled

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/EnsureControllerServiceConfigurationCorrect.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/EnsureControllerServiceConfigurationCorrect.java
@@ -26,7 +26,6 @@ import org.apache.nifi.controller.VerifiableControllerService;
 import org.apache.nifi.logging.ComponentLog;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,7 +71,12 @@ public class EnsureControllerServiceConfigurationCorrect extends AbstractControl
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return Arrays.asList(SUCCESSFUL_VERIFICATION, VERIFICATION_STEPS, EXCEPTION_ON_VERIFICATION, FAILURE_NODE_NUMBER);
+        return List.of(
+            SUCCESSFUL_VERIFICATION,
+            VERIFICATION_STEPS,
+            EXCEPTION_ON_VERIFICATION,
+            FAILURE_NODE_NUMBER
+        );
     }
 
     @Override

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/LifecycleFailureService.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/LifecycleFailureService.java
@@ -24,7 +24,6 @@ import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.processor.util.StandardValidators;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -50,7 +49,10 @@ public class LifecycleFailureService extends AbstractControllerService {
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return Arrays.asList(ENABLE_FAILURE_COUNT, FAIL_ON_DISABLE);
+        return List.of(
+                ENABLE_FAILURE_COUNT,
+                FAIL_ON_DISABLE
+        );
     }
 
     @OnEnabled

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/StandardCountService.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/StandardCountService.java
@@ -23,7 +23,6 @@ import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.processor.util.StandardValidators;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -48,7 +47,10 @@ public class StandardCountService extends AbstractControllerService implements C
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        return Arrays.asList(COUNT_SERVICE, START_VALUE);
+        return List.of(
+                COUNT_SERVICE,
+                START_VALUE
+        );
     }
 
     @OnEnabled

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/StandardSleepService.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions-services/src/main/java/org/apache/nifi/cs/tests/system/StandardSleepService.java
@@ -25,7 +25,6 @@ import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.processor.util.StandardValidators;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -69,13 +68,13 @@ public class StandardSleepService extends AbstractControllerService implements S
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        final List<PropertyDescriptor> properties = new ArrayList<>();
-        properties.add(VALIDATE_SLEEP_TIME);
-        properties.add(ON_ENABLED_SLEEP_TIME);
-        properties.add(TRIGGER_SLEEP_TIME);
-        properties.add(ON_DISABLED_SLEEP_TIME);
-        properties.add(DEPENDENT_SERVICE);
-        return properties;
+        return List.of(
+            VALIDATE_SLEEP_TIME,
+            ON_ENABLED_SLEEP_TIME,
+            TRIGGER_SLEEP_TIME,
+            ON_DISABLED_SLEEP_TIME,
+            DEPENDENT_SERVICE
+        );
     }
 
     @Override


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14109](https://issues.apache.org/jira/browse/NIFI-14109)
This PR aims to have a lists of `PropertyDescriptor` objects and sets of `Relationship` objects all be defined with one `PropertyDescriptor` and  `Relationship` per line for increased readability. The list variables are named `PROPERTY_DESCRIPTORS` and the set variables are named `RELATIONSHIPS`. Also for common `PropertyDescriptor` objects defined in a parent a method, a method  `getCommonPropertyDescriptors` is defined to allow children to use them. This was done for the following parent and children classes (parents on left and children which use the method are on the right).

1. AbstractAMQPProcessor - ConsumeAMQP, PublishAMQP
2. AbstractAwsMachineLearningJobStarter - StartAwsTextractJob
3. AbstractAwsMachineLearningJobStatusProcessor - GetAwsTextractJobStatus
4. AbstractAzureCosmosDBProcessor - PutAzureCosmosDBRecord
5. AbstractEmailProcessor - ConsumeIMAP, ConsumePOP3
6. AbstractGridFSProcessor (applies this also to relationships) - FetchGridFS, PutGridFS
7. AbstractHadoopProcessor - AbstractFetchHDFSRecord, AbstractPutHDFSRecord (PutParquet but doesn't use common method), CreateHadoopSequenceFile, DeleteHDFS, FetchHDFS, GetHDFS, GetHDFSEvents, GetHDFSFileInfo, ListHDFS, MoveHDFS, PutHDFS
8. AbstractJoltTransform - JoltTransformJSON, JoltTransformRecord
9. AbstractMongoProcessor - DeleteMongo, GetMongo, PutMongo, PutMongoBulkOperations, PutMongoRecord, RunMongoAggregation
10. SplunkAPICall - PutSplunkHTTP, QuerySplunkIndexingStatus

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
