### PR TITLE
NIFI-14288 fetch S3 Object Tags

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/s3/AbstractS3Processor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/s3/AbstractS3Processor.java
@@ -145,6 +145,13 @@ public abstract class AbstractS3Processor extends AbstractAWSCredentialsProvider
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .defaultValue("${filename}")
             .build();
+    public static final PropertyDescriptor VERSION_ID = new PropertyDescriptor.Builder()
+            .name("Version")
+            .description("The Version of the Object to download")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .required(false)
+            .build();
     public static final PropertyDescriptor SIGNER_OVERRIDE = new PropertyDescriptor.Builder()
             .name("Signer Override")
             .description("The AWS S3 library uses Signature Version 4 by default but this property allows you to specify the Version 2 signer to support older S3-compatible services" +

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/CopyS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/CopyS3Object.java
@@ -53,7 +53,7 @@ import static org.apache.nifi.processors.aws.util.RegionUtilV1.S3_REGION;
 @Tags({"Amazon", "S3", "AWS", "Archive", "Copy"})
 @InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
 @CapabilityDescription("Copies a file from one bucket and key to another in AWS S3")
-@SeeAlso({PutS3Object.class, DeleteS3Object.class, ListS3.class, TagS3Object.class, DeleteS3Object.class, FetchS3Object.class})
+@SeeAlso({PutS3Object.class, DeleteS3Object.class, ListS3.class, TagS3Object.class, DeleteS3Object.class, FetchS3Object.class, GetS3ObjectMetadata.class, GetS3ObjectTags.class})
 public class CopyS3Object extends AbstractS3Processor {
     public static final long MULTIPART_THRESHOLD = 5L * 1024L * 1024L * 1024L;
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/DeleteS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/DeleteS3Object.java
@@ -48,7 +48,7 @@ import static org.apache.nifi.processors.aws.util.RegionUtilV1.S3_REGION;
         @WritesAttribute(attribute = "s3.statusCode", description = "The HTTP error code (if available) from the failed operation"),
         @WritesAttribute(attribute = "s3.errorCode", description = "The S3 moniker of the failed operation"),
         @WritesAttribute(attribute = "s3.errorMessage", description = "The S3 exception message from the failed operation")})
-@SeeAlso({PutS3Object.class, FetchS3Object.class, ListS3.class, CopyS3Object.class, GetS3ObjectMetadata.class, TagS3Object.class})
+@SeeAlso({PutS3Object.class, FetchS3Object.class, ListS3.class, CopyS3Object.class, GetS3ObjectMetadata.class, GetS3ObjectTags.class, TagS3Object.class})
 @Tags({"Amazon", "S3", "AWS", "Archive", "Delete"})
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @CapabilityDescription("Deletes a file from an Amazon S3 Bucket. If attempting to delete a file that does not exist, FlowFile is routed to success.")

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/FetchS3Object.java
@@ -65,7 +65,7 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.nifi.processors.aws.util.RegionUtilV1.S3_REGION;
 
 @SupportsBatching
-@SeeAlso({PutS3Object.class, DeleteS3Object.class, ListS3.class, CopyS3Object.class, GetS3ObjectMetadata.class, TagS3Object.class})
+@SeeAlso({PutS3Object.class, DeleteS3Object.class, ListS3.class, CopyS3Object.class, GetS3ObjectMetadata.class, GetS3ObjectTags.class, TagS3Object.class})
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @Tags({"Amazon", "S3", "AWS", "Get", "Fetch"})
 @CapabilityDescription("Retrieves the contents of an S3 Object and writes it to the content of a FlowFile")
