### PR TITLE
NIFI-14189 Upgrade Bouncy Castle from 1.79 to 1.80

### DIFF
--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/DecryptContentPGP.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/main/java/org/apache/nifi/processors/pgp/DecryptContentPGP.java
@@ -42,6 +42,7 @@ import org.apache.nifi.pgp.service.api.KeyIdentifierConverter;
 import org.apache.nifi.stream.io.StreamUtils;
 
 import org.apache.nifi.util.StringUtils;
+import org.bouncycastle.bcpg.KeyIdentifier;
 import org.bouncycastle.openpgp.PGPCompressedData;
 import org.bouncycastle.openpgp.PGPEncryptedData;
 import org.bouncycastle.openpgp.PGPEncryptedDataList;
@@ -323,7 +324,8 @@ public class DecryptContentPGP extends AbstractProcessor {
             } else if (publicKeyData.hasNext()) {
                 while (publicKeyData.hasNext()) {
                     final PGPPublicKeyEncryptedData publicKeyEncryptedData = publicKeyData.next();
-                    final long keyId = publicKeyEncryptedData.getKeyID();
+                    final KeyIdentifier publicKeyIdentifier = publicKeyEncryptedData.getKeyIdentifier();
+                    final long keyId = publicKeyIdentifier.getKeyId();
                     final Optional<PGPPrivateKey> privateKey = privateKeyService.findPrivateKey(keyId);
                     if (privateKey.isPresent()) {
                         supportedEncryptedData = publicKeyEncryptedData;
@@ -404,7 +406,8 @@ public class DecryptContentPGP extends AbstractProcessor {
             if (privateKeyService == null) {
                 throw new PGPProcessException("PGP Public Key Encryption Found: Private Key Service not configured");
             } else {
-                final long keyId = publicKeyEncryptedData.getKeyID();
+                final KeyIdentifier publicKeyIdentifier = publicKeyEncryptedData.getKeyIdentifier();
+                final long keyId = publicKeyIdentifier.getKeyId();
                 final Optional<PGPPrivateKey> foundPrivateKey = privateKeyService.findPrivateKey(keyId);
                 if (foundPrivateKey.isPresent()) {
                     final PGPPrivateKey privateKey = foundPrivateKey.get();
@@ -421,9 +424,13 @@ public class DecryptContentPGP extends AbstractProcessor {
         }
 
         private void setSymmetricKeyAlgorithmAttributes(final int symmetricAlgorithm) {
-            final String blockCipher = PGPUtil.getSymmetricCipherName(symmetricAlgorithm);
-            attributes.put(PGPAttributeKey.SYMMETRIC_KEY_ALGORITHM_BLOCK_CIPHER, blockCipher);
-            attributes.put(PGPAttributeKey.SYMMETRIC_KEY_ALGORITHM_ID, Integer.toString(symmetricAlgorithm));
+            try {
+                final String blockCipher = PGPUtil.getSymmetricCipherName(symmetricAlgorithm);
+                attributes.put(PGPAttributeKey.SYMMETRIC_KEY_ALGORITHM_BLOCK_CIPHER, blockCipher);
+                attributes.put(PGPAttributeKey.SYMMETRIC_KEY_ALGORITHM_ID, Integer.toString(symmetricAlgorithm));
+            } catch (final IllegalArgumentException e) {
+                throw new PGPDecryptionException("PGP Symmetric Algorithm [%d] not valid".formatted(symmetricAlgorithm));
+            }
         }
 
         private boolean isVerified(final PGPEncryptedData encryptedData) {

--- a/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/DecryptContentPGPTest.java
+++ b/nifi-extension-bundles/nifi-pgp-bundle/nifi-pgp-processors/src/test/java/org/apache/nifi/processors/pgp/DecryptContentPGPTest.java
@@ -48,9 +48,9 @@ import org.bouncycastle.openpgp.PGPUtil;
 import org.bouncycastle.openpgp.jcajce.JcaPGPObjectFactory;
 import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptor;
 import org.bouncycastle.openpgp.operator.PGPDataEncryptorBuilder;
+import org.bouncycastle.openpgp.operator.bc.BcPBEKeyEncryptionMethodGenerator;
 import org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder;
 import org.bouncycastle.openpgp.operator.bc.BcPublicKeyKeyEncryptionMethodGenerator;
-import org.bouncycastle.openpgp.operator.jcajce.JcePBEKeyEncryptionMethodGenerator;
 import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyDecryptorBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -437,14 +437,14 @@ public class DecryptContentPGPTest {
     private byte[] getPasswordBasedEncryptedData(final int encryptionAlgorithm, final byte[] contents, final boolean integrityEnabled) throws IOException, PGPException {
         final PGPDataEncryptorBuilder builder = new BcPGPDataEncryptorBuilder(encryptionAlgorithm).setWithIntegrityPacket(integrityEnabled);
         final PGPEncryptedDataGenerator generator = new PGPEncryptedDataGenerator(builder);
-        generator.addMethod(new JcePBEKeyEncryptionMethodGenerator(PASSPHRASE.toCharArray()));
+        generator.addMethod(new BcPBEKeyEncryptionMethodGenerator(PASSPHRASE.toCharArray()));
         return getEncryptedData(generator, contents);
     }
 
     private byte[] getPasswordBasedAndPublicKeyEncryptedData(final byte[] contents, final PGPPublicKey publicKey) throws IOException, PGPException {
         final PGPDataEncryptorBuilder builder = new BcPGPDataEncryptorBuilder(ENCRYPTION_ALGORITHM).setWithIntegrityPacket(INTEGRITY_ENABLED);
         final PGPEncryptedDataGenerator generator = new PGPEncryptedDataGenerator(builder);
-        generator.addMethod(new JcePBEKeyEncryptionMethodGenerator(PASSPHRASE.toCharArray()));
+        generator.addMethod(new BcPBEKeyEncryptionMethodGenerator(PASSPHRASE.toCharArray()));
         generator.addMethod(new BcPublicKeyKeyEncryptionMethodGenerator(publicKey));
         return getEncryptedData(generator, contents);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <org.apache.commons.text.version>1.13.0</org.apache.commons.text.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
-        <org.bouncycastle.version>1.79</org.bouncycastle.version>
+        <org.bouncycastle.version>1.80</org.bouncycastle.version>
         <pmd.version>7.9.0</pmd.version>
         <testcontainers.version>1.20.4</testcontainers.version>
         <org.slf4j.version>2.0.16</org.slf4j.version>


### PR DESCRIPTION
# Summary

[NIFI-14189](https://issues.apache.org/jira/browse/NIFI-14189) Upgrades Bouncy Castle dependencies from 1.79 to [1.80](https://www.bouncycastle.org/download/bouncy-castle-java/?filter=java%3Drelease-1-80).

Changes in Bouncy Castle algorithm resolution required updating the unit test to use the Bouncy Castle implementation of the encryption method instead of the JCE implementation.

Updates to `DecryptContentPGP` included replacing deprecated usage of `getKeyID()` with `getKeyIdentifier().getKeyId()` and introducing a try-catch block around `PGPUtil.getSymmetricCipherName()`. The `getSymmetricAlgorithm()` method can return an invalid value when the passphrase is incorrect, so catching the exception and throwing a `PGPDecryptionException` handles this scenario.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
