### PR TITLE
NIFI-10831 enable JWT realm authentication with Elasticsearch

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/pom.xml
@@ -36,9 +36,8 @@
             <artifactId>nifi-proxy-configuration-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <scope>compile</scope>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-oauth2-provider-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>nifi-proxy-configuration-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-oauth2-provider-api</artifactId>
         </dependency>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/AuthorizationScheme.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/AuthorizationScheme.java
@@ -22,7 +22,8 @@ public enum AuthorizationScheme implements DescribedValue {
     NONE("None", "No authorization scheme."),
     PKI("PKI", "Mutual TLS with PKI certificate authorization scheme."),
     BASIC("Basic", "Basic authorization scheme."),
-    API_KEY("API Key", "API key authorization scheme.");
+    API_KEY("API Key", "API key authorization scheme."),
+    JWT("JWT", "JWT realm scheme.");
 
     private final String displayName;
     private final String description;

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientService.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientService.java
@@ -69,9 +69,19 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
             .displayName("OAuth2 Access Token Provider")
             .description("The OAuth2 Access Token Provider used to provide JWTs for Bearer Token Authorization with Elasticsearch.")
             .dependsOn(AUTHORIZATION_SCHEME, AuthorizationScheme.JWT)
-            .required(false)
+            .required(true)
             .identifiesControllerService(OAuth2AccessTokenProvider.class)
             .addValidator(Validator.VALID)
+            .build();
+
+    PropertyDescriptor JWT_SHARED_SECRET = new PropertyDescriptor.Builder()
+            .name("jwt-shared-secret")
+            .displayName("JWT Shared Secret")
+            .description("JWT realm Shared Secret.")
+            .dependsOn(AUTHORIZATION_SCHEME, AuthorizationScheme.JWT)
+            .required(true)
+            .sensitive(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
     PropertyDescriptor RUN_AS_USER = new PropertyDescriptor.Builder()
@@ -88,7 +98,7 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
             .displayName("Username")
             .description("The username to use with XPack security.")
             .dependsOn(AUTHORIZATION_SCHEME, AuthorizationScheme.BASIC)
-            .required(false)
+            .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
@@ -98,7 +108,7 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
             .displayName("Password")
             .description("The password to use with XPack security.")
             .dependsOn(AUTHORIZATION_SCHEME, AuthorizationScheme.BASIC)
-            .required(false)
+            .required(true)
             .sensitive(true)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
@@ -109,7 +119,7 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
             .displayName("API Key ID")
             .description("Unique identifier of the API key.")
             .dependsOn(AUTHORIZATION_SCHEME, AuthorizationScheme.API_KEY)
-            .required(false)
+            .required(true)
             .sensitive(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
@@ -119,17 +129,7 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
             .displayName("API Key")
             .description("Encoded API key.")
             .dependsOn(AUTHORIZATION_SCHEME, AuthorizationScheme.API_KEY)
-            .required(false)
-            .sensitive(true)
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .build();
-
-    PropertyDescriptor JWT_SHARED_SECRET = new PropertyDescriptor.Builder()
-            .name("jwt-shared-secret")
-            .displayName("JWT Shared Secret")
-            .description("JWT realm Shared Secret.")
-            .dependsOn(AUTHORIZATION_SCHEME, AuthorizationScheme.JWT)
-            .required(false)
+            .required(true)
             .sensitive(true)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientService.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service-api/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientService.java
@@ -22,6 +22,7 @@ import org.apache.nifi.components.Validator;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.VerifiableControllerService;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.oauth2.OAuth2AccessTokenProvider;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.proxy.ProxyConfiguration;
 import org.apache.nifi.proxy.ProxySpec;
@@ -50,6 +51,7 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
             .identifiesControllerService(SSLContextProvider.class)
             .addValidator(Validator.VALID)
             .build();
+
     PropertyDescriptor PROXY_CONFIGURATION_SERVICE = ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxySpec.HTTP);
 
     PropertyDescriptor AUTHORIZATION_SCHEME = new PropertyDescriptor.Builder()
@@ -59,6 +61,25 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
             .allowableValues(AuthorizationScheme.class)
             .defaultValue(AuthorizationScheme.BASIC)
             .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    PropertyDescriptor OAUTH2_ACCESS_TOKEN_PROVIDER = new PropertyDescriptor.Builder()
+            .name("el-cs-oauth2-token-provider")
+            .displayName("OAuth2 Access Token Provider")
+            .description("The OAuth2 Access Token Provider used to provide JWTs for Bearer Token Authorization with Elasticsearch.")
+            .dependsOn(AUTHORIZATION_SCHEME, AuthorizationScheme.JWT)
+            .required(false)
+            .identifiesControllerService(OAuth2AccessTokenProvider.class)
+            .addValidator(Validator.VALID)
+            .build();
+
+    PropertyDescriptor RUN_AS_USER = new PropertyDescriptor.Builder()
+            .name("el-cs-run-as-user")
+            .displayName("Run As User")
+            .description("The username to impersonate within Elasticsearch.")
+            .required(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
 
@@ -98,6 +119,16 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
             .displayName("API Key")
             .description("Encoded API key.")
             .dependsOn(AUTHORIZATION_SCHEME, AuthorizationScheme.API_KEY)
+            .required(false)
+            .sensitive(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    PropertyDescriptor JWT_SHARED_SECRET = new PropertyDescriptor.Builder()
+            .name("jwt-shared-secret")
+            .displayName("JWT Shared Secret")
+            .description("JWT realm Shared Secret.")
+            .dependsOn(AUTHORIZATION_SCHEME, AuthorizationScheme.JWT)
             .required(false)
             .sensitive(true)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
@@ -220,7 +251,7 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
             .name("el-cs-sniff-failure")
             .displayName("Sniff on Failure")
             .description("Enable sniffing on failure, meaning that after each failure the Elasticsearch nodes list gets updated " +
-                    "straightaway rather than at the following ordinary sniffing round")
+                    "straight away rather than at the following ordinary sniffing round")
             .dependsOn(SNIFF_CLUSTER_NODES, "true")
             .allowableValues("true", "false")
             .defaultValue("false")
@@ -370,7 +401,7 @@ public interface ElasticSearchClientService extends ControllerService, Verifiabl
     /**
      * Perform a search using the JSON DSL.
      *
-     * @param query A JSON string reprensenting the query.
+     * @param query A JSON string representing the query.
      * @param index The index to target. Optional.
      * @param type The type to target. Optional. Will not be used in future versions of Elasticsearch.
      * @param requestParameters A collection of URL request parameters. Optional.

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/pom.xml
@@ -49,6 +49,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-oauth2-provider-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-elasticsearch-client-service-api</artifactId>
             <version>2.3.0-SNAPSHOT</version>
             <scope>provided</scope>
@@ -84,21 +88,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.stephenc.findbugs</groupId>
             <artifactId>findbugs-annotations</artifactId>
             <version>1.3.9-1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opentest4j</groupId>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -164,16 +164,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
 
         final AuthorizationScheme authorizationScheme = validationContext.getProperty(AUTHORIZATION_SCHEME).asAllowableValue(AuthorizationScheme.class);
 
-        final boolean usernameSet = validationContext.getProperty(USERNAME).isSet();
-        final boolean passwordSet = validationContext.getProperty(PASSWORD).isSet();
-
-        final boolean apiKeyIdSet = validationContext.getProperty(API_KEY_ID).isSet();
-        final boolean apiKeySet = validationContext.getProperty(API_KEY).isSet();
-
         final SSLContextProvider sslContextProvider = validationContext.getProperty(PROP_SSL_CONTEXT_SERVICE).asControllerService(SSLContextProvider.class);
-
-        final boolean jwtSharedSecretSet = validationContext.getProperty(JWT_SHARED_SECRET).isSet();
-        final OAuth2AccessTokenProvider oAuth2Provider = validationContext.getProperty(OAUTH2_ACCESS_TOKEN_PROVIDER).asControllerService(OAuth2AccessTokenProvider.class);
 
         if (authorizationScheme == AuthorizationScheme.PKI && (sslContextProvider == null)) {
             results.add(new ValidationResult.Builder().subject(PROP_SSL_CONTEXT_SERVICE.getName()).valid(false)
@@ -181,35 +172,6 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
                             AUTHORIZATION_SCHEME.getDisplayName(), authorizationScheme.getDisplayName(), PROP_SSL_CONTEXT_SERVICE.getDisplayName())
                     ).build()
             );
-        }
-
-        if (authorizationScheme == AuthorizationScheme.JWT) {
-            if (oAuth2Provider == null) {
-                results.add(new ValidationResult.Builder().subject(OAUTH2_ACCESS_TOKEN_PROVIDER.getName()).valid(false)
-                        .explanation(String.format("if '%s' is '%s' then '%s' must be set.",
-                                AUTHORIZATION_SCHEME.getDisplayName(), authorizationScheme.getDisplayName(), OAUTH2_ACCESS_TOKEN_PROVIDER.getDisplayName())
-                        ).build()
-                );
-            }
-            if (!jwtSharedSecretSet) {
-                results.add(new ValidationResult.Builder().subject(JWT_SHARED_SECRET.getName()).valid(false)
-                        .explanation(String.format("if '%s' is '%s' then '%s' must be set.",
-                                AUTHORIZATION_SCHEME.getDisplayName(), authorizationScheme.getDisplayName(), JWT_SHARED_SECRET.getDisplayName())
-                        ).build()
-                );
-            }
-        }
-
-        if (usernameSet && !passwordSet) {
-            addAuthorizationPropertiesValidationIssue(results, USERNAME, PASSWORD);
-        } else if (passwordSet && !usernameSet) {
-            addAuthorizationPropertiesValidationIssue(results, PASSWORD, USERNAME);
-        }
-
-        if (apiKeyIdSet && !apiKeySet) {
-            addAuthorizationPropertiesValidationIssue(results, API_KEY_ID, API_KEY);
-        } else if (apiKeySet && !apiKeyIdSet) {
-            addAuthorizationPropertiesValidationIssue(results, API_KEY, API_KEY_ID);
         }
 
         final boolean sniffClusterNodes = validationContext.getProperty(SNIFF_CLUSTER_NODES).asBoolean();
@@ -220,13 +182,6 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
         }
 
         return results;
-    }
-
-    private void addAuthorizationPropertiesValidationIssue(final List<ValidationResult> results, final PropertyDescriptor presentProperty, final PropertyDescriptor missingProperty) {
-        results.add(new ValidationResult.Builder().subject(missingProperty.getName()).valid(false)
-                .explanation(String.format("if '%s' is set, then '%s' must be set.", presentProperty.getDisplayName(), missingProperty.getDisplayName()))
-                .build()
-        );
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchLookupService.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchLookupService.java
@@ -209,12 +209,12 @@ public class ElasticSearchLookupService extends JsonInferenceSchemaRegistryServi
             return null;
         }
 
-        final Map<String, Object> source = (Map<String, Object>) response.getHits().get(0).get("_source");
+        final Map<String, Object> source = (Map<String, Object>) response.getHits().getFirst().get("_source");
 
         final RecordSchema toUse = getSchema(context, source, null);
 
         Record record = new MapRecord(toUse, source);
-        if (recordPathMappings.size() > 0) {
+        if (!recordPathMappings.isEmpty()) {
             record = applyMappings(record, source);
         }
 
@@ -239,7 +239,7 @@ public class ElasticSearchLookupService extends JsonInferenceSchemaRegistryServi
                                     put(e.getKey(), e.getValue());
                                 }});
                             }
-                        }}).collect(Collectors.toList())
+                        }}).toList()
                 );
             }});
         }};
@@ -256,10 +256,10 @@ public class ElasticSearchLookupService extends JsonInferenceSchemaRegistryServi
             if (response.getNumberOfHits() == 0) {
                 return null;
             } else {
-                final Map<String, Object> source = (Map<String, Object>) response.getHits().get(0).get("_source");
+                final Map<String, Object> source = (Map<String, Object>) response.getHits().getFirst().get("_source");
                 final RecordSchema toUse = getSchema(context, source, null);
                 Record record = new MapRecord(toUse, source);
-                if (recordPathMappings.size() > 0) {
+                if (!recordPathMappings.isEmpty()) {
                     record = applyMappings(record, source);
                 }
 

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchClientService_IT.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchClientService_IT.java
@@ -263,7 +263,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
                         "four", 4, "five", 5)
                 .build();
 
-        buckets.forEach( (aggRes) -> {
+        buckets.forEach(aggRes -> {
             final String key = (String) aggRes.get("key");
             final Integer docCount = (Integer) aggRes.get("doc_count");
             assertEquals(expected.get(key), docCount, String.format("%s did not match.", key));

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchLookupService_IT.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchLookupService_IT.java
@@ -49,6 +49,7 @@ class ElasticSearchLookupService_IT extends AbstractElasticsearch_IT {
 
     private ElasticSearchLookupService lookupService;
 
+    @Override
     @BeforeEach
     void before() throws Exception {
         super.before();

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/unit/ElasticSearchClientServiceImplTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/unit/ElasticSearchClientServiceImplTest.java
@@ -73,14 +73,11 @@ class ElasticSearchClientServiceImplTest {
         runner.assertValid(service);
 
         runner.removeProperty(service, ElasticSearchClientService.PASSWORD);
-        assertAuthorizationPropertyValidationErrorMessage(ElasticSearchClientService.USERNAME, ElasticSearchClientService.PASSWORD);
-
-        runner.removeProperty(service, ElasticSearchClientService.USERNAME);
-        runner.assertValid(service);
+        assertAuthorizationPropertyValidationErrorMessage(ElasticSearchClientService.PASSWORD);
 
         runner.setProperty(service, ElasticSearchClientService.PASSWORD, "password");
         runner.removeProperty(service, ElasticSearchClientService.USERNAME);
-        assertAuthorizationPropertyValidationErrorMessage(ElasticSearchClientService.PASSWORD, ElasticSearchClientService.USERNAME);
+        assertAuthorizationPropertyValidationErrorMessage(ElasticSearchClientService.USERNAME);
     }
 
     @Test
@@ -91,14 +88,11 @@ class ElasticSearchClientServiceImplTest {
         runner.assertValid(service);
 
         runner.removeProperty(service, ElasticSearchClientService.API_KEY_ID);
-        assertAuthorizationPropertyValidationErrorMessage(ElasticSearchClientService.API_KEY, ElasticSearchClientService.API_KEY_ID);
-
-        runner.removeProperty(service, ElasticSearchClientService.API_KEY);
-        runner.assertValid(service);
+        assertAuthorizationPropertyValidationErrorMessage(ElasticSearchClientService.API_KEY_ID);
 
         runner.setProperty(service, ElasticSearchClientService.API_KEY_ID, "api-key-id");
         runner.removeProperty(service, ElasticSearchClientService.API_KEY);
-        assertAuthorizationPropertyValidationErrorMessage(ElasticSearchClientService.API_KEY_ID, ElasticSearchClientService.API_KEY);
+        assertAuthorizationPropertyValidationErrorMessage(ElasticSearchClientService.API_KEY);
     }
 
     @Test
@@ -119,7 +113,7 @@ class ElasticSearchClientServiceImplTest {
     void testValidateJwtAuth() throws InitializationException {
         runner.setProperty(service, ElasticSearchClientService.AUTHORIZATION_SCHEME, AuthorizationScheme.JWT);
         runner.setProperty(service, ElasticSearchClientService.JWT_SHARED_SECRET, "jwt-shared-secret");
-        assertJWTAuthorizationValidationErrorMessage(ElasticSearchClientService.OAUTH2_ACCESS_TOKEN_PROVIDER);
+        assertAuthorizationPropertyValidationErrorMessage(ElasticSearchClientService.OAUTH2_ACCESS_TOKEN_PROVIDER);
 
         final OAuth2AccessTokenProvider oAuth2AccessTokenProvider = mock(OAuth2AccessTokenProvider.class);
         when(oAuth2AccessTokenProvider.getIdentifier()).thenReturn("oauth2-access-token-provider");
@@ -128,12 +122,13 @@ class ElasticSearchClientServiceImplTest {
         runner.assertValid(service);
 
         runner.removeProperty(service, ElasticSearchClientService.JWT_SHARED_SECRET);
-        assertJWTAuthorizationValidationErrorMessage(ElasticSearchClientService.JWT_SHARED_SECRET);
+        assertAuthorizationPropertyValidationErrorMessage(ElasticSearchClientService.JWT_SHARED_SECRET);
     }
 
-    private void assertAuthorizationPropertyValidationErrorMessage(final PropertyDescriptor presentProperty, final PropertyDescriptor missingProperty) {
+    private void assertAuthorizationPropertyValidationErrorMessage(final PropertyDescriptor missingProperty) {
         final AssertionFailedError afe = assertThrows(AssertionFailedError.class, () -> runner.assertValid(service));
-        assertTrue(afe.getMessage().contains(String.format("if '%s' is set, then '%s' must be set.", presentProperty.getDisplayName(), missingProperty.getDisplayName())));
+        final String expectedMessage = String.format("%s is required", missingProperty.getDisplayName());
+        assertTrue(afe.getMessage().contains(expectedMessage), String.format("Validation error message \"%s\" does not contain \"%s\"", afe.getMessage(), expectedMessage));
     }
 
     private void assertPKIAuthorizationValidationErrorMessage() {
@@ -143,16 +138,6 @@ class ElasticSearchClientServiceImplTest {
                 ElasticSearchClientService.AUTHORIZATION_SCHEME.getDisplayName(),
                 AuthorizationScheme.PKI.getDisplayName(),
                 ElasticSearchClientService.PROP_SSL_CONTEXT_SERVICE.getDisplayName()
-        )));
-    }
-
-    private void assertJWTAuthorizationValidationErrorMessage(final PropertyDescriptor expectedMissingProperty) {
-        final AssertionFailedError afe = assertThrows(AssertionFailedError.class, () -> runner.assertValid(service));
-        assertTrue(afe.getMessage().contains(String.format(
-                "if '%s' is '%s' then '%s' must be set.",
-                ElasticSearchClientService.AUTHORIZATION_SCHEME.getDisplayName(),
-                AuthorizationScheme.JWT.getDisplayName(),
-                expectedMissingProperty.getDisplayName()
         )));
     }
 }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/unit/ElasticSearchStringLookupServiceTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/unit/ElasticSearchStringLookupServiceTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ElasticSearchStringLookupServiceTest {
+class ElasticSearchStringLookupServiceTest {
     private ElasticSearchClientService mockClientService;
     private ElasticSearchStringLookupService lookupService;
 
@@ -56,8 +56,9 @@ public class ElasticSearchStringLookupServiceTest {
         runner.enableControllerService(lookupService);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    public void simpleLookupTest() throws Exception {
+    void simpleLookupTest() throws Exception {
         Map<String, Object> coordinates = new HashMap<>();
         coordinates.put(ElasticSearchStringLookupService.ID, "12345");
 

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/pom.xml
@@ -72,8 +72,9 @@ language governing permissions and limitations under the License. -->
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-oauth2-provider-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/pom.xml
@@ -22,16 +22,6 @@ language governing permissions and limitations under the License. -->
 
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-api</artifactId>
             <version>3.4.1</version>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
@@ -52,7 +52,7 @@ import static org.apache.http.auth.AuthScope.ANY;
 public abstract class AbstractElasticsearchITBase {
     // default Elasticsearch version should (ideally) match that in the nifi-elasticsearch-bundle#pom.xml for the integration-tests profile
     protected static final DockerImageName IMAGE = DockerImageName
-            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.15.1"));
+            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.17.0"));
     protected static final String ELASTIC_USER_PASSWORD = System.getProperty("elasticsearch.elastic_user.password", RandomStringUtils.randomAlphanumeric(10, 20));
     private static final int PORT = 9200;
     protected static final ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer(IMAGE)

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -114,7 +114,7 @@ language governing permissions and limitations under the License. -->
         <profile>
             <id>elasticsearch7</id>
             <properties>
-                <elasticsearch_docker_image>7.17.23</elasticsearch_docker_image>
+                <elasticsearch_docker_image>7.17.26</elasticsearch_docker_image>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10831](https://issues.apache.org/jira/browse/NIFI-10831) enable JWT realm authentication with Elasticsearch.

Also allow for setting of `runas_user` in the Elasticsearch Controller Service, which may be of use to impersonate a user within Elasticsearch from NiFi, without having the user's credentials (but where the connecting NiFi user/token is granted permission to impersonate the alternate user).

Other changes include:
- removing unused dependencies from Elasticsearch component POMs

Testing:
- Attempted to verify changes using LogTo.io as an OIDC and JWT IdP, but it turns out that LogTo provides Access Token JWTs with a `typ` of `at+jwt`, which Elasticsearch cannot currently handle (https://github.com/elastic/elasticsearch/issues/119370)
- Verified using Keycloak instead (with a machine-to-machine/service-account only `Client` setup to provide Access Tokens)
- Configure Elasticsearch to allow [JWT realm](https://www.elastic.co/guide/en/elasticsearch/reference/current/jwt-auth-realm.html) authentication, an example might be like:

```yml
    jwt.keycloak_test_jwt:
      order: 3
      token_type: access_token
      client_authentication.type: shared_secret
      allowed_issuer: https://localhost:9443/realms/elasticsearch-test
      allowed_audiences: [account]
      allowed_subjects: [e61503d0-8fab-473e-9f70-95d91b085f52]
      allowed_signature_algorithms: [ES384]
      pkc_jwkset_path: https://keycloak:9443/realms/elasticsearch-test/protocol/openid-connect/certs
      claims.principal: preferred_username
      ssl.certificate_authorities:
        [/usr/share/elasticsearch/config/step/certs/root_ca.crt]
```

Note that NiFi requires the IdP to be running over HTTPS (for which SmallStep CA was used to generate certificates locally).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- ~~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~~
- ~~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~~

### Documentation

- ~~[ ] Documentation formatting appears as expected in rendered files~~