@@ -229,14 +229,6 @@ import static org.apache.nifi.processors.aws.util.RegionUtilV1.S3_REGION;
     }
 )
 public class FetchS3Object extends AbstractS3Processor {
-
-    public static final PropertyDescriptor VERSION_ID = new PropertyDescriptor.Builder()
-            .name("Version")
-            .description("The Version of the Object to download")
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
-            .required(false)
-            .build();
 
     public static final PropertyDescriptor REQUESTER_PAYS = new PropertyDescriptor.Builder()
             .name("requester-pays")

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/ListS3.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/ListS3.java
@@ -105,7 +105,7 @@ import static org.apache.nifi.processors.aws.util.RegionUtilV1.REGION;
 @TriggerWhenEmpty
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
 @Tags({"Amazon", "S3", "AWS", "list"})
-@SeeAlso({FetchS3Object.class, PutS3Object.class, DeleteS3Object.class, CopyS3Object.class, GetS3ObjectMetadata.class, TagS3Object.class})
+@SeeAlso({FetchS3Object.class, PutS3Object.class, DeleteS3Object.class, CopyS3Object.class, GetS3ObjectMetadata.class, GetS3ObjectTags.class, TagS3Object.class})
 @CapabilityDescription("Retrieves a listing of objects from an S3 bucket. For each object that is listed, creates a FlowFile that represents "
         + "the object so that it can be fetched in conjunction with FetchS3Object. This Processor is designed to run on Primary Node only "
         + "in a cluster. If the primary node changes, the new Primary Node will pick up where the previous node left off without duplicating "

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/PutS3Object.java
@@ -95,7 +95,7 @@ import static org.apache.nifi.processors.transfer.ResourceTransferProperties.RES
 import static org.apache.nifi.processors.transfer.ResourceTransferUtils.getFileResource;
 
 @SupportsBatching
-@SeeAlso({FetchS3Object.class, DeleteS3Object.class, ListS3.class, CopyS3Object.class, GetS3ObjectMetadata.class, TagS3Object.class})
+@SeeAlso({FetchS3Object.class, DeleteS3Object.class, ListS3.class, CopyS3Object.class, GetS3ObjectMetadata.class, GetS3ObjectTags.class, TagS3Object.class})
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @Tags({"Amazon", "S3", "AWS", "Archive", "Put"})
 @CapabilityDescription("Writes the contents of a FlowFile as an S3 Object to an Amazon S3 Bucket.")

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/TagS3Object.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/TagS3Object.java
@@ -59,7 +59,7 @@ import static org.apache.nifi.processors.aws.util.RegionUtilV1.S3_REGION;
         @WritesAttribute(attribute = "s3.statusCode", description = "The HTTP error code (if available) from the failed operation"),
         @WritesAttribute(attribute = "s3.errorCode", description = "The S3 moniker of the failed operation"),
         @WritesAttribute(attribute = "s3.errorMessage", description = "The S3 exception message from the failed operation")})
