### PR TITLE
NIFI-14163: Enhance GCP Credential to use delegate user

### DIFF
--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/factory/CredentialPropertyDescriptors.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/factory/CredentialPropertyDescriptors.java
@@ -91,4 +91,22 @@ public final class CredentialPropertyDescriptors {
             .sensitive(true)
             .build();
 
+    public static final PropertyDescriptor DELEGATION_STRATEGY = new PropertyDescriptor.Builder()
+            .name("Delegation Strategy")
+            .required(true)
+            .defaultValue(DelegationStrategy.SERVICE_ACCOUNT)
+            .allowableValues(DelegationStrategy.class)
+            .description("The Delegation Strategy determines which account is used when calls are made with the GCP Credential.")
+            .build();
+
+    public static final PropertyDescriptor DELEGATION_USER = new PropertyDescriptor.Builder()
+            .name("Delegation User")
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .required(true)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .dependsOn(DELEGATION_STRATEGY, DelegationStrategy.DELEGATED_ACCOUNT)
+            .description("This user will be impersonated by the service account for api calls. " +
+                    "API calls made using this credential will appear as if they are coming from delegate user with the delegate user's access. " +
+                    "Any scopes supplied from processors to this credential must have domain-wide delegation setup with the service account.")
+            .build();
 }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/factory/DelegationStrategy.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/factory/DelegationStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.gcp.credentials.factory;
+
+import org.apache.nifi.components.DescribedValue;
+
+public enum DelegationStrategy implements DescribedValue {
+    SERVICE_ACCOUNT("Service Account", "The service account should access data using it's own identity and permissions."),
+    DELEGATED_ACCOUNT("Delegated Account", "The service account should access data on behalf of a specified user account." +
+            " This setting requires domain-wide delgation to be enabled for the service account for the scopes that it will be used in.");
+
+    private final String displayName;
+    private final String description;
+
+    private DelegationStrategy(final String displayName, final String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getValue() {
+        return displayName;
+    }
+}

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/factory/strategies/AbstractServiceAccountCredentialsStrategy.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/factory/strategies/AbstractServiceAccountCredentialsStrategy.java
@@ -19,6 +19,8 @@ package org.apache.nifi.processors.gcp.credentials.factory.strategies;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.GoogleCredentials;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors;
+import org.apache.nifi.processors.gcp.credentials.factory.DelegationStrategy;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,7 +39,13 @@ public abstract class AbstractServiceAccountCredentialsStrategy extends Abstract
 
     @Override
     public GoogleCredentials getGoogleCredentials(Map<PropertyDescriptor, String> properties, HttpTransportFactory transportFactory) throws IOException {
+        final String delegationStrategy = properties.get(CredentialPropertyDescriptors.DELEGATION_STRATEGY);
+        if (delegationStrategy != null && delegationStrategy.equals(DelegationStrategy.DELEGATED_ACCOUNT.getValue())) {
+            final String delegationUser = properties.get(CredentialPropertyDescriptors.DELEGATION_USER);
+            return GoogleCredentials.fromStream(getServiceAccountJson(properties), transportFactory).createDelegated(delegationUser);
+        } else {
             return GoogleCredentials.fromStream(getServiceAccountJson(properties), transportFactory);
+        }
     }
 
 }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/service/GCPCredentialsControllerService.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/service/GCPCredentialsControllerService.java
@@ -47,6 +47,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors.DELEGATION_STRATEGY;
+import static org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors.DELEGATION_USER;
 import static org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors.SERVICE_ACCOUNT_JSON;
 import static org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors.SERVICE_ACCOUNT_JSON_FILE;
 import static org.apache.nifi.processors.gcp.credentials.factory.CredentialPropertyDescriptors.USE_APPLICATION_DEFAULT_CREDENTIALS;
@@ -82,6 +84,8 @@ public class GCPCredentialsControllerService extends AbstractControllerService i
         props.add(SERVICE_ACCOUNT_JSON_FILE);
         props.add(SERVICE_ACCOUNT_JSON);
         props.add(ProxyConfiguration.createProxyConfigPropertyDescriptor(ProxyAwareTransportFactory.PROXY_SPECS));
+        props.add(DELEGATION_STRATEGY);
+        props.add(DELEGATION_USER);
         properties = Collections.unmodifiableList(props);
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14163](https://issues.apache.org/jira/browse/NIFI-14163)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

To verify this change you must use a service account credential that has been configured to use domain-wide delegation with the scopes that your processors are expecting to use (per https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority).  Ex ListGoogleDrive specifically requires the https://www.googleapis.com/auth/drive.metadata.readonly scope.

To verify positve and negative cases:
Use a Google Drive that has the service account user added and configure the GCPCredentialControllerService to use  a Service Account JSON.
Expected Result: Drive Files should appear

Remove the same Service Account email from the drive permissions.
Expected Result: Drive Files will not appear.  (Service Account can't access them)

Configure GCPCredentialControllerService to use the delegation user of an email that currently has access to the drive.
Expected Result: Drive Files will appear.,

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
