### PR TITLE
NIFI-14111 Add a check to WriteAheadStorePartition

### DIFF
--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/WriteAheadStorePartition.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/store/WriteAheadStorePartition.java
@@ -76,7 +76,7 @@ public class WriteAheadStorePartition implements EventStorePartition {
     private final EventFileManager eventFileManager;
     private volatile boolean closed = false;
 
-    private AtomicReference<RecordWriterLease> eventWriterLeaseRef = new AtomicReference<>();
+    private final AtomicReference<RecordWriterLease> eventWriterLeaseRef = new AtomicReference<>();
 
     private final SortedMap<Long, File> minEventIdToPathMap = new TreeMap<>();  // guarded by synchronizing on object
 
@@ -561,7 +561,7 @@ public class WriteAheadStorePartition implements EventStorePartition {
 
         eventFileManager.obtainWriteLock(file);
         try {
-            if (!file.delete()) {
+            if (file.exists() && !file.delete()) {
                 logger.warn("Failed to remove Provenance Event file {}; this file should be cleaned up manually", file);
                 return false;
             }
@@ -617,11 +617,7 @@ public class WriteAheadStorePartition implements EventStorePartition {
         int fileCount = 0;
         for (final File eventFile : eventFilesToReindex) {
             final boolean skipToEvent;
-            if (fileCount++ == 0) {
-                skipToEvent = true;
-            } else {
-                skipToEvent = false;
-            }
+            skipToEvent = fileCount++ == 0;
 
             final Runnable reindexTask = () -> {
                 final Map<ProvenanceEventRecord, StorageSummary> storageMap = new HashMap<>(1000);
@@ -702,7 +698,7 @@ public class WriteAheadStorePartition implements EventStorePartition {
         // within the given time range. If we then reach a file whose first event comes before our minTimestamp,
         // this means that all other files that we later encounter will have a max timestamp that comes before
         // our earliest event time, so we can stop adding files at that point.
-        final List<File> eventFiles = getEventFilesFromDisk().sorted(DirectoryUtils.LARGEST_ID_FIRST).collect(Collectors.toList());
+        final List<File> eventFiles = getEventFilesFromDisk().sorted(DirectoryUtils.LARGEST_ID_FIRST).toList();
         if (eventFiles.isEmpty()) {
             return EventIterator.EMPTY;
         }


### PR DESCRIPTION
Add a check to WriteAheadStorePartition to see if the file exists before logging a message and deleting

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14111](https://issues.apache.org/jira/browse/NIFI-14111)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [X] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [X] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