-@SeeAlso({PutS3Object.class, FetchS3Object.class, ListS3.class, CopyS3Object.class, GetS3ObjectMetadata.class, DeleteS3Object.class})
+@SeeAlso({PutS3Object.class, FetchS3Object.class, ListS3.class, CopyS3Object.class, GetS3ObjectMetadata.class, GetS3ObjectTags.class, DeleteS3Object.class})
 @Tags({"Amazon", "S3", "AWS", "Archive", "Tag"})
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @CapabilityDescription("Adds or updates a tag on an Amazon S3 Object.")
@@ -96,13 +96,8 @@ public class TagS3Object extends AbstractS3Processor {
             .defaultValue("true")
             .build();
 
-    public static final PropertyDescriptor VERSION_ID = new PropertyDescriptor.Builder()
-            .name("version")
-            .displayName("Version ID")
+    static final PropertyDescriptor VERSION_ID = new PropertyDescriptor.Builder().fromPropertyDescriptor(AbstractS3Processor.VERSION_ID)
             .description("The Version of the Object to tag")
-            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
-            .required(false)
             .build();
 
     public static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/api/MetadataTarget.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/api/MetadataTarget.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.aws.s3.api;
+
+import org.apache.nifi.components.DescribedValue;
+
+public enum MetadataTarget implements DescribedValue {
+    ATTRIBUTES("Attributes", """
+            When selected, the metadata will be written to FlowFile attributes with the prefix "s3." following the convention used in other processors. For example:
+            the standard S3 attribute Content-Type will be written as s3.Content-Type when using the default value. User-defined metadata
+            will be included in the attributes added to the FlowFile
+            """),
+    FLOWFILE_BODY("FlowFile Body", "Write the metadata to FlowFile content as JSON data.");
+
+    private final String displayName;
+    private final String description;
+
+    MetadataTarget(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/api/TagsTarget.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/s3/api/TagsTarget.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.aws.s3.api;
+
+import org.apache.nifi.components.DescribedValue;
+
+public enum TagsTarget implements DescribedValue {
+    ATTRIBUTES("Attributes", """
+            When selected, the tags will be written to FlowFile attributes with the prefix "s3.tag." following the convention used in other processors. For example:
+            the S3 tag GuardDutyMalwareScanStatusType will be written as s3.tag.GuardDutyMalwareScanStatus when using the default value
+            """),
+    FLOWFILE_BODY("FlowFile Body", "Write the tags to FlowFile content as JSON data.");
+
+    private final String displayName;
+    private final String description;
+
+    TagsTarget(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -14,6 +14,7 @@
 # limitations under the License.
 org.apache.nifi.processors.aws.s3.CopyS3Object
 org.apache.nifi.processors.aws.s3.GetS3ObjectMetadata
+org.apache.nifi.processors.aws.s3.GetS3ObjectTags
 org.apache.nifi.processors.aws.s3.FetchS3Object
 org.apache.nifi.processors.aws.s3.PutS3Object
 org.apache.nifi.processors.aws.s3.DeleteS3Object

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestGetS3ObjectMetadata.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestGetS3ObjectMetadata.java
@@ -23,6 +23,7 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Region;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processors.aws.testutil.AuthUtils;
@@ -38,7 +39,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -91,8 +92,7 @@ class TestGetS3ObjectMetadata {
         when(mockMetadata.getRawMetadata()).thenReturn(rawMetadata);
         when(mockMetadata.getUserMetadata()).thenReturn(userMetadata);
 
-        when(mockS3Client.getObjectMetadata(anyString(), anyString()))
-                .thenReturn(mockMetadata);
+        when(mockS3Client.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(mockMetadata);
 
         return combined;
     }
@@ -145,8 +145,7 @@ class TestGetS3ObjectMetadata {
         exception.setStatusCode(501);
 
         runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_ATTRIBUTES.getValue());
-        when(mockS3Client.getObjectMetadata(anyString(), anyString()))
-                .thenThrow(exception);
+        when(mockS3Client.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenThrow(exception);
         run();
         runner.assertTransferCount(GetS3ObjectMetadata.REL_FAILURE, 1);
     }
@@ -158,8 +157,7 @@ class TestGetS3ObjectMetadata {
         exception.setStatusCode(404);
 
         runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_ATTRIBUTES.getValue());
-        when(mockS3Client.getObjectMetadata(anyString(), anyString()))
-                .thenThrow(exception);
+        when(mockS3Client.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenThrow(exception);
         run();
         runner.assertTransferCount(GetS3ObjectMetadata.REL_NOT_FOUND, 1);
     }
@@ -168,8 +166,7 @@ class TestGetS3ObjectMetadata {
     @Test
     void testFetchMetadataToBodyExists() {
         runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_FLOWFILE_BODY.getValue());
-        when(mockS3Client.getObjectMetadata(anyString(), anyString()))
-                .thenReturn(mockMetadata);
+        when(mockS3Client.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(mockMetadata);
         run();
         runner.assertTransferCount(GetS3ObjectMetadata.REL_FOUND, 1);
     }
@@ -181,8 +178,7 @@ class TestGetS3ObjectMetadata {
         exception.setStatusCode(404);
 
         runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_FLOWFILE_BODY.getValue());
-        when(mockS3Client.getObjectMetadata(anyString(), anyString()))
-                .thenThrow(exception);
+        when(mockS3Client.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenThrow(exception);
         run();
         runner.assertTransferCount(GetS3ObjectMetadata.REL_NOT_FOUND, 1);
     }
@@ -194,8 +190,7 @@ class TestGetS3ObjectMetadata {
         exception.setStatusCode(501);
 
         runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_FLOWFILE_BODY.getValue());
-        when(mockS3Client.getObjectMetadata(anyString(), anyString()))
-                .thenThrow(exception);
+        when(mockS3Client.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenThrow(exception);
         run();
         runner.assertTransferCount(GetS3ObjectMetadata.REL_FAILURE, 1);
     }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestGetS3ObjectMetadata.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestGetS3ObjectMetadata.java
@@ -26,6 +26,7 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processors.aws.s3.api.MetadataTarget;
 import org.apache.nifi.processors.aws.testutil.AuthUtils;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
@@ -100,7 +101,7 @@ class TestGetS3ObjectMetadata {
     @DisplayName("Validate fetch metadata to attribute routes to found when the file exists")
     @Test
     void testFetchMetadataToAttributeExists() {
-        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_ATTRIBUTES.getValue());
+        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, MetadataTarget.ATTRIBUTES);
         runner.setProperty(GetS3ObjectMetadata.ATTRIBUTE_INCLUDE_PATTERN, "");
 
         Map<String, Object> combined = setupObjectMetadata();
@@ -118,7 +119,7 @@ class TestGetS3ObjectMetadata {
     @DisplayName("Validate attribution exclusion")
     @Test
     void testFetchMetadataToAttributeExclusion() {
-        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_ATTRIBUTES.getValue());
+        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, MetadataTarget.ATTRIBUTES);
         runner.setProperty(GetS3ObjectMetadata.ATTRIBUTE_INCLUDE_PATTERN, "(raw|user)");
 
         Map<String, Object> metadata = setupObjectMetadata();
@@ -144,7 +145,7 @@ class TestGetS3ObjectMetadata {
         AmazonS3Exception exception = new AmazonS3Exception("test");
         exception.setStatusCode(501);
 
-        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_ATTRIBUTES.getValue());
+        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, MetadataTarget.ATTRIBUTES);
         when(mockS3Client.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenThrow(exception);
         run();
         runner.assertTransferCount(GetS3ObjectMetadata.REL_FAILURE, 1);
@@ -156,7 +157,7 @@ class TestGetS3ObjectMetadata {
         AmazonS3Exception exception = new AmazonS3Exception("test");
         exception.setStatusCode(404);
 
-        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_ATTRIBUTES.getValue());
+        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, MetadataTarget.ATTRIBUTES);
         when(mockS3Client.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenThrow(exception);
         run();
         runner.assertTransferCount(GetS3ObjectMetadata.REL_NOT_FOUND, 1);
@@ -165,7 +166,7 @@ class TestGetS3ObjectMetadata {
     @DisplayName("Validate fetch metadata to FlowFile body routes to found when the file exists")
     @Test
     void testFetchMetadataToBodyExists() {
-        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_FLOWFILE_BODY.getValue());
+        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, MetadataTarget.FLOWFILE_BODY);
         when(mockS3Client.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenReturn(mockMetadata);
         run();
         runner.assertTransferCount(GetS3ObjectMetadata.REL_FOUND, 1);
@@ -177,7 +178,7 @@ class TestGetS3ObjectMetadata {
         AmazonS3Exception exception = new AmazonS3Exception("test");
         exception.setStatusCode(404);
 
-        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_FLOWFILE_BODY.getValue());
+        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, MetadataTarget.FLOWFILE_BODY);
         when(mockS3Client.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenThrow(exception);
         run();
         runner.assertTransferCount(GetS3ObjectMetadata.REL_NOT_FOUND, 1);
@@ -189,7 +190,7 @@ class TestGetS3ObjectMetadata {
         AmazonS3Exception exception = new AmazonS3Exception("test");
         exception.setStatusCode(501);
 
-        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, GetS3ObjectMetadata.TARGET_FLOWFILE_BODY.getValue());
+        runner.setProperty(GetS3ObjectMetadata.METADATA_TARGET, MetadataTarget.FLOWFILE_BODY);
         when(mockS3Client.getObjectMetadata(any(GetObjectMetadataRequest.class))).thenThrow(exception);
         run();
         runner.assertTransferCount(GetS3ObjectMetadata.REL_FAILURE, 1);

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestGetS3ObjectTags.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestGetS3ObjectTags.java
@@ -27,6 +27,7 @@ import com.amazonaws.services.s3.model.GetObjectTaggingRequest;
 import com.amazonaws.services.s3.model.GetObjectTaggingResult;
 import com.amazonaws.services.s3.model.Tag;
 import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processors.aws.s3.api.TagsTarget;
 import org.apache.nifi.processors.aws.testutil.AuthUtils;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
@@ -92,7 +93,7 @@ class TestGetS3ObjectTags {
     @DisplayName("Validate fetch tags to attribute routes to found when the file exists")
     @Test
     void testFetchTagsToAttributeExists() {
-        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_ATTRIBUTES.getValue());
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, TagsTarget.ATTRIBUTES);
         runner.setProperty(GetS3ObjectTags.ATTRIBUTE_INCLUDE_PATTERN, "");
 
         final List<Tag> tags = setupObjectTags();
@@ -111,7 +112,7 @@ class TestGetS3ObjectTags {
     @DisplayName("Validate attribute exclusion")
     @Test
     void testFetchTagsToAttributeExclusion() {
-        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_ATTRIBUTES.getValue());
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, TagsTarget.ATTRIBUTES);
         runner.setProperty(GetS3ObjectTags.ATTRIBUTE_INCLUDE_PATTERN, "(raw|user)");
 
         final List<Tag> tags = setupObjectTags();
@@ -136,7 +137,7 @@ class TestGetS3ObjectTags {
         final AmazonS3Exception exception = new AmazonS3Exception("test");
         exception.setStatusCode(501);
 
-        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_ATTRIBUTES.getValue());
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, TagsTarget.ATTRIBUTES);
         when(mockS3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenThrow(exception);
         run();
 
@@ -149,7 +150,7 @@ class TestGetS3ObjectTags {
         final AmazonS3Exception exception = new AmazonS3Exception("test");
         exception.setStatusCode(404);
 
-        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_ATTRIBUTES.getValue());
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, TagsTarget.ATTRIBUTES);
         when(mockS3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenThrow(exception);
         run();
 
@@ -159,7 +160,7 @@ class TestGetS3ObjectTags {
     @DisplayName("Validate fetch tags to FlowFile body routes to found when the file exists")
     @Test
     void testFetchTagsToBodyExists() {
-        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_FLOWFILE_BODY.getValue());
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, TagsTarget.FLOWFILE_BODY);
         when(mockS3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenReturn(mockTags);
         run();
 
@@ -172,7 +173,7 @@ class TestGetS3ObjectTags {
         final AmazonS3Exception exception = new AmazonS3Exception("test");
         exception.setStatusCode(404);
 
-        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_FLOWFILE_BODY.getValue());
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, TagsTarget.FLOWFILE_BODY);
         when(mockS3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenThrow(exception);
         run();
 
@@ -185,7 +186,7 @@ class TestGetS3ObjectTags {
         final AmazonS3Exception exception = new AmazonS3Exception("test");
         exception.setStatusCode(501);
 
-        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_FLOWFILE_BODY.getValue());
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, TagsTarget.FLOWFILE_BODY);
         when(mockS3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenThrow(exception);
         run();
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestGetS3ObjectTags.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/s3/TestGetS3ObjectTags.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.processors.aws.s3;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Region;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.GetObjectTaggingRequest;
+import com.amazonaws.services.s3.model.GetObjectTaggingResult;
+import com.amazonaws.services.s3.model.Tag;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processors.aws.testutil.AuthUtils;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestGetS3ObjectTags {
+    private TestRunner runner;
+
+    private AmazonS3Client mockS3Client;
+
+    private GetObjectTaggingResult mockTags;
+
+    @BeforeEach
+    void setUp() {
+        mockS3Client = mock(AmazonS3Client.class);
+        GetS3ObjectTags mockGetS3ObjectTags = new GetS3ObjectTags() {
+            @Override
+            protected AmazonS3Client createClient(final ProcessContext context, final AWSCredentialsProvider credentialsProvider, final Region region, final ClientConfiguration config,
+                                                  final AwsClientBuilder.EndpointConfiguration endpointConfiguration) {
+                return mockS3Client;
+            }
+        };
+        runner = TestRunners.newTestRunner(mockGetS3ObjectTags);
+        AuthUtils.enableAccessKey(runner, "accessKeyId", "secretKey");
+
+        mockTags = mock(GetObjectTaggingResult.class);
+        List<Tag> tags = List.of(new Tag("foo", "bar"), new Tag("zip", "zap"));
+        when(mockTags.getTagSet()).thenReturn(tags);
+    }
+
+    private void run() {
+        runner.setProperty(GetS3ObjectTags.BUCKET_WITH_DEFAULT_VALUE, "${s3.bucket}");
+        runner.setProperty(GetS3ObjectTags.KEY, "${filename}");
+
+        runner.setProperty(GetS3ObjectTags.VERSION_ID, "${versionId}");
+        runner.enqueue("", Map.of("s3.bucket", "test-data", "filename", "test.txt", "versionId", "a-version"));
+
+        runner.run();
+    }
+
+    private List<Tag> setupObjectTags() {
+        final List<Tag> rawTags = List.of(new Tag("raw1", "x"), new Tag("user2", "y"), new Tag("mightHaveTo", "z"));
+
+        when(mockTags.getTagSet()).thenReturn(rawTags);
+
+        when(mockS3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenReturn(mockTags);
+
+        return rawTags;
+    }
+
+    @DisplayName("Validate fetch tags to attribute routes to found when the file exists")
+    @Test
+    void testFetchTagsToAttributeExists() {
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_ATTRIBUTES.getValue());
+        runner.setProperty(GetS3ObjectTags.ATTRIBUTE_INCLUDE_PATTERN, "");
+
+        final List<Tag> tags = setupObjectTags();
+
+        run();
+        runner.assertTransferCount(GetS3ObjectTags.REL_FOUND, 1);
+
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(GetS3ObjectTags.REL_FOUND).getFirst();
+        tags.forEach(tag -> {
+            final String key = String.format("s3.tag.%s", tag.getKey());
+            final String val = flowFile.getAttribute(key);
+            assertEquals(tag.getValue(), val);
+        });
+    }
+
+    @DisplayName("Validate attribute exclusion")
+    @Test
+    void testFetchTagsToAttributeExclusion() {
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_ATTRIBUTES.getValue());
+        runner.setProperty(GetS3ObjectTags.ATTRIBUTE_INCLUDE_PATTERN, "(raw|user)");
+
+        final List<Tag> tags = setupObjectTags();
+        final List<Tag> mustHave = tags.stream().filter(tag -> !"mightHaveTo".equals(tag.getKey())).toList();
+
+        run();
+        runner.assertTransferCount(GetS3ObjectTags.REL_FOUND, 1);
+
+        final MockFlowFile flowFile = runner.getFlowFilesForRelationship(GetS3ObjectTags.REL_FOUND).getFirst();
+        mustHave.forEach(tag -> {
+            final String key = String.format("s3.tag.%s", tag.getKey());
+            final String val = flowFile.getAttribute(key);
+            assertEquals(tag.getValue(), val);
+        });
+
+        assertNull(flowFile.getAttribute("s3.tag.mightHaveTo"));
+    }
+
+    @DisplayName("Validate fetch to attribute mode routes to failure on S3 error")
+    @Test
+    void testFetchTagsToAttributeS3Error() {
+        final AmazonS3Exception exception = new AmazonS3Exception("test");
+        exception.setStatusCode(501);
+
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_ATTRIBUTES.getValue());
+        when(mockS3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenThrow(exception);
+        run();
+
+        runner.assertTransferCount(GetS3ObjectTags.REL_FAILURE, 1);
+    }
+
+    @DisplayName("Validate fetch tags to attribute routes to not-found when when the file doesn't exist")
+    @Test
+    void testFetchTagsToAttributeNotExist() {
+        final AmazonS3Exception exception = new AmazonS3Exception("test");
+        exception.setStatusCode(404);
+
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_ATTRIBUTES.getValue());
+        when(mockS3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenThrow(exception);
+        run();
+
+        runner.assertTransferCount(GetS3ObjectTags.REL_NOT_FOUND, 1);
+    }
+
+    @DisplayName("Validate fetch tags to FlowFile body routes to found when the file exists")
+    @Test
+    void testFetchTagsToBodyExists() {
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_FLOWFILE_BODY.getValue());
+        when(mockS3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenReturn(mockTags);
+        run();
+
+        runner.assertTransferCount(GetS3ObjectTags.REL_FOUND, 1);
+    }
+
+    @DisplayName("Validate fetch tags to FlowFile body routes to not-found when when the file doesn't exist")
+    @Test
+    void testFetchTagsToBodyNotExist() {
+        final AmazonS3Exception exception = new AmazonS3Exception("test");
+        exception.setStatusCode(404);
+
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_FLOWFILE_BODY.getValue());
+        when(mockS3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenThrow(exception);
+        run();
+
+        runner.assertTransferCount(GetS3ObjectTags.REL_NOT_FOUND, 1);
+    }
+
+    @DisplayName("Validate fetch to FlowFile body mode routes to failure on S3 error")
+    @Test
+    void testFetchTagsToBodyS3Error() {
+        final AmazonS3Exception exception = new AmazonS3Exception("test");
+        exception.setStatusCode(501);
+
+        runner.setProperty(GetS3ObjectTags.TAGS_TARGET, GetS3ObjectTags.TARGET_FLOWFILE_BODY.getValue());
+        when(mockS3Client.getObjectTagging(any(GetObjectTaggingRequest.class))).thenThrow(exception);
+        run();
+
+        runner.assertTransferCount(GetS3ObjectTags.REL_FAILURE, 1);
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14288](https://issues.apache.org/jira/browse/NIFI-14288) fetch S3 Object Tags

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- ~[ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)~
- ~[ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files~

### Documentation

- ~[ ] Documentation formatting appears as expected in rendered files~
