### PR TITLE
NIFI-14285 ConsumeKinesisStream Record Wrapper

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/property/OutputStrategy.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/property/OutputStrategy.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.kinesis.property;
+
+import org.apache.nifi.components.DescribedValue;
+
+/**
+ * Enumeration of supported Kinesis Output Strategies
+ */
+public enum OutputStrategy implements DescribedValue {
+    USE_VALUE("USE_VALUE", "Use Content as Value", "Write only the Kinesis Record value to the FlowFile record."),
+    USE_WRAPPER("USE_WRAPPER", "Use Wrapper", "Write the Kinesis Record value and metadata into the FlowFile record.");
+
+    private final String value;
+    private final String displayName;
+    private final String description;
+
+    OutputStrategy(final String value, final String displayName, final String description) {
+        this.value = value;
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/property/OutputStrategy.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/property/OutputStrategy.java
@@ -22,22 +22,20 @@ import org.apache.nifi.components.DescribedValue;
  * Enumeration of supported Kinesis Output Strategies
  */
 public enum OutputStrategy implements DescribedValue {
-    USE_VALUE("USE_VALUE", "Use Content as Value", "Write only the Kinesis Record value to the FlowFile record."),
-    USE_WRAPPER("USE_WRAPPER", "Use Wrapper", "Write the Kinesis Record value and metadata into the FlowFile record.");
+    USE_VALUE("Use Content as Value", "Write only the Kinesis Record value to the FlowFile record."),
+    USE_WRAPPER("Use Wrapper", "Write the Kinesis Record value and metadata into the FlowFile record.");
 
-    private final String value;
     private final String displayName;
     private final String description;
 
-    OutputStrategy(final String value, final String displayName, final String description) {
-        this.value = value;
+    OutputStrategy(final String displayName, final String description) {
         this.displayName = displayName;
         this.description = description;
     }
 
     @Override
     public String getValue() {
-        return value;
+        return name();
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -47,9 +47,13 @@ import org.apache.nifi.processor.ProcessSessionFactory;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.aws.kinesis.property.OutputStrategy;
 import org.apache.nifi.processors.aws.kinesis.stream.record.AbstractKinesisRecordProcessor;
 import org.apache.nifi.processors.aws.kinesis.stream.record.KinesisRecordProcessorRaw;
 import org.apache.nifi.processors.aws.kinesis.stream.record.KinesisRecordProcessorRecord;
+import org.apache.nifi.processors.aws.kinesis.stream.record.converter.RecordConverter;
+import org.apache.nifi.processors.aws.kinesis.stream.record.converter.RecordConverterIdentity;
+import org.apache.nifi.processors.aws.kinesis.stream.record.converter.RecordConverterWrapper;
 import org.apache.nifi.processors.aws.v2.AbstractAwsAsyncProcessor;
 import org.apache.nifi.processors.aws.v2.AbstractAwsProcessor;
 import org.apache.nifi.serialization.RecordReaderFactory;
@@ -101,7 +105,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 @InputRequirement(InputRequirement.Requirement.INPUT_FORBIDDEN)
 @TriggerSerially
@@ -308,6 +311,15 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
             .required(true)
             .build();
 
+    public static final PropertyDescriptor OUTPUT_STRATEGY = new PropertyDescriptor.Builder()
+            .name("Output Strategy")
+            .description("The format used to output the Kinesis Record into a FlowFile Record.")
+            .required(true)
+            .defaultValue(OutputStrategy.USE_VALUE)
+            .allowableValues(OutputStrategy.class)
+            .dependsOn(RECORD_WRITER)
+            .build();
+
     public static final Relationship REL_PARSE_FAILURE = new Relationship.Builder()
             .name("parse.failure")
             .description("If a message from Kinesis cannot be parsed using the configured Record Reader" +
@@ -333,6 +345,7 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
             NUM_RETRIES,
             RETRY_WAIT,
             REPORT_CLOUDWATCH_METRICS,
+            OUTPUT_STRATEGY,
 
             // generic AWS processor properties
             TIMEOUT,
@@ -631,8 +644,7 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
                 .keySet()
                 .stream()
                 .filter(PropertyDescriptor::isDynamic)
-                .collect(Collectors.toList());
-
+                .toList();
 
         final RetrievalConfig retrievalConfig = configsBuilder.retrievalConfig()
                 .retrievalSpecificConfig(new PollingConfig(streamName, kinesisClient));
@@ -688,11 +700,15 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
     private ShardRecordProcessorFactory prepareRecordProcessorFactory(final ProcessContext context, final ProcessSessionFactory sessionFactory) {
         return () -> {
             if (isRecordReaderSet && isRecordWriterSet) {
+                final String value = context.getProperty(OUTPUT_STRATEGY).getValue();
+                final RecordConverter recordConverter = OutputStrategy.USE_WRAPPER.getValue().equals(value)
+                        ? new RecordConverterWrapper()
+                        : new RecordConverterIdentity();
                 return new KinesisRecordProcessorRecord(
                         sessionFactory, getLogger(), getStreamName(context), getEndpointPrefix(context),
                         getKinesisEndpoint(context).orElse(null), getCheckpointIntervalMillis(context),
                         getRetryWaitMillis(context), getNumRetries(context), getDateTimeFormatter(context),
-                        getReaderFactory(context), getWriterFactory(context)
+                        getReaderFactory(context), getWriterFactory(context), recordConverter
                 );
             } else {
                 return new KinesisRecordProcessorRaw(

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -333,6 +333,7 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
             APPLICATION_NAME,
             RECORD_READER,
             RECORD_WRITER,
+            OUTPUT_STRATEGY,
             REGION,
             ENDPOINT_OVERRIDE,
             DYNAMODB_ENDPOINT_OVERRIDE,
@@ -345,7 +346,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
             NUM_RETRIES,
             RETRY_WAIT,
             REPORT_CLOUDWATCH_METRICS,
-            OUTPUT_STRATEGY,
 
             // generic AWS processor properties
             TIMEOUT,

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -700,8 +700,8 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
     private ShardRecordProcessorFactory prepareRecordProcessorFactory(final ProcessContext context, final ProcessSessionFactory sessionFactory) {
         return () -> {
             if (isRecordReaderSet && isRecordWriterSet) {
-                final String value = context.getProperty(OUTPUT_STRATEGY).getValue();
-                final RecordConverter recordConverter = OutputStrategy.USE_WRAPPER.getValue().equals(value)
+                final OutputStrategy outputStrategy = context.getProperty(OUTPUT_STRATEGY).asAllowableValue(OutputStrategy.class);
+                final RecordConverter recordConverter = OutputStrategy.USE_WRAPPER == outputStrategy
                         ? new RecordConverterWrapper()
                         : new RecordConverterIdentity();
                 return new KinesisRecordProcessorRecord(

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/AbstractKinesisRecordProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/AbstractKinesisRecordProcessor.java
@@ -313,6 +313,10 @@ public abstract class AbstractKinesisRecordProcessor implements ShardRecordProce
         return log;
     }
 
+    String getStreamName() {
+        return streamName;
+    }
+
     String getKinesisShardId() {
         return kinesisShardId;
     }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/KinesisRecordProcessorRecord.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/KinesisRecordProcessorRecord.java
@@ -31,6 +31,7 @@ import org.apache.nifi.serialization.RecordSetWriter;
 import org.apache.nifi.serialization.RecordSetWriterFactory;
 import org.apache.nifi.serialization.WriteResult;
 import org.apache.nifi.serialization.record.PushBackRecordSet;
+import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.util.StopWatch;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
@@ -92,14 +93,10 @@ public class KinesisRecordProcessorRecord extends AbstractKinesisRecordProcessor
         try (final InputStream in = new ByteArrayInputStream(data);
              final RecordReader reader = readerFactory.createRecordReader(schemaRetrievalVariables, in, data.length, getLogger())
         ) {
-            org.apache.nifi.serialization.record.Record intermediateRecord;
+            Record intermediateRecord;
             final PushBackRecordSet recordSet = new PushBackRecordSet(reader.createRecordSet());
             while ((intermediateRecord = recordSet.next()) != null) {
-                org.apache.nifi.serialization.record.Record outputRecord =
-                        recordConverter.convert(intermediateRecord,
-                                kinesisRecord,
-                                getStreamName(),
-                                getKinesisShardId());
+                Record outputRecord = recordConverter.convert(intermediateRecord, kinesisRecord, getStreamName(), getKinesisShardId());
                 if (flowFiles.isEmpty()) {
                     flowFile = session.create();
                     flowFiles.add(flowFile);
@@ -130,8 +127,7 @@ public class KinesisRecordProcessorRecord extends AbstractKinesisRecordProcessor
         }
     }
 
-    private void createWriter(final FlowFile flowFile, final ProcessSession session,
-                              final org.apache.nifi.serialization.record.Record outputRecord)
+    private void createWriter(final FlowFile flowFile, final ProcessSession session, final Record outputRecord)
             throws IOException, SchemaNotFoundException {
 
         final RecordSchema readerSchema = outputRecord.getSchema();

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverter.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverter.java
@@ -16,11 +16,10 @@
  */
 package org.apache.nifi.processors.aws.kinesis.stream.record.converter;
 
+import org.apache.nifi.serialization.record.Record;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 public interface RecordConverter {
 
-    org.apache.nifi.serialization.record.Record convert(
-            final org.apache.nifi.serialization.record.Record record, final KinesisClientRecord kinesisRecord,
-            final String streamName, final String shardId);
+    Record convert(final Record record, final KinesisClientRecord kinesisRecord, final String streamName, final String shardId);
 }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverter.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverter.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.kinesis.stream.record.converter;
+
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
+
+public interface RecordConverter {
+
+    org.apache.nifi.serialization.record.Record convert(
+            final org.apache.nifi.serialization.record.Record record, final KinesisClientRecord kinesisRecord,
+            final String streamName, final String shardId);
+}

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterIdentity.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterIdentity.java
@@ -16,13 +16,12 @@
  */
 package org.apache.nifi.processors.aws.kinesis.stream.record.converter;
 
+import org.apache.nifi.serialization.record.Record;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 public class RecordConverterIdentity implements RecordConverter {
     @Override
-    public org.apache.nifi.serialization.record.Record convert(
-            final org.apache.nifi.serialization.record.Record record, final KinesisClientRecord kinesisRecord,
-            final String streamName, final String shardId) {
+    public Record convert(final Record record, final KinesisClientRecord kinesisRecord, final String streamName, final String shardId) {
         return record;
     }
 }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterIdentity.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterIdentity.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.kinesis.stream.record.converter;
+
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
+
+public class RecordConverterIdentity implements RecordConverter {
+    @Override
+    public org.apache.nifi.serialization.record.Record convert(
+            final org.apache.nifi.serialization.record.Record record, final KinesisClientRecord kinesisRecord,
+            final String streamName, final String shardId) {
+        return record;
+    }
+}

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterWrapper.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterWrapper.java
@@ -35,11 +35,11 @@ public class RecordConverterWrapper implements RecordConverter {
     private static final String VALUE = "value";
     private static final String METADATA = "metadata";
 
-    private static final String STREAM = "aws.kinesis.stream";
-    private static final String SHARD_ID = "aws.kinesis.shard.id";
-    private static final String SEQUENCE_NUMBER = "aws.kinesis.sequence.number";
-    private static final String PARTITION_KEY = "aws.kinesis.partition.key";
-    private static final String APPROX_ARRIVAL_TIMESTAMP = "aws.kinesis.approximate.arrival.timestamp";
+    private static final String STREAM = "stream";
+    private static final String SHARD_ID = "shardId";
+    private static final String SEQUENCE_NUMBER = "sequenceNumber";
+    private static final String PARTITION_KEY = "partitionKey";
+    private static final String APPROX_ARRIVAL_TIMESTAMP = "approximateArrival";
 
     private static final RecordField FIELD_STREAM = new RecordField(STREAM, RecordFieldType.STRING.getDataType());
     private static final RecordField FIELD_SHARD_ID = new RecordField(SHARD_ID, RecordFieldType.STRING.getDataType());

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterWrapper.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterWrapper.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.kinesis.stream.record.converter;
+
+import org.apache.nifi.serialization.SimpleRecordSchema;
+import org.apache.nifi.serialization.record.MapRecord;
+import org.apache.nifi.serialization.record.RecordField;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.util.Tuple;
+import software.amazon.kinesis.retrieval.KinesisClientRecord;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RecordConverterWrapper implements RecordConverter {
+
+    private static final String VALUE = "value";
+    private static final String METADATA = "metadata";
+
+    private static final String STREAM = "kinesis.stream";
+    private static final String SHARD_ID = "aws.kinesis.shard.id";
+    private static final String SEQUENCE_NUMBER = "aws.kinesis.sequence.number";
+    private static final String PARTITION_KEY = "aws.kinesis.partition.key";
+    private static final String APPROX_ARRIVAL_TIMESTAMP = "aws.kinesis.approximate.arrival.timestamp";
+
+    private static final RecordField FIELD_STREAM = new RecordField(STREAM, RecordFieldType.STRING.getDataType());
+    private static final RecordField FIELD_SHARD_ID = new RecordField(SHARD_ID, RecordFieldType.STRING.getDataType());
+    private static final RecordField FIELD_SEQUENCE_NUMBER = new RecordField(SEQUENCE_NUMBER, RecordFieldType.STRING.getDataType());
+    private static final RecordField FIELD_PARTITION_KEY = new RecordField(PARTITION_KEY, RecordFieldType.STRING.getDataType());
+    private static final RecordField FIELD_APPROX_ARRIVAL_TIMESTAMP = new RecordField(APPROX_ARRIVAL_TIMESTAMP, RecordFieldType.TIMESTAMP.getDataType());
+    private static final RecordSchema SCHEMA_METADATA = new SimpleRecordSchema(Arrays.asList(
+            FIELD_STREAM, FIELD_SHARD_ID, FIELD_SEQUENCE_NUMBER, FIELD_PARTITION_KEY, FIELD_APPROX_ARRIVAL_TIMESTAMP));
+
+    public static final RecordField FIELD_METADATA = new RecordField(METADATA, RecordFieldType.RECORD.getRecordDataType(SCHEMA_METADATA));
+
+
+    @Override
+    public org.apache.nifi.serialization.record.Record convert(
+            final org.apache.nifi.serialization.record.Record record,
+            final KinesisClientRecord kinesisRecord, final String streamName, final String shardId) {
+        final Tuple<String, Object> metadata = toWrapperRecordMetadata(kinesisRecord, streamName, shardId);
+        return new MapRecord(convertToWriteSchema(record.getSchema()), Map.of(metadata.getKey(), metadata.getValue(), VALUE, record));
+    }
+
+    private Tuple<String, Object> toWrapperRecordMetadata(final KinesisClientRecord consumerRecord, final String streamName, final String shardId) {
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put(STREAM, streamName);
+        metadata.put(SHARD_ID, shardId);
+        metadata.put(SEQUENCE_NUMBER, consumerRecord.sequenceNumber());
+        metadata.put(PARTITION_KEY, consumerRecord.partitionKey());
+        final Instant approxArrivalTimestamp = consumerRecord.approximateArrivalTimestamp();
+        metadata.put(APPROX_ARRIVAL_TIMESTAMP, approxArrivalTimestamp != null ? approxArrivalTimestamp.toEpochMilli() : null);
+        final org.apache.nifi.serialization.record.Record record = new MapRecord(SCHEMA_METADATA, metadata);
+        return new Tuple<>(METADATA, record);
+    }
+
+    private RecordSchema convertToWriteSchema(final RecordSchema readerSchema) {
+        final RecordField recordField = new RecordField(VALUE, RecordFieldType.RECORD.getRecordDataType(readerSchema));
+        return new SimpleRecordSchema(Arrays.asList(FIELD_METADATA, recordField));
+    }
+}

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterWrapper.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterWrapper.java
@@ -33,7 +33,7 @@ public class RecordConverterWrapper implements RecordConverter {
     private static final String VALUE = "value";
     private static final String METADATA = "metadata";
 
-    private static final String STREAM = "kinesis.stream";
+    private static final String STREAM = "aws.kinesis.stream";
     private static final String SHARD_ID = "aws.kinesis.shard.id";
     private static final String SEQUENCE_NUMBER = "aws.kinesis.sequence.number";
     private static final String PARTITION_KEY = "aws.kinesis.partition.key";

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/docs/org.apache.nifi.processors.aws.kinesis.stream.ConsumeKinesisStream/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/docs/org.apache.nifi.processors.aws.kinesis.stream.ConsumeKinesisStream/additionalDetails.md
@@ -37,3 +37,8 @@ within the batch of Kinesis Records (messages), instead of a separate FlowFile p
 The FlowFiles emitted in this mode will include the standard `record.*` attributes along with the same Kinesis Shard ID,
 Sequence Number and Approximate Arrival Timestamp; but the values will relate to the **last** Kinesis Record that was
 processed in the batch of messages constituting the content of the FlowFile.
+
+Once a Record Writer is set the Output Strategy can be set to `Use Wrapper` or `Use Content`. When `Use Wrapper` is 
+picked the original content of the Kinesis Record will be wrapped under `value` key and an additional `metadata`
+key will be populated with Stream Name, Shard ID, Partition Key, Sequence Number and Approximate Arrival Timestamp. 
+When `Use Content` is picked the original content of the Kinesis Record will be used as is.

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/TestConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/TestConsumeKinesisStream.java
@@ -97,10 +97,11 @@ public class TestConsumeKinesisStream {
         runner.setProperty(ConsumeKinesisStream.INITIAL_STREAM_POSITION, "not-an-enum-match");
         runner.setProperty(ConsumeKinesisStream.RECORD_READER, "not-a-reader");
         runner.setProperty(ConsumeKinesisStream.RECORD_WRITER, "not-a-writer");
+        runner.setProperty(ConsumeKinesisStream.OUTPUT_STRATEGY, "not-an-enum-match");
         runner.assertNotValid();
 
         final AssertionError assertionError = assertThrows(AssertionError.class, runner::run);
-        assertEquals(assertionError.getMessage(), String.format("Processor has 14 validation failures:\n" +
+        assertEquals(assertionError.getMessage(), String.format("Processor has 15 validation failures:\n" +
                         "'%s' validated against ' ' is invalid because %s must contain at least one character that is not white space\n" +
                         "'%s' validated against 'not-a-reader' is invalid because Property references a Controller Service that does not exist\n" +
                         "'%s' validated against 'not-a-writer' is invalid because Property references a Controller Service that does not exist\n" +
@@ -117,6 +118,7 @@ public class TestConsumeKinesisStream {
                         "'%s' validated against 'not-a-long' is invalid because Must be of format <duration> <TimeUnit> where <duration> is a non-negative integer and " +
                         "TimeUnit is a supported Time Unit, such as: nanos, millis, secs, mins, hrs, days\n" +
                         "'%s' validated against 'not-a-boolean' is invalid because Given value not found in allowed set 'true, false'\n" +
+                        "'Output Strategy' validated against 'not-an-enum-match' is invalid because Given value not found in allowed set 'USE_VALUE, USE_WRAPPER'\n" +
                         "'%s' validated against 'not-a-reader' is invalid because Invalid Controller Service: not-a-reader is not a valid Controller Service Identifier\n" +
                         "'%s' validated against 'not-a-writer' is invalid because Invalid Controller Service: not-a-writer is not a valid Controller Service Identifier\n",
                 ConsumeKinesisStream.APPLICATION_NAME.getName(), ConsumeKinesisStream.APPLICATION_NAME.getName(),

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/TestConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/TestConsumeKinesisStream.java
@@ -97,11 +97,10 @@ public class TestConsumeKinesisStream {
         runner.setProperty(ConsumeKinesisStream.INITIAL_STREAM_POSITION, "not-an-enum-match");
         runner.setProperty(ConsumeKinesisStream.RECORD_READER, "not-a-reader");
         runner.setProperty(ConsumeKinesisStream.RECORD_WRITER, "not-a-writer");
-        runner.setProperty(ConsumeKinesisStream.OUTPUT_STRATEGY, "not-an-enum-match");
         runner.assertNotValid();
 
         final AssertionError assertionError = assertThrows(AssertionError.class, runner::run);
-        assertEquals(assertionError.getMessage(), String.format("Processor has 15 validation failures:\n" +
+        assertEquals(assertionError.getMessage(), String.format("Processor has 14 validation failures:\n" +
                         "'%s' validated against ' ' is invalid because %s must contain at least one character that is not white space\n" +
                         "'%s' validated against 'not-a-reader' is invalid because Property references a Controller Service that does not exist\n" +
                         "'%s' validated against 'not-a-writer' is invalid because Property references a Controller Service that does not exist\n" +
@@ -118,7 +117,6 @@ public class TestConsumeKinesisStream {
                         "'%s' validated against 'not-a-long' is invalid because Must be of format <duration> <TimeUnit> where <duration> is a non-negative integer and " +
                         "TimeUnit is a supported Time Unit, such as: nanos, millis, secs, mins, hrs, days\n" +
                         "'%s' validated against 'not-a-boolean' is invalid because Given value not found in allowed set 'true, false'\n" +
-                        "'Output Strategy' validated against 'not-an-enum-match' is invalid because Given value not found in allowed set 'USE_VALUE, USE_WRAPPER'\n" +
                         "'%s' validated against 'not-a-reader' is invalid because Invalid Controller Service: not-a-reader is not a valid Controller Service Identifier\n" +
                         "'%s' validated against 'not-a-writer' is invalid because Invalid Controller Service: not-a-writer is not a valid Controller Service Identifier\n",
                 ConsumeKinesisStream.APPLICATION_NAME.getName(), ConsumeKinesisStream.APPLICATION_NAME.getName(),

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
@@ -219,14 +219,14 @@ public class TestKinesisRecordProcessorRecord {
 
     private String expectRecordContentWrapper() {
         return """
-                {"metadata":{"aws.kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"1","aws.kinesis.partition.key":"partition-1",\
-                "aws.kinesis.approximate.arrival.timestamp":1609459140000},"value":{"record":"1"}}
-                {"metadata":{"aws.kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"1","aws.kinesis.partition.key":"partition-1",\
-                "aws.kinesis.approximate.arrival.timestamp":1609459140000},"value":{"record":"1b"}}
-                {"metadata":{"aws.kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"no-date","aws.kinesis.partition.key":"partition-no-date",\
-                "aws.kinesis.approximate.arrival.timestamp":null},"value":{"record":"no-date"}}
-                {"metadata":{"aws.kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"2","aws.kinesis.partition.key":"partition-2",\
-                "aws.kinesis.approximate.arrival.timestamp":1609459200000},"value":{"record":"2"}}""";
+                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"1","partitionKey":"partition-1",\
+                "approximateArrival":1609459140000},"value":{"record":"1"}}
+                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"1","partitionKey":"partition-1",\
+                "approximateArrival":1609459140000},"value":{"record":"1b"}}
+                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"no-date","partitionKey":"partition-no-date",\
+                "approximateArrival":null},"value":{"record":"no-date"}}
+                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"2","partitionKey":"partition-2",\
+                "approximateArrival":1609459200000},"value":{"record":"2"}}""";
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
@@ -21,6 +21,8 @@ import org.apache.nifi.json.JsonRecordSetWriter;
 import org.apache.nifi.json.JsonTreeReader;
 import org.apache.nifi.processor.ProcessSessionFactory;
 import org.apache.nifi.processors.aws.kinesis.stream.ConsumeKinesisStream;
+import org.apache.nifi.processors.aws.kinesis.stream.record.converter.RecordConverterIdentity;
+import org.apache.nifi.processors.aws.kinesis.stream.record.converter.RecordConverterWrapper;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.schema.access.SchemaAccessUtils;
 import org.apache.nifi.schema.inference.SchemaInferenceUtil;
@@ -101,7 +103,7 @@ public class TestKinesisRecordProcessorRecord {
         // default test fixture will try operations twice with very little wait in between
         fixture = new KinesisRecordProcessorRecord(processSessionFactory, runner.getLogger(), "kinesis-test",
                 "endpoint-prefix", null, 10_000L, 1L, 2, DATE_TIME_FORMATTER,
-                reader, writer);
+                reader, writer, new RecordConverterIdentity());
     }
 
     @AfterEach
@@ -133,17 +135,28 @@ public class TestKinesisRecordProcessorRecord {
 
     @Test
     public void testProcessRecordsNoCheckpoint() {
-        processMultipleRecordsAssertProvenance(false);
+        processMultipleRecordsAssertProvenance(false, false);
     }
 
     @Test
     public void testProcessRecordsWithEndpointOverride() {
-        processMultipleRecordsAssertProvenance(true);
+        processMultipleRecordsAssertProvenance(true, false);
     }
 
-    private void processMultipleRecordsAssertProvenance(final boolean endpointOverridden) {
-        final Date firstDate = Date.from(Instant.now().minus(1, ChronoUnit.MINUTES));
-        final Date secondDate = new Date();
+    @Test
+    public void testProcessWrappedRecordsNoCheckpoint() {
+        processMultipleRecordsAssertProvenance(false, true);
+    }
+
+    @Test
+    public void testProcessWrappedRecordsWithEndpointOverride() {
+        processMultipleRecordsAssertProvenance(true, true);
+    }
+
+    private void processMultipleRecordsAssertProvenance(final boolean endpointOverridden, final boolean useWrapper) {
+        final Instant referenceInstant = Instant.parse("2021-01-01T00:00:00.000Z");
+        final Date firstDate = Date.from(referenceInstant.minus(1, ChronoUnit.MINUTES));
+        final Date secondDate = Date.from(referenceInstant);
 
         final ProcessRecordsInput processRecordsInput = ProcessRecordsInput.builder()
                 .records(Arrays.asList(
@@ -170,11 +183,9 @@ public class TestKinesisRecordProcessorRecord {
                 .build();
 
         final String transitUriPrefix = endpointOverridden ? "https://another-endpoint.com:8443" : "http://endpoint-prefix.amazonaws.com";
-        if (endpointOverridden) {
-            fixture = new KinesisRecordProcessorRecord(processSessionFactory, runner.getLogger(), "kinesis-test",
-                    "endpoint-prefix", "https://another-endpoint.com:8443", 10_000L, 1L, 2, DATE_TIME_FORMATTER,
-                    reader, writer);
-        }
+        fixture = new KinesisRecordProcessorRecord(processSessionFactory, runner.getLogger(), "kinesis-test",
+                "endpoint-prefix", transitUriPrefix, 10_000L, 1L, 2, DATE_TIME_FORMATTER,
+                reader, writer, useWrapper ? new RecordConverterWrapper() : new RecordConverterIdentity());
 
         // skip checkpoint
         fixture.setNextCheckpointTimeInMillis(System.currentTimeMillis() + 10_000L);
@@ -190,14 +201,32 @@ public class TestKinesisRecordProcessorRecord {
 
         final List<MockFlowFile> flowFiles = session.getFlowFilesForRelationship(ConsumeKinesisStream.REL_SUCCESS);
         // 4 records in single output file, attributes equating to that of the last record
-        assertFlowFile(flowFiles.get(0), secondDate, "partition-2", "2", "another-shard", "{\"record\":\"1\"}\n" +
-                "{\"record\":\"1b\"}\n" +
-                "{\"record\":\"no-date\"}\n" +
-                "{\"record\":\"2\"}", 4);
+        final String expectedContent = useWrapper ? expectRecordContentWrapper() : expectRecordContentIdentity();
+        assertFlowFile(flowFiles.getFirst(), secondDate, "partition-2", "2", "another-shard", expectedContent, 4);
         session.assertTransferCount(ConsumeKinesisStream.REL_PARSE_FAILURE, 0);
 
         session.assertCommitted();
         session.assertNotRolledBack();
+    }
+
+    private String expectRecordContentIdentity() {
+        return """
+                {"record":"1"}
+                {"record":"1b"}
+                {"record":"no-date"}
+                {"record":"2"}""";
+    }
+
+    private String expectRecordContentWrapper() {
+        return """
+                {"metadata":{"kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"1","aws.kinesis.partition.key":"partition-1",\
+                "aws.kinesis.approximate.arrival.timestamp":1609459140000},"value":{"record":"1"}}
+                {"metadata":{"kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"1","aws.kinesis.partition.key":"partition-1",\
+                "aws.kinesis.approximate.arrival.timestamp":1609459140000},"value":{"record":"1b"}}
+                {"metadata":{"kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"no-date","aws.kinesis.partition.key":"partition-no-date",\
+                "aws.kinesis.approximate.arrival.timestamp":null},"value":{"record":"no-date"}}
+                {"metadata":{"kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"2","aws.kinesis.partition.key":"partition-2",\
+                "aws.kinesis.approximate.arrival.timestamp":1609459200000},"value":{"record":"2"}}""";
     }
 
     @Test
@@ -235,7 +264,7 @@ public class TestKinesisRecordProcessorRecord {
         session.assertTransferCount(ConsumeKinesisStream.REL_SUCCESS, 1);
         final List<MockFlowFile> flowFiles = session.getFlowFilesForRelationship(ConsumeKinesisStream.REL_SUCCESS);
         // 2 successful records in single output file, attributes equating to that of the last successful record
-        assertFlowFile(flowFiles.get(0), null, "partition-3", "3", "test-shard", "{\"record\":\"1\"}\n" +
+        assertFlowFile(flowFiles.getFirst(), null, "partition-3", "3", "test-shard", "{\"record\":\"1\"}\n" +
                 "{\"record\":\"3\"}", 2);
 
         // check no poison-pill output (as the raw data could not be retrieved)
@@ -288,14 +317,14 @@ public class TestKinesisRecordProcessorRecord {
         session.assertTransferCount(ConsumeKinesisStream.REL_SUCCESS, 1);
         final List<MockFlowFile> flowFiles = session.getFlowFilesForRelationship(ConsumeKinesisStream.REL_SUCCESS);
         // 2 successful records in single output file, attributes equating to that of the last successful record
-        assertFlowFile(flowFiles.get(0), null, "partition-3", "3", "test-shard", "{\"record\":\"1\"}\n" +
+        assertFlowFile(flowFiles.getFirst(), null, "partition-3", "3", "test-shard", "{\"record\":\"1\"}\n" +
                 "{\"record\":\"3\"}", 2);
 
         // check poison-pill output (as the raw data could not be retrieved)
         session.assertTransferCount(ConsumeKinesisStream.REL_PARSE_FAILURE, 1);
         final List<MockFlowFile> failureFlowFiles = session.getFlowFilesForRelationship(ConsumeKinesisStream.REL_PARSE_FAILURE);
-        assertFlowFile(failureFlowFiles.get(0), null, "unparsable-partition", "unparsable-sequence", "test-shard", "invalid-json", 0);
-        failureFlowFiles.get(0).assertAttributeExists("record.error.message");
+        assertFlowFile(failureFlowFiles.getFirst(), null, "unparsable-partition", "unparsable-sequence", "test-shard", "invalid-json", 0);
+        failureFlowFiles.getFirst().assertAttributeExists("record.error.message");
 
         // check the invalid json record was *not* retried a 2nd time
         assertNull(verify(kinesisRecord, times(1)).partitionKey());

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
@@ -219,13 +219,13 @@ public class TestKinesisRecordProcessorRecord {
 
     private String expectRecordContentWrapper() {
         return """
-                {"metadata":{"kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"1","aws.kinesis.partition.key":"partition-1",\
+                {"metadata":{"aws.kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"1","aws.kinesis.partition.key":"partition-1",\
                 "aws.kinesis.approximate.arrival.timestamp":1609459140000},"value":{"record":"1"}}
-                {"metadata":{"kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"1","aws.kinesis.partition.key":"partition-1",\
+                {"metadata":{"aws.kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"1","aws.kinesis.partition.key":"partition-1",\
                 "aws.kinesis.approximate.arrival.timestamp":1609459140000},"value":{"record":"1b"}}
-                {"metadata":{"kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"no-date","aws.kinesis.partition.key":"partition-no-date",\
+                {"metadata":{"aws.kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"no-date","aws.kinesis.partition.key":"partition-no-date",\
                 "aws.kinesis.approximate.arrival.timestamp":null},"value":{"record":"no-date"}}
-                {"metadata":{"kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"2","aws.kinesis.partition.key":"partition-2",\
+                {"metadata":{"aws.kinesis.stream":"kinesis-test","aws.kinesis.shard.id":"another-shard","aws.kinesis.sequence.number":"2","aws.kinesis.partition.key":"partition-2",\
                 "aws.kinesis.approximate.arrival.timestamp":1609459200000},"value":{"record":"2"}}""";
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14285](https://issues.apache.org/jira/browse/NIFI-14285)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-14285`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-14285`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] (no new) New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] (no new) New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
