### PR TITLE
NIFI-14141 Accept Expression Language statement in GenerateFlowFile, …

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateFlowFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateFlowFile.java
@@ -76,7 +76,7 @@ public class GenerateFlowFile extends AbstractProcessor {
             .description("The size of the file that will be used")
             .required(true)
             .defaultValue("0B")
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
     public static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
@@ -187,8 +187,6 @@ public class GenerateFlowFile extends AbstractProcessor {
             results.add(new ValidationResult.Builder().subject("Custom Text").valid(false).explanation("If Custom Text is set, then Data Format must be "
                     + "text and Unique FlowFiles must be false.").build());
         }
-
-        results.add(StandardValidators.DATA_SIZE_VALIDATOR.validate("File Size", validationContext.getProperty(FILE_SIZE).evaluateAttributeExpressions().getValue(), validationContext));
 
         return results;
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateFlowFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/GenerateFlowFile.java
@@ -76,7 +76,8 @@ public class GenerateFlowFile extends AbstractProcessor {
             .description("The size of the file that will be used")
             .required(true)
             .defaultValue("0B")
-            .addValidator(StandardValidators.DATA_SIZE_VALIDATOR)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
     public static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
             .name("Batch Size")
@@ -187,11 +188,13 @@ public class GenerateFlowFile extends AbstractProcessor {
                     + "text and Unique FlowFiles must be false.").build());
         }
 
+        results.add(StandardValidators.DATA_SIZE_VALIDATOR.validate("File Size", validationContext.getProperty(FILE_SIZE).evaluateAttributeExpressions().getValue(), validationContext));
+
         return results;
     }
 
     private byte[] generateData(final ProcessContext context) {
-        final int byteCount = context.getProperty(FILE_SIZE).asDataSize(DataUnit.B).intValue();
+        final int byteCount = context.getProperty(FILE_SIZE).evaluateAttributeExpressions().asDataSize(DataUnit.B).intValue();
 
         final Random random = new Random();
         final byte[] array = new byte[byteCount];

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.GenerateFlowFile/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/resources/docs/org.apache.nifi.processors.standard.GenerateFlowFile/additionalDetails.md
@@ -1,0 +1,31 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# GenerateFlowFile
+
+This processor can be configured to generate variable-sized FlowFiles. The `File Size` property accepts both a literal
+value, e.g. "1 KB", and Expression Language statements. In order to create FlowFiles of variable sizes, the Expression
+Language function `random()` can be used. For example, `${random():mod(101)}` will generate values between 0 and 100,
+inclusive.  A data size label, e.g. B, KB, MB, etc., must be  included in the Expression Language statement since the
+`File Size` property holds a data size value. The table below shows some examples.
+
+| File Size Expression Language Statement    | File Sizes Generated (values are inclusive) |
+|--------------------------------------------|---------------------------------------------|
+| ${random():mod(101)}b                      | 0 - 100 bytes                               |
+| ${random():mod(101)}mb                     | 0 - 100 MB                                  |
+| ${random():mod(101):plus(20)} B            | 20 - 120 bytes                              |
+| ${random():mod(71):plus(30):append("KB")}  | 30 - 100 KB                                 |
+
+See the Expression Language Guide for more details on the `random()` function.


### PR DESCRIPTION
…File Size property allowing FlowFiles of variable sizes to be generated. Included some examples of EL statements in Additional Details for GenerateFlowFile.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14141](https://issues.apache.org/jira/browse/NIFI-14141)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
