### PR TITLE
NIFI-14228 Remove fallback Sensitive Properties Key from Commands

### DIFF
--- a/nifi-commons/nifi-flow-encryptor/src/test/java/org/apache/nifi/flow/encryptor/command/SetSensitivePropertiesAlgorithmTest.java
+++ b/nifi-commons/nifi-flow-encryptor/src/test/java/org/apache/nifi/flow/encryptor/command/SetSensitivePropertiesAlgorithmTest.java
@@ -18,6 +18,7 @@ package org.apache.nifi.flow.encryptor.command;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -37,8 +38,8 @@ public class SetSensitivePropertiesAlgorithmTest {
     }
 
     @Test
-    public void testMainPopulatedKeyAndAlgorithm() throws IOException, URISyntaxException {
-        final Path propertiesPath = FlowEncryptorCommandTest.getPopulatedNiFiProperties();
+    public void testMainPopulatedKeyAndAlgorithm(@TempDir final Path tempDir) throws IOException, URISyntaxException {
+        final Path propertiesPath = FlowEncryptorCommandTest.getPopulatedNiFiProperties(tempDir);
         System.setProperty(FlowEncryptorCommand.PROPERTIES_FILE_PATH, propertiesPath.toString());
 
         SetSensitivePropertiesAlgorithm.main(new String[]{REQUESTED_ALGORITHM});

--- a/nifi-commons/nifi-flow-encryptor/src/test/java/org/apache/nifi/flow/encryptor/command/SetSensitivePropertiesKeyTest.java
+++ b/nifi-commons/nifi-flow-encryptor/src/test/java/org/apache/nifi/flow/encryptor/command/SetSensitivePropertiesKeyTest.java
@@ -18,6 +18,7 @@ package org.apache.nifi.flow.encryptor.command;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -37,8 +38,8 @@ public class SetSensitivePropertiesKeyTest {
     }
 
     @Test
-    public void testMainBlankKeyAndAlgorithm() throws IOException, URISyntaxException {
-        final Path propertiesPath = FlowEncryptorCommandTest.getBlankNiFiProperties();
+    public void testMainPopulatedKeyAndAlgorithm(@TempDir final Path tempDir) throws IOException, URISyntaxException {
+        final Path propertiesPath = FlowEncryptorCommandTest.getPopulatedNiFiProperties(tempDir);
         System.setProperty(FlowEncryptorCommand.PROPERTIES_FILE_PATH, propertiesPath.toString());
 
         final String sensitivePropertiesKey = UUID.randomUUID().toString();


### PR DESCRIPTION
# Summary

[NIFI-14228](https://issues.apache.org/jira/browse/NIFI-14228) Removes the historical fallback Sensitive Properties Key from the `set-sensitive-properties-key` and `set-sensitive-properties-algorithm` commands, throwing an exception when it is not configured in `nifi.properties`.

This reflects the previous approach implemented for NiFi 1, before automatic key generation was implemented. NiFi 2 removed support for a blank Sensitive Properties Key, so these commands do not need to have the fallback value implemented.

Changes include updating unit tests to expect failures for a blank key.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
