### PR TITLE
[NIFI-14241] - Replace deprecated imports of setup-jest with new approach

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi-jolt-transform-ui/setup-jest.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi-jolt-transform-ui/setup-jest.ts
@@ -14,4 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv({
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true
+});

--- a/nifi-frontend/src/main/frontend/apps/nifi/setup-jest.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/setup-jest.ts
@@ -14,4 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv({
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true
+});

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/controller-service/controller-services.component.spec.ts
@@ -26,6 +26,7 @@ import { MockComponent } from 'ng-mocks';
 import { Navigation } from '../../../../ui/common/navigation/navigation.component';
 import { canvasFeatureKey } from '../../state';
 import { controllerServicesFeatureKey } from '../../state/controller-services';
+import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 
 describe('ControllerServices', () => {
     let component: ControllerServices;
@@ -34,7 +35,12 @@ describe('ControllerServices', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [ControllerServices],
-            imports: [RouterTestingModule, MockComponent(Navigation), HttpClientTestingModule],
+            imports: [
+                RouterTestingModule,
+                MockComponent(Navigation),
+                HttpClientTestingModule,
+                MockComponent(NgxSkeletonLoaderComponent)
+            ],
             providers: [
                 provideMockStore({
                     initialState: {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/manage-remote-ports/manage-remote-ports.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/manage-remote-ports/manage-remote-ports.component.spec.ts
@@ -25,6 +25,7 @@ import { initialState } from '../../state/manage-remote-ports/manage-remote-port
 import { MockComponent } from 'ng-mocks';
 import { Navigation } from '../../../../ui/common/navigation/navigation.component';
 import { remotePortsFeatureKey } from '../../state/manage-remote-ports';
+import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 
 describe('ManageRemotePorts', () => {
     let component: ManageRemotePorts;
@@ -33,7 +34,12 @@ describe('ManageRemotePorts', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [ManageRemotePorts],
-            imports: [RouterTestingModule, MockComponent(Navigation), HttpClientTestingModule],
+            imports: [
+                RouterTestingModule,
+                MockComponent(Navigation),
+                HttpClientTestingModule,
+                MockComponent(NgxSkeletonLoaderComponent)
+            ],
             providers: [
                 provideMockStore({
                     initialState: {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/users/feature/users.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/users/feature/users.component.spec.ts
@@ -26,6 +26,7 @@ import { MockComponent } from 'ng-mocks';
 import { Navigation } from '../../../ui/common/navigation/navigation.component';
 import { usersFeatureKey } from '../state';
 import { BannerText } from '../../../ui/common/banner-text/banner-text.component';
+import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 
 describe('Users', () => {
     let component: Users;
@@ -34,7 +35,13 @@ describe('Users', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [Users, UserListing],
-            imports: [RouterModule, RouterTestingModule, MockComponent(BannerText), MockComponent(Navigation)],
+            imports: [
+                RouterModule,
+                RouterTestingModule,
+                MockComponent(BannerText),
+                MockComponent(Navigation),
+                MockComponent(NgxSkeletonLoaderComponent)
+            ],
             providers: [
                 provideMockStore({
                     initialState: {

--- a/nifi-frontend/src/main/frontend/apps/standard-content-viewer/setup-jest.ts
+++ b/nifi-frontend/src/main/frontend/apps/standard-content-viewer/setup-jest.ts
@@ -14,4 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv({
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true
+});

--- a/nifi-frontend/src/main/frontend/apps/update-attribute/setup-jest.ts
+++ b/nifi-frontend/src/main/frontend/apps/update-attribute/setup-jest.ts
@@ -14,4 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv({
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true
+});

--- a/nifi-frontend/src/main/frontend/libs/shared/setup-jest.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/setup-jest.ts
@@ -14,4 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv({
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true
+});


### PR DESCRIPTION
# Summary

[NIFI-14241](https://issues.apache.org/jira/browse/NIFI-14241)
Replace deprecated imports of setup-jest with new approach


Migrated to use 
```
setupZoneTestEnv({
    errorOnUnknownElements: true,
    errorOnUnknownProperties: true
});
```