### PR TITLE
NIFI-14310 Update System Test Suite to use HTTPS

### DIFF
--- a/nifi-system-tests/nifi-system-test-authorizer-bundle/nifi-system-test-authorizer-nar/pom.xml
+++ b/nifi-system-tests/nifi-system-test-authorizer-bundle/nifi-system-test-authorizer-nar/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
-  contributor license agreements.  See the NOTICE file distributed with
+  contributor license agreements. See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
-  the License.  You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,24 +15,21 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>nifi</artifactId>
         <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-system-test-authorizer-bundle</artifactId>
         <version>2.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>nifi-system-tests</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>nifi-system-test-authorizer-nar</artifactId>
+    <packaging>nar</packaging>
 
-    <modules>
-        <module>nifi-system-test-authorizer-bundle</module>
-        <module>nifi-system-test-extensions-bundle</module>
-        <module>nifi-system-test-extensions2-bundle</module>
-        <module>nifi-alternate-config-extensions-bundle</module>
-        <module>nifi-system-test-nar-provider-bundles</module>
-        <module>nifi-python-test-extensions-nar</module>
-        <module>nifi-system-test-suite</module>
-        <module>nifi-stateless-system-test-suite</module>
-    </modules>
-
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-system-test-authorizer</artifactId>
+            <version>2.3.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/nifi-system-tests/nifi-system-test-authorizer-bundle/nifi-system-test-authorizer/pom.xml
+++ b/nifi-system-tests/nifi-system-test-authorizer-bundle/nifi-system-test-authorizer/pom.xml
@@ -14,25 +14,20 @@
   limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>nifi</artifactId>
+        <artifactId>nifi-system-test-authorizer-bundle</artifactId>
         <groupId>org.apache.nifi</groupId>
         <version>2.3.0-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>nifi-system-tests</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>nifi-system-test-authorizer</artifactId>
 
-    <modules>
-        <module>nifi-system-test-authorizer-bundle</module>
-        <module>nifi-system-test-extensions-bundle</module>
-        <module>nifi-system-test-extensions2-bundle</module>
-        <module>nifi-alternate-config-extensions-bundle</module>
-        <module>nifi-system-test-nar-provider-bundles</module>
-        <module>nifi-python-test-extensions-nar</module>
-        <module>nifi-system-test-suite</module>
-        <module>nifi-stateless-system-test-suite</module>
-    </modules>
-
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-framework-api</artifactId>
+            <version>2.3.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/nifi-system-tests/nifi-system-test-authorizer-bundle/nifi-system-test-authorizer/src/main/java/org/apache/nifi/authorization/SystemTestAuthorizer.java
+++ b/nifi-system-tests/nifi-system-test-authorizer-bundle/nifi-system-test-authorizer/src/main/java/org/apache/nifi/authorization/SystemTestAuthorizer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.authorization;
+
+import org.apache.nifi.authorization.exception.AuthorizationAccessException;
+import org.apache.nifi.authorization.exception.AuthorizerCreationException;
+import org.apache.nifi.authorization.exception.AuthorizerDestructionException;
+
+public class SystemTestAuthorizer implements Authorizer {
+    @Override
+    public AuthorizationResult authorize(final AuthorizationRequest request) throws AuthorizationAccessException {
+        return AuthorizationResult.approved();
+    }
+
+    @Override
+    public void initialize(AuthorizerInitializationContext initializationContext) throws AuthorizerCreationException {
+
+    }
+
+    @Override
+    public void onConfigured(AuthorizerConfigurationContext configurationContext) throws AuthorizerCreationException {
+
+    }
+
+    @Override
+    public void preDestruction() throws AuthorizerDestructionException {
+
+    }
+}

--- a/nifi-system-tests/nifi-system-test-authorizer-bundle/nifi-system-test-authorizer/src/main/resources/META-INF/services/org.apache.nifi.authorization.Authorizer
+++ b/nifi-system-tests/nifi-system-test-authorizer-bundle/nifi-system-test-authorizer/src/main/resources/META-INF/services/org.apache.nifi.authorization.Authorizer
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.authorization.SystemTestAuthorizer

--- a/nifi-system-tests/nifi-system-test-authorizer-bundle/pom.xml
+++ b/nifi-system-tests/nifi-system-test-authorizer-bundle/pom.xml
@@ -14,25 +14,18 @@
   limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>nifi</artifactId>
+        <artifactId>nifi-system-tests</artifactId>
         <groupId>org.apache.nifi</groupId>
         <version>2.3.0-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>nifi-system-tests</artifactId>
