### PR TITLE
NIFI-14301 ConsumeKinesisStream HTTPClient maxConcurrency increase

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsAsyncProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsAsyncProcessor.java
@@ -63,10 +63,10 @@ public abstract class AbstractAwsAsyncProcessor<
 
     @Override
     protected <B extends AwsClientBuilder> void configureHttpClient(final B clientBuilder, final ProcessContext context) {
-        ((AwsAsyncClientBuilder) clientBuilder).httpClient(createSdkAsyncHttpClient(context));
+        ((AwsAsyncClientBuilder) clientBuilder).httpClient(createSdkAsyncHttpClient(clientBuilder, context));
     }
 
-    private SdkAsyncHttpClient createSdkAsyncHttpClient(final ProcessContext context) {
+    private <B extends AwsClientBuilder<?, ?>> SdkAsyncHttpClient createSdkAsyncHttpClient(final B clientBuilder, final ProcessContext context) {
         final NettyNioAsyncHttpClient.Builder builder = NettyNioAsyncHttpClient.builder();
 
         final AwsHttpClientConfigurer configurer = new AwsHttpClientConfigurer() {
@@ -98,8 +98,23 @@ public abstract class AbstractAwsAsyncProcessor<
         };
 
         this.configureSdkHttpClient(context, configurer);
+        this.customizeAsyncHttpClientBuilderConfiguration(context, builder, clientBuilder.getClass());
 
         return builder.build();
+    }
+
+    /**
+     * Customize the {@link NettyNioAsyncHttpClient.Builder} for the given {@link AwsClientBuilder} class.
+     *
+     * @param context the process context
+     * @param builder the {@link NettyNioAsyncHttpClient.Builder} to customize
+     * @param customizationTargetClass for which the HTTP client builder is being customized
+     */
+    protected void customizeAsyncHttpClientBuilderConfiguration(
+            final ProcessContext context,
+            final NettyNioAsyncHttpClient.Builder builder,
+            final Class<? extends AwsClientBuilder> customizationTargetClass) {
+        // no-op
     }
 
 }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsAsyncProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsAsyncProcessor.java
@@ -62,8 +62,8 @@ public abstract class AbstractAwsAsyncProcessor<
     }
 
     @Override
