### PR TITLE
NIFI-14311 Fix Elasticsearch verification message checks

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchClientService_IT.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchClientService_IT.java
@@ -166,7 +166,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         assertEquals(3, results.stream().filter(result -> result.getOutcome() == ConfigVerificationResult.Outcome.SKIPPED).count(), results.toString());
         assertEquals(1, results.stream().filter(
                 result -> Objects.equals(result.getVerificationStepName(), ElasticSearchClientServiceImpl.VERIFICATION_STEP_CLIENT_SETUP)
-                        && Objects.equals(result.getExplanation(), "Incorrect/invalid " + ElasticSearchClientService.HTTP_HOSTS.getDisplayName())
+                        && result.getExplanation().contains(ElasticSearchClientService.HTTP_HOSTS.getDisplayName())
                         && result.getOutcome() == ConfigVerificationResult.Outcome.FAILED).count(),
                 results.toString()
         );
@@ -188,7 +188,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         assertEquals(2, results.stream().filter(result -> result.getOutcome() == ConfigVerificationResult.Outcome.SKIPPED).count(), results.toString());
         assertEquals(1, results.stream().filter(
                 result -> Objects.equals(result.getVerificationStepName(), ElasticSearchClientServiceImpl.VERIFICATION_STEP_CONNECTION)
-                        && Objects.equals(result.getExplanation(), "Unable to retrieve system summary from Elasticsearch root endpoint")
                         && result.getOutcome() == ConfigVerificationResult.Outcome.FAILED).count(),
                 results.toString()
         );
@@ -214,7 +213,6 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         assertEquals(2, results.stream().filter(result -> result.getOutcome() == ConfigVerificationResult.Outcome.SKIPPED).count(), results.toString());
         assertEquals(1, results.stream().filter(
                 result -> Objects.equals(result.getVerificationStepName(), ElasticSearchClientServiceImpl.VERIFICATION_STEP_CONNECTION)
-                        && Objects.equals(result.getExplanation(), "Unable to retrieve system summary from Elasticsearch root endpoint")
                         && result.getOutcome() == ConfigVerificationResult.Outcome.FAILED).count(),
                 results.toString()
         );
@@ -985,7 +983,7 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
     private void assertVerifySnifferSkipped(final List<ConfigVerificationResult> results) {
         assertEquals(1, results.stream().filter(
                         result -> Objects.equals(result.getVerificationStepName(), ElasticSearchClientServiceImpl.VERIFICATION_STEP_SNIFFER)
-                                && Objects.equals(result.getExplanation(), "Sniff on Connection not enabled")
+                                && result.getExplanation().contains("Sniff")
                                 && result.getOutcome() == ConfigVerificationResult.Outcome.SKIPPED).count(),
                 results.toString()
         );


### PR DESCRIPTION
# Summary

[NIFI-14311](https://issues.apache.org/jira/browse/NIFI-14311) Corrects Elasticsearch Client integration test methods to avoid comparing exact verification message strings. Changes include removing some checks and replacing others with checking for a single keyword.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
