### PR TITLE
NIFI-14206 allow configuration of OIDC Groups claim by env var for NiFi Registry Docker Image startup

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-docker/dockerhub/README.md
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docker/dockerhub/README.md
@@ -149,6 +149,7 @@ user with administrative privileges.
       -e NIFI_REGISTRY_SECURITY_USER_OIDC_PREFERRED_JWSALGORITHM=RS256 \
       -e NIFI_REGISTRY_SECURITY_USER_OIDC_ADDITIONAL_SCOPES=profile \
       -e NIFI_REGISTRY_SECURITY_USER_OIDC_CLAIM_IDENTIFYING_USER=preferred_username \
+      -e NIFI_REGISTRY_SECURITY_USER_OIDC_CLAIM_GROUPS=groups \
       -d \
       apache/nifi-registry:latest
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-docker/dockerhub/sh/update_oidc_properties.sh
+++ b/nifi-registry/nifi-registry-core/nifi-registry-docker/dockerhub/sh/update_oidc_properties.sh
@@ -23,3 +23,4 @@ prop_replace 'nifi.registry.security.user.oidc.client.secret'                   
 prop_replace 'nifi.registry.security.user.oidc.preferred.jwsalgorithm'           "${NIFI_REGISTRY_SECURITY_USER_OIDC_PREFERRED_JWSALGORITHM}"
 prop_replace 'nifi.registry.security.user.oidc.additional.scopes'                "${NIFI_REGISTRY_SECURITY_USER_OIDC_ADDITIONAL_SCOPES}"
 prop_replace 'nifi.registry.security.user.oidc.claim.identifying.user'           "${NIFI_REGISTRY_SECURITY_USER_OIDC_CLAIM_IDENTIFYING_USER}"
+prop_replace 'nifi.registry.security.user.oidc.claim.groups'                     "${NIFI_REGISTRY_SECURITY_USER_OIDC_CLAIM_GROUPS}"


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14206](https://issues.apache.org/jira/browse/NIFI-14206) allow configuration of OIDC Groups claim by env var for NiFi Registry Docker Image startup

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ x Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- ~~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~~
- ~~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~~

### Documentation

- ~~[ ] Documentation formatting appears as expected in rendered files~~
