### PR TITLE
NIFI-14187 - Dep Upgrades - Spring, Netty, Flyway, AWS, GCP, etc

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <ant.version>1.10.15</ant.version>
         <org.apache.sshd.version>2.14.0</org.apache.sshd.version>
-        <mime4j.version>0.8.11</mime4j.version>
+        <mime4j.version>0.8.12</mime4j.version>
     </properties>
 
     <!-- Managed Dependency Versions for referenced modules required based on different parent bundle project -->
@@ -89,7 +89,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.2.1</version>
+                <version>1.2.2</version>
             </dependency>
             <!-- SSHD from Registry and other modules -->
             <dependency>

--- a/nifi-commons/nifi-metrics/pom.xml
+++ b/nifi-commons/nifi-metrics/pom.xml
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jvm</artifactId>
-            <version>4.2.29</version>
+            <version>4.2.30</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>4.2.29</version>
+            <version>4.2.30</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.7.1</version>
+            <version>3.7.2</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.7.1</version>
+            <version>3.7.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.box</groupId>
                 <artifactId>box-java-sdk</artifactId>
-                <version>4.13.1</version>
+                <version>4.14.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/pom.xml
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-standard-record-utils/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.12.0</version>
+            <version>1.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.52.0</google.libraries.version>
+        <google.libraries.version>26.53.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <activemq.version>6.1.4</activemq.version>
+        <activemq.version>6.1.5</activemq.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-media-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-media-bundle/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <poi.version>5.4.0</poi.version>
-        <mime4j.version>0.8.11</mime4j.version>
+        <mime4j.version>0.8.12</mime4j.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring.data.redis.version>3.4.1</spring.data.redis.version>
+        <spring.data.redis.version>3.4.2</spring.data.redis.version>
         <jedis.version>5.2.0</jedis.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring.data.redis.version>3.4.2</spring.data.redis.version>
+        <spring.data.redis.version>3.4.1</spring.data.redis.version>
         <jedis.version>5.2.0</jedis.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
@@ -57,7 +57,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>1.5.4</version>
+            <version>1.5.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-salesforce</artifactId>
-            <version>4.8.2</version>
+            <version>4.9.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.slack.api</groupId>
             <artifactId>bolt-socket-mode</artifactId>
-            <version>1.45.0</version>
+            <version>1.45.1</version>
         </dependency>
         <!-- Required by bolt-socket-mode but the library itself doesn't have the dependency. -->
         <dependency>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -589,7 +589,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.4</version>
+            <version>42.7.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -226,7 +226,7 @@
             <dependency>
                 <groupId>com.networknt</groupId>
                 <artifactId>json-schema-validator</artifactId>
-                <version>1.5.4</version>
+                <version>1.5.5</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.12.0</version>
+            <version>1.13.0</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.12.0</version>
+            <version>1.13.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/pom.xml
@@ -24,8 +24,8 @@
     <artifactId>nifi-python-framework</artifactId>
 
     <properties>
-        <py4j.version>0.10.9.8</py4j.version>
-        <py4j.url>https://files.pythonhosted.org/packages/53/75/15967ccc1a9bb2c85364a4eceb64116fbf8734528315338f16efd4191f35/py4j-${py4j.version}-py2.py3-none-any.whl</py4j.url>
+        <py4j.version>0.10.9.9</py4j.version>
+        <py4j.url>https://files.pythonhosted.org/packages/bd/db/ea0203e495be491c85af87b66e37acfd3bf756fd985f87e46fc5e3bf022c/py4j-${py4j.version}-py2.py3-none-any.whl</py4j.url>
     </properties>
 
     <build>
@@ -46,7 +46,7 @@
                             <outputFileName>py4j-${py4j.version}.zip</outputFileName>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}/py4j-${py4j.version}</outputDirectory>
-                            <sha256>84226a9d382448c36af1ca4bc2ab7ab9df49ec54fc83f033f620e00c8a6da0ca</sha256>
+                            <sha256>c7c26e4158defb37b0bb124933163641a2ff6e3a3913f7811b0ddbe07ed61533</sha256>
                         </configuration>
                     </execution>
                 </executions>

--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -309,7 +309,7 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
-                <version>4.2.29</version>
+                <version>4.2.30</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>9.1.0</version>
+            <version>9.2.0</version>
             <exclusions>
                 <!-- Exclude unused protobuf-java -->
                 <exclusion>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.4</version>
