### PR TITLE
NIFI-14262 Upgrade Netty to 4.1.118 and JSON Smart to 2.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
-        <json.smart.version>2.5.1</json.smart.version>
+        <json.smart.version>2.5.2</json.smart.version>
         <groovy.version>4.0.25</groovy.version>
         <surefire.version>3.5.1</surefire.version>
         <hadoop.version>3.4.1</hadoop.version>
@@ -153,7 +153,7 @@
         <mockito.version>5.15.2</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.3</snakeyaml.version>
-        <netty.4.version>4.1.117.Final</netty.4.version>
+        <netty.4.version>4.1.118.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.version>6.2.2</spring.version>
         <spring.security.version>6.4.2</spring.security.version>


### PR DESCRIPTION
# Summary

[NIFI-14262](https://issues.apache.org/jira/browse/NIFI-14262) Upgrades Netty from 4.1.117 to [4.1.118](https://netty.io/news/2025/02/10/4-1-118-Final.html) and JSON Smart from 2.5.1 to [2.5.2](https://github.com/netplex/json-smart-v2/releases/tag/2.5.2) resolving several associated vulnerabilities.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
