### PR TITLE
[NIFI-14317] - Handle flow version change failure by displaying the failure reason in an error banner

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/state/flow/flow.effects.ts
@@ -4148,8 +4148,7 @@ export class FlowEffects {
             map((action) => action.request),
             tap(() => {
                 const dialogRef = this.dialog.open(ChangeVersionProgressDialog, {
-                    ...SMALL_DIALOG,
-                    minWidth: 365,
+                    ...MEDIUM_DIALOG,
                     disableClose: true,
                     autoFocus: false
                 });
@@ -4324,8 +4323,7 @@ export class FlowEffects {
             map((action) => action.request),
             tap(() => {
                 const dialogRef = this.dialog.open(ChangeVersionProgressDialog, {
-                    ...SMALL_DIALOG,
-                    minWidth: 365,
+                    ...MEDIUM_DIALOG,
                     disableClose: true,
                     autoFocus: false
                 });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/change-version-progress-dialog/change-version-progress-dialog.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/change-version-progress-dialog/change-version-progress-dialog.html
@@ -29,7 +29,9 @@
         <div class="flex flex-col gap-y-4">
             @if (flowUpdateRequest$ | async; as versionChangeRequest) {
                 <div class="tertiary-color font-medium">
-                    @if (versionChangeRequest.request.complete && !versionChangeRequest.request.failureReason) {
+                    @if (versionChangeRequest.request.complete && versionChangeRequest.request.failureReason) {
+                        There was an error changing versions.
+                    } @else if (versionChangeRequest.request.complete) {
                         This Process Group version has changed.
                     } @else {
                         {{ versionChangeRequest.request.state }}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/change-version-progress-dialog/change-version-progress-dialog.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/change-version-progress-dialog/change-version-progress-dialog.html
@@ -16,6 +16,14 @@
   -->
 
 <h2 mat-dialog-title>Change Flow Version</h2>
+@if (flowUpdateRequest$ | async; as versionChangeRequest) {
+    @if (versionChangeRequest.request.complete && versionChangeRequest.request.failureReason) {
+        <error-banner
+            [messages]="[versionChangeRequest.request.failureReason]"
+            [showErrorIcon]="true"
+            [allowDismiss]="false"></error-banner>
+    }
+}
 <div class="change-version-progress">
     <mat-dialog-content>
         <div class="flex flex-col gap-y-4">

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/change-version-progress-dialog/change-version-progress-dialog.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/change-version-progress-dialog/change-version-progress-dialog.html
@@ -29,7 +29,7 @@
         <div class="flex flex-col gap-y-4">
             @if (flowUpdateRequest$ | async; as versionChangeRequest) {
                 <div class="tertiary-color font-medium">
-                    @if (versionChangeRequest.request.complete) {
+                    @if (versionChangeRequest.request.complete && !versionChangeRequest.request.failureReason) {
                         This Process Group version has changed.
                     } @else {
                         {{ versionChangeRequest.request.state }}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/change-version-progress-dialog/change-version-progress-dialog.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/flow/change-version-progress-dialog/change-version-progress-dialog.ts
@@ -22,10 +22,11 @@ import { FlowUpdateRequestEntity } from '../../../../../state/flow';
 import { Observable, of } from 'rxjs';
 import { AsyncPipe } from '@angular/common';
 import { MatProgressBar } from '@angular/material/progress-bar';
+import { ErrorBanner } from '../../../../../../../ui/common/error-banner/error-banner.component';
 
 @Component({
     selector: 'change-version-progress-dialog',
-    imports: [MatDialogTitle, MatDialogModule, MatButton, AsyncPipe, MatProgressBar],
+    imports: [MatDialogTitle, MatDialogModule, MatButton, AsyncPipe, MatProgressBar, ErrorBanner],
     templateUrl: './change-version-progress-dialog.html',
     styleUrl: './change-version-progress-dialog.scss'
 })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/error-banner/error-banner.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/error-banner/error-banner.component.html
@@ -35,8 +35,10 @@
                 </ul>
             }
         </div>
-        <div class="flex flex-1 mt-auto justify-end w-full">
-            <button mat-flat-button class="error-button" (click)="dismissClicked()">Dismiss</button>
-        </div>
+        @if (allowDismiss) {
+            <div class="flex flex-1 mt-auto justify-end w-full">
+                <button mat-flat-button class="error-button" (click)="dismissClicked()">Dismiss</button>
+            </div>
+        }
     </div>
 }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/error-banner/error-banner.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/error-banner/error-banner.component.html
@@ -26,11 +26,11 @@
                 <i class="fa fa-exclamation-triangle error-color fa-2x"></i>
             }
             @if (messages.length === 1) {
-                <div>{{ messages[0] }}</div>
+                <div class="error-banner-message">{{ messages[0] }}</div>
             } @else {
                 <ul>
                     @for (message of messages; track message) {
-                        <li>{{ message }}</li>
+                        <li class="error-banner-message">{{ message }}</li>
                     }
                 </ul>
             }

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/error-banner/error-banner.component.scss
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/error-banner/error-banner.component.scss
@@ -20,6 +20,10 @@
 .banner-container {
     @include mat.button-density(-1);
 
+    .error-banner-message {
+        word-break: break-word;
+    }
+
     ul {
         list-style-type: disc;
         list-style-position: inside;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/error-banner/error-banner.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/error-banner/error-banner.component.ts
@@ -29,6 +29,7 @@ export class ErrorBanner {
     @Input() messages: string[] | null = null;
     @Input() showErrorIcon = true;
     @Input() showBorder = true;
+    @Input() allowDismiss = true;
 
     @Output() dismiss: EventEmitter<void> = new EventEmitter<void>();
 


### PR DESCRIPTION
# Summary

[NIFI-14317](https://issues.apache.org/jira/browse/NIFI-14317)

_Verification Note:_ You can force the error banner to appear when changing a flow version by modifying `FlowUpdateResource.java#createUpdateRequestResponse` to return a failureReason and setting complete to true.

From:
```
        updateRequestDto.setComplete(asyncRequest.isComplete());
        updateRequestDto.setFailureReason(asyncRequest.getFailureReason());
```

To: 
```
        updateRequestDto.setComplete(true);
        updateRequestDto.setFailureReason("There was an error");
```