### PR TITLE
[NIFI-14327][NIFI-14249] - Copy/Paste handling when clipboard is not available

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
@@ -956,7 +956,16 @@ export class CanvasUtils {
         return { x, y };
     }
 
+    public isClipboardAvailable(): boolean {
+        // system clipboard interaction requires the browser to be in a secured context.
+        return window.isSecureContext && Object.hasOwn(window, 'ClipboardItem');
+    }
+
     public isCopyable(selection: d3.Selection<any, any, any, any>): boolean {
+        if (!this.isClipboardAvailable()) {
+            return false;
+        }
+
         // if nothing is selected return
         if (selection.empty()) {
             return false;
@@ -1001,7 +1010,7 @@ export class CanvasUtils {
     }
 
     public isPastable(): boolean {
-        return this.canvasPermissions.canWrite;
+        return this.isClipboardAvailable() && this.canvasPermissions.canWrite;
     }
 
     /**

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.actions.ts
@@ -112,7 +112,7 @@ import {
 import { StatusHistoryRequest } from '../../../../state/status-history';
 import { FetchComponentVersionsRequest, RegistryClientEntity } from '../../../../state/shared';
 import { ErrorContext } from '../../../../state/error';
-import { CopyRequest, CopyResponseContext, CopyResponseEntity } from '../../../../state/copy';
+import { CopyResponseContext, CopyResponseEntity } from '../../../../state/copy';
 
 const CANVAS_PREFIX = '[Canvas]';
 
@@ -503,8 +503,6 @@ export const moveComponents = createAction(
     `${CANVAS_PREFIX} Move Components`,
     props<{ request: MoveComponentsRequest }>()
 );
-
-export const copy = createAction(`${CANVAS_PREFIX} Copy`, props<{ request: CopyRequest }>());
 
 export const copySuccess = createAction(`${CANVAS_PREFIX} Copy Success`, props<{ response: CopyResponseContext }>());
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -20,6 +20,14 @@ import { FlowService } from '../../service/flow.service';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { concatLatestFrom } from '@ngrx/operators';
 import * as FlowActions from './flow.actions';
+import {
+    disableComponent,
+    enableComponent,
+    setRegistryClients,
+    startComponent,
+    startPollingProcessorUntilStopped,
+    stopComponent
+} from './flow.actions';
 import * as StatusHistoryActions from '../../../../state/status-history/status-history.actions';
 import * as ErrorActions from '../../../../state/error/error.actions';
 import * as CopyActions from '../../../../state/copy/copy.actions';
@@ -82,9 +90,9 @@ import {
     selectMaxZIndex,
     selectOutputPort,
     selectParentProcessGroupId,
+    selectPollingProcessor,
     selectProcessGroup,
     selectProcessor,
-    selectPollingProcessor,
     selectRefreshRpgDetails,
     selectRemoteProcessGroup,
     selectSaving,
@@ -119,7 +127,17 @@ import { OkDialog } from '../../../../ui/common/ok-dialog/ok-dialog.component';
 import { GroupComponents } from '../../ui/canvas/items/process-group/group-components/group-components.component';
 import { EditProcessGroup } from '../../ui/canvas/items/process-group/edit-process-group/edit-process-group.component';
 import { ControllerServiceService } from '../../service/controller-service.service';
-import { YesNoDialog } from '@nifi/shared';
+import {
+    ComponentType,
+    isDefinedAndNotNull,
+    LARGE_DIALOG,
+    MEDIUM_DIALOG,
+    NiFiCommon,
+    SMALL_DIALOG,
+    Storage,
+    XL_DIALOG,
+    YesNoDialog
+} from '@nifi/shared';
 import { PropertyTableHelperService } from '../../../../service/property-table-helper.service';
 import { ParameterHelperService } from '../../service/parameter-helper.service';
 import { RegistryService } from '../../service/registry.service';
@@ -151,32 +169,13 @@ import {
 } from '../../../../state/property-verification/property-verification.selectors';
 import { VerifyPropertiesRequestContext } from '../../../../state/property-verification';
 import { BackNavigation } from '../../../../state/navigation';
-import {
-    ComponentType,
-    isDefinedAndNotNull,
-    LARGE_DIALOG,
-    MEDIUM_DIALOG,
-    SMALL_DIALOG,
-    XL_DIALOG,
-    NiFiCommon,
-    Storage
-} from '@nifi/shared';
 import { resetPollingFlowAnalysis } from '../flow-analysis/flow-analysis.actions';
 import { selectDocumentVisibilityState } from '../../../../state/document-visibility/document-visibility.selectors';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DocumentVisibility } from '../../../../state/document-visibility';
 import { ErrorContextKey } from '../../../../state/error';
-import {
-    disableComponent,
-    enableComponent,
-    setRegistryClients,
-    startComponent,
-    startPollingProcessorUntilStopped,
-    stopComponent
-} from './flow.actions';
 import { CopyPasteService } from '../../service/copy-paste.service';
 import { selectCopiedContent } from '../../../../state/copy/copy.selectors';
-import { CopyRequestContext, CopyResponseContext } from '../../../../state/copy';
 import * as ParameterActions from '../parameter/parameter.actions';
 import { ParameterContextService } from '../../../parameter-contexts/service/parameter-contexts.service';
 
@@ -2488,45 +2487,6 @@ export class FlowEffects {
                         return FlowActions.deleteComponentsSuccess({
                             response: deleteResponses
                         });
-                    }),
-                    catchError((errorResponse: HttpErrorResponse) => of(this.snackBarOrFullScreenError(errorResponse)))
-                );
-            })
-        )
-    );
-
-    copy$ = createEffect(() =>
-        this.actions$.pipe(
-            ofType(FlowActions.copy),
-            map((action) => action.request),
-            concatLatestFrom(() => this.store.select(selectCurrentProcessGroupId)),
-            switchMap(([request, processGroupId]) => {
-                const copyRequest: CopyRequestContext = {
-                    ...request,
-                    processGroupId
-                };
-                return from(this.copyPasteService.copy(copyRequest)).pipe(
-                    switchMap((response) => {
-                        const copyBlob = new Blob([JSON.stringify(response, null, 2)], { type: 'text/plain' });
-                        const clipboardItem: ClipboardItem = new ClipboardItem({
-                            'text/plain': copyBlob
-                        });
-                        return from(navigator.clipboard.write([clipboardItem])).pipe(
-                            switchMap(() => {
-                                return of(
-                                    FlowActions.copySuccess({
-                                        response: {
-                                            copyResponse: response,
-                                            processGroupId,
-                                            pasteCount: 0
-                                        } as CopyResponseContext
-                                    })
-                                );
-                            }),
-                            catchError(() => {
-                                return of(FlowActions.flowSnackbarError({ error: 'Copy failed' }));
-                            })
-                        );
                     }),
                     catchError((errorResponse: HttpErrorResponse) => of(this.snackBarOrFullScreenError(errorResponse)))
                 );

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/canvas.component.ts
@@ -689,6 +689,10 @@ export class Canvas implements OnInit, OnDestroy {
 
     @HostListener('window:keydown.control.c', ['$event'])
     handleKeyDownCtrlC(event: KeyboardEvent) {
+        if (!this.canvasUtils.isClipboardAvailable()) {
+            return;
+        }
+
         if (this.executeAction('copy', event)) {
             event.preventDefault();
         }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/operation-control.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/operation-control.component.html
@@ -101,14 +101,6 @@
                         </button>
                         <button
                             mat-icon-button
-                            class="primary-icon-button mr-2"
-                            type="button"
-                            [disabled]="!canPaste()"
-                            (click)="paste()">
-                            <i class="fa fa-paste"></i>
-                        </button>
-                        <button
-                            mat-icon-button
                             class="primary-icon-button"
                             type="button"
                             [disabled]="!canGroup(selection)"

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/operation-control.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/graph-controls/operation-control/operation-control.component.ts
@@ -233,14 +233,6 @@ export class OperationControl {
         this.canvasActionsService.getActionFunction('copy')(selection);
     }
 
-    canPaste(): boolean {
-        return this.canvasActionsService.getConditionFunction('paste')(d3.select(null));
-    }
-
-    paste(): void {
-        return this.canvasActionsService.getActionFunction('paste')(d3.select(null));
-    }
-
     canGroup(selection: d3.Selection<any, any, any, any>): boolean {
         return this.canvasActionsService.getConditionFunction('group')(selection);
     }

--- a/nifi-frontend/src/main/frontend/libs/shared/src/directives/copy/copy.directive.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/directives/copy/copy.directive.spec.ts
@@ -24,7 +24,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 @Component({
     standalone: true,
-    template: `<div [copy]="copyText">test</div>`,
+    template: ` <div [copy]="copyText">test</div>`,
     imports: [CopyDirective]
 })
 class TestComponent {
@@ -35,6 +35,7 @@ describe('CopyDirective', () => {
     let component: TestComponent;
     let fixture: ComponentFixture<TestComponent>;
     let directiveDebugEl: any;
+    let windowSpy;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -44,10 +45,20 @@ describe('CopyDirective', () => {
         component = fixture.componentInstance;
         fixture.detectChanges();
         directiveDebugEl = fixture.debugElement.query(By.directive(CopyDirective));
+        window.isSecureContext = true;
     });
 
     afterEach(() => {
         jest.restoreAllMocks();
+    });
+
+    it('should not create a copy button on mouse enter if the clipboard is not available', () => {
+        window.isSecureContext = false;
+
+        directiveDebugEl.triggerEventHandler('mouseenter', null);
+        fixture.detectChanges();
+        const copyButton = directiveDebugEl.nativeElement.querySelector('.copy-button');
+        expect(copyButton).toBeNull();
     });
 
     it('should create a copy button on mouse enter', () => {

--- a/nifi-frontend/src/main/frontend/libs/shared/src/directives/copy/copy.directive.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/directives/copy/copy.directive.ts
@@ -19,7 +19,6 @@
 
 import { Directive, ElementRef, HostListener, Input, NgZone, Renderer2 } from '@angular/core';
 import { fromEvent, Subscription, switchMap, take } from 'rxjs';
-import { CanvasUtils } from '../../../../../apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service';
 
 @Directive({
     selector: '[copy]',


### PR DESCRIPTION
# Summary

[NIFI-14237](https://issues.apache.org/jira/browse/NIFI-14237) - Disable copy when system clipboard is not available
[NIFI-14249](https://issues.apache.org/jira/browse/NIFI-14249) - Remove paste from operation panel as only keyboard shortcuts allow for paste.

Also removed the copy effect as it is not used and can not be used due to it making the copy asynchronous, a potential security issue prevented by browsers without explicit acceptance.