### PR TITLE
NIFI-14284 ConsumeKinesisStream migrate property names to new convention

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -171,7 +171,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     static final PropertyDescriptor KINESIS_STREAM_NAME = new PropertyDescriptor.Builder()
             .name("Amazon Kinesis Stream Name")
-            .displayName("Amazon Kinesis Stream Name")
             .description("The name of Kinesis Stream")
             .required(true)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
@@ -179,14 +178,12 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor APPLICATION_NAME = new PropertyDescriptor.Builder()
             .name("Application Name")
-            .displayName("Application Name")
             .description("The Kinesis stream reader application name.")
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .required(true).build();
 
     public static final PropertyDescriptor INITIAL_STREAM_POSITION = new PropertyDescriptor.Builder()
             .name("Initial Stream Position")
-            .displayName("Initial Stream Position")
             .description("Initial position to read Kinesis streams.")
             .allowableValues(LATEST, TRIM_HORIZON, AT_TIMESTAMP)
             .defaultValue(LATEST.getValue())
@@ -194,7 +191,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor STREAM_POSITION_TIMESTAMP = new PropertyDescriptor.Builder()
             .name("Stream Position Timestamp")
-            .displayName("Stream Position Timestamp")
             .description("Timestamp position in stream from which to start reading Kinesis Records. " +
                     "Required if " + INITIAL_STREAM_POSITION.getDescription() + " is " + AT_TIMESTAMP.getDisplayName() + ". " +
                     "Uses the Timestamp Format to parse value into a Date.")
@@ -204,7 +200,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor TIMESTAMP_FORMAT = new PropertyDescriptor.Builder()
             .name("Timestamp Format")
