### PR TITLE
NIFI-14327 - Upgrade versions for Spring, Netty, SLF4J, Jackson, logback and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <ant.version>1.10.15</ant.version>
-        <org.apache.sshd.version>2.14.0</org.apache.sshd.version>
+        <org.apache.sshd.version>2.15.0</org.apache.sshd.version>
         <mime4j.version>0.8.12</mime4j.version>
     </properties>
 
@@ -89,7 +89,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.2.2</version>
+                <version>1.2.3</version>
             </dependency>
             <!-- SSHD from Registry and other modules -->
             <dependency>
@@ -117,7 +117,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.25.5</version>
+                <version>3.25.6</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-commons/nifi-calcite-utils/pom.xml
+++ b/nifi-commons/nifi-calcite-utils/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.25.5</version>
+            <version>3.25.6</version>
         </dependency>
     </dependencies>
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -70,7 +70,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.25.5</version>
+                <version>3.25.6</version>
             </dependency>
             <!-- Override kotlin-stdlib-common from amazon-kinesis-client -->
             <!-- can be removed when not relying on kotlin-stdlib-common:jar anymore -->

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.7.2</version>
+            <version>3.7.3</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.7.2</version>
+            <version>3.7.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.box</groupId>
                 <artifactId>box-java-sdk</artifactId>
-                <version>4.14.0</version>
+                <version>4.15.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-cipher-bundle/nifi-cipher-processors/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>nifi-cipher-processors</artifactId>
 
     <dependencies>
-
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>8.17.2</elasticsearch.client.version>
+        <elasticsearch.client.version>8.17.3</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>nifi-email-processors</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <spring.integration.version>6.4.1</spring.integration.version>
+        <spring.integration.version>6.4.2</spring.integration.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20250122-2.0.0</version>
+            <version>v3-rev20250216-2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.tdunning</groupId>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.54.0</google.libraries.version>
+        <google.libraries.version>26.56.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-github-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-github-bundle/pom.xml
@@ -26,7 +26,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <github-api.version>1.326</github-api.version>
+        <github-api.version>1.327</github-api.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
     <properties>
         <gremlin.version>3.7.3</gremlin.version>
-        <janusgraph.version>1.2.0-20250206-164517.a71898b</janusgraph.version>
+        <janusgraph.version>1.2.0-20250219-143145.6c030f7</janusgraph.version>
         <guava.version>33.4.0-jre</guava.version>
         <amqp-client.version>5.25.0</amqp-client.version>
     </properties>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/pom.xml
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <neo4j.driver.version>5.28.1</neo4j.driver.version>
+        <neo4j.driver.version>5.28.2</neo4j.driver.version>
         <neo4j.docker.version>5.19</neo4j.docker.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-hl7-bundle/nifi-hl7-processors/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.hivemq</groupId>
             <artifactId>hivemq-mqtt-client</artifactId>
-            <version>1.3.4</version>
+            <version>1.3.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
@@ -32,7 +32,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
-                <version>3.25.5</version>
+                <version>3.25.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/nifi-extension-bundles/nifi-parquet-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-parquet-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.10.0</version>
+                <version>1.10.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-poi-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-poi-bundle/pom.xml
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>com.github.pjfanning</groupId>
                 <artifactId>excel-streaming-reader</artifactId>
-                <version>5.0.2</version>
+                <version>5.0.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -26,8 +26,8 @@
     <artifactId>nifi-protobuf-services</artifactId>
 
     <properties>
-        <protobuf.version>3.25.5</protobuf.version>
-        <wire.version>5.2.1</wire.version>
+        <protobuf.version>3.25.6</protobuf.version>
+        <wire.version>5.3.0</wire.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
@@ -57,7 +57,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>1.5.5</version>
+            <version>1.5.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-salesforce</artifactId>
-            <version>4.9.0</version>
+            <version>4.10.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.slack.api</groupId>
             <artifactId>bolt-socket-mode</artifactId>
