### PR TITLE
NIFI-14297 Added support for Avro schemas with String default for type bytes and 'decimal' logicalType.

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -1318,6 +1318,7 @@ public class DataTypeUtils {
             case null -> false;
             case Number ignored -> true;
             case String s -> stringPredicate.test(s);
+            case byte[] bytes -> stringPredicate.test(new String(bytes, StandardCharsets.UTF_8));
             default -> false;
         };
 

--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/util/DataTypeUtils.java
@@ -1282,6 +1282,10 @@ public class DataTypeUtils {
                 }
 
             }
+            case byte[] byteArray -> {
+                final String byteString = new String(byteArray, StandardCharsets.UTF_8);
+                return new BigDecimal(byteString);
+            }
             default -> {
             }
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestConvertRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestConvertRecord.java
@@ -436,4 +436,47 @@ public class TestConvertRecord {
         final MockFlowFile flowFile = runner.getFlowFilesForRelationship(ConvertRecord.REL_SUCCESS).getFirst();
         assertFalse(flowFile.getContent().contains("fieldThatShouldBeRemoved"));
     }
+
+    @Test
+    public void testJSONWithDefinedFieldTypeBytesAndLogicalTypeDecimal() throws Exception {
+        String schema = """
+                {
+                  "type": "record",
+                  "name": "ExampleRecord",
+                  "fields": [
+                    {
+                      "name": "big_decimal_field",
+                      "type": {
+                        "type": "bytes",
+                        "logicalType": "decimal",
+                        "precision": 10,
+                        "scale": 4
+                      },
+                      "default": "0.0000"
+                    }
+                  ]
+                }
+                """;
+
+        final JsonTreeReader jsonReader = new JsonTreeReader();
+        runner.addControllerService(READER_ID, jsonReader);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_TEXT, schema);
+        runner.enableControllerService(jsonReader);
+
+        final JsonRecordSetWriter jsonWriter = new JsonRecordSetWriter();
+        runner.addControllerService(WRITER_ID, jsonWriter);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.SCHEMA_TEXT_PROPERTY);
+        runner.setProperty(jsonWriter, SchemaAccessUtils.SCHEMA_TEXT, schema);
+        runner.setProperty(jsonWriter, "Schema Write Strategy", "full-schema-attribute");
+        runner.enableControllerService(jsonWriter);
+
+        runner.setProperty(ConvertRecord.RECORD_READER, READER_ID);
+        runner.setProperty(ConvertRecord.RECORD_WRITER, WRITER_ID);
+        runner.enqueue("{\"big_decimal_field\" : 140000.5833}");
+
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(ConvertRecord.REL_SUCCESS, 1);
+    }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14297 ](https://issues.apache.org/jira/browse/NIFI-14297 )
This fix in this PR addresses the need to support Avro schema byes type and decimal logical type when a default is specified. As part of fix the unit test `testIsBigDecimalTypeCompatible` in `TestDataTypeUtils` was converted to a JUnit 5 Paramaeterized test and the particular use case of a decimal as bytes was added.
In addition a unit test was added to `TestConvertRecord` to exercise the use case of the user who submitted the ticket although this may not be necessary.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