-    protected <B extends AwsClientBuilder> void configureHttpClient(final B clientBuilder, final ProcessContext context) {
-        ((AwsAsyncClientBuilder) clientBuilder).httpClient(createSdkAsyncHttpClient(clientBuilder, context));
+    protected <B extends AwsClientBuilder<?, ?>> void configureHttpClient(final B clientBuilder, final ProcessContext context) {
+        ((AwsAsyncClientBuilder<?, ?>) clientBuilder).httpClient(createSdkAsyncHttpClient(clientBuilder, context));
     }
 
     private <B extends AwsClientBuilder<?, ?>> SdkAsyncHttpClient createSdkAsyncHttpClient(final B clientBuilder, final ProcessContext context) {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsProcessor.java
@@ -157,7 +157,7 @@ public abstract class AbstractAwsProcessor<T extends SdkClient> extends Abstract
      * @param clientBuilder The client builder
      * @param context The process context
      */
-    protected abstract <B extends AwsClientBuilder> void configureHttpClient(B clientBuilder, ProcessContext context);
+    protected abstract <B extends AwsClientBuilder<?, ?>> void configureHttpClient(B clientBuilder, ProcessContext context);
 
     /*
      * Allow optional override of onTrigger with the ProcessSessionFactory where required for AWS processors (e.g. ConsumeKinesisStream)

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsProcessor.java
@@ -285,7 +285,7 @@ public abstract class AbstractAwsProcessor<T extends SdkClient> extends Abstract
 
     protected void configureSdkHttpClient(final ProcessContext context, final AwsHttpClientConfigurer httpClientConfigurer) {
         final int communicationsTimeout = context.getProperty(TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue();
-        httpClientConfigurer.configureBasicSettings(Duration.ofMillis(communicationsTimeout), getMaxHttpConcurrentTasks(context));
+        httpClientConfigurer.configureBasicSettings(Duration.ofMillis(communicationsTimeout), context.getMaxConcurrentTasks());
 
         if (this.getSupportedPropertyDescriptors().contains(SSL_CONTEXT_SERVICE)) {
             final SSLContextProvider sslContextProvider = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextProvider.class);
@@ -313,10 +313,6 @@ public abstract class AbstractAwsProcessor<T extends SdkClient> extends Abstract
         if (Proxy.Type.HTTP.equals(proxyConfig.getProxyType())) {
             httpClientConfigurer.configureProxy(proxyConfig);
         }
-    }
-
-    protected int getMaxHttpConcurrentTasks(final ProcessContext context) {
-        return context.getMaxConcurrentTasks();
     }
 
     protected Region getRegion(final ProcessContext context) {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsProcessor.java
@@ -285,7 +285,7 @@ public abstract class AbstractAwsProcessor<T extends SdkClient> extends Abstract
 
     protected void configureSdkHttpClient(final ProcessContext context, final AwsHttpClientConfigurer httpClientConfigurer) {
         final int communicationsTimeout = context.getProperty(TIMEOUT).asTimePeriod(TimeUnit.MILLISECONDS).intValue();
-        httpClientConfigurer.configureBasicSettings(Duration.ofMillis(communicationsTimeout), context.getMaxConcurrentTasks());
+        httpClientConfigurer.configureBasicSettings(Duration.ofMillis(communicationsTimeout), getMaxHttpConcurrentTasks(context));
 
         if (this.getSupportedPropertyDescriptors().contains(SSL_CONTEXT_SERVICE)) {
             final SSLContextProvider sslContextProvider = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextProvider.class);
@@ -313,6 +313,10 @@ public abstract class AbstractAwsProcessor<T extends SdkClient> extends Abstract
         if (Proxy.Type.HTTP.equals(proxyConfig.getProxyType())) {
             httpClientConfigurer.configureProxy(proxyConfig);
         }
+    }
+
+    protected int getMaxHttpConcurrentTasks(final ProcessContext context) {
+        return context.getMaxConcurrentTasks();
     }
 
     protected Region getRegion(final ProcessContext context) {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsSyncProcessor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/v2/AbstractAwsSyncProcessor.java
@@ -67,8 +67,8 @@ public abstract class AbstractAwsSyncProcessor<
     }
 
     @Override
-    protected <B extends AwsClientBuilder> void configureHttpClient(final B clientBuilder, final ProcessContext context) {
-        ((AwsSyncClientBuilder) clientBuilder).httpClient(createSdkHttpClient(context));
+    protected <B extends AwsClientBuilder<?, ?>> void configureHttpClient(final B clientBuilder, final ProcessContext context) {
+        ((AwsSyncClientBuilder<?, ?>) clientBuilder).httpClient(createSdkHttpClient(context));
     }
 
     private SdkHttpClient createSdkHttpClient(final ProcessContext context) {

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -151,6 +151,10 @@ import java.util.stream.Collectors;
 @SeeAlso(PutKinesisStream.class)
 public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsyncClient, KinesisAsyncClientBuilder> {
 
+    private static final int INITIAL_WINDOW_SIZE_BYTES = 512 * 1024; // 512 KB - suggested by KinesisClientUtil
+    private static final Duration HEALTH_CHECK_PING_PERIOD_MILLIS = Duration.ofMinutes(1); // suggested by KinesisClientUtil
+    private static final Protocol PROTOCOL = Protocol.HTTP2; // suggested by KinesisClientUtil
+
     private static final String CHECKPOINT_CONFIG = "checkpointConfig";
     private static final String COORDINATOR_CONFIG = "coordinatorConfig";
     private static final String LEASE_MANAGEMENT_CONFIG = "leaseManagementConfig";
@@ -859,16 +863,13 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
             final NettyNioAsyncHttpClient.Builder builder,
             final Class<? extends AwsClientBuilder> customizationTargetClass) {
         if (KinesisAsyncClientBuilder.class.isAssignableFrom(customizationTargetClass)) {
-            // suggested values from KinesisClientUtil
-            final int initialWindowSizeBytes = 512 * 1024; // 512 KB
-            final long healthCheckPingPeriodMillis = 60 * 1000;
             builder
                     .maxConcurrency(Runtime.getRuntime().availableProcessors())
                     .http2Configuration(Http2Configuration.builder()
-                            .initialWindowSize(initialWindowSizeBytes)
-                            .healthCheckPingPeriod(Duration.ofMillis(healthCheckPingPeriodMillis))
+                            .initialWindowSize(INITIAL_WINDOW_SIZE_BYTES)
+                            .healthCheckPingPeriod(HEALTH_CHECK_PING_PERIOD_MILLIS)
                             .build())
-                    .protocol(Protocol.HTTP2);
+                    .protocol(PROTOCOL);
         }
     }
 }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -858,7 +858,7 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
             final ProcessContext context,
             final NettyNioAsyncHttpClient.Builder builder,
             final Class<? extends AwsClientBuilder> customizationTargetClass) {
-        if (customizationTargetClass == KinesisAsyncClientBuilder.class) {
+        if (KinesisAsyncClientBuilder.class.isAssignableFrom(customizationTargetClass)) {
             // suggested values from KinesisClientUtil
             final int initialWindowSizeBytes = 512 * 1024; // 512 KB
             final long healthCheckPingPeriodMillis = 60 * 1000;

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/ConsumeKinesisStream.java
@@ -847,4 +847,9 @@ public class ConsumeKinesisStream extends AbstractAwsAsyncProcessor<KinesisAsync
     protected KinesisAsyncClientBuilder createClientBuilder(final ProcessContext context) {
         return KinesisAsyncClient.builder();
     }
+
+    @Override
+    protected int getMaxHttpConcurrentTasks(ProcessContext context) {
+        return Math.max(Runtime.getRuntime().availableProcessors(), super.getMaxHttpConcurrentTasks(context));
+    }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14301](https://issues.apache.org/jira/browse/NIFI-14301)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-14301`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-14301`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] (no new) New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] (no new) New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] (no changes) Documentation formatting appears as expected in rendered files