-            <version>1.45.2</version>
+            <version>1.45.3</version>
         </dependency>
         <!-- Required by bolt-socket-mode but the library itself doesn't have the dependency. -->
         <dependency>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -40,7 +40,7 @@
                 <groupId>net.snowflake</groupId>
                 <artifactId>snowflake-jdbc</artifactId>
                 <!-- please check snowflake-ingest-sdk compatibility before upgrade -->
-                <version>3.22.0</version>
+                <version>3.23.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-content-viewer/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-content-viewer/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>nifi-standard-content-viewer</artifactId>
     <packaging>war</packaging>
     <properties>
-        <spring.boot.version>3.4.2</spring.boot.version>
+        <spring.boot.version>3.4.3</spring.boot.version>
         <standard-content-viewer.ui.working.dir>${project.build.directory}/standard-content-viewer-ui-working-directory</standard-content-viewer.ui.working.dir>
     </properties>
     <dependencies>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-common</artifactId>
-            <version>2.14.0</version>
+            <version>${org.apache.sshd.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -34,7 +34,7 @@
         <module>nifi-standard-content-viewer-nar</module>
     </modules>
     <properties>
-        <org.apache.sshd.version>2.14.0</org.apache.sshd.version>
+        <org.apache.sshd.version>2.15.0</org.apache.sshd.version>
         <tika.version>3.1.0</tika.version>
     </properties>
     <dependencyManagement>
@@ -226,7 +226,7 @@
             <dependency>
                 <groupId>com.networknt</groupId>
                 <artifactId>json-schema-validator</artifactId>
-                <version>1.5.5</version>
+                <version>1.5.6</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>${caffeine.version}</version>
         </dependency>
         <dependency>
             <groupId>com.maxmind.db</groupId>
@@ -64,7 +63,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -94,7 +93,6 @@
         <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio-jvm</artifactId>
-            <version>${okio.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
@@ -121,7 +121,7 @@
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
-                <version>3.48.4</version>
+                <version>3.49.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -106,7 +106,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>oauth2-oidc-sdk</artifactId>
-                <version>11.20.1</version>
+                <version>11.23.1</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>
@@ -358,7 +358,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.10.0</version>
+                <version>1.10.1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>3.5.1</version>
+            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>oauth2-oidc-sdk</artifactId>
-                <version>11.20.1</version>
+                <version>11.23.1</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -35,12 +35,12 @@
         <module>nifi-registry-docker-maven</module>
     </modules>
     <properties>
-        <spring.boot.version>3.4.2</spring.boot.version>
-        <flyway.version>11.3.1</flyway.version>
+        <spring.boot.version>3.4.3</spring.boot.version>
+        <flyway.version>11.3.4</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.1.0.202411261347-r</jgit.version>
-        <org.apache.sshd.version>2.14.0</org.apache.sshd.version>
+        <org.apache.sshd.version>2.15.0</org.apache.sshd.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
-        <com.amazonaws.version>1.12.780</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.30.16</software.amazon.awssdk.version>
+        <com.amazonaws.version>1.12.782</com.amazonaws.version>
+        <software.amazon.awssdk.version>2.30.33</software.amazon.awssdk.version>
         <gson.version>2.12.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.1.0</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.1.10</kotlin.version>
@@ -119,7 +119,7 @@
         <org.apache.commons.cli.version>1.9.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.18.0</org.apache.commons.codec.version>
         <org.apache.commons.compress.version>1.27.1</org.apache.commons.compress.version>
-        <com.github.luben.zstd-jni.version>1.5.6-9</com.github.luben.zstd-jni.version>
+        <com.github.luben.zstd-jni.version>1.5.7-1</com.github.luben.zstd-jni.version>
         <org.apache.commons.configuration.version>2.11.0</org.apache.commons.configuration.version>
         <org.apache.commons.lang3.version>3.17.0</org.apache.commons.lang3.version>
         <org.apache.commons.net.version>3.11.1</org.apache.commons.net.version>
@@ -129,19 +129,19 @@
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
         <org.bouncycastle.version>1.80</org.bouncycastle.version>
         <pmd.version>7.10.0</pmd.version>
-        <testcontainers.version>1.20.4</testcontainers.version>
-        <org.slf4j.version>2.0.16</org.slf4j.version>
+        <testcontainers.version>1.20.6</testcontainers.version>
+        <org.slf4j.version>2.0.17</org.slf4j.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <derby.version>10.17.1.0</derby.version>
         <jetty.version>12.0.16</jetty.version>
-        <jackson.bom.version>2.18.2</jackson.bom.version>
+        <jackson.bom.version>2.18.3</jackson.bom.version>
         <avro.version>1.11.4</avro.version>
         <jaxb.runtime.version>4.0.5</jaxb.runtime.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
         <json.smart.version>2.5.2</json.smart.version>
-        <groovy.version>4.0.25</groovy.version>
+        <groovy.version>4.0.26</groovy.version>
         <surefire.version>3.5.1</surefire.version>
         <hadoop.version>3.4.1</hadoop.version>
         <ozone.version>1.4.1</ozone.version>
@@ -149,14 +149,14 @@
         <aspectj.version>1.9.22.1</aspectj.version>
         <jersey.bom.version>3.1.10</jersey.bom.version>
         <log4j2.version>2.24.3</log4j2.version>
-        <logback.version>1.5.16</logback.version>
-        <mockito.version>5.15.2</mockito.version>
+        <logback.version>1.5.17</logback.version>
+        <mockito.version>5.16.0</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
-        <snakeyaml.version>2.3</snakeyaml.version>
-        <netty.4.version>4.1.118.Final</netty.4.version>
+        <snakeyaml.version>2.4</snakeyaml.version>
+        <netty.4.version>4.1.119.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
-        <spring.version>6.2.2</spring.version>
-        <spring.security.version>6.4.2</spring.security.version>
+        <spring.version>6.2.3</spring.version>
+        <spring.security.version>6.4.3</spring.security.version>
         <swagger.annotations.version>2.2.28</swagger.annotations.version>
         <h2.version>2.3.232</h2.version>
         <zookeeper.version>3.9.3</zookeeper.version>
@@ -538,7 +538,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.18.3</version>
+                <version>1.19.1</version>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>
@@ -754,7 +754,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.17.1</version>
+                    <version>2.18.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.rat</groupId>
@@ -783,12 +783,12 @@
                 <plugin>
                     <groupId>io.swagger.core.v3</groupId>
                     <artifactId>swagger-maven-plugin-jakarta</artifactId>
-                    <version>2.2.25</version>
+                    <version>2.2.28</version>
                 </plugin>
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>3.0.64</version>
+                    <version>3.0.68</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
# Summary

[NIFI-14327](https://issues.apache.org/jira/browse/NIFI-14327)

- SSHD from 2.14.0 to 2.15.0 - https://github.com/apache/mina-sshd/blob/master/docs/changes/2.15.0.md
- Reactor Netty HTTP from 1.2.2 to 1.2.3 - https://github.com/reactor/reactor-netty/releases/tag/v1.2.3
- Protobuf Java from 3.25.5 to 3.25.6 - https://github.com/protocolbuffers/protobuf/releases/tag/v25.6
- Common Beanutils from 1.10.0 to 1.10.1 - https://commons.apache.org/proper/commons-beanutils/changes.html#a1.10.1
- Reactor from 3.7.2 to 3.7.3 - https://github.com/reactor/reactor-core/releases/tag/v3.7.3
- Box Java SDK from 4.14.0 to 4.15.2 - https://github.com/box/box-java-sdk/releases
- Elasticsearch client from 8.17.2 to 8.17.3 - https://github.com/elastic/elasticsearch-java/compare/v8.17.2...v8.17.3
- Spring Integration from 6.4.1 to 6.4.2 - https://github.com/spring-projects/spring-integration/releases/tag/v6.4.2
- Google Drive API from v3-rev20250122-2.0.0 to v3-rev20250216-2.0.0 - https://github.com/googleapis/google-api-java-client-services/tree/main/clients/google-api-services-drive/v3/2.0.0
- GCP BOM from 26.54.0 to 26.56.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.56.0
- Github API from 1.326 to 1.327 - https://github.com/hub4j/github-api/releases/tag/github-api-1.327
- JanusGraph from 1.2.0-20250206-164517.a71898b to 1.2.0-20250219-143145.6c030f7 - https://github.com/JanusGraph/janusgraph
- Neo4J driver from 5.28.1 to 5.28.2 - https://github.com/neo4j/neo4j-java-driver/releases/tag/5.28.2
- Hive MQTT Client from 1.3.4 to 1.3.5 - https://github.com/hivemq/hivemq-mqtt-client/releases/tag/v1.3.5
- Excel streaming reader from 5.0.2 to 5.0.3 - https://github.com/pjfanning/excel-streaming-reader/releases/tag/v5.0.3
- Wire from 5.2.1 to 5.3.0 - https://github.com/square/wire/blob/master/CHANGELOG.md#version-530
- JSON Schema Validator from 1.5.5 to 1.5.6 - https://github.com/networknt/json-schema-validator/blob/master/CHANGELOG.md#156--2025-02-19
- Camel Salesforce from 4.9.0 to 4.10.1 - https://github.com/apache/camel/releases/tag/camel-4.10.1
- Slack Bolt from 1.45.2 to 1.45.3 - https://github.com/slackapi/java-slack-sdk/releases/tag/v1.45.3
- Snowflake JDBC from 3.22.0 to 3.23.0 - https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc-2025#version-3-23-0-february-27-2025
- Spring Boot from 3.4.2 to 3.4.3 - https://github.com/spring-projects/spring-boot/releases/tag/v3.4.3
- Checker-qual from 3.48.4 to 3.49.1 - https://github.com/typetools/checker-framework/blob/master/docs/CHANGELOG.md#version-3491-march-3-2025
- OAuth2 OIDC SDK from 11.20.1 to 11.23.1 - https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/master/CHANGELOG.txt
- MariaDB client from 3.5.1 to 3.5.2 - https://mariadb.com/kb/en/mariadb-connector-j-3-5-2-release-notes/
- FlywayDB from 11.3.1 to 11.3.4 - https://github.com/flyway/flyway/releases/tag/flyway-11.3.4
- AWS SDK v1 from 1.12.780 to 1.12.782 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md#23033-2025-03-04
- AWS SDK v2 from 2.30.16 to 2.30.33 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md#23033-2025-03-04
- zstd jni from 1.5.6-9 to 1.5.7-1 - https://github.com/luben/zstd-jni/releases/tag/v1.5.7-1
- Test containers from 1.20.4 to 1.20.6 - https://github.com/testcontainers/testcontainers-java/releases/tag/1.20.6
- SLF4J from 2.0.16 to 2.0.17 - https://www.slf4j.org/news.html#2.0.17
- Jackson from 2.18.2 to 2.18.3 - https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.18.3
- Groovy from 4.0.25 to 4.0.26 - https://github.com/apache/groovy/releases/tag/GROOVY_4_0_26
- Logback from 1.5.16 to 1.5.17 - https://github.com/qos-ch/logback/releases/tag/v_1.5.17
- Mockito from 5.15.2 to 5.16.0 - https://github.com/mockito/mockito/releases/tag/v5.16.0
- SnakeYAML from 2.3 to 2.4 - https://github.com/mockito/mockito/releases/tag/v5.16.0
- Netty from 4.1.118.Final to 4.1.119.Final - https://netty.io/news/2025/02/26/4-1-119-Final.html
- Spring from 6.2.2 to 6.2.3 - https://github.com/spring-projects/spring-framework/releases/tag/v6.2.3
- Spring Security from 6.4.2 to 6.4.3 - https://github.com/spring-projects/spring-security/releases/tag/6.4.3
- Jsoup from 1.18.3 to 1.19.1 - https://github.com/jhy/jsoup/blob/master/CHANGES.md#1191-2025-03-04
- Versions Maven Plugin from 2.17.1 to 2.18.0 - https://github.com/mojohaus/versions/releases/tag/2.18.0
- Swagger Maven Plugin from 2.2.25 to 2.2.28 - https://github.com/swagger-api/swagger-core/releases/tag/v2.2.28
- Swagger Codegen Maven Plugin from 3.0.64 to 3.0.68 - https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.68

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