+    <artifactId>nifi-system-test-authorizer-bundle</artifactId>
     <packaging>pom</packaging>
 
     <modules>
-        <module>nifi-system-test-authorizer-bundle</module>
-        <module>nifi-system-test-extensions-bundle</module>
-        <module>nifi-system-test-extensions2-bundle</module>
-        <module>nifi-alternate-config-extensions-bundle</module>
-        <module>nifi-system-test-nar-provider-bundles</module>
-        <module>nifi-python-test-extensions-nar</module>
-        <module>nifi-system-test-suite</module>
-        <module>nifi-stateless-system-test-suite</module>
+        <module>nifi-system-test-authorizer</module>
+        <module>nifi-system-test-authorizer-nar</module>
     </modules>
-
 </project>

--- a/nifi-system-tests/nifi-system-test-suite/pom.xml
+++ b/nifi-system-tests/nifi-system-test-suite/pom.xml
@@ -335,6 +335,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-system-test-authorizer-nar</artifactId>
+            <version>2.3.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-system-test-extensions-nar</artifactId>
             <version>2.3.0-SNAPSHOT</version>
             <type>nar</type>

--- a/nifi-system-tests/nifi-system-test-suite/src/test/assembly/dependencies.xml
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/assembly/dependencies.xml
@@ -35,8 +35,6 @@
                 <include>*:commons-lang3</include>
                 <include>*:slf4j-api</include>
                 <include>*:nifi-api</include>
-                <include>*:nifi-property-encryptor</include>
-                <include>*:nifi-security-crypto-key</include>
             </includes>
         </dependencySet>
 
@@ -65,6 +63,7 @@
                 <include>*:log4j-over-slf4j</include>
                 <include>*:jul-to-slf4j</include>
                 <include>*:slf4j-api</include>
+                <include>*:nifi-system-test-authorizer-nar</include>
                 <include>*:nifi-system-test-extensions-nar</include>
                 <include>*:nifi-system-test-extensions-services-nar</include>
                 <include>*:nifi-system-test-extensions-services-api-nar</include>

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/AggregateNiFiInstance.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/AggregateNiFiInstance.java
@@ -16,11 +16,13 @@
  */
 package org.apache.nifi.tests.system;
 
