### PR TITLE
NIFI-14308 Make as-user optional in JsonConfigBasedBoxClientService

### DIFF
--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-services/src/main/java/org/apache/nifi/box/controllerservices/BoxAppActor.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-services/src/main/java/org/apache/nifi/box/controllerservices/BoxAppActor.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.box.controllerservices;
+
+import org.apache.nifi.components.DescribedValue;
+
+/**
+ * An enumeration of the possible actors a Box App will act on behalf of.
+ */
+public enum BoxAppActor implements DescribedValue {
+    SERVICE_ACCOUNT("service-account", "Service Account", "Make Box API calls with a service account associated with the app"),
+    IMPERSONATED_USER("impersonated-user", "Impersonated User", "Make Box API call on behalf of the specified Box user with as-user header");
+
+    private final String value;
+    private final String displayName;
+    private final String description;
+
+    BoxAppActor(String value, String displayName, String description) {
+        this.value = value;
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-services/src/main/resources/docs/org.apache.nifi.box.controllerservices.JsonConfigBasedBoxClientService/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-services/src/main/resources/docs/org.apache.nifi.box.controllerservices.JsonConfigBasedBoxClientService/additionalDetails.md
@@ -28,7 +28,7 @@ The App should have the following configuration:
 * Should have a 'Client ID' and 'Client Secret'.
 * 'App Access Level' should be 'App + Enterprise Access'.
 * 'Application Scopes' should have 'Write all files and folders in Box' enabled.
-* 'Advanced Features' should have 'Generate user access tokens' and 'Make API calls using the as-user header' enabled.
+* If 'App Actor' is 'Impersonated User', 'Advanced Features' should have 'Generate user access tokens' and 'Make API calls using the as-user header' enabled.
 * Under 'Add and Manage Public Keys' generate a Public/Private Keypair and download the configuration JSON file (under
   App Settings). The full path of this file should be set in the 'Box Config File' property.  
   Note that you can only download the configuration JSON with the keypair details only once, when you generate the

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-services/src/test/java/org/apache/nifi/box/controllerservices/JsonConfigBasedBoxClientServiceTestRunnerTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-services/src/test/java/org/apache/nifi/box/controllerservices/JsonConfigBasedBoxClientServiceTestRunnerTest.java
@@ -55,6 +55,7 @@ public class JsonConfigBasedBoxClientServiceTestRunnerTest {
     @Test
     void invalidWhenAccountIdIsMissing() {
         testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.APP_CONFIG_JSON, "{}");
+        // App Actor is Impersonated User by default.
         testRunner.assertNotValid(testSubject);
     }
 
@@ -83,6 +84,36 @@ public class JsonConfigBasedBoxClientServiceTestRunnerTest {
     void invalidWhenAppConfigJsonIsNotValid() {
         testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.ACCOUNT_ID, "account_id");
         testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.APP_CONFIG_JSON, "not_valid_json_string");
+        testRunner.assertNotValid(testSubject);
+    }
+
+    @Test
+    void validWhenAppActorIsServiceAccount() {
+        testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.APP_ACTOR, BoxAppActor.SERVICE_ACCOUNT);
+        testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.APP_CONFIG_JSON, "{}");
+        testRunner.assertValid(testSubject);
+    }
+
+    @Test
+    void invalidWhenAppActorIsServiceAccountAndAccountIdIsSet() {
+        testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.APP_ACTOR, BoxAppActor.SERVICE_ACCOUNT);
+        testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.ACCOUNT_ID, "account_id");
+        testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.APP_CONFIG_JSON, "{}");
+        testRunner.assertValid(testSubject);
+    }
+
+    @Test
+    void validWhenAppActorIsImpersonatedUserAndAccountIdIsSet() {
+        testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.APP_ACTOR, BoxAppActor.IMPERSONATED_USER);
+        testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.ACCOUNT_ID, "account_id");
+        testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.APP_CONFIG_JSON, "{}");
+        testRunner.assertValid(testSubject);
+    }
+
+    @Test
+    void invalidWhenAppActorIsImpersonatedUserAndAccountIdIsMissing() {
+        testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.APP_ACTOR, BoxAppActor.IMPERSONATED_USER);
+        testRunner.setProperty(testSubject, JsonConfigBasedBoxClientService.APP_CONFIG_JSON, "{}");
         testRunner.assertNotValid(testSubject);
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14308](https://issues.apache.org/jira/browse/NIFI-14308)

Making usages of `as-user` header optional.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-14308`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-14308`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

**No new dependencies.**

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
