### PR TITLE
NIFI-14135 Added PMD's UseStandardCharsets check, fixed those places where there violations and used Intellij's rule to find other places where StandardCharsets could be used and corrected them.

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/Base64DecodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/Base64DecodeEvaluator.java
@@ -22,7 +22,7 @@ import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResult;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 public class Base64DecodeEvaluator extends StringEvaluator {
@@ -40,11 +40,7 @@ public class Base64DecodeEvaluator extends StringEvaluator {
             return new StringQueryResult(null);
         }
 
-        try {
-            return new StringQueryResult(new String(Base64.getDecoder().decode(subjectValue), "UTF-8"));
-        } catch (final UnsupportedEncodingException e) {
-            return null;    // won't happen. It's UTF-8
-        }
+        return new StringQueryResult(new String(Base64.getDecoder().decode(subjectValue), StandardCharsets.UTF_8));
     }
 
     @Override

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/UrlDecodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/UrlDecodeEvaluator.java
@@ -22,8 +22,8 @@ import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResult;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 public class UrlDecodeEvaluator extends StringEvaluator {
 
@@ -40,11 +40,7 @@ public class UrlDecodeEvaluator extends StringEvaluator {
             return new StringQueryResult(null);
         }
 
-        try {
-            return new StringQueryResult(URLDecoder.decode(subjectValue, "UTF-8"));
-        } catch (final UnsupportedEncodingException e) {
-            return null;    // won't happen. It's UTF-8
-        }
+        return new StringQueryResult(URLDecoder.decode(subjectValue, StandardCharsets.UTF_8));
     }
 
     @Override

--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/UrlEncodeEvaluator.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/evaluation/functions/UrlEncodeEvaluator.java
@@ -22,8 +22,8 @@ import org.apache.nifi.attribute.expression.language.evaluation.QueryResult;
 import org.apache.nifi.attribute.expression.language.evaluation.StringEvaluator;
 import org.apache.nifi.attribute.expression.language.evaluation.StringQueryResult;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 public class UrlEncodeEvaluator extends StringEvaluator {
 
@@ -40,11 +40,7 @@ public class UrlEncodeEvaluator extends StringEvaluator {
             return new StringQueryResult(null);
         }
 
-        try {
-            return new StringQueryResult(URLEncoder.encode(subjectValue, "UTF-8"));
-        } catch (final UnsupportedEncodingException e) {
-            return null;    // won't happen. It's UTF-8
-        }
+        return new StringQueryResult(URLEncoder.encode(subjectValue, StandardCharsets.UTF_8));
     }
 
     @Override

--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFilePackagerV2.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFilePackagerV2.java
@@ -19,6 +19,7 @@ package org.apache.nifi.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -107,7 +108,7 @@ public class FlowFilePackagerV2 implements FlowFilePackager {
     }
 
     private void writeString(final String val, final OutputStream out) throws IOException {
-        final byte[] bytes = val.getBytes("UTF-8");
+        final byte[] bytes = val.getBytes(StandardCharsets.UTF_8);
         writeFieldLength(out, bytes.length);
         out.write(bytes);
     }

