### PR TITLE
NIFI-14255: Removed any use of List.stream() from SimpleRecordSchema …

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/DataType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/DataType.java
@@ -41,7 +41,6 @@ public class DataType {
         // intentionally blank - to be overridden by concrete DataTypes
     }
 
-    @SuppressWarnings("unused")
     public boolean isRecursive(final List<RecordSchema> schemas) {
         return false;
     }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordSchema.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/RecordSchema.java
@@ -116,7 +116,12 @@ public interface RecordSchema {
      * @param schemas the list of schemas to check whether the current schema is contained within
      * @return true if the current schema is present within the list of schemas (object reference equality), false otherwise
      */
-    default boolean sameAsAny(List<RecordSchema> schemas) {
-        return schemas.stream().anyMatch(schema -> schema == this); // reference equality check used on purpose
+    default boolean sameAsAny(final List<RecordSchema> schemas) {
+        for (final RecordSchema schema : schemas) {
+            if (schema == this) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/ChoiceDataType.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/type/ChoiceDataType.java
@@ -54,8 +54,15 @@ public class ChoiceDataType extends DataType {
     public boolean isRecursive(final List<RecordSchema> schemas) {
         // allow for null possibleSubTypes during scheme inference
         if (!schemas.isEmpty() && getPossibleSubTypes() != null) {
-            return getPossibleSubTypes().stream().anyMatch(possibleSubType -> possibleSubType.isRecursive(schemas));
+            for (final DataType possibleSubType : getPossibleSubTypes()) {
+                if (possibleSubType.isRecursive(schemas)) {
+                    return true;
+                }
+            }
+
+            return false;
         }
+
         return false;
     }
 


### PR DESCRIPTION
…and instead used standard iterative practices. Added a lazily-initialized member variable for use in isRecursive

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14255](https://issues.apache.org/jira/browse/NIFI-14255)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
