### PR TITLE
NIFI-14296 Fix Timestamp to LocalDateTime nanosecond handling

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectLocalDateTimeFieldConverter.java
@@ -18,6 +18,7 @@ package org.apache.nifi.serialization.record.field;
 
 import org.apache.nifi.serialization.record.util.IllegalTypeConversionException;
 
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -56,7 +57,11 @@ class ObjectLocalDateTimeFieldConverter implements FieldConverter<Object, LocalD
             case LocalDateTime localDateTime -> {
                 return localDateTime;
             }
+            case Timestamp timestamp -> {
+                return timestamp.toLocalDateTime();
+            }
             case Date date -> {
+                // java.sql.Date and java.sql.Time do not support the toInstant() method so using getTime() is required
                 final Instant instant = Instant.ofEpochMilli(date.getTime());
                 return ofInstant(instant);
             }

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectTimestampFieldConverterTest.java
@@ -19,6 +19,7 @@ package org.apache.nifi.serialization.record.field;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -43,6 +44,8 @@ public class ObjectTimestampFieldConverterTest {
 
     private static final String EMPTY = "";
 
+    private static final String DATE_DEFAULT = "2000-01-01";
+
     private static final String DATE_TIME_DEFAULT = "2000-01-01 12:00:00";
 
     private static final String DATE_TIME_ZONE_OFFSET_PATTERN = "yyyy-MM-dd HH:mm:ssZZZZZ";
@@ -52,6 +55,8 @@ public class ObjectTimestampFieldConverterTest {
     private static final Optional<String> DATE_TIME_NANOSECONDS_PATTERN = Optional.of("yyyy-MM-dd HH:mm:ss.SSSSSSSSS");
 
     private static final String DATE_TIME_NANOSECONDS = "2000-01-01 12:00:00.123456789";
+
+    private static final String TIME_DEFAULT = "12:30:45";
 
     @Test
     public void testConvertFieldNull() {
@@ -64,6 +69,27 @@ public class ObjectTimestampFieldConverterTest {
         final Timestamp field = new Timestamp(System.currentTimeMillis());
         final Timestamp timestamp = CONVERTER.convertField(field, DEFAULT_PATTERN, FIELD_NAME);
         assertEquals(field, timestamp);
+    }
+
+    @Test
+    public void testConvertFieldTimestampNanoseconds() {
+        final Timestamp field = Timestamp.valueOf(DATE_TIME_NANOSECONDS);
+        final Timestamp timestamp = CONVERTER.convertField(field, DEFAULT_PATTERN, FIELD_NAME);
+        assertEquals(field, timestamp);
+    }
+
+    @Test
+    public void testConvertFieldSqlDate() {
+        final java.sql.Date field = java.sql.Date.valueOf(DATE_DEFAULT);
+        final Timestamp timestamp = CONVERTER.convertField(field, DEFAULT_PATTERN, FIELD_NAME);
+        assertEquals(field.getTime(), timestamp.getTime());
+    }
+
+    @Test
+    public void testConvertFieldSqlTime() {
+        final Time field = Time.valueOf(TIME_DEFAULT);
+        final Timestamp timestamp = CONVERTER.convertField(field, DEFAULT_PATTERN, FIELD_NAME);
+        assertEquals(field.getTime(), timestamp.getTime());
     }
 
     @Test


### PR DESCRIPTION
# Summary

[NIFI-14296](https://issues.apache.org/jira/browse/NIFI-14296) Corrects conversion from `java.sql.Timestamp` to `java.time.LocalDateTime` to ensure that nanosecond precision is retained.

The resolution adds specific handling for `java.sql.Timestamp` and uses the `toInstant()` method which retains nanosecond precision.

Additional unit tests verify the updated behavior and also add checks for `java.sql.Date` and `java.sql.Time` to confirm expected behavior for classes that do not support the `toInstant()` method.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