--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFilePackagerV3.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFilePackagerV3.java
@@ -19,6 +19,7 @@ package org.apache.nifi.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class FlowFilePackagerV3 implements FlowFilePackager {
@@ -54,7 +55,7 @@ public class FlowFilePackagerV3 implements FlowFilePackager {
     }
 
     private void writeString(final String val, final OutputStream out) throws IOException {
-        final byte[] bytes = val.getBytes("UTF-8");
+        final byte[] bytes = val.getBytes(StandardCharsets.UTF_8);
         writeFieldLength(out, bytes.length);
         out.write(bytes);
     }

--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV2.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV2.java
@@ -20,6 +20,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -77,7 +78,7 @@ public class FlowFileUnpackagerV2 implements FlowFileUnpackager {
         }
         final byte[] bytes = new byte[numBytes];
         fillBuffer(in, bytes, numBytes);
-        return new String(bytes, "UTF-8");
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     private void fillBuffer(final InputStream in, final byte[] buffer, final int length) throws IOException {

--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV3.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/FlowFileUnpackagerV3.java
@@ -20,6 +20,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -94,7 +95,7 @@ public class FlowFileUnpackagerV3 implements FlowFileUnpackager {
         }
         final byte[] bytes = new byte[numBytes];
         fillBuffer(in, bytes, numBytes);
-        return new String(bytes, "UTF-8");
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     private void fillBuffer(final InputStream in, final byte[] buffer, final int length) throws IOException {

--- a/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/Unpackage.java
+++ b/nifi-commons/nifi-flowfile-packager/src/main/java/org/apache/nifi/util/Unpackage.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.UUID;
 
@@ -93,7 +94,7 @@ public class Unpackage {
                             final BufferedOutputStream bufferedOut = new BufferedOutputStream(fos)) {
 
                         for (final Map.Entry<String, String> entry : attributes.entrySet()) {
-                            bufferedOut.write((entry.getKey() + "=" + entry.getValue() + "\n").getBytes("UTF-8"));
+                            bufferedOut.write((entry.getKey() + "=" + entry.getValue() + "\n").getBytes(StandardCharsets.UTF_8));
                         }
                     }
                 }

--- a/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/Base64Encode.java
+++ b/nifi-commons/nifi-record-path/src/main/java/org/apache/nifi/record/path/functions/Base64Encode.java
@@ -22,7 +22,7 @@ import org.apache.nifi.record.path.RecordPathEvaluationContext;
 import org.apache.nifi.record.path.StandardFieldValue;
 import org.apache.nifi.record.path.paths.RecordPathSegment;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.stream.Stream;
 
@@ -42,11 +42,7 @@ public class Base64Encode extends RecordPathSegment {
 
                     Object value = fv.getValue();
                     if (value instanceof String) {
-                        try {
-                            return new StandardFieldValue(Base64.getEncoder().encodeToString(value.toString().getBytes("UTF-8")), fv.getField(), fv.getParent().orElse(null));
-                        } catch (final UnsupportedEncodingException e) {
-                            return null;    // won't happen.
-                        }
+                        return new StandardFieldValue(Base64.getEncoder().encodeToString(value.toString().getBytes(StandardCharsets.UTF_8)), fv.getField(), fv.getParent().orElse(null));
                     } else if (value instanceof byte[]) {
                         return new StandardFieldValue(Base64.getEncoder().encode((byte[]) value), fv.getField(), fv.getParent().orElse(null));
                     } else {

--- a/nifi-commons/nifi-schema-utils/src/test/java/org/apache/nifi/repository/schema/TestSchemaRecordReaderWriter.java
+++ b/nifi-commons/nifi-schema-utils/src/test/java/org/apache/nifi/repository/schema/TestSchemaRecordReaderWriter.java
@@ -24,7 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -198,7 +198,7 @@ public class TestSchemaRecordReaderWriter {
         final String utfString = utfStringOneByte + utfStringTwoByte + utfStringThreeByte;  // 3 chars and 6 utf8 bytes
         final String seventyK = StringUtils.repeat(utfString, 21845);  // 65,535 chars and 131070 utf8 bytes
         assertTrue(seventyK.length() == 65535);
-        assertTrue(seventyK.getBytes("UTF-8").length == 131070);
+        assertTrue(seventyK.getBytes(StandardCharsets.UTF_8).length == 131070);
         values.put(createField("string present", FieldType.STRING), seventyK);
 
         final FieldMapRecord originalRecord = new FieldMapRecord(values, schema);
@@ -224,7 +224,7 @@ public class TestSchemaRecordReaderWriter {
 
                     assertNotNull(record);
                     assertEquals(42, record.getFieldValue("int present"));
-                    assertTrue(MAX_ALLOWED_UTF_LENGTH - ((String) record.getFieldValue("string present")).getBytes("utf-8").length <= 3);
+                    assertTrue(MAX_ALLOWED_UTF_LENGTH - ((String) record.getFieldValue("string present")).getBytes(StandardCharsets.UTF_8).length <= 3);
                     assertEquals(32768, ((String) record.getFieldValue("string present")).length());
                 }
 
@@ -265,7 +265,7 @@ public class TestSchemaRecordReaderWriter {
     }
 
     @Test
-    public void testSmallCharUTFLengths() throws UnsupportedEncodingException {
+    public void testSmallCharUTFLengths() {
         final String string12b = StringUtils.repeat(utfStringOneByte + utfStringTwoByte + utfStringThreeByte, 2);
 
         assertEquals(0, SchemaRecordWriter.getCharsInUTF8Limit(string12b,  0), "test multi-char string truncated to  0 utf bytes should be 0");

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/codec/StandardFlowFileCodec.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/codec/StandardFlowFileCodec.java
@@ -29,6 +29,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -93,7 +94,7 @@ public class StandardFlowFileCodec implements FlowFileCodec {
     }
 
     private void writeString(final String val, final DataOutputStream out) throws IOException {
-        final byte[] bytes = val.getBytes("UTF-8");
+        final byte[] bytes = val.getBytes(StandardCharsets.UTF_8);
         out.writeInt(bytes.length);
         out.write(bytes);
     }
@@ -102,7 +103,7 @@ public class StandardFlowFileCodec implements FlowFileCodec {
         final int numBytes = in.readInt();
         final byte[] bytes = new byte[numBytes];
         StreamUtils.fillBuffer(in, bytes, true);
-        return new String(bytes, "UTF-8");
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/protocol/SiteToSiteTestUtils.java
+++ b/nifi-commons/nifi-site-to-site-client/src/test/java/org/apache/nifi/remote/protocol/SiteToSiteTestUtils.java
@@ -24,7 +24,7 @@ import org.apache.nifi.stream.io.StreamUtils;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,19 +36,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SiteToSiteTestUtils {
     public static DataPacket createDataPacket(String contents) {
-        try {
-            byte[] bytes = contents.getBytes("UTF-8");
-            ByteArrayInputStream is = new ByteArrayInputStream(bytes);
-            return new StandardDataPacket(new HashMap<>(), is, bytes.length);
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        byte[] bytes = contents.getBytes(StandardCharsets.UTF_8);
+        ByteArrayInputStream is = new ByteArrayInputStream(bytes);
+        return new StandardDataPacket(new HashMap<>(), is, bytes.length);
     }
 
     public static String readContents(DataPacket packet) throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream((int) packet.getSize());
         StreamUtils.copy(packet.getData(), os);
-        return new String(os.toByteArray(), "UTF-8");
+        return new String(os.toByteArray(), StandardCharsets.UTF_8);
     }
 
     public static void execReceiveZeroFlowFile(Transaction transaction) throws IOException {

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/monitor/TestCompoundUpdateMonitor.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/monitor/TestCompoundUpdateMonitor.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.UUID;
 
@@ -58,7 +59,7 @@ public class TestCompoundUpdateMonitor {
 
         final long lastModifiedDate = file.lastModified();
         try (final OutputStream out = new FileOutputStream(file)) {
-            out.write("Hello".getBytes("UTF-8"));
+            out.write("Hello".getBytes(StandardCharsets.UTF_8));
         }
 
         file.setLastModified(lastModifiedDate);

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/monitor/TestSynchronousFileWatcher.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/file/monitor/TestSynchronousFileWatcher.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -34,7 +35,7 @@ public class TestSynchronousFileWatcher {
     @Test
     public void testIt() throws IOException, InterruptedException {
         final Path path = Paths.get("target/1.txt");
-        Files.copy(new ByteArrayInputStream("Hello, World!".getBytes("UTF-8")), path, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(new ByteArrayInputStream("Hello, World!".getBytes(StandardCharsets.UTF_8)), path, StandardCopyOption.REPLACE_EXISTING);
         final UpdateMonitor monitor = new DigestUpdateMonitor();
 
         final SynchronousFileWatcher watcher = new SynchronousFileWatcher(path, monitor, 0L);
@@ -42,7 +43,7 @@ public class TestSynchronousFileWatcher {
         assertFalse(watcher.checkAndReset());
 
         try (FileOutputStream fos = new FileOutputStream(path.toFile())) {
-            fos.write("Good-bye, World!".getBytes("UTF-8"));
+            fos.write("Good-bye, World!".getBytes(StandardCharsets.UTF_8));
             fos.getFD().sync();
         }
 

--- a/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/test/java/org/apache/nifi/processors/avro/TestSplitAvro.java
+++ b/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/test/java/org/apache/nifi/processors/avro/TestSplitAvro.java
@@ -38,6 +38,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -82,7 +83,7 @@ public class TestSplitAvro {
         try (final DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(new GenericDatumWriter<>(schema))) {
             dataFileWriter.setMeta(META_KEY1, META_VALUE1);
             dataFileWriter.setMeta(META_KEY2, META_VALUE2);
-            dataFileWriter.setMeta(META_KEY3, META_VALUE3.getBytes("UTF-8"));
+            dataFileWriter.setMeta(META_KEY3, META_VALUE3.getBytes(StandardCharsets.UTF_8));
 
             dataFileWriter.create(schema, users);
             for (GenericRecord user : userList) {
@@ -263,7 +264,7 @@ public class TestSplitAvro {
         final TestRunner runner = TestRunners.newTestRunner(new SplitAvro());
         runner.setProperty(SplitAvro.OUTPUT_SIZE, "200");
 
-        runner.enqueue("not avro".getBytes("UTF-8"));
+        runner.enqueue("not avro".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount(SplitAvro.REL_SPLIT, 0);
@@ -318,7 +319,7 @@ public class TestSplitAvro {
                 if (checkMetadata) {
                     assertEquals(META_VALUE1, reader.getMetaString(META_KEY1));
                     assertEquals(META_VALUE2, reader.getMetaLong(META_KEY2));
-                    assertEquals(META_VALUE3, new String(reader.getMeta(META_KEY3), "UTF-8"));
+                    assertEquals(META_VALUE3, new String(reader.getMeta(META_KEY3), StandardCharsets.UTF_8));
                 }
             }
         }

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/client/RestSchemaRegistryClient.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/client/RestSchemaRegistryClient.java
@@ -41,8 +41,8 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -238,13 +238,13 @@ public class RestSchemaRegistryClient implements SchemaRegistryClient {
         }
     }
 
-    private String getSubjectPath(final String schemaName, final Integer schemaVersion) throws UnsupportedEncodingException {
-        return "/subjects/" + URLEncoder.encode(schemaName, "UTF-8") + "/versions/" +
-                (schemaVersion == null ? "latest" : URLEncoder.encode(String.valueOf(schemaVersion), "UTF-8"));
+    private String getSubjectPath(final String schemaName, final Integer schemaVersion) {
+        return "/subjects/" + URLEncoder.encode(schemaName, StandardCharsets.UTF_8) + "/versions/" +
+                (schemaVersion == null ? "latest" : URLEncoder.encode(String.valueOf(schemaVersion), StandardCharsets.UTF_8));
     }
 
-    private String getSchemaPath(final int schemaId) throws UnsupportedEncodingException {
-        return "/schemas/ids/" + URLEncoder.encode(String.valueOf(schemaId), "UTF-8");
+    private String getSchemaPath(final int schemaId) {
+        return "/schemas/ids/" + URLEncoder.encode(String.valueOf(schemaId), StandardCharsets.UTF_8);
     }
 
     private JsonNode postJsonResponse(final String pathSuffix, final JsonNode schema, final String schemaDescription) throws SchemaNotFoundException {

--- a/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/main/java/org/apache/nifi/processors/evtx/parser/bxml/value/WStringArrayTypeNode.java
+++ b/nifi-extension-bundles/nifi-evtx-bundle/nifi-evtx-processors/src/main/java/org/apache/nifi/processors/evtx/parser/bxml/value/WStringArrayTypeNode.java
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.evtx.parser.bxml.value;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -57,7 +58,7 @@ public class WStringArrayTypeNode extends VariantTypeNode {
         } catch (XMLStreamException e) {
             throw new IOException(e);
         }
-        value = stream.toString("UTF-8");
+        value = stream.toString(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/main/java/org/apache/nifi/util/db/JdbcCommon.java
@@ -49,6 +49,7 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.PreparedStatement;
@@ -865,7 +866,7 @@ public class JdbcCommon {
                     switch (valueFormat) {
                         case "":
                         case "ascii":
-                            bValue = parameterValue.getBytes("ASCII");
+                            bValue = parameterValue.getBytes(StandardCharsets.US_ASCII);
                             break;
                         case "hex":
                             try {

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
@@ -762,7 +762,7 @@ public class TestAvroTypeUtil {
 
     @Test
     public void testListToArrayConversion() {
-        final Charset charset = Charset.forName("UTF-8");
+        final Charset charset = StandardCharsets.UTF_8;
         Object o = AvroTypeUtil.convertToAvroObject(Collections.singletonList("Hello"), Schema.createArray(Schema.create(Type.STRING)), charset);
         assertTrue(o instanceof List);
         assertEquals(1, ((List) o).size());
@@ -771,7 +771,7 @@ public class TestAvroTypeUtil {
 
     @Test
     public void testMapToRecordConversion() {
-        final Charset charset = Charset.forName("UTF-8");
+        final Charset charset = StandardCharsets.UTF_8;
         Object o = AvroTypeUtil.convertToAvroObject(Collections.singletonMap("Hello", "World"),
             Schema.createRecord(null, null, null, false, Collections.singletonList(new Field("Hello", Schema.create(Type.STRING), "", ""))), charset);
         assertTrue(o instanceof Record);

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-syslog-utils/src/test/java/org/apache/nifi/syslog/TestSyslogParser.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-syslog-utils/src/test/java/org/apache/nifi/syslog/TestSyslogParser.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestSyslogParser {
 
-    static final Charset CHARSET = Charset.forName("UTF-8");
+    static final Charset CHARSET = StandardCharsets.UTF_8;
 
     private SyslogParser parser;
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateImagesOperationTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/vision/StartGcpVisionAnnotateImagesOperationTest.java
@@ -30,6 +30,7 @@ import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.cloud.vision.v1.ImageAnnotatorClient;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
 import org.apache.commons.io.FileUtils;
 import org.apache.nifi.gcp.credentials.service.GCPCredentialsService;
@@ -58,7 +59,7 @@ public class StartGcpVisionAnnotateImagesOperationTest {
 
     @BeforeEach
     public void setUp() throws InitializationException, IOException {
-        String jsonPayloadValue = FileUtils.readFileToString(new File("src/test/resources/vision/annotate-image.json"), "UTF-8");
+        String jsonPayloadValue = FileUtils.readFileToString(new File("src/test/resources/vision/annotate-image.json"), StandardCharsets.UTF_8);
         GCPCredentialsService gcpCredentialsService = new GCPCredentialsControllerService();
         StartGcpVisionAnnotateImagesOperation processor = new StartGcpVisionAnnotateImagesOperation() {
             @Override

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScriptTest.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScriptTest.java
@@ -281,7 +281,7 @@ public class ExecuteGroovyScriptTest {
         runner.assertAllFlowFilesTransferred(ExecuteGroovyScript.REL_SUCCESS.getName(), 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteGroovyScript.REL_SUCCESS.getName());
         MockFlowFile resultFile = result.getFirst();
-        resultFile.assertContentEquals("OK", "UTF-8");
+        resultFile.assertContentEquals("OK", StandardCharsets.UTF_8);
     }
 
     @Test
@@ -296,7 +296,7 @@ public class ExecuteGroovyScriptTest {
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteGroovyScript.REL_SUCCESS.getName());
         MockFlowFile resultFile = result.getFirst();
         resultFile.assertAttributeEquals("filename", "test.txt");
-        resultFile.assertContentEquals("Joe Smith\nCarrie Jones\n", "UTF-8");
+        resultFile.assertContentEquals("Joe Smith\nCarrie Jones\n", StandardCharsets.UTF_8);
     }
 
     @Test
@@ -350,7 +350,7 @@ public class ExecuteGroovyScriptTest {
         MockFlowFile resultFile = result.getFirst();
         List<String> lines = ResourceGroovyMethods.readLines(new File(TEST_RESOURCE_LOCATION + "test_sql_04_insert_and_json.json"), "UTF-8");
         //pass through to&from json before compare
-        resultFile.assertContentEquals(JsonOutput.toJson(new JsonSlurper().parseText(lines.get(1))), "UTF-8");
+        resultFile.assertContentEquals(JsonOutput.toJson(new JsonSlurper().parseText(lines.get(1))), StandardCharsets.UTF_8);
     }
 
     @Test
@@ -367,7 +367,7 @@ public class ExecuteGroovyScriptTest {
         runner.assertAllFlowFilesTransferred(ExecuteGroovyScript.REL_SUCCESS.getName(), 1);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteGroovyScript.REL_SUCCESS.getName());
         MockFlowFile resultFile = result.getFirst();
-        resultFile.assertContentEquals("\"1\",\"A\",\"XYZ\"\n", "UTF-8");
+        resultFile.assertContentEquals("\"1\",\"A\",\"XYZ\"\n", StandardCharsets.UTF_8);
     }
 
     @Test
@@ -386,8 +386,8 @@ public class ExecuteGroovyScriptTest {
         runner.assertAllFlowFilesTransferred(ExecuteGroovyScript.REL_SUCCESS.getName(), 2);
         final List<MockFlowFile> result = runner.getFlowFilesForRelationship(ExecuteGroovyScript.REL_SUCCESS.getName());
 
-        result.get(0).assertContentEquals("31", "UTF-8");
-        result.get(1).assertContentEquals("32", "UTF-8");
+        result.get(0).assertContentEquals("31", StandardCharsets.UTF_8);
+        result.get(1).assertContentEquals("32", StandardCharsets.UTF_8);
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/FlowFileStreamUnpackerSequenceFileWriter.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/main/java/org/apache/nifi/processors/hadoop/FlowFileStreamUnpackerSequenceFileWriter.java
@@ -20,6 +20,7 @@ import java.io.BufferedInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -116,7 +117,7 @@ public class FlowFileStreamUnpackerSequenceFileWriter extends SequenceFileWriter
             }
             final byte[] bytes = new byte[numBytes];
             fillBuffer(in, bytes, numBytes);
-            return new String(bytes, "UTF-8");
+            return new String(bytes, StandardCharsets.UTF_8);
         }
 
         private void fillBuffer(final InputStream in, final byte[] buffer, final int length) throws IOException {

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestCreateHadoopSequenceFile.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/TestCreateHadoopSequenceFile.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -106,7 +106,7 @@ public class TestCreateHadoopSequenceFile {
 
         final byte[] data = successSeqFiles.iterator().next().toByteArray();
 
-        final String magicHeader = new String(data, 0, 3, "UTF-8");
+        final String magicHeader = new String(data, 0, 3, StandardCharsets.UTF_8);
         assertEquals("SEQ", magicHeader);
         // Format of header is SEQ followed by the version (1 byte).
         // Then, the length of the Key type (1 byte), then the Key type
@@ -116,7 +116,7 @@ public class TestCreateHadoopSequenceFile {
         final int valueTypeLength = data[5 + keyType.length()];
         final String valueType = BytesWritable.class.getCanonicalName();
         assertEquals(valueType.length(), valueTypeLength);
-        assertEquals(valueType, new String(data, valueTypeStart, valueType.length(), "UTF-8"));
+        assertEquals(valueType, new String(data, valueTypeStart, valueType.length(), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -175,7 +175,7 @@ public class TestCreateHadoopSequenceFile {
     }
 
     @Test
-    public void testSequenceFileBzipCompressionCodec() throws UnsupportedEncodingException, IOException {
+    public void testSequenceFileBzipCompressionCodec() throws IOException {
 
         controller.setProperty(AbstractHadoopProcessor.COMPRESSION_CODEC, CompressionType.BZIP.name());
         controller.setProperty(CreateHadoopSequenceFile.COMPRESSION_TYPE, SequenceFile.CompressionType.BLOCK.name());
@@ -196,7 +196,7 @@ public class TestCreateHadoopSequenceFile {
         byte[] data = ff.toByteArray();
 
 
-        final String magicHeader = new String(data, 0, 3, "UTF-8");
+        final String magicHeader = new String(data, 0, 3, StandardCharsets.UTF_8);
         assertEquals("SEQ", magicHeader);
         // Format of header is SEQ followed by the version (1 byte).
         // Then, the length of the Key type (1 byte), then the Key type
@@ -207,7 +207,7 @@ public class TestCreateHadoopSequenceFile {
         final String valueType = BytesWritable.class.getCanonicalName();
 
         assertEquals(valueType.length(), valueTypeLength);
-        assertEquals(valueType, new String(data, valueTypeStart, valueType.length(), "UTF-8"));
+        assertEquals(valueType, new String(data, valueTypeStart, valueType.length(), StandardCharsets.UTF_8));
 
         final int compressionIndex = 3 + 1 + 1 + keyType.length() + 1 + valueType.length();
         final int blockCompressionIndex = compressionIndex + 1;
@@ -218,11 +218,11 @@ public class TestCreateHadoopSequenceFile {
         final int codecTypeSize = data[blockCompressionIndex + 1];
         final int codecTypeStartIndex = blockCompressionIndex + 2;
 
-        assertEquals(BZip2Codec.class.getCanonicalName(), new String(data, codecTypeStartIndex, codecTypeSize, "UTF-8"));
+        assertEquals(BZip2Codec.class.getCanonicalName(), new String(data, codecTypeStartIndex, codecTypeSize, StandardCharsets.UTF_8));
     }
 
     @Test
-    public void testSequenceFileDefaultCompressionCodec() throws UnsupportedEncodingException, IOException {
+    public void testSequenceFileDefaultCompressionCodec() throws IOException {
 
         controller.setProperty(AbstractHadoopProcessor.COMPRESSION_CODEC, CompressionType.DEFAULT.name());
         controller.setProperty(CreateHadoopSequenceFile.COMPRESSION_TYPE, SequenceFile.CompressionType.BLOCK.name());
@@ -243,7 +243,7 @@ public class TestCreateHadoopSequenceFile {
         byte[] data = ff.toByteArray();
 
 
-        final String magicHeader = new String(data, 0, 3, "UTF-8");
+        final String magicHeader = new String(data, 0, 3, StandardCharsets.UTF_8);
         assertEquals("SEQ", magicHeader);
         // Format of header is SEQ followed by the version (1 byte).
         // Then, the length of the Key type (1 byte), then the Key type
@@ -254,7 +254,7 @@ public class TestCreateHadoopSequenceFile {
         final String valueType = BytesWritable.class.getCanonicalName();
 
         assertEquals(valueType.length(), valueTypeLength);
-        assertEquals(valueType, new String(data, valueTypeStart, valueType.length(), "UTF-8"));
+        assertEquals(valueType, new String(data, valueTypeStart, valueType.length(), StandardCharsets.UTF_8));
 
         final int compressionIndex = 3 + 1 + 1 + keyType.length() + 1 + valueType.length();
         final int blockCompressionIndex = compressionIndex + 1;
@@ -265,11 +265,11 @@ public class TestCreateHadoopSequenceFile {
         final int codecTypeSize = data[blockCompressionIndex + 1];
         final int codecTypeStartIndex = blockCompressionIndex + 2;
 
-        assertEquals(DefaultCodec.class.getCanonicalName(), new String(data, codecTypeStartIndex, codecTypeSize, "UTF-8"));
+        assertEquals(DefaultCodec.class.getCanonicalName(), new String(data, codecTypeStartIndex, codecTypeSize, StandardCharsets.UTF_8));
     }
 
     @Test
-    public void testSequenceFileNoneCompressionCodec() throws UnsupportedEncodingException, IOException {
+    public void testSequenceFileNoneCompressionCodec() throws IOException {
 
         controller.setProperty(AbstractHadoopProcessor.COMPRESSION_CODEC, CompressionType.NONE.name());
         controller.setProperty(CreateHadoopSequenceFile.COMPRESSION_TYPE, SequenceFile.CompressionType.BLOCK.name());
@@ -290,7 +290,7 @@ public class TestCreateHadoopSequenceFile {
         byte[] data = ff.toByteArray();
 
 
-        final String magicHeader = new String(data, 0, 3, "UTF-8");
+        final String magicHeader = new String(data, 0, 3, StandardCharsets.UTF_8);
         assertEquals("SEQ", magicHeader);
         // Format of header is SEQ followed by the version (1 byte).
         // Then, the length of the Key type (1 byte), then the Key type
@@ -301,7 +301,7 @@ public class TestCreateHadoopSequenceFile {
         final String valueType = BytesWritable.class.getCanonicalName();
 
         assertEquals(valueType.length(), valueTypeLength);
-        assertEquals(valueType, new String(data, valueTypeStart, valueType.length(), "UTF-8"));
+        assertEquals(valueType, new String(data, valueTypeStart, valueType.length(), StandardCharsets.UTF_8));
 
         final int compressionIndex = 3 + 1 + 1 + keyType.length() + 1 + valueType.length();
         final int blockCompressionIndex = compressionIndex + 1;
@@ -312,6 +312,6 @@ public class TestCreateHadoopSequenceFile {
         final int codecTypeSize = data[blockCompressionIndex + 1];
         final int codecTypeStartIndex = blockCompressionIndex + 2;
 
-        assertEquals(DefaultCodec.class.getCanonicalName(), new String(data, codecTypeStartIndex, codecTypeSize, "UTF-8"));
+        assertEquals(DefaultCodec.class.getCanonicalName(), new String(data, codecTypeStartIndex, codecTypeSize, StandardCharsets.UTF_8));
     }
 }

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
@@ -130,12 +130,7 @@ public class MongoDBControllerService extends AbstractControllerService implemen
         final String user = context.getProperty(DB_USER).evaluateAttributeExpressions().getValue();
         final String passw = context.getProperty(DB_PASSWORD).evaluateAttributeExpressions().getValue();
         if (!uri.contains("@") && user != null && passw != null) {
-            try {
-                return uri.replaceFirst("://", "://" + URLEncoder.encode(user, StandardCharsets.UTF_8.toString()) + ":" + URLEncoder.encode(passw, StandardCharsets.UTF_8.toString()) + "@");
-            } catch (final UnsupportedEncodingException e) {
-                getLogger().warn("Failed to URL encode username and/or password. Using original URI.");
-                return uri;
-            }
+            return uri.replaceFirst("://", "://" + URLEncoder.encode(user, StandardCharsets.UTF_8) + ":" + URLEncoder.encode(passw, StandardCharsets.UTF_8) + "@");
         } else {
             return uri;
         }

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
@@ -26,7 +26,6 @@ import com.mongodb.client.MongoDatabase;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunkHTTP.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/PutSplunkHTTP.java
@@ -40,9 +40,9 @@ import org.apache.nifi.processor.util.StandardValidators;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -188,14 +188,14 @@ public class PutSplunkHTTP extends SplunkAPICall {
                     // fall-through
                 default:
                     getLogger().error("Putting data into Splunk was not successful. Response with header {} was: {}",
-                            responseMessage.getStatus(), IOUtils.toString(responseMessage.getContent(), "UTF-8"));
+                            responseMessage.getStatus(), IOUtils.toString(responseMessage.getContent(), StandardCharsets.UTF_8));
             }
         } catch (final Exception e) {
             getLogger().error("Error during communication with Splunk: {}", e.getMessage(), e);
 
             if (responseMessage != null) {
                 try {
-                    getLogger().error("The response content is: {}", IOUtils.toString(responseMessage.getContent(), "UTF-8"));
+                    getLogger().error("The response content is: {}", IOUtils.toString(responseMessage.getContent(), StandardCharsets.UTF_8));
                 } catch (final IOException ioException) {
                     getLogger().error("An error occurred during reading response content!");
                 }
@@ -259,13 +259,8 @@ public class PutSplunkHTTP extends SplunkAPICall {
         if (!queryParameters.isEmpty()) {
             final List<String> parameters = new LinkedList<>();
 
-            try {
-                for (final Map.Entry<String, String> parameter : queryParameters.entrySet()) {
-                    parameters.add(URLEncoder.encode(parameter.getKey(), "UTF-8") + '=' + URLEncoder.encode(parameter.getValue(), "UTF-8"));
-                }
-            } catch (final UnsupportedEncodingException e) {
-                getLogger().error("Could not be initialized because of: {}", e.getMessage(), e);
-                throw new ProcessException(e);
+            for (final Map.Entry<String, String> parameter : queryParameters.entrySet()) {
+                parameters.add(URLEncoder.encode(parameter.getKey(), StandardCharsets.UTF_8) + '=' + URLEncoder.encode(parameter.getValue(), StandardCharsets.UTF_8));
             }
 
             result.append('?');

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestPutSplunkHTTP.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestPutSplunkHTTP.java
@@ -224,25 +224,25 @@ public class TestPutSplunkHTTP {
 
     private MockFlowFile givenFlowFile() throws UnsupportedEncodingException {
         final MockFlowFile result = new MockFlowFile(System.currentTimeMillis());
-        result.setData(EVENT.getBytes("UTF-8"));
+        result.setData(EVENT.getBytes(StandardCharsets.UTF_8));
         result.putAttributes(Collections.singletonMap("mime.type", "application/json"));
         return result;
     }
 
     private void givenSplunkReturnsWithSuccess() throws Exception {
-        final InputStream inputStream = new ByteArrayInputStream(SUCCESS_RESPONSE.getBytes("UTF-8"));
+        final InputStream inputStream = new ByteArrayInputStream(SUCCESS_RESPONSE.getBytes(StandardCharsets.UTF_8));
         Mockito.when(response.getStatus()).thenReturn(200);
         Mockito.when(response.getContent()).thenReturn(inputStream);
     }
 
     private void givenSplunkReturnsWithFailure() throws Exception {
-        final InputStream inputStream = new ByteArrayInputStream(FAILURE_RESPONSE.getBytes("UTF-8"));
+        final InputStream inputStream = new ByteArrayInputStream(FAILURE_RESPONSE.getBytes(StandardCharsets.UTF_8));
         Mockito.when(response.getStatus()).thenReturn(200);
         Mockito.when(response.getContent()).thenReturn(inputStream);
     }
 
     private void givenSplunkReturnsWithApplicationFailure(int code) throws Exception {
-        final InputStream inputStream = new ByteArrayInputStream("non-json-content".getBytes("UTF-8"));
+        final InputStream inputStream = new ByteArrayInputStream("non-json-content".getBytes(StandardCharsets.UTF_8));
         Mockito.when(response.getStatus()).thenReturn(code);
         Mockito.when(response.getContent()).thenReturn(inputStream);
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFetchDistributedMapCache.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFetchDistributedMapCache.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -101,7 +102,7 @@ public class TestFetchDistributedMapCache {
         final Map<String, String> props = new HashMap<>();
         props.put("cacheKeyAttribute", "key");
         String flowFileContent = "content";
-        runner.enqueue(flowFileContent.getBytes("UTF-8"), props);
+        runner.enqueue(flowFileContent.getBytes(StandardCharsets.UTF_8), props);
 
         runner.run();
 
@@ -123,7 +124,7 @@ public class TestFetchDistributedMapCache {
         final Map<String, String> props = new HashMap<>();
         props.put("cacheKeyAttribute", "key");
         String flowFileContent = "content";
-        runner.enqueue(flowFileContent.getBytes("UTF-8"), props);
+        runner.enqueue(flowFileContent.getBytes(StandardCharsets.UTF_8), props);
 
         runner.run();
 
@@ -146,7 +147,7 @@ public class TestFetchDistributedMapCache {
         final Map<String, String> props = new HashMap<>();
         props.put("cacheKeyAttribute", "key");
         String flowFileContent = "content";
-        runner.enqueue(flowFileContent.getBytes("UTF-8"), props);
+        runner.enqueue(flowFileContent.getBytes(StandardCharsets.UTF_8), props);
 
         runner.run();
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetFile.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
@@ -55,7 +56,7 @@ public class TestGetFile {
 
         runner.assertAllFlowFilesTransferred(GetFile.REL_SUCCESS, 1);
         final List<MockFlowFile> successFiles = runner.getFlowFilesForRelationship(GetFile.REL_SUCCESS);
-        successFiles.get(0).assertContentEquals("Hello, World!".getBytes("UTF-8"));
+        successFiles.get(0).assertContentEquals("Hello, World!".getBytes(StandardCharsets.UTF_8));
 
         final String path = successFiles.get(0).getAttribute("path");
         assertEquals("/", path);
@@ -95,7 +96,7 @@ public class TestGetFile {
 
         runner.assertAllFlowFilesTransferred(GetFile.REL_SUCCESS, 1);
         final List<MockFlowFile> successFiles = runner.getFlowFilesForRelationship(GetFile.REL_SUCCESS);
-        successFiles.get(0).assertContentEquals("Hello, World!".getBytes("UTF-8"));
+        successFiles.get(0).assertContentEquals("Hello, World!".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -120,7 +121,7 @@ public class TestGetFile {
 
         runner.assertAllFlowFilesTransferred(GetFile.REL_SUCCESS, 1);
         final List<MockFlowFile> successFiles = runner.getFlowFilesForRelationship(GetFile.REL_SUCCESS);
-        successFiles.get(0).assertContentEquals("Hello, World!".getBytes("UTF-8"));
+        successFiles.get(0).assertContentEquals("Hello, World!".getBytes(StandardCharsets.UTF_8));
 
         final String path = successFiles.get(0).getAttribute("path");
         assertEquals(dirStruc, path.replace('\\', '/'));

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGetSFTP.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -155,7 +156,7 @@ public class TestGetSFTP {
     }
 
     private void touchFile(String file) throws IOException {
-        FileUtils.writeStringToFile(new File(file), "", "UTF-8");
+        FileUtils.writeStringToFile(new File(file), "", StandardCharsets.UTF_8);
     }
 
     private void emptyTestDirectory() throws IOException {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestMergeContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestMergeContent.java
@@ -1197,13 +1197,13 @@ public class TestMergeContent {
 
         if ("c".equals(attr1)) {
             assertEquals("b", attr2);
-            merged1.assertContentEquals("A Canal ", "UTF-8");
-            merged2.assertContentEquals("A Man A Plan Panama", "UTF-8");
+            merged1.assertContentEquals("A Canal ", StandardCharsets.UTF_8);
+            merged2.assertContentEquals("A Man A Plan Panama", StandardCharsets.UTF_8);
         } else {
             assertEquals("b", attr1);
             assertEquals("c", attr2);
-            merged1.assertContentEquals("A Man A Plan Panama", "UTF-8");
-            merged2.assertContentEquals("A Canal ", "UTF-8");
+            merged1.assertContentEquals("A Man A Plan Panama", StandardCharsets.UTF_8);
+            merged2.assertContentEquals("A Canal ", StandardCharsets.UTF_8);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutDistributedMapCache.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutDistributedMapCache.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,14 +73,14 @@ public class TestPutDistributedMapCache {
         props.put("cacheKeyAttribute", "1");
 
         String flowFileContent = "content";
-        runner.enqueue(flowFileContent.getBytes("UTF-8"), props);
+        runner.enqueue(flowFileContent.getBytes(StandardCharsets.UTF_8), props);
 
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutDistributedMapCache.REL_SUCCESS, 1);
         runner.assertTransferCount(PutDistributedMapCache.REL_SUCCESS, 1);
         byte[] value = service.get("1", new PutDistributedMapCache.StringSerializer(), new PutDistributedMapCache.CacheValueDeserializer());
-        assertEquals(flowFileContent, new String(value, "UTF-8"));
+        assertEquals(flowFileContent, new String(value, StandardCharsets.UTF_8));
 
         final MockFlowFile outputFlowFile = runner.getFlowFilesForRelationship(PutDistributedMapCache.REL_SUCCESS).get(0);
         outputFlowFile.assertAttributeEquals("cached", "true");
@@ -112,7 +113,7 @@ public class TestPutDistributedMapCache {
 
         // max length is 10 bytes, flow file content is 20 bytes
         String flowFileContent = "contentwhichistoobig";
-        runner.enqueue(flowFileContent.getBytes("UTF-8"));
+        runner.enqueue(flowFileContent.getBytes(StandardCharsets.UTF_8));
 
         runner.run();
 
@@ -139,7 +140,7 @@ public class TestPutDistributedMapCache {
         props.put("cacheKeyAttribute", "replaceme");
 
         String original = "original";
-        runner.enqueue(original.getBytes("UTF-8"), props);
+        runner.enqueue(original.getBytes(StandardCharsets.UTF_8), props);
 
         runner.run();
 
@@ -152,10 +153,10 @@ public class TestPutDistributedMapCache {
 
         runner.clearTransferState();
         byte[] value = service.get("replaceme", new PutDistributedMapCache.StringSerializer(), new PutDistributedMapCache.CacheValueDeserializer());
-        assertEquals(original, new String(value, "UTF-8"));
+        assertEquals(original, new String(value, StandardCharsets.UTF_8));
 
         String replaced = "replaced";
-        runner.enqueue(replaced.getBytes("UTF-8"), props);
+        runner.enqueue(replaced.getBytes(StandardCharsets.UTF_8), props);
 
         runner.run();
 
@@ -170,7 +171,7 @@ public class TestPutDistributedMapCache {
 
         // we expect that the cache entry is replaced
         value = service.get("replaceme", new PutDistributedMapCache.StringSerializer(), new PutDistributedMapCache.CacheValueDeserializer());
-        assertEquals(replaced, new String(value, "UTF-8"));
+        assertEquals(replaced, new String(value, StandardCharsets.UTF_8));
     }
 
     @Test
@@ -183,7 +184,7 @@ public class TestPutDistributedMapCache {
         props.put("cacheKeyAttribute", "replaceme");
 
         String original = "original";
-        runner.enqueue(original.getBytes("UTF-8"), props);
+        runner.enqueue(original.getBytes(StandardCharsets.UTF_8), props);
 
         runner.run();
 
@@ -196,10 +197,10 @@ public class TestPutDistributedMapCache {
 
         runner.clearTransferState();
         byte[] value = service.get("replaceme", new PutDistributedMapCache.StringSerializer(), new PutDistributedMapCache.CacheValueDeserializer());
-        assertEquals(original, new String(value, "UTF-8"));
+        assertEquals(original, new String(value, StandardCharsets.UTF_8));
 
         String replaced = "replaced";
-        runner.enqueue(replaced.getBytes("UTF-8"), props);
+        runner.enqueue(replaced.getBytes(StandardCharsets.UTF_8), props);
 
         runner.run();
 
@@ -214,7 +215,7 @@ public class TestPutDistributedMapCache {
 
         // we expect that the cache entry is NOT replaced
         value = service.get("replaceme", new PutDistributedMapCache.StringSerializer(), new PutDistributedMapCache.CacheValueDeserializer());
-        assertEquals(original, new String(value, "UTF-8"));
+        assertEquals(original, new String(value, StandardCharsets.UTF_8));
     }
 
     private static class MockCacheClient extends AbstractControllerService implements DistributedMapCacheClient {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
@@ -427,7 +427,7 @@ public class TestPutEmail {
             final MimeMultipart multipart = (MimeMultipart) message.getContent();
             final BodyPart part = multipart.getBodyPart(0);
             final InputStream is = part.getDataHandler().getInputStream();
-            final String encoding = Charset.forName("US-ASCII").equals(charset) ? "7bit" : "base64";
+            final String encoding = StandardCharsets.US_ASCII.equals(charset) ? "7bit" : "base64";
             final byte[] decodedTextBytes = "base64".equals(encoding) ? Base64.decodeBase64(IOUtils.toByteArray(is)) : IOUtils.toByteArray(is);
             final String decodedText = StringUtils.newString(decodedTextBytes, charset.name());
             return decodedText;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestReplaceText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestReplaceText.java
@@ -167,7 +167,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("Hlleo, World!".getBytes("UTF-8"));
+        out.assertContentEquals("Hlleo, World!".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -181,7 +181,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("a\\$b".getBytes("UTF-8"));
+        out.assertContentEquals("a\\$b".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -195,7 +195,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("a$b".getBytes("UTF-8"));
+        out.assertContentEquals("a$b".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -209,7 +209,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("TESTHello, World!".getBytes("UTF-8"));
+        out.assertContentEquals("TESTHello, World!".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -224,7 +224,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("_hello\n_there\n_madam".getBytes("UTF-8"));
+        out.assertContentEquals("_hello\n_there\n_madam".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -240,7 +240,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("_hello\nthere\nmadam".getBytes("UTF-8"));
+        out.assertContentEquals("_hello\nthere\nmadam".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -256,7 +256,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("hello\nthere\n_madam".getBytes("UTF-8"));
+        out.assertContentEquals("hello\nthere\n_madam".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -272,7 +272,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("hello\n_there\n_madam".getBytes("UTF-8"));
+        out.assertContentEquals("hello\n_there\n_madam".getBytes(StandardCharsets.UTF_8));
     }
 
 
@@ -289,7 +289,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("_hello\n_there\nmadam".getBytes("UTF-8"));
+        out.assertContentEquals("_hello\n_there\nmadam".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -303,7 +303,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("Hello, World!TEST".getBytes("UTF-8"));
+        out.assertContentEquals("Hello, World!TEST".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -496,7 +496,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("Hlleo, World!".getBytes("UTF-8"));
+        out.assertContentEquals("Hlleo, World!".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -985,7 +985,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("Hello TEST\rWorld TEST\r".getBytes("UTF-8"));
+        out.assertContentEquals("Hello TEST\rWorld TEST\r".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -1000,7 +1000,7 @@ public class TestReplaceText {
 
         runner.assertAllFlowFilesTransferred(ReplaceText.REL_SUCCESS, 1);
         final MockFlowFile out = runner.getFlowFilesForRelationship(ReplaceText.REL_SUCCESS).get(0);
-        out.assertContentEquals("Hello TEST\r\nWorld TEST\r\n".getBytes("UTF-8"));
+        out.assertContentEquals("Hello TEST\r\nWorld TEST\r\n".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestRouteText.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestRouteText.java
@@ -24,6 +24,7 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -105,7 +106,7 @@ public class TestRouteText {
         runner.setProperty(RouteText.MATCH_STRATEGY, RouteText.MATCHES_REGULAR_EXPRESSION);
         runner.setProperty("simple", "[");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         assertThrows(AssertionError.class, () -> {
             runner.run();
         });
@@ -117,16 +118,16 @@ public class TestRouteText {
         runner.setProperty(RouteText.MATCH_STRATEGY, RouteText.STARTS_WITH);
         runner.setProperty("simple", "start");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("simple", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("simple").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -136,16 +137,16 @@ public class TestRouteText {
         runner.setProperty(RouteText.IGNORE_CASE, "false");
         runner.setProperty("simple", "start");
 
-        runner.enqueue("STart middle end\nstart middle end".getBytes("UTF-8"));
+        runner.enqueue("STart middle end\nstart middle end".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("simple", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("simple").get(0);
-        outMatched.assertContentEquals("start middle end".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("STart middle end\n".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("STart middle end\n".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -155,14 +156,14 @@ public class TestRouteText {
         runner.setProperty(RouteText.IGNORE_CASE, "true");
         runner.setProperty("simple", "start");
 
-        runner.enqueue("start middle end\nSTart middle end".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nSTart middle end".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("simple", 1);
         runner.assertTransferCount("unmatched", 0);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("simple").get(0);
-        outMatched.assertContentEquals("start middle end\nSTart middle end".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\nSTart middle end".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -172,16 +173,16 @@ public class TestRouteText {
         runner.setProperty("simple", "end");
 
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("simple", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("simple").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -193,7 +194,7 @@ public class TestRouteText {
         runner.setProperty("z", "z");
 
         final String originalText = "start middle end\nnot match";
-        runner.enqueue(originalText.getBytes("UTF-8"));
+        runner.enqueue(originalText.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("t", 1);
@@ -216,7 +217,7 @@ public class TestRouteText {
         runner.setProperty("o", "o");
 
         final String originalText = "1,hello\n2,world\n1,good-bye";
-        runner.enqueue(originalText.getBytes("UTF-8"));
+        runner.enqueue(originalText.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("o", 2);
@@ -251,7 +252,7 @@ public class TestRouteText {
         runner.setProperty("o", "o");
 
         final String originalText = "1,5,hello\n2,5,world\n1,8,good-bye\n1,5,overt";
-        runner.enqueue(originalText.getBytes("UTF-8"));
+        runner.enqueue(originalText.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("o", 3);
@@ -291,7 +292,7 @@ public class TestRouteText {
         runner.setProperty("l", "l");
 
         final String originalText = "1,hello\n2,world\n1,good-bye\n3,ciao";
-        runner.enqueue(originalText.getBytes("UTF-8"));
+        runner.enqueue(originalText.getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("l", 2);
@@ -340,16 +341,16 @@ public class TestRouteText {
         runner.setProperty(RouteText.MATCH_STRATEGY, RouteText.CONTAINS);
         runner.setProperty("simple", "middle");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("simple", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("simple").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -359,16 +360,16 @@ public class TestRouteText {
         runner.setProperty(RouteText.IGNORE_CASE, "true");
         runner.setProperty("simple", "miDDlE");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("simple", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("simple").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
 
@@ -378,16 +379,16 @@ public class TestRouteText {
         runner.setProperty(RouteText.MATCH_STRATEGY, RouteText.EQUALS);
         runner.setProperty("simple", "start middle end");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("simple", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("simple").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -396,16 +397,16 @@ public class TestRouteText {
         runner.setProperty(RouteText.MATCH_STRATEGY, RouteText.MATCHES_REGULAR_EXPRESSION);
         runner.setProperty("simple", ".*(mid).*");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("simple", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("simple").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -414,16 +415,16 @@ public class TestRouteText {
         runner.setProperty(RouteText.MATCH_STRATEGY, RouteText.CONTAINS_REGULAR_EXPRESSION);
         runner.setProperty("simple", "(m.d)");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("simple", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("simple").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     /* ------------------------------------------------------ */
@@ -436,16 +437,16 @@ public class TestRouteText {
         runner.setProperty("simple", "start");
         runner.setProperty("no", "no match");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("matched", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("matched").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -456,16 +457,16 @@ public class TestRouteText {
         runner.setProperty("simple", "end");
         runner.setProperty("no", "no match");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("matched", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("matched").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -476,16 +477,16 @@ public class TestRouteText {
         runner.setProperty("simple", "start middle end");
         runner.setProperty("no", "no match");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("matched", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("matched").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -496,16 +497,16 @@ public class TestRouteText {
         runner.setProperty("simple", ".*(m.d).*");
         runner.setProperty("no", "no match");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("matched", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("matched").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -516,16 +517,16 @@ public class TestRouteText {
         runner.setProperty("simple", "(m.d)");
         runner.setProperty("no", "no match");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("matched", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("matched").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     /* ------------------------------------------------------ */
@@ -538,16 +539,16 @@ public class TestRouteText {
         runner.setProperty("simple", "start middle");
         runner.setProperty("second", "star");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("matched", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("matched").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -558,16 +559,16 @@ public class TestRouteText {
         runner.setProperty("simple", "middle end");
         runner.setProperty("second", "nd");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("matched", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("matched").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -578,16 +579,16 @@ public class TestRouteText {
         runner.setProperty("simple", "start middle end");
         runner.setProperty("second", "start middle end");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("matched", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("matched").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -598,16 +599,16 @@ public class TestRouteText {
         runner.setProperty("simple", ".*(m.d).*");
         runner.setProperty("second", ".*(t.*m).*");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("matched", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("matched").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -618,16 +619,16 @@ public class TestRouteText {
         runner.setProperty("simple", "(m.d)");
         runner.setProperty("second", "(t.*m)");
 
-        runner.enqueue("start middle end\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("matched", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("matched").get(0);
-        outMatched.assertContentEquals("start middle end\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -636,16 +637,16 @@ public class TestRouteText {
         runner.setProperty(RouteText.MATCH_STRATEGY, RouteText.STARTS_WITH);
         runner.setProperty("simple", "start");
 
-        runner.enqueue("start middle end\r\nnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\r\nnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("simple", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("simple").get(0);
-        outMatched.assertContentEquals("start middle end\r\n".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\r\n".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -654,16 +655,16 @@ public class TestRouteText {
         runner.setProperty(RouteText.MATCH_STRATEGY, RouteText.STARTS_WITH);
         runner.setProperty("simple", "start");
 
-        runner.enqueue("start middle end\rnot match".getBytes("UTF-8"));
+        runner.enqueue("start middle end\rnot match".getBytes(StandardCharsets.UTF_8));
         runner.run();
 
         runner.assertTransferCount("simple", 1);
         runner.assertTransferCount("unmatched", 1);
         runner.assertTransferCount("original", 1);
         final MockFlowFile outMatched = runner.getFlowFilesForRelationship("simple").get(0);
-        outMatched.assertContentEquals("start middle end\r".getBytes("UTF-8"));
+        outMatched.assertContentEquals("start middle end\r".getBytes(StandardCharsets.UTF_8));
         final MockFlowFile outUnmatched = runner.getFlowFilesForRelationship("unmatched").get(0);
-        outUnmatched.assertContentEquals("not match".getBytes("UTF-8"));
+        outUnmatched.assertContentEquals("not match".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestScanContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestScanContent.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -60,7 +61,7 @@ public class TestScanContent {
 
         try (final DataOutputStream dictionaryOut = new DataOutputStream(baos)) {
             for (final String term : terms) {
-                final byte[] termBytes = term.getBytes("UTF-8");
+                final byte[] termBytes = term.getBytes(StandardCharsets.UTF_8);
                 dictionaryOut.writeInt(termBytes.length);
                 dictionaryOut.write(termBytes);
             }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestWait.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestWait.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.ConcurrentModificationException;
@@ -259,7 +260,7 @@ public class TestWait {
         waitAttributes.put("wait.only", "waitValue");
         waitAttributes.put("both", "waitValue");
         String flowFileContent = "content";
-        runner.enqueue(flowFileContent.getBytes("UTF-8"), waitAttributes);
+        runner.enqueue(flowFileContent.getBytes(StandardCharsets.UTF_8), waitAttributes);
 
         // make sure the key is in the cache before Wait runs
         assertNotNull(protocol.getSignal("key"));
@@ -304,7 +305,7 @@ public class TestWait {
         waitAttributes.put("wait.only", "waitValue");
         waitAttributes.put("both", "waitValue");
         String flowFileContent = "content";
-        runner.enqueue(flowFileContent.getBytes("UTF-8"), waitAttributes);
+        runner.enqueue(flowFileContent.getBytes(StandardCharsets.UTF_8), waitAttributes);
 
         runner.run();
 
@@ -344,7 +345,7 @@ public class TestWait {
         waitAttributes.put("wait.only", "waitValue");
         waitAttributes.put("both", "waitValue");
         String flowFileContent = "content";
-        runner.enqueue(flowFileContent.getBytes("UTF-8"), waitAttributes);
+        runner.enqueue(flowFileContent.getBytes(StandardCharsets.UTF_8), waitAttributes);
 
         /*
          * 1st iteration
@@ -432,7 +433,7 @@ public class TestWait {
         waitAttributes.put("wait.only", "waitValue");
         waitAttributes.put("both", "waitValue");
         String flowFileContent = "content";
-        runner.enqueue(flowFileContent.getBytes("UTF-8"), waitAttributes);
+        runner.enqueue(flowFileContent.getBytes(StandardCharsets.UTF_8), waitAttributes);
 
         /*
          * 1st iteration
@@ -534,7 +535,7 @@ public class TestWait {
         waitAttributes.put("both", "waitValue");
         waitAttributes.put("uuid", UUID.randomUUID().toString());
         String flowFileContent = "content";
-        runner.enqueue(flowFileContent.getBytes("UTF-8"), waitAttributes);
+        runner.enqueue(flowFileContent.getBytes(StandardCharsets.UTF_8), waitAttributes);
 
         /*
          * 1st iteration
@@ -550,7 +551,7 @@ public class TestWait {
         assertEquals("1", Long.toString(protocol.getSignal("key").getReleasableCount()));
 
         // introduce a second flow file with the same signal attribute
-        runner.enqueue(flowFileContent.getBytes("UTF-8"), waitAttributes);
+        runner.enqueue(flowFileContent.getBytes(StandardCharsets.UTF_8), waitAttributes);
 
         /*
          * 2nd iteration

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/syslog/TestSyslogRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/syslog/TestSyslogRecordReader.java
@@ -29,13 +29,14 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestSyslogRecordReader {
-    private static final Charset CHARSET = Charset.forName("UTF-8");
+    private static final Charset CHARSET = StandardCharsets.UTF_8;
     private static final String PRI = "34";
     private static final String SEV = "2";
     private static final String FAC = "4";

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/PutWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/main/java/org/apache/nifi/processors/websocket/PutWebSocket.java
@@ -24,7 +24,7 @@ import static org.apache.nifi.processors.websocket.WebSocketProcessorAttributes.
 import static org.apache.nifi.processors.websocket.WebSocketProcessorAttributes.ATTR_WS_MESSAGE_TYPE;
 import static org.apache.nifi.processors.websocket.WebSocketProcessorAttributes.ATTR_WS_REMOTE_ADDRESS;
 import static org.apache.nifi.processors.websocket.WebSocketProcessorAttributes.ATTR_WS_SESSION_ID;
-import static org.apache.nifi.websocket.WebSocketMessage.CHARSET_NAME;
+import static org.apache.nifi.websocket.WebSocketMessage.CHARSET;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -206,7 +206,7 @@ public class PutWebSocket extends AbstractProcessor {
             webSocketService.sendMessage(webSocketServiceEndpoint, sessionId, sender -> {
                 switch (messageType) {
                     case TEXT:
-                        sender.sendString(new String(messageContent, CHARSET_NAME));
+                        sender.sendString(new String(messageContent, CHARSET));
                         break;
                     case BINARY:
                         sender.sendBinary(ByteBuffer.wrap(messageContent));

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/WebSocketMessage.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/WebSocketMessage.java
@@ -16,10 +16,11 @@
  */
 package org.apache.nifi.websocket;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class WebSocketMessage {
-    public static final String CHARSET_NAME = "UTF-8";
+    public static final Charset CHARSET = StandardCharsets.UTF_8;
 
     public enum Type {
         TEXT,
@@ -49,13 +50,10 @@ public class WebSocketMessage {
             return;
         }
 
-        try {
-            final byte[] bytes = text.getBytes(CHARSET_NAME);
-            setPayload(bytes, 0, bytes.length);
-            type = Type.TEXT;
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException("Failed to serialize messageStr, due to " + e, e);
-        }
+        final byte[] bytes = text.getBytes(CHARSET);
+        setPayload(bytes, 0, bytes.length);
+        type = Type.TEXT;
+
     }
 
     public void setPayload(final byte[] payload, final int offset, final int length) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiWebConfigurationContext.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiWebConfigurationContext.java
@@ -66,10 +66,11 @@ import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
-import java.io.UnsupportedEncodingException;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -364,9 +365,9 @@ public class StandardNiFiWebConfigurationContext implements NiFiWebConfiguration
                 // create the request URL
                 URI requestUrl;
                 try {
-                    final String path = "/nifi-api/processors/" + URLEncoder.encode(id, "UTF-8");
+                    final String path = "/nifi-api/processors/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
                     requestUrl = new URI(requestContext.getScheme(), null, "localhost", 0, path, null, null);
-                } catch (final URISyntaxException | UnsupportedEncodingException use) {
+                } catch (final URISyntaxException use) {
                     throw new ClusterRequestException(use);
                 }
 
@@ -422,9 +423,9 @@ public class StandardNiFiWebConfigurationContext implements NiFiWebConfiguration
                 // create the request URL
                 URI requestUrl;
                 try {
-                    final String path = "/nifi-api/processors/" + URLEncoder.encode(id, "UTF-8");
+                    final String path = "/nifi-api/processors/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
                     requestUrl = new URI(requestContext.getScheme(), null, "localhost", 0, path, null, null);
-                } catch (final URISyntaxException | UnsupportedEncodingException use) {
+                } catch (final URISyntaxException use) {
                     throw new ClusterRequestException(use);
                 }
 
@@ -549,9 +550,9 @@ public class StandardNiFiWebConfigurationContext implements NiFiWebConfiguration
                 // create the request URL
                 URI requestUrl;
                 try {
-                    String path = "/nifi-api/controller-services/" + URLEncoder.encode(id, "UTF-8");
+                    String path = "/nifi-api/controller-services/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
                     requestUrl = new URI(requestContext.getScheme(), null, "localhost", 0, path, null, null);
-                } catch (final URISyntaxException | UnsupportedEncodingException use) {
+                } catch (final URISyntaxException use) {
                     throw new ClusterRequestException(use);
                 }
 
@@ -607,9 +608,9 @@ public class StandardNiFiWebConfigurationContext implements NiFiWebConfiguration
                 // create the request URL
                 URI requestUrl;
                 try {
-                    String path = "/nifi-api/controller-services/" + URLEncoder.encode(id, "UTF-8");
+                    String path = "/nifi-api/controller-services/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
                     requestUrl = new URI(requestContext.getScheme(), null, "localhost", 0, path, null, null);
-                } catch (final URISyntaxException | UnsupportedEncodingException use) {
+                } catch (final URISyntaxException use) {
                     throw new ClusterRequestException(use);
                 }
 
@@ -697,9 +698,9 @@ public class StandardNiFiWebConfigurationContext implements NiFiWebConfiguration
                 // create the request URL
                 URI requestUrl;
                 try {
-                    String path = "/nifi-api/reporting-tasks/" + URLEncoder.encode(id, "UTF-8");
+                    String path = "/nifi-api/reporting-tasks/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
                     requestUrl = new URI(requestContext.getScheme(), null, "localhost", 0, path, null, null);
-                } catch (final URISyntaxException | UnsupportedEncodingException use) {
+                } catch (final URISyntaxException use) {
                     throw new ClusterRequestException(use);
                 }
 
@@ -751,9 +752,9 @@ public class StandardNiFiWebConfigurationContext implements NiFiWebConfiguration
                 // create the request URL
                 URI requestUrl;
                 try {
-                    String path = "/nifi-api/reporting-tasks/" + URLEncoder.encode(id, "UTF-8");
+                    String path = "/nifi-api/reporting-tasks/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
                     requestUrl = new URI(requestContext.getScheme(), null, "localhost", 0, path, null, null);
-                } catch (final URISyntaxException | UnsupportedEncodingException use) {
+                } catch (final URISyntaxException use) {
                     throw new ClusterRequestException(use);
                 }
 
@@ -842,9 +843,9 @@ public class StandardNiFiWebConfigurationContext implements NiFiWebConfiguration
                 // create the request URL
                 URI requestUrl;
                 try {
-                    String path = "/nifi-api/parameter-providers/" + URLEncoder.encode(id, "UTF-8");
+                    String path = "/nifi-api/parameter-providers/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
                     requestUrl = new URI(requestContext.getScheme(), null, "localhost", 0, path, null, null);
-                } catch (final URISyntaxException | UnsupportedEncodingException use) {
+                } catch (final URISyntaxException use) {
                     throw new ClusterRequestException(use);
                 }
 
@@ -896,9 +897,9 @@ public class StandardNiFiWebConfigurationContext implements NiFiWebConfiguration
                 // create the request URL
                 URI requestUrl;
                 try {
-                    String path = "/nifi-api/parameter-providers/" + URLEncoder.encode(id, "UTF-8");
+                    String path = "/nifi-api/parameter-providers/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
                     requestUrl = new URI(requestContext.getScheme(), null, "localhost", 0, path, null, null);
-                } catch (final URISyntaxException | UnsupportedEncodingException use) {
+                } catch (final URISyntaxException use) {
                     throw new ClusterRequestException(use);
                 }
 
@@ -986,9 +987,9 @@ public class StandardNiFiWebConfigurationContext implements NiFiWebConfiguration
                 // create the request URL
                 URI requestUrl;
                 try {
-                    String path = "/nifi-api/controller/registry-clients/" + URLEncoder.encode(id, "UTF-8");
+                    String path = "/nifi-api/controller/registry-clients/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
                     requestUrl = new URI(requestContext.getScheme(), null, "localhost", 0, path, null, null);
-                } catch (final URISyntaxException | UnsupportedEncodingException use) {
+                } catch (final URISyntaxException use) {
                     throw new ClusterRequestException(use);
                 }
 
@@ -1040,9 +1041,9 @@ public class StandardNiFiWebConfigurationContext implements NiFiWebConfiguration
                 // create the request URL
                 URI requestUrl;
                 try {
-                    String path = "/nifi-api/controller/registry-clients/" + URLEncoder.encode(id, "UTF-8");
+                    String path = "/nifi-api/controller/registry-clients/" + URLEncoder.encode(id, StandardCharsets.UTF_8);
                     requestUrl = new URI(requestContext.getScheme(), null, "localhost", 0, path, null, null);
-                } catch (final URISyntaxException | UnsupportedEncodingException use) {
+                } catch (final URISyntaxException use) {
                     throw new ClusterRequestException(use);
                 }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/service/extension/docs/TestHtmlExtensionDocWriter.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/service/extension/docs/TestHtmlExtensionDocWriter.java
@@ -90,6 +90,6 @@ public class TestHtmlExtensionDocWriter {
             extensionSerializer.serialize(tempExtension, serializedExtension);
         }
 
-        return serializedExtension.toString("UTF-8");
+        return serializedExtension.toString(StandardCharsets.UTF_8);
     }
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-security-api/src/main/java/org/apache/nifi/registry/security/authentication/BasicAuthIdentityProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-security-api/src/main/java/org/apache/nifi/registry/security/authentication/BasicAuthIdentityProvider.java
@@ -20,7 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.nio.charset.Charset;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 public abstract class BasicAuthIdentityProvider implements IdentityProvider {
@@ -74,7 +75,7 @@ public abstract class BasicAuthIdentityProvider implements IdentityProvider {
 
             // Authorization: Basic {base64credentials}
             String base64Credentials = authorization.substring(BASIC.length()).trim();
-            String credentials = new String(Base64.getDecoder().decode(base64Credentials), Charset.forName("UTF-8"));
+            String credentials = new String(Base64.getDecoder().decode(base64Credentials), StandardCharsets.UTF_8);
             // credentials = username:password
             final String[] credentialParts = credentials.split(":", 2);
             String username = credentialParts[0];

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/SecureKerberosIT.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/SecureKerberosIT.java
@@ -36,8 +36,8 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import jakarta.ws.rs.core.Response;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 
@@ -69,11 +69,7 @@ public class SecureKerberosIT extends IntegrationTestBase {
         public KerberosTicketValidation validateTicket(byte[] token) throws BadCredentialsException {
 
             boolean validTicket;
-            try {
-                 validTicket = Arrays.equals(validKerberosTicket.getBytes("UTF-8"), token);
-            } catch (UnsupportedEncodingException e) {
-                throw new IllegalStateException(e);
-            }
+            validTicket = Arrays.equals(validKerberosTicket.getBytes(StandardCharsets.UTF_8), token);
 
             if (!validTicket) {
                 throw new BadCredentialsException(MockKerberosTicketValidator.class.getSimpleName() + " does not validate token");
@@ -104,7 +100,7 @@ public class SecureKerberosIT extends IntegrationTestBase {
 
     @BeforeEach
     public void generateAuthToken() {
-        String validTicket = new String(Base64.getEncoder().encode(validKerberosTicket.getBytes(Charset.forName("UTF-8"))));
+        String validTicket = new String(Base64.getEncoder().encode(validKerberosTicket.getBytes(StandardCharsets.UTF_8)));
         final String token = client
                 .target(createURL("/access/token/kerberos"))
                 .request()
@@ -142,7 +138,7 @@ public class SecureKerberosIT extends IntegrationTestBase {
         assertEquals("Negotiate", tokenResponse1.getHeaders().get("www-authenticate").get(0));
 
         // When: the /access/token/kerberos endpoint is accessed again with an invalid ticket
-        String invalidTicket = new String(java.util.Base64.getEncoder().encode(invalidKerberosTicket.getBytes(Charset.forName("UTF-8"))));
+        String invalidTicket = new String(java.util.Base64.getEncoder().encode(invalidKerberosTicket.getBytes(StandardCharsets.UTF_8)));
         final Response tokenResponse2 = client
                 .target(createURL("/access/token/kerberos"))
                 .request()
@@ -153,7 +149,7 @@ public class SecureKerberosIT extends IntegrationTestBase {
         assertEquals(401, tokenResponse2.getStatus());
 
         // When: the /access/token/kerberos endpoint is accessed with a valid ticket
-        String validTicket = new String(Base64.getEncoder().encode(validKerberosTicket.getBytes(Charset.forName("UTF-8"))));
+        String validTicket = new String(Base64.getEncoder().encode(validKerberosTicket.getBytes(StandardCharsets.UTF_8)));
         final Response tokenResponse3 = client
                 .target(createURL("/access/token/kerberos"))
                 .request()
@@ -166,7 +162,7 @@ public class SecureKerberosIT extends IntegrationTestBase {
         assertTrue(StringUtils.isNotEmpty(token));
         String[] jwtParts = token.split("\\.");
         assertEquals(3, jwtParts.length);
-        String jwtPayload = new String(Base64.getDecoder().decode(jwtParts[1]), "UTF-8");
+        String jwtPayload = new String(Base64.getDecoder().decode(jwtParts[1]), StandardCharsets.UTF_8);
         JSONAssert.assertEquals(expectedJwtPayloadJson, jwtPayload, false);
 
         // When: the token is returned in the Authorization header

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/extensions/NexusExtensionClient.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/extensions/NexusExtensionClient.java
@@ -38,13 +38,15 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 public class NexusExtensionClient implements ExtensionClient {
     private static final Logger logger = LoggerFactory.getLogger(NexusExtensionClient.class);
     private static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
-    private static final String URL_CHARSET = "UTF-8";
+    private static final Charset URL_CHARSET = StandardCharsets.UTF_8;
 
     private final String baseUrl;
     private final long timeoutMillis;

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -38,6 +38,7 @@ under the License.
     <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation" />
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
     <rule ref="category/java/bestpractices.xml/UnnecessaryVarargsArrayCreation" />
+    <rule ref="category/java/bestpractices.xml/UseStandardCharsets" />
 
     <rule ref="category/java/codestyle.xml/AvoidDollarSigns" />
     <rule ref="category/java/codestyle.xml/ExtendsObject" />


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14135](https://issues.apache.org/jira/browse/NIFI-14135)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