+import javax.net.ssl.SSLContext;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 public class AggregateNiFiInstance implements NiFiInstance {
@@ -110,6 +112,12 @@ public class AggregateNiFiInstance implements NiFiInstance {
         }
 
         return instances.get(nodeIndex - 1);
+    }
+
+    @Override
+    public Optional<SSLContext> getSslContext() {
+        final NiFiInstance firstInstance = instances.getFirst();
+        return firstInstance.getSslContext();
     }
 
     @Override

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiClientUtil.java
@@ -1618,7 +1618,7 @@ public class NiFiClientUtil {
 
     public RemoteProcessGroupEntity createRPG(final String parentGroupId, final int httpPort, final SiteToSiteTransportProtocol transportProtocol) throws NiFiClientException, IOException {
         final RemoteProcessGroupDTO component = new RemoteProcessGroupDTO();
-        component.setTargetUri("http://localhost:" + httpPort);
+        component.setTargetUri("https://localhost:%d".formatted(httpPort));
         component.setName(component.getTargetUri());
         component.setTransportProtocol(transportProtocol.name());
 

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiInstance.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiInstance.java
@@ -16,9 +16,11 @@
  */
 package org.apache.nifi.tests.system;
 
+import javax.net.ssl.SSLContext;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 public interface NiFiInstance {
@@ -71,6 +73,13 @@ public interface NiFiInstance {
      * @throws UnsupportedOperationException if the NiFi instance is not clustered
      */
     NiFiInstance getNodeInstance(int nodeIndex);
+
+    /**
+     * Get SSLContext from configured properties
+     *
+     * @return SSLContext or empty when not configured
+     */
+    Optional<SSLContext> getSslContext();
 
     /**
      * Returns the NiFiProperties for the node

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiInstanceCache.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiInstanceCache.java
@@ -20,10 +20,12 @@ package org.apache.nifi.tests.system;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLContext;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 
 public class NiFiInstanceCache {
@@ -213,6 +215,11 @@ public class NiFiInstanceCache {
         @Override
         public int getNumberOfNodes(final boolean includeOnlyAutoStartInstances) {
             return rawInstance.getNumberOfNodes(includeOnlyAutoStartInstances);
+        }
+
+        @Override
+        public Optional<SSLContext> getSslContext() {
+            return rawInstance.getSslContext();
         }
 
         @Override

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiSystemIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/NiFiSystemIT.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLContext;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -52,6 +53,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -331,11 +333,15 @@ public abstract class NiFiSystemIT implements NiFiInstanceProvider {
     }
 
     protected NiFiClient createClient(final int port) {
-        final NiFiClientConfig clientConfig = new NiFiClientConfig.Builder()
-                .baseUrl("http://localhost:" + port)
-                .connectTimeout(30000)
-                .readTimeout(30000)
-                .build();
+        final NiFiClientConfig.Builder clientConfigBuilder = new NiFiClientConfig.Builder()
+                .baseUrl("https://localhost:" + port)
+                .connectTimeout(15000)
+                .readTimeout(30000);
+
+        final NiFiInstance nifiInstance = nifiRef.get();
+        final Optional<SSLContext> sslContextFound = nifiInstance.getSslContext();
+        sslContextFound.ifPresent(clientConfigBuilder::sslContext);
+        final NiFiClientConfig clientConfig = clientConfigBuilder.build();
 
         return new JerseyNiFiClient.Builder()
                 .config(clientConfig)

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/RestartWithDifferentPortIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/RestartWithDifferentPortIT.java
@@ -57,8 +57,8 @@ public class RestartWithDifferentPortIT extends NiFiSystemIT {
         final NiFiInstance secondNode = getNiFiInstance().getNodeInstance(2);
         secondNode.stop();
 
-        // Change the value of the nifi.web.http.port property from 5672 to 5673
-        secondNode.setProperty("nifi.web.http.port", "5673");
+        // Change the value of the nifi.web.https.port property from 5672 to 5673
+        secondNode.setProperty("nifi.web.https.port", "5673");
 
         // Restart the second node
         secondNode.start();

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/authorizers.xml
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/authorizers.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<authorizers>
+    <authorizer>
+        <identifier>system-test-authorizer</identifier>
+        <class>org.apache.nifi.authorization.SystemTestAuthorizer</class>
+    </authorizer>
+</authorizers>

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node1/nifi.properties
@@ -130,8 +130,8 @@ nifi.nar.persistence.provider.properties.directory=./nar_repository
 nifi.asset.manager.properties.directory=./assets
 
 # Site to Site properties
-nifi.remote.input.host=
-nifi.remote.input.secure=false
+nifi.remote.input.host=localhost
+nifi.remote.input.secure=true
 nifi.remote.input.socket.port=7781
 nifi.remote.input.http.enabled=true
 nifi.remote.input.http.transaction.ttl=30 sec
@@ -140,10 +140,10 @@ nifi.remote.contents.cache.expiration=30 secs
 # web properties #
 nifi.web.war.directory=./lib
 nifi.web.http.host=
-nifi.web.http.port=5671
+nifi.web.http.port=
 nifi.web.http.network.interface.default=
-nifi.web.https.host=
-nifi.web.https.port=
+nifi.web.https.host=localhost
+nifi.web.https.port=5671
 nifi.web.https.network.interface.default=
 nifi.web.jetty.working.directory=./work/jetty
 nifi.web.jetty.threads=200
@@ -157,12 +157,12 @@ nifi.sensitive.props.algorithm=NIFI_PBKDF2_AES_GCM_256
 
 nifi.security.keystore=certs/keystore.p12
 nifi.security.keystoreType=PKCS12
-nifi.security.keystorePasswd=NiFiSystemKeyStoreProvider
-nifi.security.keyPasswd=NiFiSystemKeyStoreProvider
+nifi.security.keystorePasswd=
+nifi.security.keyPasswd=
 nifi.security.truststore=certs/truststore.p12
 nifi.security.truststoreType=PKCS12
-nifi.security.truststorePasswd=NiFiSystemKeyStoreProvider
-nifi.security.user.authorizer=managed-authorizer
+nifi.security.truststorePasswd=
+nifi.security.user.authorizer=system-test-authorizer
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
@@ -197,7 +197,7 @@ nifi.security.user.oidc.preferred.jwsalgorithm=
 
 # cluster common properties (all nodes must have same values) #
 nifi.cluster.protocol.heartbeat.interval=2 sec
-nifi.cluster.protocol.is.secure=false
+nifi.cluster.protocol.is.secure=true
 
 # cluster node properties (only configure for cluster nodes) #
 nifi.cluster.is.node=true

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/authorizers.xml
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/authorizers.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<authorizers>
+    <authorizer>
+        <identifier>system-test-authorizer</identifier>
+        <class>org.apache.nifi.authorization.SystemTestAuthorizer</class>
+    </authorizer>
+</authorizers>

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/clustered/node2/nifi.properties
@@ -130,8 +130,8 @@ nifi.nar.persistence.provider.properties.directory=./nar_repository
 nifi.asset.manager.properties.directory=./assets
 
 # Site to Site properties
-nifi.remote.input.host=
-nifi.remote.input.secure=false
+nifi.remote.input.host=localhost
+nifi.remote.input.secure=true
 nifi.remote.input.socket.port=7782
 nifi.remote.input.http.enabled=true
 nifi.remote.input.http.transaction.ttl=30 sec
@@ -140,10 +140,10 @@ nifi.remote.contents.cache.expiration=30 secs
 # web properties #
 nifi.web.war.directory=./lib
 nifi.web.http.host=
-nifi.web.http.port=5672
+nifi.web.http.port=
 nifi.web.http.network.interface.default=
-nifi.web.https.host=
-nifi.web.https.port=
+nifi.web.https.host=localhost
+nifi.web.https.port=5672
 nifi.web.https.network.interface.default=
 nifi.web.jetty.working.directory=./work/jetty
 nifi.web.jetty.threads=200
@@ -157,12 +157,12 @@ nifi.sensitive.props.algorithm=NIFI_PBKDF2_AES_GCM_256
 
 nifi.security.keystore=certs/keystore.p12
 nifi.security.keystoreType=PKCS12
-nifi.security.keystorePasswd=NiFiSystemKeyStoreProvider
-nifi.security.keyPasswd=NiFiSystemKeyStoreProvider
+nifi.security.keystorePasswd=
+nifi.security.keyPasswd=
 nifi.security.truststore=certs/truststore.p12
 nifi.security.truststoreType=PKCS12
-nifi.security.truststorePasswd=NiFiSystemKeyStoreProvider
-nifi.security.user.authorizer=managed-authorizer
+nifi.security.truststorePasswd=
+nifi.security.user.authorizer=system-test-authorizer
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
@@ -197,7 +197,7 @@ nifi.security.user.oidc.preferred.jwsalgorithm=
 
 # cluster common properties (all nodes must have same values) #
 nifi.cluster.protocol.heartbeat.interval=2 sec
-nifi.cluster.protocol.is.secure=false
+nifi.cluster.protocol.is.secure=true
 
 # cluster node properties (only configure for cluster nodes) #
 nifi.cluster.is.node=true

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/authorizers.xml
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/authorizers.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<authorizers>
+    <authorizer>
+        <identifier>system-test-authorizer</identifier>
+        <class>org.apache.nifi.authorization.SystemTestAuthorizer</class>
+    </authorizer>
+</authorizers>

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/default/nifi.properties
@@ -131,8 +131,8 @@ nifi.nar.persistence.provider.properties.directory=./nar_repository
 nifi.asset.manager.properties.directory=./assets
 
 # Site to Site properties
-nifi.remote.input.host=
-nifi.remote.input.secure=false
+nifi.remote.input.host=localhost
+nifi.remote.input.secure=true
 nifi.remote.input.socket.port=7780
 nifi.remote.input.http.enabled=true
 nifi.remote.input.http.transaction.ttl=30 sec
@@ -141,10 +141,10 @@ nifi.remote.contents.cache.expiration=30 secs
 # web properties #
 nifi.web.war.directory=./lib
 nifi.web.http.host=
-nifi.web.http.port=5670
+nifi.web.http.port=
 nifi.web.http.network.interface.default=
-nifi.web.https.host=
-nifi.web.https.port=
+nifi.web.https.host=localhost
+nifi.web.https.port=5670
 nifi.web.https.network.interface.default=
 nifi.web.jetty.working.directory=./work/jetty
 nifi.web.jetty.threads=200
@@ -158,12 +158,12 @@ nifi.sensitive.props.algorithm=NIFI_PBKDF2_AES_GCM_256
 
 nifi.security.keystore=certs/keystore.p12
 nifi.security.keystoreType=PKCS12
-nifi.security.keystorePasswd=NiFiSystemKeyStoreProvider
-nifi.security.keyPasswd=NiFiSystemKeyStoreProvider
+nifi.security.keystorePasswd=
+nifi.security.keyPasswd=
 nifi.security.truststore=certs/truststore.p12
 nifi.security.truststoreType=PKCS12
-nifi.security.truststorePasswd=NiFiSystemKeyStoreProvider
-nifi.security.user.authorizer=managed-authorizer
+nifi.security.truststorePasswd=
+nifi.security.user.authorizer=system-test-authorizer
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=
@@ -198,7 +198,7 @@ nifi.security.user.oidc.preferred.jwsalgorithm=
 
 # cluster common properties (all nodes must have same values) #
 nifi.cluster.protocol.heartbeat.interval=5 sec
-nifi.cluster.protocol.is.secure=false
+nifi.cluster.protocol.is.secure=true
 
 # cluster node properties (only configure for cluster nodes) #
 nifi.cluster.is.node=false

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/authorizers.xml
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/authorizers.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<authorizers>
+    <authorizer>
+        <identifier>system-test-authorizer</identifier>
+        <class>org.apache.nifi.authorization.SystemTestAuthorizer</class>
+    </authorizer>
+</authorizers>

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/logback.xml
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/logback.xml
@@ -100,6 +100,8 @@
     <logger name="org.apache.nifi.processors.standard.LogMessage" level="INFO"/>
     <logger name="org.apache.nifi.controller.repository.StandardProcessSession" level="WARN" />
 
+    <!-- Py4J set to WARN to avoid verbose socket communication messages -->
+    <logger name="py4j" level="WARN" />
 
     <logger name="org.apache.zookeeper.ClientCnxn" level="ERROR" />
     <logger name="org.apache.zookeeper.server.NIOServerCnxn" level="ERROR" />

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/nifi.properties
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/nifi.properties
@@ -18,7 +18,7 @@
 #
 
 # Core Properties #
-nifi.flow.configuration.file=./conf/flow.xml.gz
+nifi.flow.configuration.file=./conf/flow.json.gz
 nifi.flow.configuration.archive.enabled=true
 nifi.flow.configuration.archive.dir=./conf/archive/
 nifi.flow.configuration.archive.max.time=30 days
@@ -135,8 +135,8 @@ nifi.nar.persistence.provider.properties.directory=./nar_repository
 nifi.asset.manager.properties.directory=./assets
 
 # Site to Site properties
-nifi.remote.input.host=
-nifi.remote.input.secure=false
+nifi.remote.input.host=localhost
+nifi.remote.input.secure=true
 nifi.remote.input.socket.port=7780
 nifi.remote.input.http.enabled=true
 nifi.remote.input.http.transaction.ttl=30 sec
@@ -145,10 +145,10 @@ nifi.remote.contents.cache.expiration=30 secs
 # web properties #
 nifi.web.war.directory=./lib
 nifi.web.http.host=
-nifi.web.http.port=5670
+nifi.web.http.port=
 nifi.web.http.network.interface.default=
-nifi.web.https.host=
-nifi.web.https.port=
+nifi.web.https.host=localhost
+nifi.web.https.port=5670
 nifi.web.https.network.interface.default=
 nifi.web.jetty.working.directory=./work/jetty
 nifi.web.jetty.threads=200
@@ -162,12 +162,12 @@ nifi.sensitive.props.algorithm=NIFI_PBKDF2_AES_GCM_256
 
 nifi.security.keystore=certs/keystore.p12
 nifi.security.keystoreType=PKCS12
-nifi.security.keystorePasswd=NiFiSystemKeyStoreProvider
-nifi.security.keyPasswd=NiFiSystemKeyStoreProvider
+nifi.security.keystorePasswd=
+nifi.security.keyPasswd=
 nifi.security.truststore=certs/truststore.p12
 nifi.security.truststoreType=PKCS12
-nifi.security.truststorePasswd=NiFiSystemKeyStoreProvider
-nifi.security.user.authorizer=managed-authorizer
+nifi.security.truststorePasswd=
+nifi.security.user.authorizer=system-test-authorizer
 nifi.security.user.login.identity.provider=
 nifi.security.ocsp.responder.url=
 nifi.security.ocsp.responder.certificate=


### PR DESCRIPTION
# Summary

[NIFI-14310](https://issues.apache.org/jira/browse/NIFI-14310) Updates the System Test Suite modules to use HTTPS instead of HTTP for node and client communication.

Enabling HTTPS in the System Test Suite provides better alignment with standard deployment configuration where HTTPS is enabled by default for system communication.

Changes include a new `SystemTestAuthorizer` for test modules to allow all communication, and updates to the Key Store provisioning process to generate a random password.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