+            <version>42.7.5</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>3.4.1</spring.boot.version>
-        <flyway.version>11.1.1</flyway.version>
+        <flyway.version>11.2.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.1.0.202411261347-r</jgit.version>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.9</version>
+            <version>5.10</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <org.apache.commons.text.version>1.13.0</org.apache.commons.text.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
-        <org.bouncycastle.version>1.80</org.bouncycastle.version>
+        <org.bouncycastle.version>1.79</org.bouncycastle.version>
         <pmd.version>7.9.0</pmd.version>
         <testcontainers.version>1.20.4</testcontainers.version>
         <org.slf4j.version>2.0.16</org.slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.780</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.29.48</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.30.3</software.amazon.awssdk.version>
         <gson.version>2.11.0</gson.version>
         <io.fabric8.kubernetes.client.version>7.0.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.1.0</kotlin.version>
@@ -127,7 +127,7 @@
         <org.apache.commons.text.version>1.13.0</org.apache.commons.text.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
-        <org.bouncycastle.version>1.79</org.bouncycastle.version>
+        <org.bouncycastle.version>1.80</org.bouncycastle.version>
         <pmd.version>7.9.0</pmd.version>
         <testcontainers.version>1.20.4</testcontainers.version>
         <org.slf4j.version>2.0.16</org.slf4j.version>
@@ -153,11 +153,11 @@
         <mockito.version>5.15.2</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.3</snakeyaml.version>
-        <netty.4.version>4.1.116.Final</netty.4.version>
+        <netty.4.version>4.1.117.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
-        <spring.version>6.2.1</spring.version>
+        <spring.version>6.2.2</spring.version>
         <spring.security.version>6.4.2</spring.security.version>
-        <swagger.annotations.version>2.2.27</swagger.annotations.version>
+        <swagger.annotations.version>2.2.28</swagger.annotations.version>
         <h2.version>2.3.232</h2.version>
         <zookeeper.version>3.9.3</zookeeper.version>
         <caffeine.version>3.1.8</caffeine.version>


### PR DESCRIPTION
# Summary

[NIFI-14187](https://issues.apache.org/jira/browse/NIFI-14187) - Dep Upgrades - Spring, Netty, Bouncycastle, Flyway, AWS, GCP, etc

- AWS SDK v2 from 2.29.48 to 2.30.3 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Spring Framework from 6.2.1 to 6.2.2 - https://github.com/spring-projects/spring-framework/releases
- ~~Spring Data Redis from 3.4.1 to 3.4.2 - https://github.com/spring-projects/spring-data-redis/releases~~
- PostgreSQL from 42.7.4 to 42.7.5 - https://jdbc.postgresql.org/changelogs/2025-01-14-42.7.5-release/
- MIME4J from 0.8.11 to 0.8.12 - https://github.com/apache/james-mime4j/compare/apache-mime4j-project-0.8.11...apache-mime4j-project-0.8.12
- Reactor Netty HTTP from 1.2.1 to 1.2.2 - https://github.com/reactor/reactor-netty/releases
- Reactor Core from 3.7.1 to 3.7.2 - https://github.com/reactor/reactor-core/releases
- Dropwizard Metrics from 4.2.29 to 4.2.30 - https://github.com/dropwizard/metrics/releases/tag/v4.2.30
- Box SDK from 4.13.1 to 4.14.0 - https://developer.box.com/changelog/#2025-01-22-box-java-sdk-v4140-released
- Commons CSV from 1.12.0 to 1.13.0 - https://commons.apache.org/proper/commons-csv/changes.html#a1.13.0
- GCP from 26.52.0 to 26.53.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.53.0
- ActiveMQ from 6.1.4 to 6.1.5 - https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12355276
- JSON Schema Validator from 1.5.4 to 1.5.5 - https://github.com/networknt/json-schema-validator/blob/master/CHANGELOG.md
- Camel Salesforce from 4.8.2 to 4.9.0 - https://github.com/apache/camel/compare/camel-4.8.2...camel-4.9.0
- Slack Bolt from 1.45.0 to 1.45.1 - https://github.com/slackapi/java-slack-sdk/releases/tag/v1.45.1
- PY4J from 0.10.9.8 to 0.10.9.9 - https://www.py4j.org/changelog.html#py4j-0-10-9-9
- MySQL from 9.1.0 to 9.2.0 - https://dev.mysql.com/doc/relnotes/connector-j/en/news-9-2-0.html
- Flyway from 11.1.1 to 11.2.0 - https://documentation.red-gate.com/flyway/release-notes-and-older-versions/release-notes-for-flyway-engine
- OpenCSV from 5.9 to 5.10 - https://sourceforge.net/p/opencsv/wiki/What%27s%20new/
- ~~Bouncycastle from 1.79 to 1.80 - https://www.bouncycastle.org/download/bouncy-castle-java/?filter=java%3Drelease-1-80~~
- Netty from 4.1.116.Final to 4.1.117.Final - https://netty.io/news/2025/01/14/4-1-117-Final.html
- Swagger annotations from 2.2.27 to 2.2.28 - https://github.com/swagger-api/swagger-core/releases/tag/v2.2.28

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
