### PR TITLE
NIFI-14188 Fix NPE in FrameworkSslContextProvider

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/framework/ssl/FrameworkSslContextProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/framework/ssl/FrameworkSslContextProvider.java
@@ -150,7 +150,7 @@ public class FrameworkSslContextProvider {
     }
 
     private boolean isPemStoreType(final String storeTypePropertyName) {
-        final String storeType = properties.getProperty(storeTypePropertyName);
+        final String storeType = properties.getProperty(storeTypePropertyName, EMPTY);
         return PEM_STORE_TYPE.contentEquals(storeType);
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-14188](https://issues.apache.org/jira/browse/NIFI-14188) Fixes a potential `NullPointerException` in the `FrameworkSslContextProvider` when evaluating the `nifi.security.keystoreType` or `nifi.security.truststoreType` properties. The solution returns a default empty string when the property value is `null`, avoiding the NPE on the subsequent comparison.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