-            .displayName("Timestamp Format")
             .description("Format to use for parsing the " + STREAM_POSITION_TIMESTAMP.getDisplayName() + " into a Date " +
                     "and converting the Kinesis Record's Approximate Arrival Timestamp into a FlowFile attribute.")
             .addValidator((subject, input, context) -> {
@@ -225,7 +220,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor FAILOVER_TIMEOUT = new PropertyDescriptor.Builder()
             .name("Failover Timeout")
-            .displayName("Failover Timeout")
             .description("Kinesis Client Library failover timeout")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("30 secs")
@@ -233,7 +227,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor GRACEFUL_SHUTDOWN_TIMEOUT = new PropertyDescriptor.Builder()
             .name("Graceful Shutdown Timeout")
-            .displayName("Graceful Shutdown Timeout")
             .description("Kinesis Client Library graceful shutdown timeout")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("20 secs")
@@ -241,7 +234,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor CHECKPOINT_INTERVAL = new PropertyDescriptor.Builder()
             .name("Checkpoint Interval")
-            .displayName("Checkpoint Interval")
             .description("Interval between Kinesis checkpoints")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("3 secs")
@@ -249,7 +241,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor NUM_RETRIES = new PropertyDescriptor.Builder()
             .name("Retry Count")
-            .displayName("Retry Count")
             .description("Number of times to retry a Kinesis operation (process record, checkpoint, shutdown)")
             .addValidator(StandardValidators.INTEGER_VALIDATOR)
             .defaultValue("10")
@@ -257,7 +248,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor RETRY_WAIT = new PropertyDescriptor.Builder()
             .name("Retry Wait")
-            .displayName("Retry Wait")
             .description("Interval between Kinesis operation retries (process record, checkpoint, shutdown)")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("1 sec")
@@ -265,7 +255,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor DYNAMODB_ENDPOINT_OVERRIDE = new PropertyDescriptor.Builder()
             .name("DynamoDB Override")
-            .displayName("DynamoDB Override")
             .description("DynamoDB override to use non-AWS deployments")
             .addValidator(StandardValidators.URL_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -273,7 +262,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor REPORT_CLOUDWATCH_METRICS = new PropertyDescriptor.Builder()
             .name("Report Metrics to CloudWatch")
-            .displayName("Report Metrics to CloudWatch")
             .description("Whether to report Kinesis usage metrics to CloudWatch.")
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .allowableValues("true", "false")
@@ -282,7 +270,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor RECORD_READER = new PropertyDescriptor.Builder()
             .name("Record Reader")
-            .displayName("Record Reader")
             .description("The Record Reader to use for reading received messages." +
                     " The Kinesis Stream name can be referred to by Expression Language '${" +
                     AbstractKinesisRecordProcessor.KINESIS_RECORD_SCHEMA_KEY + "}' to access a schema." +
@@ -294,7 +281,6 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
 
     public static final PropertyDescriptor RECORD_WRITER = new PropertyDescriptor.Builder()
             .name("Record Writer")
-            .displayName("Record Writer")
             .description("The Record Writer to use for serializing Records to an output FlowFile." +
                     " The Kinesis Stream name can be referred to by Expression Language '${" +
                     AbstractKinesisRecordProcessor.KINESIS_RECORD_SCHEMA_KEY + "}' to access a schema." +

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -41,6 +41,7 @@ import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.ProcessSessionFactory;
@@ -169,7 +170,7 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
     );
 
     static final PropertyDescriptor KINESIS_STREAM_NAME = new PropertyDescriptor.Builder()
-            .name("kinesis-stream-name")
+            .name("Amazon Kinesis Stream Name")
             .displayName("Amazon Kinesis Stream Name")
             .description("The name of Kinesis Stream")
             .required(true)
@@ -177,23 +178,23 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
             .build();
 
     public static final PropertyDescriptor APPLICATION_NAME = new PropertyDescriptor.Builder()
+            .name("Application Name")
             .displayName("Application Name")
-            .name("amazon-kinesis-stream-application-name")
             .description("The Kinesis stream reader application name.")
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .required(true).build();
 
     public static final PropertyDescriptor INITIAL_STREAM_POSITION = new PropertyDescriptor.Builder()
+            .name("Initial Stream Position")
             .displayName("Initial Stream Position")
-            .name("amazon-kinesis-stream-initial-position")
             .description("Initial position to read Kinesis streams.")
             .allowableValues(LATEST, TRIM_HORIZON, AT_TIMESTAMP)
             .defaultValue(LATEST.getValue())
             .required(true).build();
 
     public static final PropertyDescriptor STREAM_POSITION_TIMESTAMP = new PropertyDescriptor.Builder()
+            .name("Stream Position Timestamp")
             .displayName("Stream Position Timestamp")
-            .name("amazon-kinesis-stream-position-timestamp")
             .description("Timestamp position in stream from which to start reading Kinesis Records. " +
                     "Required if " + INITIAL_STREAM_POSITION.getDescription() + " is " + AT_TIMESTAMP.getDisplayName() + ". " +
                     "Uses the Timestamp Format to parse value into a Date.")
@@ -202,8 +203,8 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
             .required(false).build();
 
     public static final PropertyDescriptor TIMESTAMP_FORMAT = new PropertyDescriptor.Builder()
+            .name("Timestamp Format")
             .displayName("Timestamp Format")
-            .name("amazon-kinesis-stream-timestamp-format")
             .description("Format to use for parsing the " + STREAM_POSITION_TIMESTAMP.getDisplayName() + " into a Date " +
                     "and converting the Kinesis Record's Approximate Arrival Timestamp into a FlowFile attribute.")
             .addValidator((subject, input, context) -> {
@@ -223,56 +224,56 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
             .required(true).build();
 
     public static final PropertyDescriptor FAILOVER_TIMEOUT = new PropertyDescriptor.Builder()
+            .name("Failover Timeout")
             .displayName("Failover Timeout")
-            .name("amazon-kinesis-stream-failover-timeout")
             .description("Kinesis Client Library failover timeout")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("30 secs")
             .required(true).build();
 
     public static final PropertyDescriptor GRACEFUL_SHUTDOWN_TIMEOUT = new PropertyDescriptor.Builder()
+            .name("Graceful Shutdown Timeout")
             .displayName("Graceful Shutdown Timeout")
-            .name("amazon-kinesis-stream-graceful-shutdown-timeout")
             .description("Kinesis Client Library graceful shutdown timeout")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("20 secs")
             .required(true).build();
 
     public static final PropertyDescriptor CHECKPOINT_INTERVAL = new PropertyDescriptor.Builder()
+            .name("Checkpoint Interval")
             .displayName("Checkpoint Interval")
-            .name("amazon-kinesis-stream-checkpoint-interval")
             .description("Interval between Kinesis checkpoints")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("3 secs")
             .required(true).build();
 
     public static final PropertyDescriptor NUM_RETRIES = new PropertyDescriptor.Builder()
+            .name("Retry Count")
             .displayName("Retry Count")
-            .name("amazon-kinesis-stream-retry-count")
             .description("Number of times to retry a Kinesis operation (process record, checkpoint, shutdown)")
             .addValidator(StandardValidators.INTEGER_VALIDATOR)
             .defaultValue("10")
             .required(true).build();
 
     public static final PropertyDescriptor RETRY_WAIT = new PropertyDescriptor.Builder()
+            .name("Retry Wait")
             .displayName("Retry Wait")
-            .name("amazon-kinesis-stream-retry-wait")
             .description("Interval between Kinesis operation retries (process record, checkpoint, shutdown)")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .defaultValue("1 sec")
             .required(true).build();
 
     public static final PropertyDescriptor DYNAMODB_ENDPOINT_OVERRIDE = new PropertyDescriptor.Builder()
+            .name("DynamoDB Override")
             .displayName("DynamoDB Override")
-            .name("amazon-kinesis-stream-dynamodb-override")
             .description("DynamoDB override to use non-AWS deployments")
             .addValidator(StandardValidators.URL_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .required(false).build();
 
     public static final PropertyDescriptor REPORT_CLOUDWATCH_METRICS = new PropertyDescriptor.Builder()
+            .name("Report Metrics to CloudWatch")
             .displayName("Report Metrics to CloudWatch")
-            .name("amazon-kinesis-stream-cloudwatch-flag")
             .description("Whether to report Kinesis usage metrics to CloudWatch.")
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .allowableValues("true", "false")
@@ -280,7 +281,7 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
             .required(true).build();
 
     public static final PropertyDescriptor RECORD_READER = new PropertyDescriptor.Builder()
-            .name("amazon-kinesis-stream-record-reader")
+            .name("Record Reader")
             .displayName("Record Reader")
             .description("The Record Reader to use for reading received messages." +
                     " The Kinesis Stream name can be referred to by Expression Language '${" +
@@ -292,7 +293,7 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
             .build();
 
     public static final PropertyDescriptor RECORD_WRITER = new PropertyDescriptor.Builder()
-            .name("amazon-kinesis-stream-record-writer")
+            .name("Record Writer")
             .displayName("Record Writer")
             .description("The Record Writer to use for serializing Records to an output FlowFile." +
                     " The Kinesis Stream name can be referred to by Expression Language '${" +
@@ -403,6 +404,24 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
         } else if (RECORD_WRITER.equals(descriptor)) {
             isRecordWriterSet = StringUtils.isNotEmpty(newValue);
         }
+    }
+
+    @Override
+    public void migrateProperties(final PropertyConfiguration config) {
+        config.renameProperty("kinesis-stream-name", "Amazon Kinesis Stream Name");
+        config.renameProperty("amazon-kinesis-stream-application-name", "Application Name");
+        config.renameProperty("amazon-kinesis-stream-initial-position", "Initial Stream Position");
+        config.renameProperty("amazon-kinesis-stream-position-timestamp", "Stream Position Timestamp");
+        config.renameProperty("amazon-kinesis-stream-timestamp-format", "Timestamp Format");
+        config.renameProperty("amazon-kinesis-stream-failover-timeout", "Failover Timeout");
+        config.renameProperty("amazon-kinesis-stream-graceful-shutdown-timeout", "Graceful Shutdown Timeout");
+        config.renameProperty("amazon-kinesis-stream-checkpoint-interval", "Checkpoint Interval");
+        config.renameProperty("amazon-kinesis-stream-retry-count", "Retry Count");
+        config.renameProperty("amazon-kinesis-stream-retry-wait", "Retry Wait");
+        config.renameProperty("amazon-kinesis-stream-dynamodb-override", "DynamoDB Override");
+        config.renameProperty("amazon-kinesis-stream-cloudwatch-flag", "Report Metrics to CloudWatch");
+        config.renameProperty("amazon-kinesis-stream-record-reader", "Record Reader");
+        config.renameProperty("amazon-kinesis-stream-record-writer", "Record Writer");
     }
 
     @Override
@@ -833,8 +852,8 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
         final String streamTimestamp = context.getProperty(STREAM_POSITION_TIMESTAMP).getValue();
         return new Date(
                 LocalDateTime.parse(streamTimestamp, dateTimeFormatter).atZone(ZoneId.systemDefault()) // parse date/time with system timezone
-                .withZoneSameInstant(ZoneOffset.UTC) // convert to UTC
-                .toInstant().toEpochMilli() // convert to epoch milliseconds for creating Date
+                        .withZoneSameInstant(ZoneOffset.UTC) // convert to UTC
+                        .toInstant().toEpochMilli() // convert to epoch milliseconds for creating Date
         );
     }
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -838,8 +838,8 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
         final String streamTimestamp = context.getProperty(STREAM_POSITION_TIMESTAMP).getValue();
         return new Date(
                 LocalDateTime.parse(streamTimestamp, dateTimeFormatter).atZone(ZoneId.systemDefault()) // parse date/time with system timezone
-                        .withZoneSameInstant(ZoneOffset.UTC) // convert to UTC
-                        .toInstant().toEpochMilli() // convert to epoch milliseconds for creating Date
+                    .withZoneSameInstant(ZoneOffset.UTC) // convert to UTC
+                    .toInstant().toEpochMilli() // convert to epoch milliseconds for creating Date
         );
     }
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -838,8 +838,8 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
         final String streamTimestamp = context.getProperty(STREAM_POSITION_TIMESTAMP).getValue();
         return new Date(
                 LocalDateTime.parse(streamTimestamp, dateTimeFormatter).atZone(ZoneId.systemDefault()) // parse date/time with system timezone
-                    .withZoneSameInstant(ZoneOffset.UTC) // convert to UTC
-                    .toInstant().toEpochMilli() // convert to epoch milliseconds for creating Date
+                .withZoneSameInstant(ZoneOffset.UTC) // convert to UTC
+                .toInstant().toEpochMilli() // convert to epoch milliseconds for creating Date
         );
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14284](https://issues.apache.org/jira/browse/NIFI-14284)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-14284`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-14284`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] (no new) New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] (no new) New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] (no changes) Documentation formatting appears as expected in rendered files
