### PR TITLE
NIFI-14305 Remove unnecessary declaration of Bouncy Castle dependencies

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
@@ -63,10 +63,6 @@
             <artifactId>nifi-record</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-standard-record-utils</artifactId>
             <version>2.3.0-SNAPSHOT</version>

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
@@ -28,19 +28,7 @@
     <properties>
         <tika.version>3.1.0</tika.version>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- Override Xerces 2.12.1 from Tika -->
-            <dependency>
-                <groupId>xerces</groupId>
-                <artifactId>xercesImpl</artifactId>
-                <version>2.12.2</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
-
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
@@ -64,39 +52,7 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcpkix-jdk15on</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcmail-jdk15on</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcutil-jdk15on</artifactId>
-                </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk18on</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcmail-jdk18on</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcutil-jdk18on</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/pom.xml
@@ -56,10 +56,6 @@
             <artifactId>smbj</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-smbj-client/pom.xml
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-smbj-client/pom.xml
@@ -51,10 +51,6 @@
             <artifactId>smbj</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/nifi-extension-bundles/nifi-smb-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-smb-bundle/pom.xml
@@ -40,12 +40,6 @@
                 <groupId>com.hierynomus</groupId>
                 <artifactId>smbj</artifactId>
                 <version>0.14.0</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcprov-jdk15on</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>net.engio</groupId>


### PR DESCRIPTION
# Summary

[NIFI-14305](https://issues.apache.org/jira/browse/NIFI-14305) Removes unnecessary direct dependency references to Bouncy Castle from the AWS, Media, and SMB extension modules, along with removing the `jdk15on` exclusions. These changes were necessary with Bouncy Castle 1.71 introducing a change to the artifact naming, but referencing libraries and updated their transitive dependencies, removing the need for this approach.

Additional changes include removing the declaration of `xercesImpl` from the Media module, which is no longer a dependency of Apache Tika 3.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
