### PR TITLE
NIFI-14068 Fix Domain Name Handling for SFTP Proxy Access

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHClient.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHClient.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.ssh;
+
+import com.exceptionfactory.socketbroker.BrokeredSocketFactory;
+import net.schmizz.sshj.Config;
+import net.schmizz.sshj.SSHClient;
+import org.apache.nifi.processors.standard.socket.ProxySocketFactory;
+
+import javax.net.SocketFactory;
+import java.net.InetSocketAddress;
+
+/**
+ * Standard extension of SSHJ SSHClient supporting unresolved Socket Addresses for control over proxy behavior
+ */
+public class StandardSSHClient extends SSHClient {
+
+    public StandardSSHClient(final Config config) {
+        super(config);
+    }
+
+    /**
+     * Create InetSocketAddress to based on proxy configuration
+     *
+     * @param hostname Hostname or Internet Protocol address
+     * @param port TCP port number
+     * @return Socket Address resolved or unresolved based on proxy configuration
+     */
+    @Override
+    protected InetSocketAddress makeInetSocketAddress(final String hostname, final int port) {
+        final SocketFactory socketFactory = getSocketFactory();
+        final boolean proxyConfigured = socketFactory instanceof ProxySocketFactory || socketFactory instanceof BrokeredSocketFactory;
+
+        final InetSocketAddress socketAddress;
+        if (proxyConfigured) {
+            socketAddress = InetSocketAddress.createUnresolved(hostname, port);
+        } else {
+            socketAddress = new InetSocketAddress(hostname, port);
+        }
+        return socketAddress;
+    }
+}

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHClientProvider.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ssh/StandardSSHClientProvider.java
@@ -97,7 +97,7 @@ public class StandardSSHClientProvider implements SSHClientProvider {
         final List<AuthMethod> authMethods = getPasswordAuthMethods(context, attributes);
 
         final Config config = SSH_CONFIG_PROVIDER.getConfig(address, context);
-        final SSHClient client = new SSHClient(config);
+        final SSHClient client = new StandardSSHClient(config);
 
         try {
             setClientProperties(client, context);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/ssh/StandardSSHClientTest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/ssh/StandardSSHClientTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.standard.ssh;
+
+import net.schmizz.sshj.DefaultConfig;
+import org.apache.nifi.processors.standard.socket.ProxySocketFactory;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardSSHClientTest {
+    private static final String HOSTNAME = "localhost";
+
+    private static final int PORT = 22;
+
+    private static final int PROXY_PORT = 8080;
+
+    @Test
+    void testMakeInetSocketAddressResolved() throws IOException {
+        try (StandardSSHClient client = new StandardSSHClient(new DefaultConfig())) {
+            final InetSocketAddress address = client.makeInetSocketAddress(HOSTNAME, PORT);
+
+            assertFalse(address.isUnresolved());
+            assertEquals(PORT, address.getPort());
+            assertEquals(HOSTNAME, address.getHostString());
+        }
+    }
+
+    @Test
+    void testMakeInetSocketAddressUnresolved() throws IOException {
+        final InetSocketAddress proxyAddress = InetSocketAddress.createUnresolved(HOSTNAME, PROXY_PORT);
+        final Proxy proxy = new Proxy(Proxy.Type.HTTP, proxyAddress);
+        final ProxySocketFactory proxySocketFactory = new ProxySocketFactory(proxy);
+
+        try (StandardSSHClient client = new StandardSSHClient(new DefaultConfig())) {
+            client.setSocketFactory(proxySocketFactory);
+            final InetSocketAddress address = client.makeInetSocketAddress(HOSTNAME, PORT);
+
+            assertTrue(address.isUnresolved());
+            assertEquals(PORT, address.getPort());
+            assertEquals(HOSTNAME, address.getHostString());
+        }
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-14068](https://issues.apache.org/jira/browse/NIFI-14068) Corrects the behavior of SFTP processors when configured for proxy access using a DNS name.

The current implementation of the SSHJ `SSHClient` always attempts to resolve DNS names to IP addresses when constructing an `InetSocketAddress` for the socket connection. This behavior is not ideal when connecting through a proxy server because NiFi may not be able to resolve the DNS address and should rely on the proxy server to perform DNS resolution.

The revised implementation introduces an extension of `SSHClient` that overrides the `makeInetSocketAddress` method to return an unresolved address when the client is configured with a Proxy Socket Factory. The unresolved status instructs HTTP and SOCKS proxy socket clients to send a DNS address instead of a resolved IP address.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
