### PR TITLE
[NIFI-14193] correct icon alignment when a parameter is inherited and…

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/parameter-contexts/ui/parameter-context-listing/parameter-table/parameter-table.component.html
@@ -44,22 +44,24 @@
                                     [title]="item.originalEntity.parameter.name">
                                     {{ item.originalEntity.parameter.name }}
                                 </div>
-                                @if (hasDescription(item)) {
-                                    <i
-                                        class="fa fa-info-circle primary-color"
-                                        nifiTooltip
-                                        [tooltipComponentType]="TextTip"
-                                        [tooltipInputData]="getDescription(item)"
-                                        [delayClose]="false"></i>
-                                }
-                                @if (canOverride(item)) {
-                                    <i
-                                        class="fa fa-level-down primary-color"
-                                        nifiTooltip
-                                        [tooltipComponentType]="TextTip"
-                                        tooltipInputData="This parameter is inherited form another Parameter Context."
-                                        [delayClose]="false"></i>
-                                }
+                                <div class="flex gap-x-2 justify-end">
+                                    @if (hasDescription(item)) {
+                                        <i
+                                            class="fa fa-info-circle primary-color"
+                                            nifiTooltip
+                                            [tooltipComponentType]="TextTip"
+                                            [tooltipInputData]="getDescription(item)"
+                                            [delayClose]="false"></i>
+                                    }
+                                    @if (canOverride(item)) {
+                                        <i
+                                            class="fa fa-level-down primary-color"
+                                            nifiTooltip
+                                            [tooltipComponentType]="TextTip"
+                                            tooltipInputData="This parameter is inherited form another Parameter Context."
+                                            [delayClose]="false"></i>
+                                    }
+                                </div>
                             </div>
                         </td>
                     </ng-container>


### PR DESCRIPTION
… has a description

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14193](https://issues.apache.org/jira/browse/NIFI-14193)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
