### PR TITLE
NIFI-14099 Adjust GetHDFSTest to use TempDir for test files

### DIFF
--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/GetHDFSTest.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/GetHDFSTest.java
@@ -23,21 +23,24 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.ProcessContext;
-import org.apache.nifi.provenance.ProvenanceEventRecord;
-import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.ietf.jgss.GSSException;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.PrivilegedExceptionAction;
 import java.util.Collection;
 import java.util.HashSet;
@@ -54,6 +57,21 @@ import static org.mockito.Mockito.when;
 
 @DisabledOnOs(OS.WINDOWS)
 public class GetHDFSTest {
+
+    private static final String TESTDATA_SOURCE_DIR = "src/test/resources/testdata";
+
+    @TempDir
+    private static File tempDir;
+
+    @BeforeAll
+    static void setTestData() throws IOException {
+        final File sourceDir = Paths.get(TESTDATA_SOURCE_DIR).toFile();
+        final File[] sourceFiles = sourceDir.listFiles();
+        for (final File sourceFile : sourceFiles) {
+            final File destinationFile = new File(tempDir, sourceFile.getName());
+            Files.copy(sourceFile.toPath(), destinationFile.toPath());
+        }
+    }
 
     @Test
     public void getPathDifferenceTest() {
@@ -130,7 +148,7 @@ public class GetHDFSTest {
     public void testGetFilesWithFilter() {
         GetHDFS proc = new GetHDFS();
         TestRunner runner = TestRunners.newTestRunner(proc);
-        runner.setProperty(PutHDFS.DIRECTORY, "src/test/resources/testdata");
+        runner.setProperty(PutHDFS.DIRECTORY, tempDir.getAbsolutePath());
         runner.setProperty(GetHDFS.FILE_FILTER_REGEX, "random.*");
         runner.setProperty(GetHDFS.KEEP_SOURCE_FILE, "true");
         runner.run();
@@ -156,7 +174,7 @@ public class GetHDFSTest {
     public void testAutomaticDecompression() throws IOException {
         GetHDFS proc = new GetHDFS();
         TestRunner runner = TestRunners.newTestRunner(proc);
-        runner.setProperty(PutHDFS.DIRECTORY, "src/test/resources/testdata");
+        runner.setProperty(PutHDFS.DIRECTORY, tempDir.getAbsolutePath());
         runner.setProperty(GetHDFS.FILE_FILTER_REGEX, "random.*.gz");
         runner.setProperty(GetHDFS.KEEP_SOURCE_FILE, "true");
         runner.setProperty(GetHDFS.COMPRESSION_CODEC, "AUTOMATIC");
@@ -175,7 +193,7 @@ public class GetHDFSTest {
     public void testInferCompressionCodecDisabled() throws IOException {
         GetHDFS proc = new GetHDFS();
         TestRunner runner = TestRunners.newTestRunner(proc);
-        runner.setProperty(PutHDFS.DIRECTORY, "src/test/resources/testdata");
+        runner.setProperty(PutHDFS.DIRECTORY, tempDir.getAbsolutePath());
         runner.setProperty(GetHDFS.FILE_FILTER_REGEX, "random.*.gz");
         runner.setProperty(GetHDFS.KEEP_SOURCE_FILE, "true");
         runner.setProperty(GetHDFS.COMPRESSION_CODEC, "NONE");
@@ -194,7 +212,7 @@ public class GetHDFSTest {
     public void testFileExtensionNotACompressionCodec() throws IOException {
         GetHDFS proc = new GetHDFS();
         TestRunner runner = TestRunners.newTestRunner(proc);
-        runner.setProperty(PutHDFS.DIRECTORY, "src/test/resources/testdata");
+        runner.setProperty(PutHDFS.DIRECTORY, tempDir.getAbsolutePath());
         runner.setProperty(GetHDFS.FILE_FILTER_REGEX, ".*.zip");
         runner.setProperty(GetHDFS.KEEP_SOURCE_FILE, "true");
         runner.setProperty(GetHDFS.COMPRESSION_CODEC, "AUTOMATIC");
@@ -207,31 +225,6 @@ public class GetHDFSTest {
         assertEquals("13545423550275052.zip", flowFile.getAttribute(CoreAttributes.FILENAME.key()));
         InputStream expected = getClass().getResourceAsStream("/testdata/13545423550275052.zip");
         flowFile.assertContentEquals(expected);
-    }
-
-    @Test
-    public void testDirectoryUsesValidEL() throws IOException {
-        GetHDFS proc = new GetHDFS();
-        TestRunner runner = TestRunners.newTestRunner(proc);
-        runner.setProperty(PutHDFS.DIRECTORY, "src/test/resources/${literal('testdata'):substring(0,8)}");
-        runner.setProperty(GetHDFS.FILE_FILTER_REGEX, ".*.zip");
-        runner.setProperty(GetHDFS.KEEP_SOURCE_FILE, "true");
-        runner.setProperty(GetHDFS.COMPRESSION_CODEC, "AUTOMATIC");
-        runner.run();
-
-        List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(GetHDFS.REL_SUCCESS);
-        assertEquals(1, flowFiles.size());
-
-        MockFlowFile flowFile = flowFiles.get(0);
-        assertEquals("13545423550275052.zip", flowFile.getAttribute(CoreAttributes.FILENAME.key()));
-        InputStream expected = getClass().getResourceAsStream("/testdata/13545423550275052.zip");
-        flowFile.assertContentEquals(expected);
-        final List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();
-        assertEquals(1, provenanceEvents.size());
-        final ProvenanceEventRecord receiveEvent = provenanceEvents.get(0);
-        assertEquals(ProvenanceEventType.RECEIVE, receiveEvent.getEventType());
-        // If it runs with a real HDFS, the protocol will be "hdfs://", but with a local filesystem, just assert the filename.
-        assertTrue(receiveEvent.getTransitUri().endsWith("13545423550275052.zip"));
     }
 
     @Test
@@ -281,7 +274,7 @@ public class GetHDFSTest {
 
         GetHDFS testSubject = new TestableGetHDFSForUGI(mockFileSystem, mockUserGroupInformation);
         TestRunner runner = TestRunners.newTestRunner(testSubject);
-        runner.setProperty(GetHDFS.DIRECTORY, "src/test/resources/testdata");
+        runner.setProperty(GetHDFS.DIRECTORY, tempDir.getAbsolutePath());
 
         // WHEN
         Answer<?> answer = new Answer<>() {
@@ -319,7 +312,7 @@ public class GetHDFSTest {
 
         GetHDFS testSubject = new TestableGetHDFSForUGI(mockFileSystem, mockUserGroupInformation);
         TestRunner runner = TestRunners.newTestRunner(testSubject);
-        runner.setProperty(GetHDFS.DIRECTORY, "src/test/resources/testdata");
+        runner.setProperty(GetHDFS.DIRECTORY, tempDir.getAbsolutePath());
         when(mockUserGroupInformation.doAs(any(PrivilegedExceptionAction.class))).thenThrow(new IOException(new GSSException(13)));
         runner.run();
 

--- a/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/GetHDFSTest.java
+++ b/nifi-extension-bundles/nifi-hadoop-bundle/nifi-hdfs-processors/src/test/java/org/apache/nifi/processors/hadoop/GetHDFSTest.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.provenance.ProvenanceEventRecord;
+import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.TestRunner;
@@ -225,6 +227,13 @@ public class GetHDFSTest {
         assertEquals("13545423550275052.zip", flowFile.getAttribute(CoreAttributes.FILENAME.key()));
         InputStream expected = getClass().getResourceAsStream("/testdata/13545423550275052.zip");
         flowFile.assertContentEquals(expected);
+
+        final List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();
+        assertEquals(1, provenanceEvents.size());
+        final ProvenanceEventRecord receiveEvent = provenanceEvents.getFirst();
+        assertEquals(ProvenanceEventType.RECEIVE, receiveEvent.getEventType());
+        // If it runs with a real HDFS, the protocol will be "hdfs://", but with a local filesystem, just assert the filename.
+        assertTrue(receiveEvent.getTransitUri().endsWith("13545423550275052.zip"));
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-14099](https://issues.apache.org/jira/browse/NIFI-14099) Adjusts the behavior of `GetHDFSTest` to use the JUnit `TempDir` annotated path for the source of reading files. This approach avoids depending on the timestamp of files located in the source directory itself, making the tests more reliable based on expected creation times.

Additional changes include removing a duplicative test for a directory defined using expression language in the property value.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
