### PR TITLE
NIFI-14274 Remove Client Auth from MongoDB Client Service

### DIFF
--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-client-service-api/src/main/java/org/apache/nifi/mongodb/MongoDBClientService.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-client-service-api/src/main/java/org/apache/nifi/mongodb/MongoDBClientService.java
@@ -25,7 +25,6 @@ import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.VerifiableControllerService;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.security.util.ClientAuth;
 import org.apache.nifi.ssl.SSLContextProvider;
 import org.bson.Document;
 
@@ -102,16 +101,6 @@ public interface MongoDBClientService extends ControllerService, VerifiableContr
                     + "connections.")
             .required(false)
             .identifiesControllerService(SSLContextProvider.class)
-            .build();
-     PropertyDescriptor CLIENT_AUTH = new PropertyDescriptor.Builder()
-            .name("ssl-client-auth")
-            .displayName("Client Auth")
-            .description("Client authentication policy when connecting to secure (TLS/SSL) cluster. "
-                    + "Possible values are REQUIRED, WANT, NONE. This property is only used when an SSL Context "
-                    + "has been defined and enabled.")
-            .required(false)
-            .allowableValues(ClientAuth.values())
-            .defaultValue("REQUIRED")
             .build();
 
      PropertyDescriptor WRITE_CONCERN = new PropertyDescriptor.Builder()

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
@@ -34,12 +34,12 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.ssl.SSLContextProvider;
 import org.bson.Document;
 
 import javax.net.ssl.SSLContext;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -62,20 +62,22 @@ public class MongoDBControllerService extends AbstractControllerService implemen
         DB_USER,
         DB_PASSWORD,
         SSL_CONTEXT_SERVICE,
-        CLIENT_AUTH,
         WRITE_CONCERN
     );
 
     protected MongoClient mongoClient;
     private String writeConcernProperty;
 
+    @Override
+    public void migrateProperties(final PropertyConfiguration propertyConfiguration) {
+        propertyConfiguration.removeProperty("ssl-client-auth");
+    }
+
     // TODO: Remove duplicate code by refactoring shared method to accept PropertyContext
     protected MongoClient createClient(ConfigurationContext context, MongoClient existing) {
         if (existing != null) {
             closeClient(existing);
         }
-
-        getLogger().info("Creating MongoClient");
 
         writeConcernProperty = context.getProperty(WRITE_CONCERN).getValue();
 
@@ -130,7 +132,7 @@ public class MongoDBControllerService extends AbstractControllerService implemen
 
     @Override
     public WriteConcern getWriteConcern() {
-        WriteConcern writeConcern = null;
+        WriteConcern writeConcern;
         switch (writeConcernProperty) {
             case WRITE_CONCERN_ACKNOWLEDGED:
                 writeConcern = WriteConcern.ACKNOWLEDGED;
@@ -209,6 +211,6 @@ public class MongoDBControllerService extends AbstractControllerService implemen
             closeClient(client);
         }
 
-        return Arrays.asList(connectionSuccessful.build());
+        return List.of(connectionSuccessful.build());
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-14274](https://issues.apache.org/jira/browse/NIFI-14274) Removes the unused `Client Auth` property from the MongoDB Client Service and also uses the `migrateProperties()` method to ensure that the property is removed when upgrading from existing flow configurations.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
