### PR TITLE
NIFI-14141 add variable size for FlowFiles created by GenerateFlowFile

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateFlowFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestGenerateFlowFile.java
@@ -19,7 +19,12 @@ package org.apache.nifi.processors.standard;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Unit tests for the GenerateFlowFile processor.
@@ -71,6 +76,33 @@ public class TestGenerateFlowFile {
         generatedFlowFile.assertAttributeEquals("plain.dynamic.property", "Plain Value");
         generatedFlowFile.assertAttributeEquals("expression.dynamic.property", "Expression Value");
         generatedFlowFile.assertAttributeEquals("mime.type", "application/text");
+    }
+
+    @Test
+    public void testVariableSize() {
+        TestRunner runner = TestRunners.newTestRunner(new GenerateFlowFile());
+        runner.setProperty(GenerateFlowFile.VARIABLE_SIZE, "true");
+        runner.setProperty(GenerateFlowFile.MINIMUM_FILE_SIZE, "1 B");
+        runner.setProperty(GenerateFlowFile.MAXIMUM_FILE_SIZE, "10 B");
+        runner.setProperty(GenerateFlowFile.UNIQUE_FLOWFILES, "true");
+        runner.assertValid();
+
+        // Execute multiple times to ensure adequate distribution of file sizes
+        runner.run(1000);
+
+        runner.assertTransferCount(GenerateFlowFile.SUCCESS, 1000);
+        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(GenerateFlowFile.SUCCESS);
+        Map<Long, Integer> fileSizeDistribution = new HashMap<>();
+        flowFiles.forEach(ff -> {
+            long fileSize = ff.getSize();
+            fileSizeDistribution.put(fileSize, fileSizeDistribution.getOrDefault(fileSize, 0) + 1);
+        });
+        long minSize = fileSizeDistribution.keySet().stream().min(Long::compareTo).orElse(-1L); //.orElseThrow(() -> new NoSuchElementException("Map is empty"));
+        long maxSize = fileSizeDistribution.keySet().stream().max(Long::compareTo).orElse(-1L);
+
+        // Assert all file sizes fall within the range and that there exists more than one unique file size value
+        Assertions.assertTrue(minSize > 0 && minSize < maxSize);
+        Assertions.assertTrue(maxSize <= 10);
     }
 
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14141](https://issues.apache.org/jira/browse/NIFI-14141)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-14141) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Configured GenerateFlowFile with Variable File Size set to true. Noted validation failures if Unique FlowFiles is set to false or Maximum File Size is less than Minimum File Size.

Executed GenerateFlowFile with varying Batch Size values. All values lead to variable sizes of FlowFiles even within the same batch.

Added unit test and ran thousands of times to assure there were no failures given that the nature of this change involves a pseudo-random FlowFile size.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
