### PR TITLE
NIFI-14307 Closing response entity stream after reading in ElasticSearchClientServiceImpl

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -597,10 +597,8 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
 
         try {
             if (code >= 200 && code < 300) {
-                final InputStream inputStream = response.getEntity().getContent();
-                final byte[] result = IOUtils.toByteArray(inputStream);
-                inputStream.close();
-                return mapper.readValue(new String(result, responseCharset), Map.class);
+                String body = this.readContentAsString(response.getEntity(), this.responseCharset);
+                return mapper.readValue(body, Map.class);
             } else {
                 final String errorMessage = String.format("ElasticSearch reported an error while trying to run the query: %s",
                         response.getStatusLine().getReasonPhrase());
@@ -710,7 +708,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
             final Response response = performRequest("POST", "/_bulk", requestParameters, entity);
             watch.stop();
 
-            final String rawResponse = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+            final String rawResponse = this.readContentAsUtf8String(response.getEntity());
             parseResponseWarningHeaders(response);
 
             if (getLogger().isDebugEnabled()) {
@@ -751,7 +749,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
             watch.stop();
 
             if (getLogger().isDebugEnabled()) {
-                getLogger().debug("Response for bulk delete: {}", IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8));
+                getLogger().debug("Response for bulk delete: {}", this.readContentAsUtf8String(response.getEntity()));
             }
 
             parseResponseWarningHeaders(response);
@@ -853,7 +851,8 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
             endpoint.append("/").append(id);
 
             final Response response = performRequest("GET", endpoint.toString(), requestParameters, null);
-            final String body = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+
+            final String body = this.readContentAsUtf8String(response.getEntity());
             parseResponseWarningHeaders(response);
 
             return (Map<String, Object>) mapper.readValue(body, Map.class).getOrDefault("_source", Collections.emptyMap());
@@ -909,7 +908,8 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
             appendIndex(endpoint, index);
             endpoint.append("/_pit");
             final Response response = performRequest("POST", endpoint.toString(), params, null);
-            final String body = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+
+            final String body = this.readContentAsUtf8String(response.getEntity());
             parseResponseWarningHeaders(response);
 
             if (getLogger().isDebugEnabled()) {
@@ -932,7 +932,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
             watch.stop();
 
             if (getLogger().isDebugEnabled()) {
-                getLogger().debug("Response for deleting Point in Time: {}", IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8));
+                getLogger().debug("Response for deleting Point in Time: {}", this.readContentAsUtf8String(response.getEntity()));
             }
 
             parseResponseWarningHeaders(response);
@@ -958,7 +958,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
             watch.stop();
 
             if (getLogger().isDebugEnabled()) {
-                getLogger().debug("Response for deleting Scroll: {}", IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8));
+                getLogger().debug("Response for deleting Scroll: {}", this.readContentAsUtf8String(response.getEntity()));
             }
 
             parseResponseWarningHeaders(response);
@@ -1069,5 +1069,15 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
         }
 
         return client.performRequest(request);
+    }
+
+    private String readContentAsUtf8String(HttpEntity entity) throws UnsupportedOperationException, IOException {
+        return this.readContentAsString(entity, StandardCharsets.UTF_8);
+    }
+
+    private String readContentAsString(HttpEntity entity, Charset charset) throws UnsupportedOperationException, IOException {
+        try (InputStream responseStream = entity.getContent()) {
+            return IOUtils.toString(responseStream, charset);
+        }
     }
 }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -597,7 +597,7 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
 
         try {
             if (code >= 200 && code < 300) {
-                String body = this.readContentAsString(response.getEntity(), this.responseCharset);
+                final String body = this.readContentAsString(response.getEntity(), this.responseCharset);
                 return mapper.readValue(body, Map.class);
             } else {
                 final String errorMessage = String.format("ElasticSearch reported an error while trying to run the query: %s",
@@ -1071,13 +1071,13 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
         return client.performRequest(request);
     }
 
-    private String readContentAsUtf8String(HttpEntity entity) throws UnsupportedOperationException, IOException {
+    private String readContentAsUtf8String(HttpEntity entity) throws IOException {
         return this.readContentAsString(entity, StandardCharsets.UTF_8);
     }
 
-    private String readContentAsString(HttpEntity entity, Charset charset) throws UnsupportedOperationException, IOException {
+    private String readContentAsString(HttpEntity entity, Charset charset) throws IOException {
         try (InputStream responseStream = entity.getContent()) {
-            return IOUtils.toString(responseStream, charset);
+            return new String(responseStream.readAllBytes(), charset);
         }
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14307](https://issues.apache.org/jira/browse/NIFI-14307)

Close InputStream after reading response content in multiple places in ElasticSearchClientServiceImpl class. 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
- [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
