### PR TITLE
NIFI-2482 Add simplified HTTP response info log to InvokeHTTP

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -860,7 +860,6 @@ public class InvokeHTTP extends AbstractProcessor {
             final String urlProperty = trimToEmpty(context.getProperty(HTTP_URL).evaluateAttributeExpressions(requestFlowFile).getValue());
 
             Request httpRequest = configureRequest(context, session, requestFlowFile, urlProperty);
-            logRequest(logger, httpRequest);
 
             if (httpRequest.body() != null) {
                 session.getProvenanceReporter().send(requestFlowFile, urlProperty, true);
@@ -868,11 +867,12 @@ public class InvokeHTTP extends AbstractProcessor {
 
             final long startNanos = System.nanoTime();
 
+            logger.debug("Request [{}] {} {} starting", txId, httpRequest.method(), httpRequest.url());
             try (Response responseHttp = okHttpClient.newCall(httpRequest).execute()) {
-                logResponse(logger, urlProperty, responseHttp);
+                final int statusCode = responseHttp.code();
+                logger.info("Request [{}] {} {} HTTP {} [{}]", txId, httpRequest.method(), httpRequest.url(), statusCode, responseHttp.protocol());
 
                 // store the status code and message
-                int statusCode = responseHttp.code();
                 String statusMessage = responseHttp.message();
 
                 // Create a map of the status attributes that are always written to the request and response FlowFiles
@@ -1231,39 +1231,6 @@ public class InvokeHTTP extends AbstractProcessor {
 
     private boolean isSuccess(int statusCode) {
         return statusCode / 100 == 2;
-    }
-
-    private void logRequest(ComponentLog logger, Request request) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("\nRequest to remote service:\n\t{}\n{}",
-                    request.url().url().toExternalForm(), getLogString(request.headers().toMultimap()));
-        }
-    }
-
-    private void logResponse(ComponentLog logger, String url, Response response) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("\nResponse from remote service:\n\t{}\n{}",
-                    url, getLogString(response.headers().toMultimap()));
-        }
-    }
-
-    private String getLogString(Map<String, List<String>> map) {
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, List<String>> entry : map.entrySet()) {
-            List<String> list = entry.getValue();
-            if (!list.isEmpty()) {
-                sb.append("\t");
-                sb.append(entry.getKey());
-                sb.append(": ");
-                if (list.size() == 1) {
-                    sb.append(list.getFirst());
-                } else {
-                    sb.append(list);
-                }
-                sb.append("\n");
-            }
-        }
-        return sb.toString();
     }
 
     /**


### PR DESCRIPTION
# Summary

[NIFI-2482](https://issues.apache.org/jira/browse/NIFI-2482) Adds simplified HTTP response logging at the informational level to the `InvokeHTTP` Processor.

The simplified log replaces the debug level logging for request and response URL and headers, which did not include the response status code and which used tabs and newlines for delimiting.

The new approach includes a debug level message indicating when a request is starting:

```
Request [591f5d4c-fa18-45e9-bccc-7885ab5fb73a] GET http://localhost:59793/ starting
```

The debug level message can be used to determine when the Processor issues an HTTP request that may or may not succeed due to network communication issues.

The new approach also includes an informational level message indicating the same request identifier information as well as the HTTP response status code and protocol version received.

```
Request [591f5d4c-fa18-45e9-bccc-7885ab5fb73a] GET http://localhost:59793/ HTTP 200 [http/1.1]
```

With the default log level of Processors set to `WARN` neither of these log messages will be visible under the standard configuration, avoiding unnecessary log messages. With the introduction of the informational level log, basic tracking and troubleshooting can be enabled as needed.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
