### PR TITLE
NIFI-14106 Fixed bug which led to loss of dates and times precision when using SplitExcel.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -103,3 +103,12 @@ This includes derived works from Spring Framework available under Apache Softwar
       https://github.com/spring-projects/spring-framework/blob/main/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
     and can be found in
       nifi-api/src/main/java/org/apache/nifi/processor/util/URLValidator.java
+
+This includes derived works from Apache POI available under Apache Software License V2
+    Copyright 2003-2025 The Apache Software Foundation
+    The derived work is adapted from
+    https://svn.apache.org/repos/asf/poi/trunk/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSheet (copyRows method)
+    https://svn.apache.org/repos/asf/poi/trunk/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRow (copyRowFrom method)
+    https://svn.apache.org/repos/asf/poi/trunk/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java (copyCell method).
+    and can be found in
+    nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/processors/excel/SplitExcel.java.SheetCopyStrategy

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/processors/excel/TestSplitExcel.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/processors/excel/TestSplitExcel.java
@@ -20,19 +20,29 @@ import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -183,6 +193,81 @@ public class TestSplitExcel {
                     assertTrue(formulaCell.getNumericCellValue() > 0.0, String.format("%s did not have expected numeric value greater than 0.0", messagePrefix));
                 }
             }
+        }
+    }
+
+    @Test
+    void testCopyDateTime() throws Exception {
+        LocalDateTime localDateTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
+        LocalDateTime nonValidExcelDate = LocalDateTime.of(1899, 12, 31, 0, 0, 0);
+        final Object[][] data = {
+                {"transaction_id", "transaction_date", "transaction_time"},
+                {75, localDateTime, nonValidExcelDate.plusHours(9).plusMinutes(53).plusSeconds(44).toLocalTime()},
+                {78, localDateTime, nonValidExcelDate.plusHours(9).plusMinutes(55).plusSeconds(16).toLocalTime()}
+        };
+
+        final ByteArrayOutputStream workbookOutputStream = new ByteArrayOutputStream();
+        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+            final XSSFSheet sheet = workbook.createSheet("SomeSheetName");
+            populateSheet(sheet, data);
+            setCellStyles(sheet, workbook);
+            workbook.write(workbookOutputStream);
+        }
+
+        ByteArrayInputStream input = new ByteArrayInputStream(workbookOutputStream.toByteArray());
+        runner.enqueue(input);
+        runner.run();
+
+        runner.assertTransferCount(SplitExcel.REL_SPLIT, 1);
+        runner.assertTransferCount(SplitExcel.REL_ORIGINAL, 1);
+        runner.assertTransferCount(SplitExcel.REL_FAILURE, 0);
+
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(SplitExcel.REL_SPLIT).getFirst();
+        try (XSSFWorkbook workbook = new XSSFWorkbook(flowFile.getContentStream())) {
+            Sheet firstSheet = workbook.sheetIterator().next();
+
+            List<List<Cell>> dateCells = Stream.iterate(firstSheet.getFirstRowNum() + 1, rowIndex -> rowIndex + 1)
+                    .limit(firstSheet.getLastRowNum())
+                    .map(firstSheet::getRow)
+                    .filter(Objects::nonNull)
+                    .map(row -> List.of(row.getCell(1), row.getCell(2)))
+                    .toList();
+
+            dateCells.stream().flatMap(Collection::stream)
+                    .forEach(dateCell -> assertTrue(DateUtil.isCellDateFormatted(dateCell)));
+        }
+    }
+
+    private static void populateSheet(XSSFSheet sheet, Object[][] data) {
+        int rowCount = 0;
+        for (Object[] dataRow : data) {
+            Row row = sheet.createRow(rowCount++);
+            int columnCount = 0;
+
+            for (Object field : dataRow) {
+                Cell cell = row.createCell(columnCount++);
+                switch (field) {
+                    case String string -> cell.setCellValue(string);
+                    case Integer integer -> cell.setCellValue(integer.doubleValue());
+                    case Long l -> cell.setCellValue(l.doubleValue());
+                    case LocalDateTime localDateTime -> cell.setCellValue(localDateTime);
+                    case LocalTime localTime -> cell.setCellValue(DateUtil.convertTime(DateTimeFormatter.ISO_LOCAL_TIME.format(localTime)));
+                    default -> { }
+                }
+            }
+        }
+    }
+
+    void setCellStyles(XSSFSheet sheet, XSSFWorkbook workbook) {
+        CreationHelper creationHelper = workbook.getCreationHelper();
+        CellStyle dayMonthYearCellStyle = workbook.createCellStyle();
+        dayMonthYearCellStyle.setDataFormat(creationHelper.createDataFormat().getFormat("dd/mm/yyyy"));
+        CellStyle hourMinuteSecond = workbook.createCellStyle();
+        hourMinuteSecond.setDataFormat((short) 21); // 21 represents format h:mm:ss
+        for (int rowNum = sheet.getFirstRowNum() + 1; rowNum < sheet.getLastRowNum() + 1; rowNum++) {
+            Row row = sheet.getRow(rowNum);
+            row.getCell(1).setCellStyle(dayMonthYearCellStyle);
+            row.getCell(2).setCellStyle(hourMinuteSecond);
         }
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14106](https://issues.apache.org/jira/browse/NIFI-14106)
As detailed in the ticket , I reverted the change made in #9466 as the `org.apache.poi.ss.usermodel.CellCopyContext` can be used to prevent exceeding the cell styles. In addition this PR involved having to correct a POI bug which I reported in the following [thread](https://lists.apache.org/thread/71pxytfsn6g30b3q5k8p904mxdr50407)  and can be found [here](https://bz.apache.org/bugzilla/show_bug.cgi?id=69583). As a result I had to copy the following methods from the following classes in order to fix the bug and make use of `org.apache.poi.ss.usermodel.CellCopyContext`.

- `copyRows` from `org.apache.poi.xssf.usermodel.XSSFSheet`
-  `copyRowFrom` from `org.apache.poi.xssf.usermodel.XSSFRow` 
-  `copyCell` from `org.apache.poi.ss.util.CellUtil`

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
