### PR TITLE
NIFI-14175 Wrong fields in C2 FlowInfo

### DIFF
--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/C2NifiClientService.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/C2NifiClientService.java
@@ -398,10 +398,10 @@ public class C2NifiClientService {
         result.setGroupId(processorStatus.getGroupId());
         result.setBytesRead(processorStatus.getBytesRead());
         result.setBytesWritten(processorStatus.getBytesWritten());
-        result.setFlowFilesIn(processorStatus.getFlowFilesReceived());
-        result.setFlowFilesOut(processorStatus.getFlowFilesSent());
-        result.setBytesIn(processorStatus.getBytesReceived());
-        result.setBytesOut(processorStatus.getBytesSent());
+        result.setFlowFilesIn(processorStatus.getInputCount());
+        result.setFlowFilesOut(processorStatus.getOutputCount());
+        result.setBytesIn(processorStatus.getInputBytes());
+        result.setBytesOut(processorStatus.getOutputBytes());
         result.setInvocations(processorStatus.getInvocations());
         result.setProcessingNanos(processorStatus.getProcessingNanos());
         result.setActiveThreadCount(processorStatus.getActiveThreadCount());


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14175](https://issues.apache.org/jira/browse/NIFI-14175)

[NIFI-13762](https://issues.apache.org/jira/browse/NIFI-13762) exposed processor metrics as a part of FlowInfo, but the FlowFileIn/FlowFilesOut has been set from the FlowFilesReceived/FlowFilesSent instead of inputCount/outputCount this makes the FlowInfo less useful for monitoring.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
