### PR TITLE
NIFI-14048 Add fallback to RSA for Framework Application Tokens

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/AuthenticationSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/AuthenticationSecurityConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 @Configuration
 @Import({
         ClientRegistrationConfiguration.class,
+        KeyPairGeneratorConfiguration.class,
         JwtAuthenticationSecurityConfiguration.class,
         JwtDecoderConfiguration.class,
         OidcSecurityConfiguration.class,

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtAuthenticationSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtAuthenticationSecurityConfiguration.java
@@ -45,6 +45,7 @@ import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthen
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 
+import java.security.KeyPairGenerator;
 import java.time.Duration;
 
 /**
@@ -180,11 +181,12 @@ public class JwtAuthenticationSecurityConfiguration {
     /**
      * Key Generation Command responsible for rotating JSON Web Signature key pairs based on configuration
      *
+     * @param keyPairGenerator Key Pair Generator for JSON Web Signatures
      * @return Key Generation Command scheduled according to application properties
      */
     @Bean
-    public KeyGenerationCommand keyGenerationCommand() {
-        final KeyGenerationCommand command = new KeyGenerationCommand(jwsSignerProvider(), verificationKeySelector);
+    public KeyGenerationCommand keyGenerationCommand(final KeyPairGenerator keyPairGenerator) {
+        final KeyGenerationCommand command = new KeyGenerationCommand(jwsSignerProvider(), verificationKeySelector, keyPairGenerator);
         commandScheduler().scheduleAtFixedRate(command, keyRotationPeriod);
         return command;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtDecoderConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtDecoderConfiguration.java
@@ -27,7 +27,7 @@ import org.apache.nifi.components.state.StateManagerProvider;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.web.security.jwt.converter.StandardIssuerJwtDecoder;
 import org.apache.nifi.web.security.jwt.jws.StandardJWSKeySelector;
-import org.apache.nifi.web.security.jwt.key.Ed25519VerifierFactory;
+import org.apache.nifi.web.security.jwt.key.StandardJWSVerifierFactory;
 import org.apache.nifi.web.security.jwt.key.StandardVerificationKeySelector;
 import org.apache.nifi.web.security.jwt.key.service.StandardVerificationKeyService;
 import org.apache.nifi.web.security.jwt.key.service.VerificationKeyService;
@@ -126,7 +126,7 @@ public class JwtDecoderConfiguration {
         final JWTClaimsSetVerifier<SecurityContext> claimsSetVerifier = new DefaultJWTClaimsVerifier<>(null, REQUIRED_CLAIMS);
         jwtProcessor.setJWTClaimsSetVerifier(claimsSetVerifier);
 
-        jwtProcessor.setJWSVerifierFactory(new Ed25519VerifierFactory());
+        jwtProcessor.setJWSVerifierFactory(new StandardJWSVerifierFactory());
         return jwtProcessor;
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/KeyPairGeneratorConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/KeyPairGeneratorConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+
+@Configuration
+public class KeyPairGeneratorConfiguration {
+    /** Standard Key Pair Algorithm for signing JSON Web Tokens */
+    private static final String STANDARD_KEY_PAIR_ALGORITHM = "Ed25519";
+
+    private static final String STANDARD_KEY_PAIR_ALGORITHM_FILTER = "KeyPairGenerator.Ed25519";
+
+    /** Fallback Key Pair Algorithm when standard algorithm not supported in current Security Provider */
+    private static final String FALLBACK_KEY_PAIR_ALGORITHM = "RSA";
+
+    private static final Logger logger = LoggerFactory.getLogger(KeyPairGeneratorConfiguration.class);
+
+    /**
+     * JSON Web Token Key Pair Generator defaults to Ed25519 and falls back to RSA when current Security Providers do
+     * not support Ed25519. The fallback strategy supports security configurations that have not included Ed25519
+     * as an approved algorithm. This strategy works with restricted providers such as those that have not incorporated
+     * algorithm approvals described in FIPS 186-5
+     *
+     * @return Key Pair Generator for JSON Web Token signing
+     * @throws NoSuchAlgorithmException Thrown on failure to get Key Pair Generator for selected algorithm
+     */
+    @Bean
+    public KeyPairGenerator jwtKeyPairGenerator() throws NoSuchAlgorithmException {
+        final String keyPairAlgorithm;
+
+        final Provider[] providers = Security.getProviders(STANDARD_KEY_PAIR_ALGORITHM_FILTER);
+        if (providers == null) {
+            keyPairAlgorithm = FALLBACK_KEY_PAIR_ALGORITHM;
+        } else {
+            keyPairAlgorithm = STANDARD_KEY_PAIR_ALGORITHM;
+        }
+
+        logger.info("Configured Key Pair Algorithm [{}] for JSON Web Signatures", keyPairAlgorithm);
+        return KeyPairGenerator.getInstance(keyPairAlgorithm);
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/configuration/KeyPairGeneratorConfigurationTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/configuration/KeyPairGeneratorConfigurationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security.configuration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class KeyPairGeneratorConfigurationTest {
+    private static final String STANDARD_KEY_PAIR_ALGORITHM_FILTER = "KeyPairGenerator.Ed25519";
+
+    private static final String STANDARD_KEY_PAIR_ALGORITHM = "Ed25519";
+
+    private static final String FALLBACK_KEY_PAIR_ALGORITHM = "RSA";
+
+    private KeyPairGeneratorConfiguration configuration;
+
+    @BeforeEach
+    void setConfiguration() {
+        configuration = new KeyPairGeneratorConfiguration();
+    }
+
+    @Test
+    void testJwtKeyPairGenerator() throws NoSuchAlgorithmException {
+        final KeyPairGenerator keyPairGenerator = configuration.jwtKeyPairGenerator();
+
+        final String algorithm = keyPairGenerator.getAlgorithm();
+        assertEquals(STANDARD_KEY_PAIR_ALGORITHM, algorithm);
+    }
+
+    @Test
+    void testJwtKeyPairGeneratorFallbackAlgorithm() throws NoSuchAlgorithmException {
+        final Provider[] providers = Security.getProviders(STANDARD_KEY_PAIR_ALGORITHM_FILTER);
+        assertNotNull(providers);
+
+        final Provider provider = providers[0];
+        try {
+            Security.removeProvider(provider.getName());
+
+            final KeyPairGenerator keyPairGenerator = configuration.jwtKeyPairGenerator();
+
+            final String algorithm = keyPairGenerator.getAlgorithm();
+            assertEquals(FALLBACK_KEY_PAIR_ALGORITHM, algorithm);
+        } finally {
+            Security.addProvider(provider);
+        }
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/key/command/KeyGenerationCommandTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/key/command/KeyGenerationCommandTest.java
@@ -29,8 +29,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.security.Key;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,8 +61,10 @@ public class KeyGenerationCommandTest {
     private KeyGenerationCommand command;
 
     @BeforeEach
-    public void setCommand() {
-        command = new KeyGenerationCommand(signerListener, verificationKeyListener);
+    public void setCommand() throws NoSuchAlgorithmException {
+        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(JWS_ALGORITHM.getName());
+
+        command = new KeyGenerationCommand(signerListener, verificationKeyListener, keyPairGenerator);
     }
 
     @Test
@@ -72,5 +78,6 @@ public class KeyGenerationCommandTest {
         verify(verificationKeyListener).onVerificationKeyGenerated(keyIdentifierCaptor.capture(), keyCaptor.capture());
         final Key key = keyCaptor.getValue();
         assertEquals(KEY_ALGORITHM, key.getAlgorithm());
+        assertInstanceOf(PublicKey.class, key);
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-14048](https://issues.apache.org/jira/browse/NIFI-14048) Adjusts the framework web application security configuration to support fallback to the `RSA` key algorithm and the `PS512` JSON Web Signature algorithm when the runtime Java Security Provider does not support the `Ed25519` key algorithm.

NiFi versions prior to 2.0.0 used `RSA` with `PS512` for signing and verifying Application Bearer Tokens. NiFi 2.0.0 changed the implementation to use `Ed25519` with `EdDSA` for smaller key and signature sizes providing similar or better security than RSA.

At the time of this writing, Java Security Providers that enforce Federal Information Processing Standards do not include `Ed25519` in the list of approved algorithms. [FIPS 186-5](https://csrc.nist.gov/pubs/fips/186-5/final) published in February 2023 adds `Ed25519` to the list of approved algorithms, and FIPS providers such as [Bouncy Castle](https://www.bouncycastle.org/download/bouncy-castle-java-fips/roadmap/) have submitted versions for approval that include `Ed25519`.

Although the project does not provide official support for operating in a mode compatible with FIPS providers, enabling fallback support for `RSA` enables a transitional upgrade path for current deployments. Instead of introducing a new framework configuration property, changes in this pull request use [java.security.Security](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/Security.html) to determine whether `Ed25519` is supported on startup. In absence of support for `Ed25519`, the framework selects `RSA` for rotating JWT key pair generation and `PS512` for token signing. The framework logs a message indicating the selected algorithm. This approach also provides the opportunity for subsequent removal when support for `Ed25519` is incorporated in providers such as Bouncy Castle.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
