### PR TITLE
NIFI-14279 - StandardFlowDifference hashCode should include fieldName

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowDifference.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowDifference.java
@@ -89,11 +89,16 @@ public class StandardFlowDifference implements FlowDifference {
 
     @Override
     public int hashCode() {
-        return 31 + 17 * (componentA == null ? 0 : Objects.hashCode(componentA.getIdentifier())) +
-            17 * (componentB == null ? 0 : Objects.hashCode(componentB.getIdentifier())) +
-            15 * (componentA == null ? 0 : Objects.hash(componentA.getInstanceIdentifier())) +
-            15 * (componentB == null ? 0 : Objects.hash(componentB.getInstanceIdentifier())) +
-            Objects.hash(description, type, valueA, valueB);
+        return Objects.hash(
+                type,
+                componentA == null ? null : componentA.getIdentifier(),
+                componentA == null ? null : componentA.getInstanceIdentifier(),
+                componentB == null ? null : componentB.getIdentifier(),
+                componentB == null ? null : componentB.getInstanceIdentifier(),
+                fieldName.orElse(null),
+                valueA,
+                valueB,
+                description);
     }
 
     @Override
@@ -128,6 +133,7 @@ public class StandardFlowDifference implements FlowDifference {
 
         return Objects.equals(componentAId, otherComponentAId) && Objects.equals(componentBId, otherComponentBId)
             && Objects.equals(description, other.description) && Objects.equals(type, other.type)
-            && Objects.equals(valueA, other.valueA) && Objects.equals(valueB, other.valueB);
+            && Objects.equals(valueA, other.valueA) && Objects.equals(valueB, other.valueB)
+            && fieldName.orElse("").equals(other.fieldName.orElse(""));
     }
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/test/java/org/apache/nifi/registry/flow/diff/TestStandardFlowComparator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/test/java/org/apache/nifi/registry/flow/diff/TestStandardFlowComparator.java
@@ -149,6 +149,33 @@ public class TestStandardFlowComparator {
         assertEquals(contextB.getIdentifier(), difference.getComponentB().getIdentifier());
     }
 
+    @Test
+    public void testMultipleParametersNamesChanged() {
+        final Set<FlowDifference> differences = new HashSet<>();
+
+        final Set<VersionedParameter> parametersA = new HashSet<>();
+        parametersA.add(createParameter("Param 1", "ABC", true));
+        parametersA.add(createParameter("Param 2", "XYZ", true));
+
+        final Set<VersionedParameter> parametersB = new HashSet<>();
+        parametersB.add(createParameter("New Param 1", "ABC", true));
+        parametersB.add(createParameter("New Param 2", "XYZ", true));
+
+        final VersionedParameterContext contextA = new VersionedParameterContext();
+        contextA.setIdentifier("id");
+        contextA.setInstanceIdentifier("instanceId");
+        contextA.setParameters(parametersA);
+
+        final VersionedParameterContext contextB = new VersionedParameterContext();
+        contextB.setIdentifier("id");
+        contextB.setInstanceIdentifier("instanceId");
+        contextB.setParameters(parametersB);
+
+        comparator.compare(contextA, contextB, differences);
+
+        assertEquals(4, differences.size());
+    }
+
     private VersionedParameter createParameter(final String name, final String value, final boolean sensitive) {
         return createParameter(name, value, sensitive, null);
     }


### PR DESCRIPTION
# Summary

[NIFI-14279](https://issues.apache.org/jira/browse/NIFI-14279) - StandardFlowDifference hashCode should include fieldName

The current hashCode method of the StandardFlowDifference object is problematic as it does not take into account the fieldName. This is causing an issue if multiple sensitive parameters are changed as everything will be equal (the description is a standard sentence given that the parameters are sensitive) except for the fieldName (which is the name of the parameter in this case).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
