### PR TITLE
NIFI-14148 | typofix: Successfull -> Successful

### DIFF
--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPConsumerTest.java
@@ -111,7 +111,7 @@ public class AMQPConsumerTest {
     }
 
     @Test
-    public void validateSuccessfullConsumeWithEmptyQueueDefaultExchange() throws Exception {
+    public void validateSuccessfulConsumeWithEmptyQueueDefaultExchange() throws Exception {
         Map<String, List<String>> routingMap = new HashMap<>();
         routingMap.put("queue1", Arrays.asList("queue1"));
         Map<String, String> exchangeToRoutingKeymap = new HashMap<>();
@@ -125,7 +125,7 @@ public class AMQPConsumerTest {
     }
 
     @Test
-    public void validateSuccessfullConsumeWithEmptyQueue() throws Exception {
+    public void validateSuccessfulConsumeWithEmptyQueue() throws Exception {
         Map<String, List<String>> routingMap = new HashMap<>();
         routingMap.put("key1", Arrays.asList("queue1"));
         Map<String, String> exchangeToRoutingKeymap = new HashMap<>();

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPPublisherTest.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AMQPPublisherTest.java
@@ -67,7 +67,7 @@ public class AMQPPublisherTest {
     }
 
     @Test
-    public void validateSuccessfullPublishingAndRouting() throws Exception {
+    public void validateSuccessfulPublishingAndRouting() throws Exception {
         Map<String, List<String>> routingMap = new HashMap<>();
         routingMap.put("key1", Arrays.asList("queue1", "queue2"));
         Map<String, String> exchangeToRoutingKeymap = new HashMap<>();
@@ -86,7 +86,7 @@ public class AMQPPublisherTest {
     }
 
     @Test
-    public void validateSuccessfullPublishingAndUndeliverableRoutingKey() throws Exception {
+    public void validateSuccessfulPublishingAndUndeliverableRoutingKey() throws Exception {
         Map<String, List<String>> routingMap = new HashMap<>();
         routingMap.put("key1", Arrays.asList("queue1", "queue2"));
         Map<String, String> exchangeToRoutingKeymap = new HashMap<>();


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14148](https://issues.apache.org/jira/browse/NIFI-14148)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
