### PR TITLE
NIFI-14213 Fixed code for(Inherited Parameter Context Not Retained Wh…

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -2220,8 +2220,7 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
 
         // If the current parameter context doesn't have any inherited param contexts but the versioned one does,
         // add the versioned ones.
-        if (versionedParameterContext.getInheritedParameterContexts() != null && !versionedParameterContext.getInheritedParameterContexts().isEmpty()
-            && currentParameterContext.getInheritedParameterContexts().isEmpty()) {
+        if (versionedParameterContext.getInheritedParameterContexts() != null && !versionedParameterContext.getInheritedParameterContexts().isEmpty()){
             currentParameterContext.setInheritedParameterContexts(versionedParameterContext.getInheritedParameterContexts().stream()
                 .map(name -> selectParameterContext(versionedParameterContexts.get(name), versionedParameterContexts, parameterProviderReferences, componentIdGenerator))
                 .collect(Collectors.toList()));


### PR DESCRIPTION
This PR addresses an issue where inherited parameter contexts were not properly attached when upgrading a versioned process group. Previously, upgrading a flow would create the new inherited parameter context but fail to link it to the parameter context, causing missing parameter references. This fix ensures that inherited parameter contexts are correctly retained and updated during flow upgrades.


NIFI Issue link: https://issues.apache.org/jira/browse/NIFI-14213