### PR TITLE
NIFI-14271 - dynamic property support in Kafka3ConnectionService

### DIFF
--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/AbstractKafkaBaseIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/AbstractKafkaBaseIT.java
@@ -38,6 +38,11 @@ public abstract class AbstractKafkaBaseIT {
 
     protected static final String IMAGE_NAME = "confluentinc/cp-kafka:7.6.1";  // April 2024
 
+    private static final String DYNAMIC_PROPERTY_KEY_PUBLISH = "delivery.timeout.ms";
+    private static final String DYNAMIC_PROPERTY_VALUE_PUBLISH = "60000";
+    private static final String DYNAMIC_PROPERTY_KEY_CONSUME = "fetch.max.wait.ms";
+    private static final String DYNAMIC_PROPERTY_VALUE_CONSUME = "1000";
+
     protected static final long TIMESTAMP = System.currentTimeMillis();
 
     protected static final String CONNECTION_SERVICE_ID = Kafka3ConnectionService.class.getSimpleName();
@@ -64,6 +69,8 @@ public abstract class AbstractKafkaBaseIT {
         runner.addControllerService(CONNECTION_SERVICE_ID, connectionService);
         runner.setProperty(connectionService, Kafka3ConnectionService.BOOTSTRAP_SERVERS, kafkaContainer.getBootstrapServers());
         runner.setProperty(connectionService, Kafka3ConnectionService.MAX_POLL_RECORDS, "1000");
+        runner.setProperty(connectionService, DYNAMIC_PROPERTY_KEY_PUBLISH, DYNAMIC_PROPERTY_VALUE_PUBLISH);
+        runner.setProperty(connectionService, DYNAMIC_PROPERTY_KEY_CONSUME, DYNAMIC_PROPERTY_VALUE_CONSUME);
         runner.enableControllerService(connectionService);
         return CONNECTION_SERVICE_ID;
     }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-service/src/test/java/org/apache/nifi/kafka/service/Kafka3ConnectionServiceBaseIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-service/src/test/java/org/apache/nifi/kafka/service/Kafka3ConnectionServiceBaseIT.java
@@ -94,6 +94,11 @@ public class Kafka3ConnectionServiceBaseIT {
 
     public static final String IMAGE_NAME = "confluentinc/cp-kafka:7.8.0";  // December 2024
 
+    private static final String DYNAMIC_PROPERTY_KEY_PUBLISH = "delivery.timeout.ms";
+    private static final String DYNAMIC_PROPERTY_VALUE_PUBLISH = "60000";
+    private static final String DYNAMIC_PROPERTY_KEY_CONSUME = "fetch.max.wait.ms";
+    private static final String DYNAMIC_PROPERTY_VALUE_CONSUME = "1000";
+
     private static final String GROUP_ID = Kafka3ConnectionService.class.getSimpleName();
 
     private static final String TOPIC = Kafka3ConnectionServiceBaseIT.class.getSimpleName();
@@ -203,6 +208,8 @@ public class Kafka3ConnectionServiceBaseIT {
         final Map<String, String> properties = new LinkedHashMap<>();
         properties.put(Kafka3ConnectionService.BOOTSTRAP_SERVERS.getName(), kafkaContainer.getBootstrapServers());
         properties.put(Kafka3ConnectionService.CLIENT_TIMEOUT.getName(), CLIENT_TIMEOUT);
+        properties.put(DYNAMIC_PROPERTY_KEY_PUBLISH, DYNAMIC_PROPERTY_VALUE_PUBLISH);
+        properties.put(DYNAMIC_PROPERTY_KEY_CONSUME, DYNAMIC_PROPERTY_VALUE_CONSUME);
         return properties;
     }
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/ConsumeKafkaTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/ConsumeKafkaTest.java
@@ -47,6 +47,11 @@ class ConsumeKafkaTest {
 
     private static final int FIRST_PARTITION = 0;
 
+    private static final String DYNAMIC_PROPERTY_KEY_PUBLISH = "delivery.timeout.ms";
+    private static final String DYNAMIC_PROPERTY_VALUE_PUBLISH = "60000";
+    private static final String DYNAMIC_PROPERTY_KEY_CONSUME = "fetch.max.wait.ms";
+    private static final String DYNAMIC_PROPERTY_VALUE_CONSUME = "1000";
+
     private static final String SERVICE_ID = KafkaConnectionService.class.getSimpleName();
 
     private static final String CONSUMER_GROUP_ID = ConsumeKafkaTest.class.getSimpleName();
@@ -113,6 +118,15 @@ class ConsumeKafkaTest {
         final ConfigVerificationResult firstResult = results.iterator().next();
         assertEquals(ConfigVerificationResult.Outcome.FAILED, firstResult.getOutcome());
         assertNotNull(firstResult.getExplanation());
+    }
+
+    @Test
+    public void testDynamicProperties() throws InitializationException {
+        when(kafkaConnectionService.getIdentifier()).thenReturn(SERVICE_ID);
+        runner.addControllerService(SERVICE_ID, kafkaConnectionService);
+        runner.setProperty(kafkaConnectionService, DYNAMIC_PROPERTY_KEY_PUBLISH, DYNAMIC_PROPERTY_VALUE_PUBLISH);
+        runner.setProperty(kafkaConnectionService, DYNAMIC_PROPERTY_KEY_CONSUME, DYNAMIC_PROPERTY_VALUE_CONSUME);
+        runner.enableControllerService(kafkaConnectionService);
     }
 
     private void setConnectionService() throws InitializationException {

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaTest.java
@@ -47,6 +47,11 @@ class PublishKafkaTest {
 
     private static final int FIRST_PARTITION = 0;
 
+    private static final String DYNAMIC_PROPERTY_KEY_PUBLISH = "delivery.timeout.ms";
+    private static final String DYNAMIC_PROPERTY_VALUE_PUBLISH = "60000";
+    private static final String DYNAMIC_PROPERTY_KEY_CONSUME = "fetch.max.wait.ms";
+    private static final String DYNAMIC_PROPERTY_VALUE_CONSUME = "1000";
+
     private static final String SERVICE_ID = KafkaConnectionService.class.getSimpleName();
 
     @Mock
@@ -108,6 +113,15 @@ class PublishKafkaTest {
         final ConfigVerificationResult firstResult = results.iterator().next();
         assertEquals(ConfigVerificationResult.Outcome.FAILED, firstResult.getOutcome());
         assertNotNull(firstResult.getExplanation());
+    }
+
+    @Test
+    public void testDynamicProperties() throws InitializationException {
+        when(kafkaConnectionService.getIdentifier()).thenReturn(SERVICE_ID);
+        runner.addControllerService(SERVICE_ID, kafkaConnectionService);
+        runner.setProperty(kafkaConnectionService, DYNAMIC_PROPERTY_KEY_PUBLISH, DYNAMIC_PROPERTY_VALUE_PUBLISH);
+        runner.setProperty(kafkaConnectionService, DYNAMIC_PROPERTY_KEY_CONSUME, DYNAMIC_PROPERTY_VALUE_CONSUME);
+        runner.enableControllerService(kafkaConnectionService);
     }
 
     private void setConnectionService() throws InitializationException {

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/DynamicPropertyValidator.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/DynamicPropertyValidator.java
@@ -22,6 +22,7 @@ import org.apache.nifi.components.Validator;
 import org.apache.nifi.kafka.shared.property.provider.KafkaPropertyNameProvider;
 import org.apache.nifi.kafka.shared.property.provider.StandardKafkaPropertyNameProvider;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -32,9 +33,12 @@ public class DynamicPropertyValidator implements Validator {
 
     private final Set<String> clientPropertyNames;
 
-    public DynamicPropertyValidator(final Class<?> kafkaClientClass) {
-        final KafkaPropertyNameProvider provider = new StandardKafkaPropertyNameProvider(kafkaClientClass);
-        clientPropertyNames = provider.getPropertyNames();
+    public DynamicPropertyValidator(final Class<?>... kafkaClientClasses) {
+        clientPropertyNames = new HashSet<>();
+        for (Class<?> kafkaClientClass : kafkaClientClasses) {
+            final KafkaPropertyNameProvider provider = new StandardKafkaPropertyNameProvider(kafkaClientClass);
+            clientPropertyNames.addAll(provider.getPropertyNames());
+        }
     }
 
     @Override


### PR DESCRIPTION
Since the component validation evaluates the service configuration as a whole, the connection service may be supplied with both publish and consume dynamic properties.  

The instantiation of a "KafkaProducerService" should filter the effective dynamic properties to those supported by a "KafkaProducer".  Similarly, a "KafkaConsumerService" only applies the dynamic properties supported by a Kafka "Consumer".  This logic should be governed by the existing NiFi ":kafka-shared" class "KafkaPropertyProvider", and may be verified at runtime via inspection of the ProducerConfig / ConsumerConfig properties written to the NiFi log at connection initiation.

# Summary

[NIFI-14271](https://issues.apache.org/jira/browse/NIFI-14271)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
