### PR TITLE
NIFI-14244 send original Records to errors output for PutElasticsearchRecord errors

### DIFF
--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -695,9 +695,9 @@ In order for a Processor to be considered valid and able to run, each Relationsh
 
 ===== Automatically Retry
 Users can also configure whether or not FlowFiles routed to a given Relationship should be retried. If a FlowFile is routed to any Relationship that is configured to be retried,
-the FlowFile will be re-queued and the Processor will attempt to process it again. If the Processor routes the FlowFile to a retriable Relationship again (either the same Relationship
+the FlowFile will be re-queued and the Processor will attempt to process it again. If the Processor routes the FlowFile to a retryable Relationship again (either the same Relationship
 or another that is configured to be retried), it will be re-queued again, up to the number of
-times specified by the user. If the Processor routes the FlowFile to a retriable Relationship after the specified number of retries, the FlowFile will be transferred to
+times specified by the user. If the Processor routes the FlowFile to a retryable Relationship after the specified number of retries, the FlowFile will be transferred to
 the Connection(s) that include that Relationship - or auto-terminated, as configured.
 If the Processor routes the FlowFile to any Relationship that is not configured to be retried, it will be routed to that Relationship immediately.
 
@@ -705,7 +705,7 @@ For example, consider a Processor with two relationships: `success` and `failure
 A user configures the `failure` Relationship to retry 10 times and also be configured to auto-terminate. In this
 case, if an incoming FlowFile is routed to the `failure` Relationship,
 it will be retried up to 10 times. After 10 attempts, if it is routed to `failure` again, it will be auto-terminated. However, if at any point it is
-routed to `success`, it will immediatley be transferred to the Connection(s) that include the `success` Relationship and not retried any further.
+routed to `success`, it will immediately be transferred to the Connection(s) that include the `success` Relationship and not retried any further.
 
 ====== Number of Retry Attempts
 For relationships set to retry, this number indicates how many times a FlowFile will attempt to reprocess before it is routed elsewhere.

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearch_IT.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearch_IT.java
@@ -65,6 +65,6 @@ abstract class AbstractElasticsearch_IT extends AbstractElasticsearchITBase {
     @AfterAll
     static void afterAll() {
         tearDownTestData(TEST_INDICES);
-        stopTestcontainer();
+        stopTestContainer();
     }
 }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractPutElasticsearch.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractPutElasticsearch.java
@@ -60,12 +60,12 @@ public abstract class AbstractPutElasticsearch extends AbstractProcessor impleme
             .description("All flowfiles that are sent to Elasticsearch without request failures go to this relationship.")
             .build();
 
-    static final Relationship REL_SUCCESSFUL = new Relationship.Builder()
+    public static final Relationship REL_SUCCESSFUL = new Relationship.Builder()
             .name("successful")
             .description("Record(s)/Flowfile(s) corresponding to Elasticsearch document(s) that did not result in an \"error\" (within Elasticsearch) will be routed here.")
             .build();
 
-    static final Relationship REL_ERRORS = new Relationship.Builder()
+    public static final Relationship REL_ERRORS = new Relationship.Builder()
             .name("errors")
             .description("Record(s)/Flowfile(s) corresponding to Elasticsearch document(s) that resulted in an \"error\" (within Elasticsearch) will be routed here.")
             .build();
@@ -96,7 +96,7 @@ public abstract class AbstractPutElasticsearch extends AbstractProcessor impleme
             .required(true)
             .build();
 
-    static final PropertyDescriptor INDEX_OP = new PropertyDescriptor.Builder()
+    public static final PropertyDescriptor INDEX_OP = new PropertyDescriptor.Builder()
             .name("put-es-record-index-op")
             .displayName("Index Operation")
             .description("The type of the operation used to index (create, delete, index, update, upsert)")

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJsonTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchJsonTest.java
@@ -330,8 +330,8 @@ public class PutElasticsearchJsonTest extends AbstractPutElasticsearchTest {
     }
 
     @Test
-    void testRetriable() {
-        clientService.setThrowRetriableError(true);
+    void testRetryable() {
+        clientService.setThrowRetryableError(true);
         basicTest(0, 1, 0);
     }
 

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecordTest.java
@@ -288,6 +288,7 @@ public class PutElasticsearchRecordTest extends AbstractPutElasticsearchTest {
         runner.addControllerService("mockReader", mockReader);
         runner.setProperty(PutElasticsearchRecord.RECORD_READER, "mockReader");
         runner.enableControllerService(mockReader);
+        runner.setAllowRecursiveReads(true);
 
         basicTest(0, 0, 1);
     }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/integration/AbstractElasticsearch_IT.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/integration/AbstractElasticsearch_IT.java
@@ -60,7 +60,9 @@ abstract class AbstractElasticsearch_IT<P extends ElasticsearchRestProcessor> ex
 
         runner.setProperty(ElasticsearchRestProcessor.CLIENT_SERVICE, CLIENT_SERVICE_NAME);
         runner.setProperty(ElasticsearchRestProcessor.INDEX, INDEX);
-        runner.setProperty(ElasticsearchRestProcessor.TYPE, type);
+        if (!"".equals(type)) {
+            runner.setProperty(ElasticsearchRestProcessor.TYPE, type);
+        }
 
         service.refresh(null, null);
     }
@@ -73,7 +75,7 @@ abstract class AbstractElasticsearch_IT<P extends ElasticsearchRestProcessor> ex
     @AfterAll
     static void afterAll() {
         tearDownTestData(TEST_INDICES);
-        stopTestcontainer();
+        stopTestContainer();
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/integration/PutElasticsearchRecord_IT.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/integration/PutElasticsearchRecord_IT.java
@@ -16,11 +16,187 @@
  */
 package org.apache.nifi.processors.elasticsearch.integration;
 
+import org.apache.nifi.json.JsonRecordSetWriter;
+import org.apache.nifi.json.JsonTreeReader;
 import org.apache.nifi.processors.elasticsearch.AbstractPutElasticsearch;
+import org.apache.nifi.processors.elasticsearch.ElasticsearchRestProcessor;
 import org.apache.nifi.processors.elasticsearch.PutElasticsearchRecord;
+import org.apache.nifi.schema.access.SchemaAccessUtils;
+import org.apache.nifi.schema.inference.SchemaInferenceUtil;
+import org.apache.nifi.serialization.RecordReaderFactory;
+import org.apache.nifi.util.MockFlowFile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PutElasticsearchRecord_IT extends AbstractElasticsearch_IT<AbstractPutElasticsearch> {
     AbstractPutElasticsearch getProcessor() {
         return new PutElasticsearchRecord();
+    }
+
+    @Override
+    @BeforeEach
+    public void before() throws Exception {
+        super.before();
+
+        final RecordReaderFactory reader = new JsonTreeReader();
+        runner.addControllerService("reader", reader);
+        runner.setProperty(reader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaInferenceUtil.INFER_SCHEMA);
+        runner.assertValid(reader);
+        runner.enableControllerService(reader);
+        runner.setProperty(PutElasticsearchRecord.RECORD_READER, "reader");
+
+        final JsonRecordSetWriter writer = new JsonRecordSetWriter();
+        runner.addControllerService("writer", writer);
+        runner.setProperty(writer, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.INHERIT_RECORD_SCHEMA);
+        runner.setProperty(writer, JsonRecordSetWriter.SUPPRESS_NULLS, JsonRecordSetWriter.ALWAYS_SUPPRESS);
+        runner.assertValid(writer);
+        runner.enableControllerService(writer);
+        runner.setProperty(PutElasticsearchRecord.RESULT_RECORD_WRITER, "writer");
+    }
+
+    @Test
+    void testErrorRecordsOutputWithoutId() {
+        final String json = """
+                [
+                    {"id": "1", "foo": false},
+                    {"id": "2", "foo": 123}
+                ]
+                """;
+
+        runner.setProperty(ElasticsearchRestProcessor.INDEX, "test-errors");
+        runner.setProperty(PutElasticsearchRecord.ID_RECORD_PATH, "/id");
+        runner.setProperty(PutElasticsearchRecord.RETAIN_ID_FIELD, "false");
+
+        runner.enqueue(json);
+        runner.run();
+
+        // record 1 should succeed and set the index mapping of "foo" to boolean, but the id field should not be in the successful output
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 1);
+        final String successfulContent = runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_SUCCESSFUL).getFirst().getContent();
+        assertFalse(successfulContent.contains("\"id\":"), successfulContent);
+        assertTrue(successfulContent.contains("\"foo\":false"), successfulContent);
+
+        // record 2 should fail because an int cannot be indexed into a boolean field, the id field should remain in the error output
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 1);
+        final String errorContent = runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).getFirst().getContent();
+        assertTrue(errorContent.contains("\"id\":\"2\""), errorContent);
+        assertTrue(errorContent.contains("\"foo\":123"), errorContent);
+    }
+
+    @Test
+    void testErrorRecordsOutputMultipleBatches() {
+        final String json = """
+                [
+                    {"id": "1", "foo": false},
+                    {"id": "2", "foo": 123},
+                    {"id": "3", "foo": true},
+                    {"id": "4", "foo": false},
+                    {"id": "5", "foo": 456}
+                ]
+                """;
+
+        runner.setProperty(ElasticsearchRestProcessor.INDEX, "test-errors-batches");
+        runner.setProperty(PutElasticsearchRecord.BATCH_SIZE, "2");
+        runner.setProperty(PutElasticsearchRecord.ID_RECORD_PATH, "/id");
+        runner.setProperty(PutElasticsearchRecord.RETAIN_ID_FIELD, "true");
+
+        // allow multiple reads of the input FlowFile
+        runner.setAllowRecursiveReads(true);
+
+        runner.enqueue(json);
+        runner.run();
+
+        // records 1, 3 & 4 (output in 2 FlowFiles) should succeed and set the index mapping of "foo" to boolean, with id field retained
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 2);
+
+        final MockFlowFile successful1 = runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_SUCCESSFUL).getFirst();
+        successful1.assertAttributeEquals("record.count", "1");
+        final String successful1Content = successful1.getContent();
+        assertTrue(successful1Content.contains("\"id\":\"1\""), successful1Content);
+        assertTrue(successful1Content.contains("\"foo\":false"), successful1Content);
+
+        final MockFlowFile successful2 = runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_SUCCESSFUL).get(1);
+        successful2.assertAttributeEquals("record.count", "2");
+        final String successful2Content = successful2.getContent();
+        assertTrue(successful2Content.contains("\"id\":\"3\""), successful2Content);
+        assertTrue(successful2Content.contains("\"id\":\"4\""), successful2Content);
+
+        // record 2 & 5 (in 2 batches) should fail because an int cannot be indexed into a boolean field, the id field should remain in the error output
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 2);
+
+        final MockFlowFile error1 = runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).getFirst();
+        error1.assertAttributeEquals("record.count", "1");
+        final String error1Content = error1.getContent();
+        assertTrue(error1Content.contains("\"id\":\"2\""), error1Content);
+        assertTrue(error1Content.contains("\"foo\":123"), error1Content);
+
+        final MockFlowFile error2 = runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).get(1);
+        error2.assertAttributeEquals("record.count", "1");
+        final String error2Content = error2.getContent();
+        assertTrue(error2Content.contains("\"id\":\"5\""), error2Content);
+        assertTrue(error2Content.contains("\"foo\":456"), error2Content);
+    }
+
+    @Test
+    void testUpdateError() {
+        final String json = """
+                {"id": "123", "foo": "bar"}
+                """;
+
+        runner.setProperty(AbstractPutElasticsearch.INDEX_OP, "update");
+        runner.setProperty(PutElasticsearchRecord.ID_RECORD_PATH, "/id");
+
+        runner.enqueue(json);
+        runner.run();
+
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 1);
+        final String errorContent = runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).getFirst().getContent();
+        assertTrue(errorContent.contains("\"id\":\"123\""), errorContent);
+        assertTrue(errorContent.contains("\"foo\":\"bar\""), errorContent);
+    }
+
+    @Test
+    void testUpdateScriptError() {
+        final String json = """
+                {"id": "123", "script": {"source": "ctx._source.counter += params.count"}}
+                """;
+
+        runner.setProperty(AbstractPutElasticsearch.INDEX_OP, "update");
+        runner.setProperty(PutElasticsearchRecord.ID_RECORD_PATH, "/id");
+        runner.setProperty(PutElasticsearchRecord.SCRIPT_RECORD_PATH, "/script");
+
+        runner.enqueue(json);
+        runner.run();
+
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 1);
+        final String errorContent = runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).getFirst().getContent();
+        assertTrue(errorContent.contains("\"id\":\"123\""), errorContent);
+        assertTrue(errorContent.contains("\"script\":{"), errorContent);
+    }
+
+    @Test
+    void testScriptedUpsertError() {
+        final String json = """
+                {"id": "123", "script": {"source": "ctx._source.counter += params.count"}, "upsert": true}
+                """;
+
+        runner.setProperty(AbstractPutElasticsearch.INDEX_OP, "upsert");
+        runner.setProperty(PutElasticsearchRecord.ID_RECORD_PATH, "/id");
+        runner.setProperty(PutElasticsearchRecord.SCRIPT_RECORD_PATH, "/script");
+        runner.setProperty(PutElasticsearchRecord.SCRIPTED_UPSERT_RECORD_PATH, "/upsert");
+
+        runner.enqueue(json);
+        runner.run();
+
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_SUCCESSFUL, 0);
+        runner.assertTransferCount(AbstractPutElasticsearch.REL_ERRORS, 1);
+        final String errorContent = runner.getFlowFilesForRelationship(AbstractPutElasticsearch.REL_ERRORS).getFirst().getContent();
+        assertTrue(errorContent.contains("\"id\":\"123\""), errorContent);
+        assertTrue(errorContent.contains("\"script\":{"), errorContent);
     }
 }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/mock/AbstractMockElasticsearchClient.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/mock/AbstractMockElasticsearchClient.java
@@ -121,12 +121,12 @@ public class AbstractMockElasticsearchClient extends AbstractControllerService i
         return String.format("http://localhost:9200/%s/%s", index, StringUtils.isNotBlank(type) ? type : "");
     }
 
-    public boolean isThrowRetriableError() {
-        return throwRetriableError;
+    public boolean isThrowRetryableError() {
+        return throwRetryableError;
     }
 
-    public void setThrowRetriableError(final boolean throwRetriableError) {
-        this.throwRetriableError = throwRetriableError;
+    public void setThrowRetryableError(final boolean throwRetryableError) {
+        this.throwRetryableError = throwRetryableError;
     }
 
     public boolean isThrowFatalError() {
@@ -137,6 +137,6 @@ public class AbstractMockElasticsearchClient extends AbstractControllerService i
         this.throwFatalError = throwFatalError;
     }
 
-    private boolean throwRetriableError;
+    private boolean throwRetryableError;
     private boolean throwFatalError;
 }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/mock/MockBulkLoadClientService.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/mock/MockBulkLoadClientService.java
@@ -30,7 +30,7 @@ public class MockBulkLoadClientService extends AbstractMockElasticsearchClient {
 
     @Override
     public IndexOperationResponse bulk(final List<IndexOperationRequest> items, final Map<String, String> requestParameters) {
-        if (isThrowRetriableError()) {
+        if (isThrowRetryableError()) {
             throw new MockElasticsearchException(true, false);
         } else if (isThrowFatalError()) {
             throw new MockElasticsearchException(false, false);

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
@@ -52,7 +52,7 @@ import static org.apache.http.auth.AuthScope.ANY;
 public abstract class AbstractElasticsearchITBase {
     // default Elasticsearch version should (ideally) match that in the nifi-elasticsearch-bundle#pom.xml for the integration-tests profile
     protected static final DockerImageName IMAGE = DockerImageName
-            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.17.0"));
+            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.17.1"));
     protected static final String ELASTIC_USER_PASSWORD = System.getProperty("elasticsearch.elastic_user.password", RandomStringUtils.randomAlphanumeric(10, 20));
     private static final int PORT = 9200;
     protected static final ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer(IMAGE)
@@ -79,7 +79,7 @@ public abstract class AbstractElasticsearchITBase {
 
     protected static final boolean ENABLE_TEST_CONTAINERS = "true".equalsIgnoreCase(System.getProperty("elasticsearch.testcontainers.enabled"));
     protected static String elasticsearchHost;
-    protected static void startTestcontainer() {
+    protected static void startTestContainer() {
         if (ENABLE_TEST_CONTAINERS) {
             if (getElasticMajorVersion() == 6) {
                 // disable system call filter check to allow Elasticsearch 6 to run on aarch64 machines (e.g. Mac M1/2)
@@ -99,7 +99,7 @@ public abstract class AbstractElasticsearchITBase {
 
     static RestClient testDataManagementClient;
 
-    protected static void stopTestcontainer() {
+    protected static void stopTestContainer() {
         if (ENABLE_TEST_CONTAINERS) {
             ELASTICSEARCH_CONTAINER.stop();
         }
@@ -107,7 +107,7 @@ public abstract class AbstractElasticsearchITBase {
 
     @BeforeAll
     static void beforeAll() throws IOException {
-        startTestcontainer();
+        startTestContainer();
         type = getElasticMajorVersion() == 6 ? "_doc" : "";
         System.out.printf("%n%n%n%n%n%n%n%n%n%n%n%n%n%n%nTYPE: %s%nIMAGE: %s:%s%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n%n",
                 type, IMAGE.getRepository(), IMAGE.getVersionPart());
@@ -201,23 +201,13 @@ public abstract class AbstractElasticsearchITBase {
         return actions;
     }
 
-    private static final class SetupAction {
-        private final String verb;
-        private final String path;
-        private final String json;
-
-        public SetupAction(final String verb, final String path, final String json) {
-            this.verb = verb;
-            this.path = path;
-            this.json = json;
-        }
-
+    private record SetupAction(String verb, String path, String json) {
         @Override
-        public String toString() {
-            return "SetupAction{" +
-                    "verb='" + verb + '\'' +
-                    ", path='" + path + '\'' +
-                    '}';
+            public String toString() {
+                return "SetupAction{" +
+                        "verb='" + verb + '\'' +
+                        ", path='" + path + '\'' +
+                        '}';
+            }
         }
-    }
 }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/src/main/java/org/apache/nifi/elasticsearch/integration/AbstractElasticsearchITBase.java
@@ -52,7 +52,7 @@ import static org.apache.http.auth.AuthScope.ANY;
 public abstract class AbstractElasticsearchITBase {
     // default Elasticsearch version should (ideally) match that in the nifi-elasticsearch-bundle#pom.xml for the integration-tests profile
     protected static final DockerImageName IMAGE = DockerImageName
-            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.17.1"));
+            .parse(System.getProperty("elasticsearch.docker.image", "docker.elastic.co/elasticsearch/elasticsearch:8.17.2"));
     protected static final String ELASTIC_USER_PASSWORD = System.getProperty("elasticsearch.elastic_user.password", RandomStringUtils.randomAlphanumeric(10, 20));
     private static final int PORT = 9200;
     protected static final ElasticsearchContainer ELASTICSEARCH_CONTAINER = new ElasticsearchContainer(IMAGE)

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -114,7 +114,7 @@ language governing permissions and limitations under the License. -->
         <profile>
             <id>elasticsearch7</id>
             <properties>
-                <elasticsearch_docker_image>7.17.26</elasticsearch_docker_image>
+                <elasticsearch_docker_image>7.17.27</elasticsearch_docker_image>
             </properties>
         </profile>
     </profiles>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>8.17.1</elasticsearch.client.version>
+        <elasticsearch.client.version>8.17.2</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockSessionFactory.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockSessionFactory.java
@@ -33,19 +33,21 @@ public class MockSessionFactory implements ProcessSessionFactory {
     private final boolean enforceReadStreamsClosed;
     private final StateManager stateManager;
     private final boolean allowSynchronousSessionCommits;
+    private final boolean allowRecursiveReads;
 
     MockSessionFactory(final SharedSessionState sharedState, final Processor processor, final boolean enforceReadStreamsClosed, final StateManager stateManager,
-                       final boolean allowSynchronousSessionCommits) {
+                       final boolean allowSynchronousSessionCommits, final boolean allowRecursiveReads) {
         this.sharedState = sharedState;
         this.processor = processor;
         this.enforceReadStreamsClosed = enforceReadStreamsClosed;
         this.stateManager = stateManager;
         this.allowSynchronousSessionCommits = allowSynchronousSessionCommits;
+        this.allowRecursiveReads = allowRecursiveReads;
     }
 
     @Override
     public ProcessSession createSession() {
-        final MockProcessSession session = new MockProcessSession(sharedState, processor, enforceReadStreamsClosed, stateManager, allowSynchronousSessionCommits);
+        final MockProcessSession session = new MockProcessSession(sharedState, processor, enforceReadStreamsClosed, stateManager, allowSynchronousSessionCommits, allowRecursiveReads);
         createdSessions.add(session);
         return session;
     }

--- a/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/StandardProcessorTestRunner.java
@@ -95,6 +95,7 @@ public class StandardProcessorTestRunner implements TestRunner {
     private int numThreads = 1;
     private MockSessionFactory sessionFactory;
     private boolean allowSynchronousSessionCommits = false;
+    private boolean allowRecursiveReads = false;
     private long runSchedule = 0;
     private final AtomicInteger invocations = new AtomicInteger(0);
 
@@ -128,7 +129,7 @@ public class StandardProcessorTestRunner implements TestRunner {
         this.sharedState = new SharedSessionState(processor, idGenerator);
         this.flowFileQueue = sharedState.getFlowFileQueue();
         this.processorStateManager = new MockStateManager(processor);
-        this.sessionFactory = new MockSessionFactory(sharedState, processor, enforceReadStreamsClosed, processorStateManager, allowSynchronousSessionCommits);
+        this.sessionFactory = new MockSessionFactory(sharedState, processor, enforceReadStreamsClosed, processorStateManager, allowSynchronousSessionCommits, allowRecursiveReads);
 
         this.context = new MockProcessContext(processor, processorName, processorStateManager, environmentVariables);
         this.kerberosContext = kerberosContext;
@@ -149,7 +150,7 @@ public class StandardProcessorTestRunner implements TestRunner {
     @Override
     public void enforceReadStreamsClosed(final boolean enforce) {
         enforceReadStreamsClosed = enforce;
-        this.sessionFactory = new MockSessionFactory(sharedState, processor, enforceReadStreamsClosed, processorStateManager, allowSynchronousSessionCommits);
+        this.sessionFactory = new MockSessionFactory(sharedState, processor, enforceReadStreamsClosed, processorStateManager, allowSynchronousSessionCommits, allowRecursiveReads);
     }
 
     @Override
@@ -161,7 +162,13 @@ public class StandardProcessorTestRunner implements TestRunner {
     @Override
     public void setAllowSynchronousSessionCommits(final boolean allowSynchronousSessionCommits) {
         this.allowSynchronousSessionCommits = allowSynchronousSessionCommits;
-        this.sessionFactory = new MockSessionFactory(sharedState, processor, enforceReadStreamsClosed, processorStateManager, allowSynchronousSessionCommits);
+        this.sessionFactory = new MockSessionFactory(sharedState, processor, enforceReadStreamsClosed, processorStateManager, allowSynchronousSessionCommits, allowRecursiveReads);
+    }
+
+    @Override
+    public void setAllowRecursiveReads(final boolean allowRecursiveReads) {
+        this.allowRecursiveReads = allowRecursiveReads;
+        this.sessionFactory = new MockSessionFactory(sharedState, processor, enforceReadStreamsClosed, processorStateManager, allowSynchronousSessionCommits, allowRecursiveReads);
     }
 
     @Override

--- a/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/TestRunner.java
@@ -891,12 +891,20 @@ public interface TestRunner {
     void setValidateExpressionUsage(boolean validate);
 
     /**
-     * Specifies whether or not the TestRunner will allow ProcessSession.commit() to be called.
+     * Specifies whether the TestRunner will allow ProcessSession.commit() to be called.
      * By default, the value is <code>false</code>, meaning that any call to ProcessSession.commit() will throw
      * an Exception. See JavaDocs for {@link ProcessSession#commit()} for more information
-     * @param allow whethr or not to allow asynchronous session commits (i.e., calls to ProcessSession.commit())
+     * @param allow whether to allow asynchronous session commits (i.e., calls to ProcessSession.commit())
      */
     void setAllowSynchronousSessionCommits(boolean allow);
+
+    /**
+     * Specifies whether the TestRunner will allow ProcessSession.read() multiple times for the same FlowFile while an InputStream is already open.
+     * By default, the value is <code>false</code>, meaning that any call to ProcessSession.read() for a FlowFile already being read will throw
+     * an Exception. See JavaDocs for {@link ProcessSession#read(FlowFile)} for more information
+     * @param allow whether to allow recursive reads of a FlowFile (i.e., calls to ProcessSession.read())
+     */
+    void setAllowRecursiveReads(boolean allow);
 
     /**
      * Removes the {@link PropertyDescriptor} from the {@link ProcessContext},


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14244](https://issues.apache.org/jira/browse/NIFI-14244) send original Records to errors output for PutElasticsearchRecord errors

Additional changes:
- update the `MockProcessSession` to allow for `recursive read` of a FlowFile (similar to the `StandardProcessSession` allows)
- rationalise `retriable` to `retryable`

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- [x] Documentation formatting appears as expected in rendered files
