### PR TITLE
NIFI-14142 Declare enum values for OpenAPI using String arrays

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/AccessPolicySummaryDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/AccessPolicySummaryDTO.java
@@ -36,7 +36,7 @@ public class AccessPolicySummaryDTO extends ComponentDTO {
      * @return The action associated with this access policy.
      */
     @Schema(description = "The action associated with this access policy.",
-            allowableValues = "read, write"
+            allowableValues = {"read", "write"}
     )
     public String getAction() {
         return action;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/AffectedComponentDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/AffectedComponentDTO.java
@@ -60,9 +60,9 @@ public class AffectedComponentDTO {
     }
 
     @Schema(description = "The type of this component",
-        allowableValues = COMPONENT_TYPE_PROCESSOR + "," + COMPONENT_TYPE_CONTROLLER_SERVICE + ", "
-            + COMPONENT_TYPE_INPUT_PORT + ", " + COMPONENT_TYPE_OUTPUT_PORT + ", "
-            + COMPONENT_TYPE_REMOTE_INPUT_PORT + ", " + COMPONENT_TYPE_REMOTE_OUTPUT_PORT + ", " + COMPONENT_TYPE_STATELESS_GROUP)
+        allowableValues = {COMPONENT_TYPE_PROCESSOR, COMPONENT_TYPE_CONTROLLER_SERVICE,
+                COMPONENT_TYPE_INPUT_PORT, COMPONENT_TYPE_OUTPUT_PORT,
+                COMPONENT_TYPE_REMOTE_INPUT_PORT, COMPONENT_TYPE_REMOTE_OUTPUT_PORT, COMPONENT_TYPE_STATELESS_GROUP})
     public String getReferenceType() {
         return referenceType;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ConfigVerificationResultDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ConfigVerificationResultDTO.java
@@ -24,7 +24,7 @@ public class ConfigVerificationResultDTO {
     private String verificationStepName;
     private String explanation;
 
-    @Schema(description = "The outcome of the verification", allowableValues = "SUCCESSFUL, FAILED, SKIPPED")
+    @Schema(description = "The outcome of the verification", allowableValues = {"SUCCESSFUL", "FAILED", "SKIPPED"})
     public String getOutcome() {
         return outcome;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ConnectableDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ConnectableDTO.java
@@ -65,7 +65,7 @@ public class ConnectableDTO {
      */
     @Schema(description = "The type of component the connectable is.",
             requiredMode = Schema.RequiredMode.REQUIRED,
-            allowableValues = "PROCESSOR, REMOTE_INPUT_PORT, REMOTE_OUTPUT_PORT, INPUT_PORT, OUTPUT_PORT, FUNNEL"
+            allowableValues = {"PROCESSOR", "REMOTE_INPUT_PORT", "REMOTE_OUTPUT_PORT", "INPUT_PORT", "OUTPUT_PORT", "FUNNEL"}
     )
     public String getType() {
         return type;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ConnectionDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ConnectionDTO.java
@@ -228,7 +228,7 @@ public class ConnectionDTO extends ComponentDTO {
     }
 
     @Schema(description = "How to load balance the data in this Connection across the nodes in the cluster.",
-        allowableValues = "DO_NOT_LOAD_BALANCE, PARTITION_BY_ATTRIBUTE, ROUND_ROBIN, SINGLE_NODE")
+        allowableValues = {"DO_NOT_LOAD_BALANCE", "PARTITION_BY_ATTRIBUTE", "ROUND_ROBIN", "SINGLE_NODE"})
     public String getLoadBalanceStrategy() {
         return loadBalanceStrategy;
     }
@@ -247,7 +247,7 @@ public class ConnectionDTO extends ComponentDTO {
     }
 
     @Schema(description = "Whether or not data should be compressed when being transferred between nodes in the cluster.",
-        allowableValues = "DO_NOT_COMPRESS, COMPRESS_ATTRIBUTES_ONLY, COMPRESS_ATTRIBUTES_AND_CONTENT")
+        allowableValues = {"DO_NOT_COMPRESS", "COMPRESS_ATTRIBUTES_ONLY", "COMPRESS_ATTRIBUTES_AND_CONTENT"})
     public String getLoadBalanceCompression() {
         return loadBalanceCompression;
     }
@@ -258,7 +258,7 @@ public class ConnectionDTO extends ComponentDTO {
 
     @Schema(description = "The current status of the Connection's Load Balancing Activities. Status can indicate that Load Balancing is not configured for the connection, that Load Balancing " +
         "is configured but inactive (not currently transferring data to another node), or that Load Balancing is configured and actively transferring data to another node.",
-        allowableValues = LOAD_BALANCE_NOT_CONFIGURED + ", " + LOAD_BALANCE_INACTIVE + ", " + LOAD_BALANCE_ACTIVE,
+        allowableValues = {LOAD_BALANCE_NOT_CONFIGURED, LOAD_BALANCE_INACTIVE, LOAD_BALANCE_ACTIVE},
         accessMode = Schema.AccessMode.READ_ONLY)
     public String getLoadBalanceStatus() {
         return loadBalanceStatus;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceDTO.java
@@ -224,7 +224,7 @@ public class ControllerServiceDTO extends ComponentDTO {
      * @return The state of this controller service. Possible values are ENABLED, ENABLING, DISABLED, DISABLING
      */
     @Schema(description = "The state of the controller service.",
-            allowableValues = "ENABLED, ENABLING, DISABLED, DISABLING"
+            allowableValues = {"ENABLED", "ENABLING", "DISABLED", "DISABLING"}
     )
     public String getState() {
         return state;
@@ -332,7 +332,7 @@ public class ControllerServiceDTO extends ComponentDTO {
 
     @Schema(description = "Indicates whether the ControllerService is valid, invalid, or still in the process of validating (i.e., it is unknown whether or not the ControllerService is valid)",
         accessMode = Schema.AccessMode.READ_ONLY,
-        allowableValues = VALID + ", " + INVALID + ", " + VALIDATING)
+        allowableValues = {VALID, INVALID, VALIDATING})
     public String getValidationStatus() {
         return validationStatus;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceReferencingComponentDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ControllerServiceReferencingComponentDTO.java
@@ -118,7 +118,7 @@ public class ControllerServiceReferencingComponentDTO {
      * @return type of reference this is (Processor, ControllerService, ParameterProvider, or ReportingTask)
      */
     @Schema(description = "The type of reference this is.",
-            allowableValues = "Processor, ControllerService, ReportingTask, FlowRegistryClient"
+            allowableValues = {"Processor", "ControllerService", "ReportingTask", "FlowRegistryClient"}
     )
     public String getReferenceType() {
         return referenceType;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/FlowAnalysisRuleDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/FlowAnalysisRuleDTO.java
@@ -185,7 +185,7 @@ public class FlowAnalysisRuleDTO extends ComponentDTO {
      * @return current scheduling state of the flow analysis rule
      */
     @Schema(description = "The state of the flow analysis rule.",
-            allowableValues = "ENABLED, DISABLED"
+            allowableValues = {"ENABLED", "DISABLED"}
     )
     public String getState() {
         return state;
@@ -265,7 +265,7 @@ public class FlowAnalysisRuleDTO extends ComponentDTO {
 
     @Schema(description = "Indicates whether the Flow Analysis Rule is valid, invalid, or still in the process of validating (i.e., it is unknown whether or not the Flow Analysis Rule is valid)",
         accessMode = Schema.AccessMode.READ_ONLY,
-        allowableValues = VALID + ", " + INVALID + ", " + VALIDATING)
+        allowableValues = {VALID, INVALID, VALIDATING})
     public String getValidationStatus() {
         return validationStatus;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/FlowRegistryClientDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/FlowRegistryClientDTO.java
@@ -213,7 +213,7 @@ public class FlowRegistryClientDTO {
 
     @Schema(description = "Indicates whether the Registry Client is valid, invalid, or still in the process of validating (i.e., it is unknown whether or not the Registry Client is valid)",
             accessMode = Schema.AccessMode.READ_ONLY,
-            allowableValues = VALID + ", " + INVALID + ", " + VALIDATING)
+            allowableValues = {VALID, INVALID, VALIDATING})
     public String getValidationStatus() {
         return validationStatus;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ParameterProviderDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ParameterProviderDTO.java
@@ -284,7 +284,7 @@ public class ParameterProviderDTO extends ComponentDTO {
 
     @Schema(description = "Indicates whether the Parameter Provider is valid, invalid, or still in the process of validating (i.e., it is unknown whether or not the Parameter Provider is valid)",
         accessMode = Schema.AccessMode.READ_ONLY,
-        allowableValues = VALID + ", " + INVALID + ", " + VALIDATING)
+        allowableValues = {VALID, INVALID, VALIDATING})
     public String getValidationStatus() {
         return validationStatus;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/PortDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/PortDTO.java
@@ -55,7 +55,7 @@ public class PortDTO extends ComponentDTO {
      * @return The state of this port. Possible states are 'RUNNING', 'STOPPED', and 'DISABLED'
      */
     @Schema(description = "The state of the port.",
-            allowableValues = "RUNNING, STOPPED, DISABLED"
+            allowableValues = {"RUNNING", "STOPPED", "DISABLED"}
     )
     public String getState() {
         return state;
@@ -71,7 +71,7 @@ public class PortDTO extends ComponentDTO {
      * @return The type of port
      */
     @Schema(description = "The type of port.",
-            allowableValues = "INPUT_PORT, OUTPUT_PORT"
+            allowableValues = {"INPUT_PORT", "OUTPUT_PORT"}
     )
     public String getType() {
         return type;
@@ -150,7 +150,7 @@ public class PortDTO extends ComponentDTO {
     }
 
     @Schema(description = "Specifies how the Port functions",
-        allowableValues = "STANDARD, FAILURE"
+        allowableValues = {"STANDARD", "FAILURE"}
     )
     public String getPortFunction() {
         return portFunction;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessGroupDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessGroupDTO.java
@@ -335,7 +335,7 @@ public class ProcessGroupDTO extends ComponentDTO {
         this.parameterContext = parameterContext;
     }
 
-    @Schema(description = "The FlowFile Concurrency for this Process Group.", allowableValues = "UNBOUNDED, SINGLE_FLOWFILE_PER_NODE, SINGLE_BATCH_PER_NODE")
+    @Schema(description = "The FlowFile Concurrency for this Process Group.", allowableValues = {"UNBOUNDED", "SINGLE_FLOWFILE_PER_NODE", "SINGLE_BATCH_PER_NODE"})
     public String getFlowfileConcurrency() {
         return flowfileConcurrency;
     }
@@ -345,7 +345,7 @@ public class ProcessGroupDTO extends ComponentDTO {
     }
 
     @Schema(description = "The Outbound Policy that is used for determining how FlowFiles should be transferred out of the Process Group.",
-        allowableValues = "STREAM_WHEN_AVAILABLE, BATCH_OUTPUT")
+        allowableValues = {"STREAM_WHEN_AVAILABLE", "BATCH_OUTPUT"})
     public String getFlowfileOutboundPolicy() {
         return flowfileOutboundPolicy;
     }
@@ -391,7 +391,7 @@ public class ProcessGroupDTO extends ComponentDTO {
     }
 
     @Schema(description = "The Execution Engine that should be used to run the flow represented by this Process Group.",
-        allowableValues = "STATELESS, STANDARD, INHERITED")
+        allowableValues = {"STATELESS", "STANDARD", "INHERITED"})
     public String getExecutionEngine() {
         return executionEngine;
     }
@@ -401,7 +401,7 @@ public class ProcessGroupDTO extends ComponentDTO {
     }
 
     @Schema(description = "If the Process Group is configured to run in using the Stateless Engine, represents the current state. Otherwise, will be STOPPED.",
-            allowableValues = "STOPPED, RUNNING")
+            allowableValues = {"STOPPED", "RUNNING"})
     public String getStatelessGroupScheduledState() {
         return statelessGroupScheduledState;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorConfigDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorConfigDTO.java
@@ -332,7 +332,7 @@ public class ProcessorConfigDTO {
     }
 
     @Schema(description = "Determines whether the FlowFile should be penalized or the processor should be yielded between retries.",
-            allowableValues = "PENALIZE_FLOWFILE, YIELD_PROCESSOR"
+            allowableValues = {"PENALIZE_FLOWFILE", "YIELD_PROCESSOR"}
     )
     public String getBackoffMechanism() {
         return backoffMechanism;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorDTO.java
@@ -108,7 +108,7 @@ public class ProcessorDTO extends ComponentDTO {
      * @return The state of this processor. Possible states are 'RUNNING', 'STOPPED', and 'DISABLED'
      */
     @Schema(description = "The state of the processor",
-            allowableValues = "RUNNING, STOPPED, DISABLED"
+            allowableValues = {"RUNNING", "STOPPED", "DISABLED"}
     )
     public String getState() {
         return state;
@@ -296,7 +296,7 @@ public class ProcessorDTO extends ComponentDTO {
 
     @Schema(description = "Indicates whether the Processor is valid, invalid, or still in the process of validating (i.e., it is unknown whether or not the Processor is valid)",
         accessMode = Schema.AccessMode.READ_ONLY,
-        allowableValues = VALID + ", " + INVALID + ", " + VALIDATING)
+        allowableValues = {VALID, INVALID, VALIDATING})
     public String getValidationStatus() {
         return validationStatus;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorRunStatusDetailsDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ProcessorRunStatusDetailsDTO.java
@@ -56,7 +56,7 @@ public class ProcessorRunStatusDetailsDTO {
     }
 
     @Schema(description = "The run status of the processor",
-        allowableValues = RUNNING + ", " + STOPPED + ", " + INVALID + ", " + VALIDATING + ", " + DISABLED
+        allowableValues = {RUNNING, STOPPED, INVALID, VALIDATING, DISABLED}
     )
     public String getRunStatus() {
         return runStatus;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ReportingTaskDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/ReportingTaskDTO.java
@@ -210,7 +210,7 @@ public class ReportingTaskDTO extends ComponentDTO {
      * @return current scheduling state of the reporting task
      */
     @Schema(description = "The state of the reporting task.",
-            allowableValues = "RUNNING, STOPPED, DISABLED"
+            allowableValues = {"RUNNING", "STOPPED", "DISABLED"}
     )
     public String getState() {
         return state;
@@ -316,7 +316,7 @@ public class ReportingTaskDTO extends ComponentDTO {
 
     @Schema(description = "Indicates whether the Reporting Task is valid, invalid, or still in the process of validating (i.e., it is unknown whether or not the Reporting Task is valid)",
         accessMode = Schema.AccessMode.READ_ONLY,
-        allowableValues = VALID + ", " + INVALID + ", " + VALIDATING)
+        allowableValues = {VALID, INVALID, VALIDATING})
     public String getValidationStatus() {
         return validationStatus;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/VersionControlInformationDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/VersionControlInformationDTO.java
@@ -145,7 +145,7 @@ public class VersionControlInformationDTO {
 
     @Schema(accessMode = Schema.AccessMode.READ_ONLY,
         description = "The current state of the Process Group, as it relates to the Versioned Flow",
-        allowableValues = LOCALLY_MODIFIED + ", " + STALE + ", " + LOCALLY_MODIFIED_AND_STALE + ", " + UP_TO_DATE + ", " + SYNC_FAILURE)
+        allowableValues = {LOCALLY_MODIFIED, STALE, LOCALLY_MODIFIED_AND_STALE, UP_TO_DATE, SYNC_FAILURE})
     public String getState() {
         return state;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/VersionedFlowDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/VersionedFlowDTO.java
@@ -98,7 +98,7 @@ public class VersionedFlowDTO {
         this.comments = comments;
     }
 
-    @Schema(description = "The action being performed", allowableValues = COMMIT_ACTION + ", " + FORCE_COMMIT_ACTION)
+    @Schema(description = "The action being performed", allowableValues = {COMMIT_ACTION, FORCE_COMMIT_ACTION})
     public String getAction() {
         return action;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/provenance/lineage/LineageRequestDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/provenance/lineage/LineageRequestDTO.java
@@ -67,7 +67,7 @@ public class LineageRequestDTO {
      */
     @Schema(description = "The type of lineage request. PARENTS will return the lineage for the flowfiles that are parents of the specified event. CHILDREN will return the lineage "
                     + "for the flowfiles that are children of the specified event. FLOWFILE will return the lineage for the specified flowfile.",
-            allowableValues = "PARENTS, CHILDREN, and FLOWFILE"
+            allowableValues = {"PARENTS", "CHILDREN", "FLOWFILE"}
     )
     public LineageRequestType getLineageRequestType() {
         return lineageRequestType;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/provenance/lineage/ProvenanceNodeDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/provenance/lineage/ProvenanceNodeDTO.java
@@ -109,7 +109,7 @@ public class ProvenanceNodeDTO {
      * @return type of node
      */
     @Schema(description = "The type of the node.",
-            allowableValues = "FLOWFILE, EVENT"
+            allowableValues = {"FLOWFILE", "EVENT"}
     )
     public String getType() {
         return type;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ComponentStatusDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ComponentStatusDTO.java
@@ -44,7 +44,7 @@ public class ComponentStatusDTO {
      */
     @Schema(description = "The run status of this component",
             accessMode = Schema.AccessMode.READ_ONLY,
-            allowableValues = "ENABLED, ENABLING, DISABLED, DISABLING")
+            allowableValues = {"ENABLED", "ENABLING", "DISABLED", "DISABLING"})
     public String getRunStatus() {
         return runStatus;
     }
@@ -56,7 +56,7 @@ public class ComponentStatusDTO {
     @Schema(description = "Indicates whether the component is valid, invalid, or still in the process of validating" +
             " (i.e., it is unknown whether or not the component is valid)",
             accessMode = Schema.AccessMode.READ_ONLY,
-            allowableValues = VALID + ", " + INVALID + ", " + VALIDATING)
+            allowableValues = {VALID, INVALID, VALIDATING})
     public String getValidationStatus() {
         return validationStatus;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ControllerServiceStatusDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ControllerServiceStatusDTO.java
@@ -29,7 +29,7 @@ public class ControllerServiceStatusDTO extends ComponentStatusDTO {
 
     @Schema(description = "The run status of this ControllerService",
             accessMode = Schema.AccessMode.READ_ONLY,
-            allowableValues = "ENABLED, ENABLING, DISABLED, DISABLING")
+            allowableValues = {"ENABLED", "ENABLING", "DISABLED", "DISABLING"})
     @Override
     public String getRunStatus() {
         return super.getRunStatus();

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/FlowAnalysisRuleStatusDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/FlowAnalysisRuleStatusDTO.java
@@ -29,7 +29,7 @@ public class FlowAnalysisRuleStatusDTO extends ComponentStatusDTO {
 
     @Schema(description = "The run status of this FlowAnalysisRule",
         accessMode = Schema.AccessMode.READ_ONLY,
-        allowableValues = "ENABLED, DISABLED")
+        allowableValues = {"ENABLED", "DISABLED"})
     @Override
     public String getRunStatus() {
         return super.getRunStatus();

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/PortStatusDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/PortStatusDTO.java
@@ -77,7 +77,7 @@ public class PortStatusDTO {
 
 
     @Schema(description = "The run status of the port.",
-            allowableValues = "Running, Stopped, Validating, Disabled, Invalid")
+            allowableValues = {"Running", "Stopped", "Validating", "Disabled", "Invalid"})
     public String getRunStatus() {
         return runStatus;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/PortStatusSnapshotDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/PortStatusSnapshotDTO.java
@@ -106,7 +106,7 @@ public class PortStatusSnapshotDTO implements Cloneable {
      */
     @Schema(
             description = "The run status of the port.",
-            allowableValues = "Running, Stopped, Validating, Disabled, Invalid"
+            allowableValues = {"Running", "Stopped", "Validating", "Disabled", "Invalid"}
     )
     public String getRunStatus() {
         return runStatus;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessGroupStatusSnapshotDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessGroupStatusSnapshotDTO.java
@@ -112,7 +112,7 @@ public class ProcessGroupStatusSnapshotDTO implements Cloneable {
 
     @Schema(description = "The current state of the Process Group, as it relates to the Versioned Flow",
             accessMode = Schema.AccessMode.READ_ONLY,
-            allowableValues = "LOCALLY_MODIFIED, STALE, LOCALLY_MODIFIED_AND_STALE, UP_TO_DATE, SYNC_FAILURE")
+            allowableValues = {"LOCALLY_MODIFIED", "STALE", "LOCALLY_MODIFIED_AND_STALE", "UP_TO_DATE", "SYNC_FAILURE"})
     public String getVersionedFlowState() {
         return versionedFlowState;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessorStatusDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessorStatusDTO.java
@@ -78,7 +78,7 @@ public class ProcessorStatusDTO implements Cloneable {
     }
 
     @Schema(description = "The run status of the Processor",
-            allowableValues = "Running, Stopped, Validating, Disabled, Invalid")
+            allowableValues = {"Running", "Stopped", "Validating", "Disabled", "Invalid"})
     public String getRunStatus() {
         return runStatus;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessorStatusSnapshotDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ProcessorStatusSnapshotDTO.java
@@ -97,7 +97,7 @@ public class ProcessorStatusSnapshotDTO implements Cloneable {
      * @return run status of this processor
      */
     @Schema(description = "The state of the processor.",
-            allowableValues = "Running, Stopped, Validating, Disabled, Invalid"
+            allowableValues = {"Running", "Stopped", "Validating", "Disabled", "Invalid"}
     )
     public String getRunStatus() {
         return runStatus;
@@ -108,7 +108,7 @@ public class ProcessorStatusSnapshotDTO implements Cloneable {
     }
 
     @Schema(description = "Indicates the node where the process will execute.",
-            allowableValues = "ALL, PRIMARY"
+            allowableValues = {"ALL", "PRIMARY"}
     )
     public String getExecutionNode() {
         return executionNode;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/RemoteProcessGroupStatusDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/RemoteProcessGroupStatusDTO.java
@@ -123,7 +123,7 @@ public class RemoteProcessGroupStatusDTO {
     @Schema(description = "Indicates whether the component is valid, invalid, or still in the process of validating" +
             " (i.e., it is unknown whether or not the component is valid)",
             accessMode = Schema.AccessMode.READ_ONLY,
-            allowableValues = "VALID, INVALID, VALIDATING")
+            allowableValues = {"VALID", "INVALID", "VALIDATING"})
     public String getValidationStatus() {
         return validationStatus;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ReportingTaskStatusDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ReportingTaskStatusDTO.java
@@ -33,7 +33,7 @@ public class ReportingTaskStatusDTO extends ComponentStatusDTO {
 
     @Schema(description = "The run status of this ReportingTask",
             accessMode = Schema.AccessMode.READ_ONLY,
-            allowableValues = "RUNNING, STOPPED, DISABLED")
+            allowableValues = {"RUNNING", "STOPPED", "DISABLED"})
     @Override
     public String getRunStatus() {
         return super.getRunStatus();

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ActivateControllerServicesEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ActivateControllerServicesEntity.java
@@ -45,7 +45,7 @@ public class ActivateControllerServicesEntity extends Entity {
      * @return The desired state of the descendant components. Possible states are 'RUNNING' and 'STOPPED'
      */
     @Schema(description = "The desired state of the descendant components",
-        allowableValues = STATE_ENABLED + ", " + STATE_DISABLED)
+        allowableValues = {STATE_ENABLED, STATE_DISABLED})
     public String getState() {
         return state;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/AffectedComponentEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/AffectedComponentEntity.java
@@ -57,9 +57,9 @@ public class AffectedComponentEntity extends ComponentEntity implements Permissi
     }
 
     @Schema(description = "The type of component referenced",
-        allowableValues = AffectedComponentDTO.COMPONENT_TYPE_PROCESSOR + "," + AffectedComponentDTO.COMPONENT_TYPE_CONTROLLER_SERVICE + ", "
-                + AffectedComponentDTO.COMPONENT_TYPE_INPUT_PORT + ", " + AffectedComponentDTO.COMPONENT_TYPE_OUTPUT_PORT + ", "
-                + AffectedComponentDTO.COMPONENT_TYPE_REMOTE_INPUT_PORT + ", " + AffectedComponentDTO.COMPONENT_TYPE_REMOTE_OUTPUT_PORT)
+        allowableValues = {AffectedComponentDTO.COMPONENT_TYPE_PROCESSOR, AffectedComponentDTO.COMPONENT_TYPE_CONTROLLER_SERVICE,
+                AffectedComponentDTO.COMPONENT_TYPE_INPUT_PORT, AffectedComponentDTO.COMPONENT_TYPE_OUTPUT_PORT,
+                AffectedComponentDTO.COMPONENT_TYPE_REMOTE_INPUT_PORT, AffectedComponentDTO.COMPONENT_TYPE_REMOTE_OUTPUT_PORT})
     public String getReferenceType() {
         return referenceType;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ConnectionEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ConnectionEntity.java
@@ -149,7 +149,7 @@ public class ConnectionEntity extends ComponentEntity implements Permissible<Con
      */
     @Schema(description = "The type of component the source connectable is.",
             requiredMode = Schema.RequiredMode.REQUIRED,
-            allowableValues = "PROCESSOR, REMOTE_INPUT_PORT, REMOTE_OUTPUT_PORT, INPUT_PORT, OUTPUT_PORT, FUNNEL"
+            allowableValues = {"PROCESSOR", "REMOTE_INPUT_PORT", "REMOTE_OUTPUT_PORT", "INPUT_PORT", "OUTPUT_PORT", "FUNNEL"}
     )
     public String getSourceType() {
         return sourceType;
@@ -177,7 +177,7 @@ public class ConnectionEntity extends ComponentEntity implements Permissible<Con
      */
     @Schema(description = "The type of component the destination connectable is.",
             requiredMode = Schema.RequiredMode.REQUIRED,
-            allowableValues = "PROCESSOR, REMOTE_INPUT_PORT, REMOTE_OUTPUT_PORT, INPUT_PORT, OUTPUT_PORT, FUNNEL"
+            allowableValues = {"PROCESSOR", "REMOTE_INPUT_PORT", "REMOTE_OUTPUT_PORT", "INPUT_PORT", "OUTPUT_PORT", "FUNNEL"}
     )
     public String getDestinationType() {
         return destinationType;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ControllerServiceRunStatusEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ControllerServiceRunStatusEntity.java
@@ -39,7 +39,7 @@ public class ControllerServiceRunStatusEntity extends ComponentRunStatusEntity {
      * @return The run status
      */
     @Schema(description = "The run status of the ControllerService.",
-            allowableValues = "ENABLED, DISABLED"
+            allowableValues = {"ENABLED", "DISABLED"}
     )
     public String getState() {
         return super.getState();

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/FlowAnalysisRuleRunStatusEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/FlowAnalysisRuleRunStatusEntity.java
@@ -38,7 +38,7 @@ public class FlowAnalysisRuleRunStatusEntity extends ComponentRunStatusEntity {
      * @return The state
      */
     @Schema(description = "The state of the FlowAnalysisRule.",
-            allowableValues = "ENABLED, DISABLED"
+            allowableValues = {"ENABLED", "DISABLED"}
     )
     public String getState() {
         return super.getState();

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/FlowBreadcrumbEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/FlowBreadcrumbEntity.java
@@ -96,7 +96,7 @@ public class FlowBreadcrumbEntity extends Entity {
 
     @Schema(
             description = "The current state of the Process Group, as it relates to the Versioned Flow",
-            allowableValues = "LOCALLY_MODIFIED, STALE, LOCALLY_MODIFIED_AND_STALE, UP_TO_DATE, SYNC_FAILURE",
+            allowableValues = {"LOCALLY_MODIFIED", "STALE", "LOCALLY_MODIFIED_AND_STALE", "UP_TO_DATE", "SYNC_FAILURE"},
             accessMode = Schema.AccessMode.READ_ONLY
     )
     public String getVersionedFlowState() {

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/PortRunStatusEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/PortRunStatusEntity.java
@@ -38,7 +38,7 @@ public class PortRunStatusEntity extends ComponentRunStatusEntity {
      * @return The run status
      */
     @Schema(description = "The run status of the Port.",
-            allowableValues = "RUNNING, STOPPED, DISABLED"
+            allowableValues = {"RUNNING", "STOPPED", "DISABLED"}
     )
     public String getState() {
         return super.getState();

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessGroupEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessGroupEntity.java
@@ -255,7 +255,7 @@ public class ProcessGroupEntity extends ComponentEntity implements Permissible<P
 
     @Schema(
             description = "The current state of the Process Group, as it relates to the Versioned Flow",
-            allowableValues = "LOCALLY_MODIFIED, STALE, LOCALLY_MODIFIED_AND_STALE, UP_TO_DATE, SYNC_FAILURE",
+            allowableValues = {"LOCALLY_MODIFIED", "STALE", "LOCALLY_MODIFIED_AND_STALE", "UP_TO_DATE", "SYNC_FAILURE"},
             accessMode = Schema.AccessMode.READ_ONLY
     )
     public String getVersionedFlowState() {
@@ -321,7 +321,7 @@ public class ProcessGroupEntity extends ComponentEntity implements Permissible<P
     }
 
     @Schema(description = "Determines the process group update strategy",
-            allowableValues = "CURRENT_GROUP, CURRENT_GROUP_WITH_CHILDREN"
+            allowableValues = {"CURRENT_GROUP", "CURRENT_GROUP_WITH_CHILDREN"}
     )
     public String getProcessGroupUpdateStrategy() {
         return processGroupUpdateStrategy;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessorRunStatusEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ProcessorRunStatusEntity.java
@@ -26,9 +26,7 @@ import jakarta.xml.bind.annotation.XmlType;
 @XmlType(name = "processorRunStatus")
 public class ProcessorRunStatusEntity extends ComponentRunStatusEntity {
 
-    private static final String ALLOWABLE_VALUES = "RUNNING, STOPPED, DISABLED, RUN_ONCE";
-
-    private static String[] SUPPORTED_STATE = ALLOWABLE_VALUES.split(", ");
+    private static final String[] SUPPORTED_STATE = {"RUNNING", "STOPPED", "DISABLED", "RUN_ONCE"};
 
     @Override
     protected String[] getSupportedState() {
@@ -39,7 +37,7 @@ public class ProcessorRunStatusEntity extends ComponentRunStatusEntity {
      * Run status for this Processor.
      * @return The run status
      */
-    @Schema(description = "The run status of the Processor.", allowableValues = ALLOWABLE_VALUES)
+    @Schema(description = "The run status of the Processor.", allowableValues = {"RUNNING", "STOPPED", "DISABLED", "RUN_ONCE"})
     public String getState() {
         return super.getState();
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/RemotePortRunStatusEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/RemotePortRunStatusEntity.java
@@ -38,7 +38,7 @@ public class RemotePortRunStatusEntity extends ComponentRunStatusEntity {
      * @return The run status
      */
     @Schema(description = "The run status of the RemotePort.",
-            allowableValues = "TRANSMITTING, STOPPED"
+            allowableValues = {"TRANSMITTING", "STOPPED"}
     )
     public String getState() {
         return super.getState();

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ReplayLastEventRequestEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ReplayLastEventRequestEntity.java
@@ -36,7 +36,7 @@ public class ReplayLastEventRequestEntity extends Entity {
     }
 
     @Schema(description = "Which nodes are to replay their last provenance event.",
-        allowableValues = "ALL, PRIMARY"
+        allowableValues = {"ALL", "PRIMARY"}
     )
     public String getNodes() {
         return nodes;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ReplayLastEventResponseEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ReplayLastEventResponseEntity.java
@@ -39,7 +39,7 @@ public class ReplayLastEventResponseEntity extends Entity {
     }
 
     @Schema(description = "Which nodes were requested to replay their last provenance event.",
-        allowableValues = "ALL, PRIMARY"
+        allowableValues = {"ALL", "PRIMARY"}
     )
     public String getNodes() {
         return nodes;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ReportingTaskRunStatusEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ReportingTaskRunStatusEntity.java
@@ -38,7 +38,7 @@ public class ReportingTaskRunStatusEntity extends ComponentRunStatusEntity {
      * @return The run status
      */
     @Schema(description = "The run status of the ReportingTask.",
-            allowableValues = "RUNNING, STOPPED"
+            allowableValues = {"RUNNING", "STOPPED"}
     )
     public String getState() {
         return super.getState();

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ScheduleComponentsEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/ScheduleComponentsEntity.java
@@ -54,7 +54,7 @@ public class ScheduleComponentsEntity extends Entity {
      * @return The desired state of the descendant components. Possible states are 'RUNNING', 'STOPPED', 'ENABLED', and 'DISABLED'
      */
     @Schema(description = "The desired state of the descendant components",
-        allowableValues = STATE_RUNNING + ", " + STATE_STOPPED + ", " + STATE_ENABLED + ", " + STATE_DISABLED
+        allowableValues = {STATE_RUNNING, STATE_STOPPED, STATE_ENABLED, STATE_DISABLED}
     )
     public String getState() {
         return state;

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/UpdateControllerServiceReferenceRequestEntity.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/entity/UpdateControllerServiceReferenceRequestEntity.java
@@ -45,7 +45,7 @@ public class UpdateControllerServiceReferenceRequestEntity extends Entity {
     }
 
     @Schema(description = "The new state of the references for the controller service.",
-        allowableValues = "ENABLED, DISABLED, RUNNING, STOPPED"
+        allowableValues = {"ENABLED", "DISABLED", "RUNNING", "STOPPED"}
     )
     public String getState() {
         return state;

--- a/nifi-registry/nifi-registry-core/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/authorization/AccessPolicySummary.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/authorization/AccessPolicySummary.java
@@ -54,7 +54,7 @@ public class AccessPolicySummary implements RevisableEntity {
 
     @Schema(
             description = "The action associated with this access policy.",
-            allowableValues = "read, write, delete"
+            allowableValues = {"read", "write", "delete"}
     )
     public String getAction() {
         return action;


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14142](https://issues.apache.org/jira/browse/NIFI-14142)

-----

<details><summary>swagger.json before change (excerpt)</summary>
<p>

```json
{
      "AffectedComponentDTO" : {
        "type" : "object",
        "properties" : {
          "activeThreadCount" : {
            "type" : "integer",
            "format" : "int32",
            "description" : "The number of active threads for the referencing component."
          },
          "id" : {
            "type" : "string",
            "description" : "The UUID of this component"
          },
          "name" : {
            "type" : "string",
            "description" : "The name of this component."
          },
          "processGroupId" : {
            "type" : "string",
            "description" : "The UUID of the Process Group that this component is in"
          },
          "referenceType" : {
            "type" : "string",
            "description" : "The type of this component",
            "enum" : [ "PROCESSOR,CONTROLLER_SERVICE, INPUT_PORT, OUTPUT_PORT, REMOTE_INPUT_PORT, REMOTE_OUTPUT_PORT, STATELESS_GROUP" ]
          },
          "state" : {
            "type" : "string",
            "description" : "The scheduled state of a processor or reporting task referencing a controller service. If this component is another controller service, this field represents the controller service state."
          },
          "validationErrors" : {
            "type" : "array",
            "description" : "The validation errors for the component.",
            "items" : {
              "type" : "string",
              "description" : "The validation errors for the component."
            }
          }
        }
      }
}
``` 

</p>
</details> 

<details><summary>swagger.json after change (excerpt)</summary>
<p>

```json
{
      "AffectedComponentDTO" : {
        "type" : "object",
        "properties" : {
          "activeThreadCount" : {
            "type" : "integer",
            "format" : "int32",
            "description" : "The number of active threads for the referencing component."
          },
          "id" : {
            "type" : "string",
            "description" : "The UUID of this component"
          },
          "name" : {
            "type" : "string",
            "description" : "The name of this component."
          },
          "processGroupId" : {
            "type" : "string",
            "description" : "The UUID of the Process Group that this component is in"
          },
          "referenceType" : {
            "type" : "string",
            "description" : "The type of this component",
            "enum" : [ "PROCESSOR", "CONTROLLER_SERVICE", "INPUT_PORT", "OUTPUT_PORT", "REMOTE_INPUT_PORT", "REMOTE_OUTPUT_PORT", "STATELESS_GROUP" ]
          },
          "state" : {
            "type" : "string",
            "description" : "The scheduled state of a processor or reporting task referencing a controller service. If this component is another controller service, this field represents the controller service state."
          },
          "validationErrors" : {
            "type" : "array",
            "description" : "The validation errors for the component.",
            "items" : {
              "type" : "string",
              "description" : "The validation errors for the component."
            }
          }
        }
      }
}
``` 

</p>
</details> 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
