### PR TITLE
NIFI-14275 Fix quoting configuration handling in UpdateDatabaseTable during ALTER

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/DatabaseAdapterDatabaseDialectService.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/DatabaseAdapterDatabaseDialectService.java
@@ -90,10 +90,10 @@ class DatabaseAdapterDatabaseDialectService extends AbstractControllerService im
         final String sql;
 
         if (StatementType.ALTER == statementType) {
-            sql = databaseAdapter.getAlterTableStatement(tableDefinition.tableName(), columnDescriptions, true, true);
+            sql = databaseAdapter.getAlterTableStatement(tableDefinition.tableName(), columnDescriptions);
         } else if (StatementType.CREATE == statementType) {
             final TableSchema tableSchema = getTableSchema(tableDefinition);
-            sql = databaseAdapter.getCreateTableStatement(tableSchema, false, false);
+            sql = databaseAdapter.getCreateTableStatement(tableSchema);
         } else if (StatementType.UPSERT == statementType) {
             sql = databaseAdapter.getUpsertStatement(tableDefinition.tableName(), columnNames, primaryKeyColumnNames);
         } else if (StatementType.INSERT_IGNORE == statementType) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MSSQLDatabaseAdapter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MSSQLDatabaseAdapter.java
@@ -104,14 +104,12 @@ public class MSSQLDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public String getAlterTableStatement(final String tableName, final List<ColumnDescription> columnsToAdd, final boolean quoteTableName, final boolean quoteColumnNames) {
+    public String getAlterTableStatement(final String tableName, final List<ColumnDescription> columnsToAdd) {
         List<String> columnsAndDatatypes = new ArrayList<>(columnsToAdd.size());
         for (ColumnDescription column : columnsToAdd) {
             String dataType = getSQLForDataType(column.getDataType());
             StringBuilder sb = new StringBuilder("ADD ")
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(column.getColumnName())
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(" ")
                     .append(dataType);
             columnsAndDatatypes.add(sb.toString());
@@ -119,9 +117,7 @@ public class MSSQLDatabaseAdapter implements DatabaseAdapter {
 
         StringBuilder alterTableStatement = new StringBuilder();
         return alterTableStatement.append("ALTER TABLE ")
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(tableName)
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(" ")
                 .append(String.join(", ", columnsAndDatatypes))
                 .toString();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MySQLDatabaseAdapter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/MySQLDatabaseAdapter.java
@@ -122,29 +122,17 @@ public class MySQLDatabaseAdapter extends GenericDatabaseAdapter {
     }
 
     @Override
-    public String getTableQuoteString() {
-        return "`";
-    }
-
-    @Override
-    public String getColumnQuoteString() {
-        return "`";
-    }
-
-    @Override
     public boolean supportsCreateTableIfNotExists() {
         return true;
     }
 
     @Override
-    public String getAlterTableStatement(final String tableName, final List<ColumnDescription> columnsToAdd, final boolean quoteTableName, final boolean quoteColumnNames) {
+    public String getAlterTableStatement(final String tableName, final List<ColumnDescription> columnsToAdd) {
         List<String> columnsAndDatatypes = new ArrayList<>(columnsToAdd.size());
         for (ColumnDescription column : columnsToAdd) {
             String dataType = getSQLForDataType(column.getDataType());
             StringBuilder sb = new StringBuilder("ADD COLUMN ")
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(column.getColumnName())
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(" ")
                     .append(dataType);
             columnsAndDatatypes.add(sb.toString());
@@ -152,9 +140,7 @@ public class MySQLDatabaseAdapter extends GenericDatabaseAdapter {
 
         StringBuilder alterTableStatement = new StringBuilder();
         return alterTableStatement.append("ALTER TABLE ")
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(tableName)
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(" ")
                 .append(String.join(", ", columnsAndDatatypes))
                 .toString();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/Oracle12DatabaseAdapter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/Oracle12DatabaseAdapter.java
@@ -200,25 +200,21 @@ public class Oracle12DatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public String getAlterTableStatement(String tableName, List<ColumnDescription> columnsToAdd, final boolean quoteTableName, final boolean quoteColumnNames) {
+    public String getAlterTableStatement(String tableName, List<ColumnDescription> columnsToAdd) {
         StringBuilder createTableStatement = new StringBuilder();
 
         List<String> columnsAndDatatypes = new ArrayList<>(columnsToAdd.size());
         for (ColumnDescription column : columnsToAdd) {
             String dataType = getSQLForDataType(column.getDataType());
             StringBuilder sb = new StringBuilder()
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(column.getColumnName())
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(" ")
                     .append(dataType);
             columnsAndDatatypes.add(sb.toString());
         }
 
         createTableStatement.append("ALTER TABLE ")
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(tableName)
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(" ADD (")
                 .append(String.join(", ", columnsAndDatatypes))
                 .append(") ");
@@ -256,15 +252,13 @@ public class Oracle12DatabaseAdapter implements DatabaseAdapter {
     /**
      * Generates a CREATE TABLE statement using the specified table schema
      * @param tableSchema The table schema including column information
-     * @param quoteTableName Whether to quote the table name in the generated DDL
-     * @param quoteColumnNames Whether to quote column names in the generated DDL
      * @return A String containing DDL to create the specified table
      */
     @Override
-    public String getCreateTableStatement(TableSchema tableSchema, boolean quoteTableName, boolean quoteColumnNames) {
+    public String getCreateTableStatement(TableSchema tableSchema) {
         StringBuilder createTableStatement = new StringBuilder()
                 .append("DECLARE\n\tsql_stmt long;\nBEGIN\n\tsql_stmt:='CREATE TABLE ")
-                .append(generateTableName(quoteTableName, tableSchema.getCatalogName(), tableSchema.getSchemaName(), tableSchema.getTableName(), tableSchema))
+                .append(generateTableName(tableSchema.getCatalogName(), tableSchema.getSchemaName(), tableSchema.getTableName(), tableSchema))
                 .append(" (");
 
         List<ColumnDescription> columns = tableSchema.getColumnsAsList();
@@ -273,9 +267,7 @@ public class Oracle12DatabaseAdapter implements DatabaseAdapter {
             ColumnDescription column = columns.get(i);
             createTableStatement
                     .append((i != 0) ? ", " : "")
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(column.getColumnName())
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(" ")
                     .append(getSQLForDataType(column.getDataType()))
                     .append(column.isNullable() ? "" : " NOT NULL")

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/OracleDatabaseAdapter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/OracleDatabaseAdapter.java
@@ -128,25 +128,21 @@ public class OracleDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public String getAlterTableStatement(String tableName, List<ColumnDescription> columnsToAdd, final boolean quoteTableName, final boolean quoteColumnNames) {
+    public String getAlterTableStatement(String tableName, List<ColumnDescription> columnsToAdd) {
         StringBuilder createTableStatement = new StringBuilder();
 
         List<String> columnsAndDatatypes = new ArrayList<>(columnsToAdd.size());
         for (ColumnDescription column : columnsToAdd) {
             String dataType = getSQLForDataType(column.getDataType());
             StringBuilder sb = new StringBuilder()
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(column.getColumnName())
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(" ")
                     .append(dataType);
             columnsAndDatatypes.add(sb.toString());
         }
 
         createTableStatement.append("ALTER TABLE ")
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(tableName)
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(" ADD (")
                 .append(String.join(", ", columnsAndDatatypes))
                 .append(") ");
@@ -184,15 +180,13 @@ public class OracleDatabaseAdapter implements DatabaseAdapter {
     /**
      * Generates a CREATE TABLE statement using the specified table schema
      * @param tableSchema The table schema including column information
-     * @param quoteTableName Whether to quote the table name in the generated DDL
-     * @param quoteColumnNames Whether to quote column names in the generated DDL
      * @return A String containing DDL to create the specified table
      */
     @Override
-    public String getCreateTableStatement(TableSchema tableSchema, boolean quoteTableName, boolean quoteColumnNames) {
+    public String getCreateTableStatement(TableSchema tableSchema) {
         StringBuilder createTableStatement = new StringBuilder()
                 .append("DECLARE\n\tsql_stmt long;\nBEGIN\n\tsql_stmt:='CREATE TABLE ")
-                .append(generateTableName(quoteTableName, tableSchema.getCatalogName(), tableSchema.getSchemaName(), tableSchema.getTableName(), tableSchema))
+                .append(generateTableName(tableSchema.getCatalogName(), tableSchema.getSchemaName(), tableSchema.getTableName(), tableSchema))
                 .append(" (");
 
         List<ColumnDescription> columns = tableSchema.getColumnsAsList();
@@ -201,9 +195,7 @@ public class OracleDatabaseAdapter implements DatabaseAdapter {
             ColumnDescription column = columns.get(i);
             createTableStatement
                     .append((i != 0) ? ", " : "")
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(column.getColumnName())
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(" ")
                     .append(getSQLForDataType(column.getDataType()))
                     .append(column.isNullable() ? "" : " NOT NULL")

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PhoenixDatabaseAdapter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PhoenixDatabaseAdapter.java
@@ -144,14 +144,12 @@ public final class PhoenixDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public String getAlterTableStatement(final String tableName, final List<ColumnDescription> columnsToAdd, final boolean quoteTableName, final boolean quoteColumnNames) {
+    public String getAlterTableStatement(final String tableName, final List<ColumnDescription> columnsToAdd) {
         List<String> columnsAndDatatypes = new ArrayList<>(columnsToAdd.size());
         for (ColumnDescription column : columnsToAdd) {
             String dataType = getSQLForDataType(column.getDataType());
             StringBuilder sb = new StringBuilder("ADD COLUMN ")
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(column.getColumnName())
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(" ")
                     .append(dataType);
             columnsAndDatatypes.add(sb.toString());
@@ -159,9 +157,7 @@ public final class PhoenixDatabaseAdapter implements DatabaseAdapter {
 
         StringBuilder alterTableStatement = new StringBuilder();
         return alterTableStatement.append("ALTER TABLE ")
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(tableName)
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(" ")
                 .append(String.join(", ", columnsAndDatatypes))
                 .toString();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PostgreSQLDatabaseAdapter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/db/impl/PostgreSQLDatabaseAdapter.java
@@ -135,14 +135,12 @@ public class PostgreSQLDatabaseAdapter extends GenericDatabaseAdapter {
     }
 
     @Override
-    public String getAlterTableStatement(final String tableName, final List<ColumnDescription> columnsToAdd, final boolean quoteTableName, final boolean quoteColumnNames) {
+    public String getAlterTableStatement(final String tableName, final List<ColumnDescription> columnsToAdd) {
         List<String> columnsAndDatatypes = new ArrayList<>(columnsToAdd.size());
         for (ColumnDescription column : columnsToAdd) {
             String dataType = getSQLForDataType(column.getDataType());
             StringBuilder sb = new StringBuilder("ADD COLUMN ")
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(column.getColumnName())
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(" ")
                     .append(dataType);
             columnsAndDatatypes.add(sb.toString());
@@ -150,9 +148,7 @@ public class PostgreSQLDatabaseAdapter extends GenericDatabaseAdapter {
 
         StringBuilder alterTableStatement = new StringBuilder();
         return alterTableStatement.append("ALTER TABLE ")
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(tableName)
-                .append(quoteTableName ? getTableQuoteString() : "")
                 .append(" ")
                 .append(String.join(", ", columnsAndDatatypes))
                 .toString();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/DerbyDatabaseAdapter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/DerbyDatabaseAdapter.java
@@ -117,7 +117,7 @@ public class DerbyDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public String getCreateTableStatement(final TableSchema tableSchema, final boolean quoteTableName, final boolean quoteColumnNames) {
+    public String getCreateTableStatement(final TableSchema tableSchema) {
         StringBuilder createTableStatement = new StringBuilder();
 
         List<ColumnDescription> columns = tableSchema.getColumnsAsList();
@@ -125,9 +125,7 @@ public class DerbyDatabaseAdapter implements DatabaseAdapter {
         Set<String> primaryKeyColumnNames = tableSchema.getPrimaryKeyColumnNames();
         for (ColumnDescription column : columns) {
             StringBuilder sb = new StringBuilder()
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(column.getColumnName())
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(" ")
                     .append(getSQLForDataType(column.getDataType()))
                     .append(column.isNullable() ? "" : " NOT NULL")
@@ -137,7 +135,7 @@ public class DerbyDatabaseAdapter implements DatabaseAdapter {
 
         // This will throw an exception if the table already exists, but it should only be used for tests
         createTableStatement.append("CREATE TABLE ")
-                .append(generateTableName(quoteTableName, tableSchema.getCatalogName(), tableSchema.getSchemaName(), tableSchema.getTableName(), tableSchema))
+                .append(generateTableName(tableSchema.getCatalogName(), tableSchema.getSchemaName(), tableSchema.getTableName(), tableSchema))
                 .append(" (")
                 .append(String.join(", ", columnsAndDatatypes))
                 .append(") ");
@@ -146,16 +144,14 @@ public class DerbyDatabaseAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public String getAlterTableStatement(final String tableName, final List<ColumnDescription> columnsToAdd, final boolean quoteTableName, final boolean quoteColumnNames) {
+    public String getAlterTableStatement(final String tableName, final List<ColumnDescription> columnsToAdd) {
         List<String> alterTableStatements = new ArrayList<>();
 
         List<String> columnsAndDatatypes = new ArrayList<>(columnsToAdd.size());
         for (ColumnDescription column : columnsToAdd) {
             String dataType = getSQLForDataType(column.getDataType());
             StringBuilder sb = new StringBuilder()
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(column.getColumnName())
-                    .append(quoteColumnNames ? getColumnQuoteString() : "")
                     .append(" ")
                     .append(dataType);
             columnsAndDatatypes.add(sb.toString());
@@ -164,9 +160,7 @@ public class DerbyDatabaseAdapter implements DatabaseAdapter {
         for (String columnAndDataType : columnsAndDatatypes) {
             StringBuilder createTableStatement = new StringBuilder();
             alterTableStatements.add(createTableStatement.append("ALTER TABLE ")
-                    .append(quoteTableName ? getTableQuoteString() : "")
                     .append(tableName)
-                    .append(quoteTableName ? getTableQuoteString() : "")
                     .append(" ADD COLUMN ")
                     .append(columnAndDataType).toString());
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestOracle12DatabaseAdapter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestOracle12DatabaseAdapter.java
@@ -159,19 +159,19 @@ public class TestOracle12DatabaseAdapter {
     public void testGetCreateTableStatement() {
         assertTrue(db.supportsCreateTableIfNotExists());
         final List<ColumnDescription> columns = Arrays.asList(
-                new ColumnDescription("col1", Types.INTEGER, true, 4, false),
-                new ColumnDescription("col2", Types.VARCHAR, false, 2000, true)
+                new ColumnDescription("\"col1\"", Types.INTEGER, true, 4, false),
+                new ColumnDescription("\"col2\"", Types.VARCHAR, false, 2000, true)
         );
         NameNormalizer normalizer = NameNormalizerFactory.getNormalizer(TranslationStrategy.REMOVE_UNDERSCORE, null);
-        TableSchema tableSchema = new TableSchema("USERS", null, "TEST_TABLE", columns,
-                true, normalizer, Collections.singleton("COL1"), db.getColumnQuoteString());
+        TableSchema tableSchema = new TableSchema("\"USERS\"", null, "\"TEST_TABLE\"", columns,
+                true, normalizer, Collections.singleton("\"COL1\""), "\"");
 
         String expectedStatement = "DECLARE\n\tsql_stmt long;\nBEGIN\n\tsql_stmt:='CREATE TABLE "
                 // Strings are returned as VARCHAR2(2000) regardless of reported size and that VARCHAR2 is not in java.sql.Types
                 + "\"USERS\".\"TEST_TABLE\" (\"col1\" INTEGER NOT NULL, \"col2\" VARCHAR2(2000))';"
                 + "\nEXECUTE IMMEDIATE sql_stmt;\nEXCEPTION\n\tWHEN OTHERS THEN\n\t\tIF SQLCODE = -955 THEN\n\t\t\t"
                 + "NULL;\n\t\tELSE\n\t\t\tRAISE;\n\t\tEND IF;\nEND;";
-        String actualStatement = db.getCreateTableStatement(tableSchema, true, true);
+        String actualStatement = db.getCreateTableStatement(tableSchema);
         assertEquals(expectedStatement, actualStatement);
     }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestOracleDatabaseAdapter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/db/impl/TestOracleDatabaseAdapter.java
@@ -117,19 +117,19 @@ public class TestOracleDatabaseAdapter {
     public void testGetCreateTableStatement() {
         assertTrue(db.supportsCreateTableIfNotExists());
         final List<ColumnDescription> columns = Arrays.asList(
-                new ColumnDescription("col1", Types.INTEGER, true, 4, false),
-                new ColumnDescription("col2", Types.VARCHAR, false, 2000, true)
+                new ColumnDescription("\"col1\"", Types.INTEGER, true, 4, false),
+                new ColumnDescription("\"col2\"", Types.VARCHAR, false, 2000, true)
         );
         NameNormalizer normalizer = NameNormalizerFactory.getNormalizer(TranslationStrategy.REMOVE_UNDERSCORE, null);
-        TableSchema tableSchema = new TableSchema("USERS", null, "TEST_TABLE", columns,
-                true, normalizer, Collections.singleton("COL1"), db.getColumnQuoteString());
+        TableSchema tableSchema = new TableSchema("\"USERS\"", null, "\"TEST_TABLE\"", columns,
+                true, normalizer, Collections.singleton("\"COL1\""), "`");
 
         String expectedStatement = "DECLARE\n\tsql_stmt long;\nBEGIN\n\tsql_stmt:='CREATE TABLE "
                 // Strings are returned as VARCHAR2(2000) regardless of reported size and that VARCHAR2 is not in java.sql.Types
                 + "\"USERS\".\"TEST_TABLE\" (\"col1\" INTEGER NOT NULL, \"col2\" VARCHAR2(2000))';"
                 + "\nEXECUTE IMMEDIATE sql_stmt;\nEXCEPTION\n\tWHEN OTHERS THEN\n\t\tIF SQLCODE = -955 THEN\n\t\t\t"
                 + "NULL;\n\t\tELSE\n\t\t\tRAISE;\n\t\tEND IF;\nEND;";
-        String actualStatement = db.getCreateTableStatement(tableSchema, true, true);
+        String actualStatement = db.getCreateTableStatement(tableSchema);
         assertEquals(expectedStatement, actualStatement);
     }
 }


### PR DESCRIPTION

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14275](https://issues.apache.org/jira/browse/NIFI-14275)

The decision about quoting column names during ALTER TABLE in the UpdateDatabaseTable processor was moved to database dialect services, causing inconsistency in behavior. This logic should remain part of the `UpdateDatabaseTable` processor, where users can explicitly choose whether to quote table and column names via the `QUOTE_COLUMN_IDENTIFIERS` and `QUOTE_TABLE_IDENTIFIER` properties.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
