### PR TITLE
NIFI-14253 - Dependency housekeeping - AWS, Azure, GCP, Tika, Slack, FTP, Parquet, etc

### DIFF
--- a/nifi-commons/nifi-xml-processing/pom.xml
+++ b/nifi-commons/nifi-xml-processing/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.8.5.0</version>
+                <version>4.8.6.6</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
@@ -20,7 +20,7 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <amqp-client.version>5.24.0</amqp-client.version>
+        <amqp-client.version>5.25.0</amqp-client.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -27,7 +27,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <aws-kinesis-client-library-version>2.6.0</aws-kinesis-client-library-version>
+        <aws-kinesis-client-library-version>2.6.1</aws-kinesis-client-library-version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -128,12 +128,12 @@
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-data</artifactId>
-            <version>5.1.1</version>
+            <version>5.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-ingest</artifactId>
-            <version>5.1.1</version>
+            <version>5.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -28,8 +28,8 @@
 
     <properties>
         <!-- when changing the Azure SDK version, also update msal4j to the version that is required by azure-identity -->
-        <azure.sdk.bom.version>1.2.30</azure.sdk.bom.version>
-        <msal4j.version>1.17.2</msal4j.version>
+        <azure.sdk.bom.version>1.2.31</azure.sdk.bom.version>
+        <msal4j.version>1.17.3</msal4j.version>
         <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
-            <version>2.1.2</version>
+            <version>2.1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20241206-2.0.0</version>
+            <version>v3-rev20250122-2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.tdunning</groupId>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.53.0</google.libraries.version>
+        <google.libraries.version>26.54.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -26,9 +26,9 @@
     <packaging>jar</packaging>
     <properties>
         <gremlin.version>3.7.3</gremlin.version>
-        <janusgraph.version>1.2.0-20241120-125614.80ef1d9</janusgraph.version>
+        <janusgraph.version>1.2.0-20250206-164517.a71898b</janusgraph.version>
         <guava.version>33.4.0-jre</guava.version>
-        <amqp-client.version>5.24.0</amqp-client.version>
+        <amqp-client.version>5.25.0</amqp-client.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/src/main/java/org/apache/commons/lang/NotImplementedException.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/src/main/java/org/apache/commons/lang/NotImplementedException.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,15 +22,42 @@ package org.apache.commons.lang;
  * Once janusgraph no longer depends on this vulnerable commons lang lib this class can be
  * deleted.
  */
