### PR TITLE
NIFI-14161: Fix QueryCassandra Processor Attribute Loss Issue

### DIFF
--- a/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
+++ b/nifi-nar-bundles/nifi-cassandra-bundle/nifi-cassandra-processors/src/main/java/org/apache/nifi/processors/cassandra/QueryCassandra.java
@@ -70,6 +70,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -262,6 +263,8 @@ public class QueryCassandra extends AbstractCassandraProcessor {
             }
         }
 
+        final Map<String, String> originalAttributes = fileToProcess != null ? fileToProcess.getAttributes() : new HashMap<>();
+
         final ComponentLog logger = getLogger();
         final String selectQuery = context.getProperty(CQL_SELECT_QUERY).evaluateAttributeExpressions(fileToProcess).getValue();
         final long queryTimeout = context.getProperty(QUERY_TIMEOUT).evaluateAttributeExpressions(fileToProcess).asTimePeriod(TimeUnit.MILLISECONDS);
@@ -321,6 +324,8 @@ public class QueryCassandra extends AbstractCassandraProcessor {
                         throw new ProcessException(e);
                     }
                 });
+
+                fileToProcess = session.putAllAttributes(fileToProcess, originalAttributes);
 
                 // set attribute how many rows were selected
                 fileToProcess = session.putAttribute(fileToProcess, RESULT_ROW_COUNT, String.valueOf(nrOfRows.get()));


### PR DESCRIPTION
Resolved an issue in the QueryCassandra processor where attributes from the incoming FlowFile were occasionally lost in subsequent FlowFiles when the processor split the results due to a configured Fetch Size (e.g., 750). This fix ensures that all FlowFiles maintain the original attributes, even when multiple FlowFiles are generated from a single query result.