### PR TITLE
NIFI-14303 Additional metadata attributes in ListGoogleDrive

### DIFF
--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDrive.java
@@ -56,6 +56,8 @@ import org.apache.nifi.processors.gcp.ProxyAwareTransportFactory;
 import org.apache.nifi.processors.gcp.util.GoogleUtils;
 import org.apache.nifi.proxy.ProxyConfiguration;
 
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE;
@@ -64,6 +66,8 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAM
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE_DESC;
@@ -84,6 +88,8 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTA
         @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
         @WritesAttribute(attribute = SIZE_AVAILABLE, description = SIZE_AVAILABLE_DESC),
         @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
+        @WritesAttribute(attribute = CREATED_TIME, description = CREATED_TIME_DESC),
+        @WritesAttribute(attribute = MODIFIED_TIME, description = MODIFIED_TIME_DESC),
         @WritesAttribute(attribute = ERROR_CODE, description = ERROR_CODE_DESC),
         @WritesAttribute(attribute = ERROR_MESSAGE, description = ERROR_MESSAGE_DESC)
 })
@@ -285,7 +291,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
         final long startNanos = System.nanoTime();
         try {
             final File fileMetadata = fetchFileMetadata(fileId);
-            final Map<String, String> attributeMap = createAttributeMap(fileMetadata);
+            final Map<String, String> attributeMap = createGoogleDriveFileInfoBuilder(fileMetadata).build().toStringMap();
 
             flowFile = fetchFile(fileMetadata, session, context, flowFile, attributeMap);
 
@@ -401,7 +407,7 @@ public class FetchGoogleDrive extends AbstractProcessor implements GoogleDriveTr
                 .files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
                 .execute();
     }
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveAttributes.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveAttributes.java
@@ -20,25 +20,48 @@ import org.apache.nifi.flowfile.attributes.CoreAttributes;
 
 public class GoogleDriveAttributes {
 
-    public static final String ID = "drive.id";
+    public static final String DRIVE_ATTR_PREFIX = "drive.";
+
+    public static final String ID = DRIVE_ATTR_PREFIX + "id";
     public static final String ID_DESC = "The id of the file";
 
     public static final String FILENAME = CoreAttributes.FILENAME.key();
     public static final String FILENAME_DESC = "The name of the file";
 
-    public static final String SIZE = "drive.size";
+    public static final String SIZE = DRIVE_ATTR_PREFIX + "size";
     public static final String SIZE_DESC = "The size of the file. Set to 0 when the file size is not available (e.g. externally stored files).";
 
-    public static final String SIZE_AVAILABLE = "drive.size.available";
+    public static final String SIZE_AVAILABLE = DRIVE_ATTR_PREFIX + "size.available";
     public static final String SIZE_AVAILABLE_DESC = "Indicates if the file size is known / available";
 
-    public static final String TIMESTAMP = "drive.timestamp";
+    public static final String TIMESTAMP = DRIVE_ATTR_PREFIX + "timestamp";
     public static final String TIMESTAMP_DESC =  "The last modified time or created time (whichever is greater) of the file." +
             " The reason for this is that the original modified date of a file is preserved when uploaded to Google Drive." +
             " 'Created time' takes the time when the upload occurs. However uploaded files can still be modified later.";
 
+    public static final String CREATED_TIME = DRIVE_ATTR_PREFIX + "created.time";
+    public static final String CREATED_TIME_DESC = "The file's creation time";
+
+    public static final String MODIFIED_TIME = DRIVE_ATTR_PREFIX + "modified.time";
+    public static final String MODIFIED_TIME_DESC = "The file's last modification time";
+
     public static final String MIME_TYPE = CoreAttributes.MIME_TYPE.key();
     public static final String MIME_TYPE_DESC =  "The MIME type of the file";
+
+    public static final String PATH = DRIVE_ATTR_PREFIX + "path";
+    public static final String PATH_DESC = "The path of the file's directory from the base directory";
+
+    public static final String OWNER = DRIVE_ATTR_PREFIX + "owner";
+    public static final String OWNER_DESC = "The owner of the file";
+
+    public static final String LAST_MODIFYING_USER = DRIVE_ATTR_PREFIX + "last.modifying.user";
+    public static final String LAST_MODIFYING_USER_DESC = "The last modifying user of the file";
+
+    public static final String WEB_VIEW_LINK = DRIVE_ATTR_PREFIX + "web.view.link";
+    public static final String WEB_VIEW_LINK_DESC = "Web view link to the file";
+
+    public static final String WEB_CONTENT_LINK = DRIVE_ATTR_PREFIX + "web.content.link";
+    public static final String WEB_CONTENT_LINK_DESC = "Web content link to the file";
 
     public static final String ERROR_MESSAGE = "error.message";
     public static final String ERROR_MESSAGE_DESC = "The error message returned by Google Drive";

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFlowFileAttribute.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/GoogleDriveFlowFileAttribute.java
@@ -16,35 +16,64 @@
  */
 package org.apache.nifi.processors.gcp.drive;
 
-import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.serialization.record.RecordField;
+import org.apache.nifi.serialization.record.RecordFieldType;
 
+import java.time.Instant;
 import java.util.function.Function;
 
 public enum GoogleDriveFlowFileAttribute {
-    ID(GoogleDriveAttributes.ID, GoogleDriveFileInfo::getId),
-    FILENAME(GoogleDriveAttributes.FILENAME, GoogleDriveFileInfo::getName),
-    SIZE(GoogleDriveAttributes.SIZE, fileInfo -> String.valueOf(fileInfo.getSize())),
-    SIZE_AVAILABLE(GoogleDriveAttributes.SIZE_AVAILABLE, fileInfo -> String.valueOf(fileInfo.isSizeAvailable())),
-    TIMESTAMP(GoogleDriveAttributes.TIMESTAMP, fileInfo -> String.valueOf(fileInfo.getTimestamp())),
-    MIME_TYPE(GoogleDriveAttributes.MIME_TYPE, GoogleDriveFileInfo::getMimeType);
+    ID(GoogleDriveAttributes.ID, GoogleDriveFileInfo::getId, RecordFieldType.STRING, false),
+    FILENAME(GoogleDriveAttributes.FILENAME, GoogleDriveFileInfo::getName, RecordFieldType.STRING, false),
+    SIZE(GoogleDriveAttributes.SIZE, GoogleDriveFileInfo::getSize, RecordFieldType.LONG, false),
+    SIZE_AVAILABLE(GoogleDriveAttributes.SIZE_AVAILABLE, GoogleDriveFileInfo::isSizeAvailable, RecordFieldType.BOOLEAN, false),
+    TIMESTAMP(GoogleDriveAttributes.TIMESTAMP, GoogleDriveFileInfo::getTimestamp, RecordFieldType.LONG, false),
+    CREATED_TIME(GoogleDriveAttributes.CREATED_TIME, fileInfo -> Instant.ofEpochMilli(fileInfo.getCreatedTime()).toString(), RecordFieldType.STRING, false),
+    MODIFIED_TIME(GoogleDriveAttributes.MODIFIED_TIME, fileInfo -> Instant.ofEpochMilli(fileInfo.getModifiedTime()).toString(), RecordFieldType.STRING, false),
+    MIME_TYPE(GoogleDriveAttributes.MIME_TYPE, GoogleDriveFileInfo::getMimeType, RecordFieldType.STRING, true),
+    PATH(GoogleDriveAttributes.PATH, GoogleDriveFileInfo::getPath, RecordFieldType.STRING, true),
+    OWNER(GoogleDriveAttributes.OWNER, GoogleDriveFileInfo::getOwner, RecordFieldType.STRING, true),
+    LAST_MODIFYING_USER(GoogleDriveAttributes.LAST_MODIFYING_USER, GoogleDriveFileInfo::getLastModifyingUser, RecordFieldType.STRING, true),
+    WEB_VIEW_LINK(GoogleDriveAttributes.WEB_VIEW_LINK, GoogleDriveFileInfo::getWebViewLink, RecordFieldType.STRING, true),
+    WEB_CONTENT_LINK(GoogleDriveAttributes.WEB_CONTENT_LINK, GoogleDriveFileInfo::getWebContentLink, RecordFieldType.STRING, true);
 
     private final String name;
-    private final Function<GoogleDriveFileInfo, String> fromFileInfo;
+    private final Function<GoogleDriveFileInfo, Object> fromFileInfo;
+    private final RecordField recordField;
 
-    GoogleDriveFlowFileAttribute(String attributeName, Function<GoogleDriveFileInfo, String> fromFileInfo) {
-        this.name = attributeName;
+    GoogleDriveFlowFileAttribute(String name, Function<GoogleDriveFileInfo, Object> fromFileInfo, RecordFieldType recordFieldType, boolean recordFieldNullable) {
+        this.name = name;
         this.fromFileInfo = fromFileInfo;
+        this.recordField = new RecordField(name, recordFieldType.getDataType(), recordFieldNullable);
     }
 
     public String getName() {
         return name;
     }
 
-    public String getValue(Record record) {
-        return record.getAsString(name);
+    public Object getValue(GoogleDriveFileInfo fileInfo) {
+        return fromFileInfo.apply(fileInfo);
     }
 
-    public String getValue(GoogleDriveFileInfo fileInfo) {
-        return fromFileInfo.apply(fileInfo);
+    public RecordField getRecordField() {
+        return recordField;
+    }
+
+    public static GoogleDriveFlowFileAttribute getByName(final String name) {
+        for (GoogleDriveFlowFileAttribute item : values()) {
+            if (item.getName().equals(name)) {
+                return item;
+            }
+        }
+        throw new IllegalArgumentException("GoogleDriveFlowFileAttribute with name [" + name + "] does not exist");
+    }
+
+    public static boolean isValidName(final String name) {
+        try {
+            getByName(name);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/drive/PutGoogleDrive.java
@@ -78,6 +78,8 @@ import static java.util.stream.Collectors.joining;
 import static org.apache.nifi.processor.util.StandardValidators.DATA_SIZE_VALIDATOR;
 import static org.apache.nifi.processors.conflict.resolution.ConflictResolutionStrategy.FAIL;
 import static org.apache.nifi.processors.conflict.resolution.ConflictResolutionStrategy.IGNORE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_CODE_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ERROR_MESSAGE;
@@ -87,6 +89,8 @@ import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAM
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE_DESC;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME_DESC;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
 import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE_DESC;
@@ -107,6 +111,8 @@ import static org.apache.nifi.processors.gcp.util.GoogleUtils.GCP_CREDENTIALS_PR
         @WritesAttribute(attribute = SIZE, description = SIZE_DESC),
         @WritesAttribute(attribute = SIZE_AVAILABLE, description = SIZE_AVAILABLE_DESC),
         @WritesAttribute(attribute = TIMESTAMP, description = TIMESTAMP_DESC),
+        @WritesAttribute(attribute = CREATED_TIME, description = CREATED_TIME_DESC),
+        @WritesAttribute(attribute = MODIFIED_TIME, description = MODIFIED_TIME_DESC),
         @WritesAttribute(attribute = ERROR_CODE, description = ERROR_CODE_DESC),
         @WritesAttribute(attribute = ERROR_MESSAGE, description = ERROR_MESSAGE_DESC)})
 public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrait {
@@ -284,7 +290,7 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
             }
 
             if (uploadedFile != null) {
-                final Map<String, String> attributes = createAttributeMap(uploadedFile);
+                final Map<String, String> attributes = createGoogleDriveFileInfoBuilder(uploadedFile).build().toStringMap();
                 final String url = DRIVE_URL + uploadedFile.getId();
                 flowFile = session.putAllAttributes(flowFile, attributes);
                 final long transferMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
@@ -328,12 +334,12 @@ public class PutGoogleDrive extends AbstractProcessor implements GoogleDriveTrai
             return driveService.files()
                     .create(fileMetadata, mediaContent)
                     .setSupportsAllDrives(true)
-                    .setFields("id, name, createdTime, mimeType, size");
+                    .setFields("id, name, createdTime, modifiedTime, mimeType, size");
         } else {
             return driveService.files()
                     .update(fileMetadata.getId(), new File(), mediaContent)
                     .setSupportsAllDrives(true)
-                    .setFields("id, name, createdTime, mimeType, size");
+                    .setFields("id, name, createdTime, modifiedTime, mimeType, size");
         }
     }
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/AbstractGoogleDriveTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/AbstractGoogleDriveTest.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.model.File;
+
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Set;
 import org.apache.nifi.processor.Relationship;
@@ -50,6 +52,7 @@ public class AbstractGoogleDriveTest {
     public static final String SUBFOLDER_ID = "subFolderId";
     public static final long TEST_SIZE = 42;
     public static final long CREATED_TIME = 1659707000;
+    public static final long MODIFIED_TIME = 1659708000;
     public static final String TEXT_TYPE = "text/plain";
 
     protected TestRunner testRunner;
@@ -74,8 +77,11 @@ public class AbstractGoogleDriveTest {
         final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(relationship).get(0);
         flowFile.assertAttributeEquals(GoogleDriveAttributes.ID, TEST_FILE_ID);
         flowFile.assertAttributeEquals(GoogleDriveAttributes.FILENAME, TEST_FILENAME);
-        flowFile.assertAttributeEquals(GoogleDriveAttributes.TIMESTAMP, String.valueOf(new DateTime(CREATED_TIME)));
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.TIMESTAMP, String.valueOf(MODIFIED_TIME));
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.CREATED_TIME, Instant.ofEpochMilli(CREATED_TIME).toString());
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.MODIFIED_TIME, Instant.ofEpochMilli(MODIFIED_TIME).toString());
         flowFile.assertAttributeEquals(GoogleDriveAttributes.SIZE, Long.toString(TEST_SIZE));
+        flowFile.assertAttributeEquals(GoogleDriveAttributes.SIZE_AVAILABLE, Boolean.toString(true));
         flowFile.assertAttributeEquals(GoogleDriveAttributes.MIME_TYPE, TEXT_TYPE);
     }
 
@@ -101,6 +107,7 @@ public class AbstractGoogleDriveTest {
         file.setName(name);
         file.setParents(singletonList(parentId));
         file.setCreatedTime(new DateTime(CREATED_TIME));
+        file.setModifiedTime(new DateTime(MODIFIED_TIME));
         file.setSize(TEST_SIZE);
         file.setMimeType(mimeType);
         return file;

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveIT.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveIT.java
@@ -122,10 +122,12 @@ public class FetchGoogleDriveIT extends AbstractGoogleDriveIT<FetchGoogleDrive> 
 
     @Override
     public Set<String> getCheckedAttributeNames() {
-        Set<String> checkedAttributeNames = OutputChecker.super.getCheckedAttributeNames();
+        Set<String> checkedAttributeNames = new HashSet<>(OutputChecker.super.getCheckedAttributeNames());
 
         checkedAttributeNames.add(GoogleDriveAttributes.ERROR_CODE);
         checkedAttributeNames.remove(GoogleDriveAttributes.TIMESTAMP);
+        checkedAttributeNames.remove(GoogleDriveAttributes.CREATED_TIME);
+        checkedAttributeNames.remove(GoogleDriveAttributes.MODIFIED_TIME);
 
         return checkedAttributeNames;
     }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/FetchGoogleDriveTest.java
@@ -104,7 +104,7 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
         when(mockDriverService.files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
                 .execute()).thenReturn(createFile());
     }
 
@@ -118,7 +118,7 @@ public class FetchGoogleDriveTest extends AbstractGoogleDriveTest {
         when(mockDriverService.files()
                 .get(fileId)
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, mimeType, size, exportLinks")
+                .setFields("id, name, createdTime, modifiedTime, mimeType, size, exportLinks")
                 .execute()).thenReturn(createFile());
     }
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveSimpleTest.java
@@ -64,6 +64,7 @@ public class ListGoogleDriveSimpleTest {
         };
 
         testSubject.onScheduled(mockProcessContext);
+        testSubject.initListedEntityTracker(mockProcessContext);
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
@@ -27,6 +27,7 @@ import com.google.api.client.util.DateTime;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.model.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -139,6 +140,8 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
                         "\"drive.size\":" + size + "," +
                         "\"drive.size.available\":" + (size != null) + "," +
                         "\"drive.timestamp\":" + modifiedTime + "," +
+                        "\"drive.created.time\":\"" + Instant.ofEpochMilli(createdTime) + "\"," +
+                        "\"drive.modified.time\":\"" + Instant.ofEpochMilli(modifiedTime) + "\"," +
                         "\"mime.type\":\"" + mimeType + "\"" +
                         "}" +
                         "]");
@@ -185,6 +188,8 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
         inputFlowFileAttributes.put(GoogleDriveAttributes.SIZE, valueOf(size != null ? size : 0L));
         inputFlowFileAttributes.put(GoogleDriveAttributes.SIZE_AVAILABLE, valueOf(size != null));
         inputFlowFileAttributes.put(GoogleDriveAttributes.TIMESTAMP, valueOf(expectedTimestamp));
+        inputFlowFileAttributes.put(GoogleDriveAttributes.CREATED_TIME, Instant.ofEpochMilli(createdTime != null ? createdTime : 0L).toString());
+        inputFlowFileAttributes.put(GoogleDriveAttributes.MODIFIED_TIME, Instant.ofEpochMilli(modifiedTime != null ? modifiedTime : 0L).toString());
         inputFlowFileAttributes.put(GoogleDriveAttributes.MIME_TYPE, mimeType);
 
         HashSet<Map<String, String>> expectedAttributes = new HashSet<>(singletonList(inputFlowFileAttributes));

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/OutputChecker.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/OutputChecker.java
@@ -20,12 +20,19 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.CREATED_TIME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.FILENAME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.ID;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MIME_TYPE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.MODIFIED_TIME;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.SIZE_AVAILABLE;
+import static org.apache.nifi.processors.gcp.drive.GoogleDriveAttributes.TIMESTAMP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public interface OutputChecker {
@@ -50,9 +57,7 @@ public interface OutputChecker {
     }
 
     default Set<String> getCheckedAttributeNames() {
-        Set<String> checkedAttributeNames = Arrays.stream(GoogleDriveFlowFileAttribute.values())
-                .map(GoogleDriveFlowFileAttribute::getName)
-                .collect(Collectors.toSet());
+        Set<String> checkedAttributeNames = Set.of(ID, FILENAME, SIZE, SIZE_AVAILABLE, TIMESTAMP, CREATED_TIME, MODIFIED_TIME, MIME_TYPE);
 
         return checkedAttributeNames;
     }

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/PutGoogleDriveTest.java
@@ -194,7 +194,7 @@ public class PutGoogleDriveTest extends AbstractGoogleDriveTest {
         when(mockDriverService.files()
                 .create(any(File.class), any(InputStreamContent.class))
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, mimeType, size")
+                .setFields("id, name, createdTime, modifiedTime, mimeType, size")
                 .execute())
                 .thenReturn(uploadedFile);
     }
@@ -203,7 +203,7 @@ public class PutGoogleDriveTest extends AbstractGoogleDriveTest {
         when(mockDriverService.files()
                 .update(eq(uploadedFile.getId()), any(File.class), any(InputStreamContent.class))
                 .setSupportsAllDrives(true)
-                .setFields("id, name, createdTime, mimeType, size")
+                .setFields("id, name, createdTime, modifiedTime, mimeType, size")
                 .execute())
                 .thenReturn(uploadedFile);
     }


### PR DESCRIPTION
Introduced optionally configurable metadata attributes in ListGoogleDrive Added drive.created.time and drive.modified.time in List/Fetch/PutGoogleDrive Fixed drive.timestamp in Fetch/PutGoogleDrive

# Summary

[NIFI-14303](https://issues.apache.org/jira/browse/NIFI-14303)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
