### PR TITLE
NIFI-14149 Fix invalid MiNiFi flow json by setting the default value of maxTimerDrivenThreadCount and update minifi-toolkit command set with examples

### DIFF
--- a/minifi/minifi-toolkit/minifi-toolkit-assembly/README.md
+++ b/minifi/minifi-toolkit/minifi-toolkit-assembly/README.md
@@ -48,7 +48,8 @@ After downloading the binary and extracting it, to run the MiNiFi Toolkit Conver
       java org.apache.nifi.minifi.toolkit.configuration.ConfigMain <command> options
 
       Valid commands include:
-      transform-yml: Transforms legacy MiNiFi flow config YAML into MiNiFi flow config JSON
+     - transform-nifi: Transform NiFi2 flow JSON format into MiNifi flow JSON format
+     - transform-yml: Transforms legacy MiNiFi flow config YAML into MiNiFi flow config JSON
 
 ## Example
 - You have an older version of MiNiFi located in <legacy_minifi_directory>.
@@ -56,6 +57,10 @@ After downloading the binary and extracting it, to run the MiNiFi Toolkit Conver
 - Run the following command to migrate the flow and the bootstrap config
 ```
 ./config.sh transform-yml <legacy_minifi_directory>/conf/config.yml <legacy_minifi_directory>/conf/bootstrap.conf <latest_minifi_directory>/conf/flow.json.raw <latest_minifi_directory>/conf/bootstrap.conf
+```
+- Run the following command to transform NiFi flow JSON format into MiNifi flow JSON format
+```
+./config.sh transform-nifi <downloaded_nifi2_flow_json_file> <minifi_flow_json_file> 
 ```
 
 ## Note

--- a/minifi/minifi-toolkit/minifi-toolkit-configuration/src/main/java/org/apache/nifi/minifi/toolkit/configuration/json/TransformNifiCommandFactory.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-configuration/src/main/java/org/apache/nifi/minifi/toolkit/configuration/json/TransformNifiCommandFactory.java
@@ -27,6 +27,7 @@ import org.apache.nifi.minifi.toolkit.configuration.ConfigMain;
 import org.apache.nifi.minifi.toolkit.configuration.ConfigTransformException;
 import org.apache.nifi.minifi.toolkit.configuration.PathInputStreamFactory;
 import org.apache.nifi.minifi.toolkit.configuration.PathOutputStreamFactory;
+import org.apache.nifi.minifi.toolkit.schema.CorePropertiesSchema;
 import org.apache.nifi.registry.flow.RegisteredFlowSnapshot;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -63,8 +64,9 @@ public class TransformNifiCommandFactory {
             RegisteredFlowSnapshot registeredFlowSnapshot = readNifiFlow(sourceNiFiJsonPath);
             VersionedDataflow versionedDataflow = new VersionedDataflow();
             versionedDataflow.setRootGroup(registeredFlowSnapshot.getFlowContents());
-            versionedDataflow
-                    .setParameterContexts(new ArrayList<>(registeredFlowSnapshot.getParameterContexts().values()));
+            versionedDataflow.setParameterContexts(new ArrayList<>(registeredFlowSnapshot.getParameterContexts().values()));
+            versionedDataflow.setMaxTimerDrivenThreadCount(CorePropertiesSchema.DEFAULT_MAX_CONCURRENT_THREADS);
+
             persistFlowJson(versionedDataflow, targetMiNiFiJsonPath);
         } catch (ConfigTransformException e) {
             System.out.println("Unable to convert NiFi JSON to MiNiFi flow JSON: " + e);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14149](https://issues.apache.org/jira/browse/NIFI-14149)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-14149`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-14149`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
