### PR TITLE
NIFI-5579: Allow ExecuteGroovyScript to DBCPConnectionLookup services

### DIFF
--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/pom.xml
@@ -69,12 +69,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-dbcp-service</artifactId>
-            <version>2.3.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock-record-utils</artifactId>
         </dependency>
         <dependency>

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/pom.xml
@@ -59,16 +59,18 @@
             <version>2.5.3</version>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-dbcp-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-record</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-dbcp-service</artifactId>
+            <version>2.3.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/resources/groovy/test_attributes_passed_to_SQL.groovy
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/resources/groovy/test_attributes_passed_to_SQL.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def flowFile = session.create();
+if (!flowFile) return
+
+
+
+flowFile = session.putAttribute(flowFile, "from-content", "test content")
+session.transfer(flowFile, REL_SUCCESS)


### PR DESCRIPTION
# Summary

[NIFI-5579](https://issues.apache.org/jira/browse/NIFI-5579) This PR allows ExecuteGroovyScript to use DBCPConnectionPoolLookup controller service(s) by passing in any available attributes

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