-public class UnhandledException extends Exception {
+public class NotImplementedException extends UnsupportedOperationException {
 
+    private final String code;
 
-    public UnhandledException(Throwable cause) {
-        super(cause);
+    public NotImplementedException() {
+        this.code = null;
     }
 
-    public UnhandledException(String message, Throwable cause) {
+    public NotImplementedException(final String message) {
+        this(message, (String) null);
+    }
+
+    public NotImplementedException(final String message, final String code) {
+        super(message);
+        this.code = code;
+    }
+
+    public NotImplementedException(final String message, final Throwable cause) {
+        this(message, cause, null);
+    }
+
+    public NotImplementedException(final String message, final Throwable cause, final String code) {
         super(message, cause);
+        this.code = code;
     }
 
+    public NotImplementedException(final Throwable cause) {
+        this(cause, null);
+    }
+
+    public NotImplementedException(final Throwable cause, final String code) {
+        super(cause);
+        this.code = code;
+    }
+
+    public String getCode() {
+        return this.code;
+    }
 }

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/pom.xml
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <neo4j.driver.version>5.27.0</neo4j.driver.version>
+        <neo4j.driver.version>5.28.1</neo4j.driver.version>
         <neo4j.docker.version>5.19</neo4j.docker.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tika.version>3.0.0</tika.version>
+        <tika.version>3.1.0</tika.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>1.14.4</version>
+            <version>1.15.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.xerial.snappy</groupId>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <protobuf.version>3.25.5</protobuf.version>
-        <wire.version>5.1.0</wire.version>
+        <wire.version>5.2.1</wire.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.slack.api</groupId>
             <artifactId>bolt-socket-mode</artifactId>
-            <version>1.45.1</version>
+            <version>1.45.2</version>
         </dependency>
         <!-- Required by bolt-socket-mode but the library itself doesn't have the dependency. -->
         <dependency>

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
@@ -20,8 +20,8 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <snmp4j.version>3.8.2</snmp4j.version>
-        <snmp4j-agent.version>3.8.1</snmp4j-agent.version>
+        <snmp4j.version>3.9.0</snmp4j.version>
+        <snmp4j-agent.version>3.8.2</snmp4j-agent.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.apache.ftpserver</groupId>
             <artifactId>ftpserver-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>org.apache.ftpserver</groupId>
             <artifactId>ftplet-api</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio-jvm</artifactId>
-            <version>3.9.1</version>
+            <version>${okio.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ftp/NifiFtpServer.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ftp/NifiFtpServer.java
@@ -227,7 +227,6 @@ public class NifiFtpServer implements org.apache.nifi.processors.standard.ftp.Ft
 
     private static class StandardSslConfiguration implements SslConfiguration {
         private final SSLContext sslContext;
-
         private final SSLParameters sslParameters;
 
         private StandardSslConfiguration(final SSLContext sslContext) {
@@ -263,6 +262,11 @@ public class NifiFtpServer implements org.apache.nifi.processors.standard.ftp.Ft
         @Override
         public ClientAuth getClientAuth() {
             return ClientAuth.WANT;
+        }
+
+        @Override
+        public String getEnabledProtocol() {
+            return sslContext.getProtocol();
         }
     }
 }

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -35,7 +35,7 @@
     </modules>
     <properties>
         <org.apache.sshd.version>2.14.0</org.apache.sshd.version>
-        <tika.version>3.0.0</tika.version>
+        <tika.version>3.1.0</tika.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>3.1.8</version>
+            <version>${caffeine.version}</version>
         </dependency>
         <dependency>
             <groupId>com.maxmind.db</groupId>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio-jvm</artifactId>
-            <version>3.9.1</version>
+            <version>${okio.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio-jvm</artifactId>
-            <version>3.9.1</version>
+            <version>${okio.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>3.1.8</version>
+            <version>${caffeine.version}</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.stax-utils</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>3.4.2</spring.boot.version>
-        <flyway.version>11.2.0</flyway.version>
+        <flyway.version>11.3.1</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.1.0.202411261347-r</jgit.version>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <jline.version>3.28.0</jline.version>
+        <jline.version>3.29.0</jline.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -110,14 +110,14 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.780</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.30.4</software.amazon.awssdk.version>
-        <gson.version>2.11.0</gson.version>
-        <io.fabric8.kubernetes.client.version>7.0.1</io.fabric8.kubernetes.client.version>
-        <kotlin.version>2.1.0</kotlin.version>
+        <software.amazon.awssdk.version>2.30.16</software.amazon.awssdk.version>
+        <gson.version>2.12.1</gson.version>
+        <io.fabric8.kubernetes.client.version>7.1.0</io.fabric8.kubernetes.client.version>
+        <kotlin.version>2.1.10</kotlin.version>
         <okhttp.version>4.12.0</okhttp.version>
         <okio.version>3.10.2</okio.version>
         <org.apache.commons.cli.version>1.9.0</org.apache.commons.cli.version>
-        <org.apache.commons.codec.version>1.17.2</org.apache.commons.codec.version>
+        <org.apache.commons.codec.version>1.18.0</org.apache.commons.codec.version>
         <org.apache.commons.compress.version>1.27.1</org.apache.commons.compress.version>
         <com.github.luben.zstd-jni.version>1.5.6-9</com.github.luben.zstd-jni.version>
         <org.apache.commons.configuration.version>2.11.0</org.apache.commons.configuration.version>
@@ -141,7 +141,7 @@
         <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
         <json.smart.version>2.5.1</json.smart.version>
-        <groovy.version>4.0.24</groovy.version>
+        <groovy.version>4.0.25</groovy.version>
         <surefire.version>3.5.1</surefire.version>
         <hadoop.version>3.4.1</hadoop.version>
         <ozone.version>1.4.1</ozone.version>
@@ -160,8 +160,8 @@
         <swagger.annotations.version>2.2.28</swagger.annotations.version>
         <h2.version>2.3.232</h2.version>
         <zookeeper.version>3.9.3</zookeeper.version>
-        <caffeine.version>3.1.8</caffeine.version>
-        <hapi.version>2.5.1</hapi.version>
+        <caffeine.version>3.2.0</caffeine.version>
+        <hapi.version>2.6.0</hapi.version>
         <commons.dbcp2.version>2.13.0</commons.dbcp2.version>
         <prometheus.version>0.16.0</prometheus.version>
         <velocity-engine-core.version>2.4.1</velocity-engine-core.version>


### PR DESCRIPTION
# Summary

[NIFI-14253](https://issues.apache.org/jira/browse/NIFI-14253) - Dependency housekeeping - AWS, Azure, GCP, Tika, Slack, FTP, Parquet, etc

- spotbugs-maven-plugin from 4.8.5.0 to 4.8.6.6 - https://github.com/spotbugs/spotbugs-maven-plugin/releases
- AMQP client from 5.24.0 to 5.25.0 - https://github.com/rabbitmq/rabbitmq-java-client/releases
- AWS Kinesis client from 2.6.0 to 2.6.1 - https://github.com/awslabs/amazon-kinesis-client/releases
- Kusto from 5.1.1 to 5.2.0 - https://github.com/Azure/azure-kusto-java/releases/tag/v5.2.0
- Azure BOM from 1.2.30 to 1.2.31 - https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/boms/azure-sdk-bom/CHANGELOG.md
- MSAL4J from 1.17.2 to 1.17.3 - https://github.com/AzureAD/microsoft-authentication-library-for-java/releases/tag/v1.17.3
- Greenmail from 2.1.2 to 2.1.3 - https://github.com/greenmail-mail-test/greenmail/releases/tag/release-2.1.3
- Google API Services Drive from v3-rev20241206-2.0.0 to v3-rev20250122-2.0.0 - https://github.com/googleapis/google-api-java-client-services/tree/main/clients/google-api-services-drive/v3
- GCP BOM from 26.53.0 to 26.54.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.54.0
- Janusgraph from 1.2.0-20241120-125614.80ef1d9 to 1.2.0-20250206-164517.a71898b
- Neo4J Driver from 5.27.0 to 5.28.1 - https://github.com/neo4j/neo4j-java-driver/releases/tag/5.28.1
- Tika from 3.0.0 to 3.1.0 - https://github.com/apache/tika/blob/main/CHANGES.txt
- Parquet Avro from 1.14.4 to 1.15.0 - https://github.com/apache/parquet-java/releases/tag/apache-parquet-1.15.0
- Wire from 5.1.0 to 5.2.1 - https://github.com/square/wire/blob/master/CHANGELOG.md
- Slack Bolt from 1.45.1 to 1.45.2 - https://github.com/slackapi/java-slack-sdk/releases/tag/v1.45.2
- SNMP4J from 3.8.2 to 3.9.0 - https://www.snmp4j.org/CHANGES.txt
- SNMP4J Agent from 3.8.1 to 3.8.2 - https://snmp4j.org/agent/CHANGES.txt
- FTP Server from 1.2.0 to 1.2.1 - https://mina.apache.org/ftpserver-project/download_1_2.html
- FlywayDB from 11.2.0 to 11.3.1 - https://github.com/flyway/flyway/releases
- JLine from 3.28.0 to 3.29.0 - https://github.com/jline/jline3/releases
- AWS SDK from 2.30.4 to 2.30.16 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- GSON from 2.11.0 to 2.12.1 - https://github.com/google/gson/releases
- Fabric8 k8s from 7.0.1 to 7.1.0 - https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md
- Kotlin from 2.1.0 to 2.1.10 - https://github.com/JetBrains/kotlin/releases/tag/v2.1.10
- Apache Commons Codec from 1.17.2 to 1.18.0 - https://commons.apache.org/proper/commons-codec/changes.html#a1.18.0
- Groovy from 4.0.24 to 4.0.25 - https://groovy-lang.org/changelogs.html
- Caffeine from 3.1.8 to 3.2.0 - https://github.com/ben-manes/caffeine/releases/tag/v3.2.0
- Hapi from 2.5.1 to 2.6.0 - https://github.com/hapifhir/hapi-hl7v2/releases/tag/v2.6.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
