### PR TITLE
NIFI-14256 - Cannot update parameter that references no longer existing controller service

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ParameterContextResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ParameterContextResource.java
@@ -757,11 +757,17 @@ public class ParameterContextResource extends AbstractParameterResource {
                 if (parameterOptional.isPresent()) {
                     final String currentParameterValue = parameterOptional.get().getValue();
                     if (currentParameterValue != null) {
-                        final ComponentAuthorizable currentControllerService = lookup.getControllerService(currentParameterValue);
-                        if (currentControllerService != null) {
-                            final Authorizable currentControllerServiceAuthorizable = currentControllerService.getAuthorizable();
-                            currentControllerServiceAuthorizable.authorize(authorizer, RequestAction.READ, user);
-                            currentControllerServiceAuthorizable.authorize(authorizer, RequestAction.WRITE, user);
+                        try {
+                            final ComponentAuthorizable currentControllerService = lookup.getControllerService(currentParameterValue);
+                            if (currentControllerService != null) {
+                                final Authorizable currentControllerServiceAuthorizable = currentControllerService.getAuthorizable();
+                                currentControllerServiceAuthorizable.authorize(authorizer, RequestAction.READ, user);
+                                currentControllerServiceAuthorizable.authorize(authorizer, RequestAction.WRITE, user);
+                            }
+                        } catch (ResourceNotFoundException e) {
+                            // the currently referenced controller service no longer exists, we can just
+                            // skip the authorization check, and move on to setting the new parameter value
+                            logger.debug("Current Controller Service with ID {} not found, skipping authorization check", currentParameterValue);
                         }
                     }
                 }


### PR DESCRIPTION
# Summary

[NIFI-14256](https://issues.apache.org/jira/browse/NIFI-14256) - Cannot update parameter that references no longer existing controller service

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
