### PR TITLE
NIFI-14323 Add Support for Astral uv to Install Python Dependencies

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -102,6 +102,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - name: Set up Astral uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.10'
+          enable-cache: false
 
       - name: Build Dependencies
         env:

--- a/nifi-docker/dockerhub/Dockerfile
+++ b/nifi-docker/dockerhub/Dockerfile
@@ -52,13 +52,14 @@ RUN groupadd -g ${GID} nifi || groupmod -n nifi `getent group ${GID} | cut -d: -
     && apt-get update \
     && apt-get install -y jq xmlstarlet procps unzip \
     && apt-get install -y python3 \
-    && apt-get install -y python3-pip \
     && apt-get install -y python3-venv \
     && apt-get -y autoremove \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 USER nifi
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Download, validate, and expand Apache NiFi Toolkit binary.
 RUN curl -fSL ${MIRROR_BASE_URL}/${NIFI_TOOLKIT_BINARY_PATH} -o ${NIFI_BASE_DIR}/nifi-toolkit-${NIFI_VERSION}-bin.zip \

--- a/nifi-docker/dockerhub/sh/common.sh
+++ b/nifi-docker/dockerhub/sh/common.sh
@@ -48,3 +48,6 @@ export nifi_bootstrap_file=${NIFI_HOME}/conf/bootstrap.conf
 export nifi_props_file=${NIFI_HOME}/conf/nifi.properties
 export nifi_toolkit_props_file=${HOME}/.nifi-cli.nifi.properties
 export hostname=$(hostname)
+
+# Set Path to include local directory for Astral uv
+export PATH=${PATH}:~/.local/bin

--- a/nifi-docker/dockermaven/Dockerfile
+++ b/nifi-docker/dockermaven/Dockerfile
@@ -84,7 +84,6 @@ RUN groupadd -g ${GID} nifi || groupmod -n nifi `getent group ${GID} | cut -d: -
     && apt-get update \
     && apt-get install -y jq xmlstarlet procps \
     && apt-get install -y python3 \
-    && apt-get install -y python3-pip \
     && apt-get install -y python3-venv \
     && apt-get -y autoremove \
     && apt-get clean autoclean \
@@ -103,6 +102,8 @@ VOLUME ${NIFI_LOG_DIR} \
        ${NIFI_HOME}/state
 
 USER nifi
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Clear nifi-env.sh in favour of configuring all environment variables in the Dockerfile
 RUN echo "#!/bin/sh\n" > "${NIFI_HOME}/bin/nifi-env.sh"

--- a/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/logback.xml
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/resources/conf/pythonic/logback.xml
@@ -101,7 +101,7 @@
     <logger name="org.apache.nifi.controller.repository.StandardProcessSession" level="WARN" />
 
     <!-- Py4J set to WARN to avoid verbose socket communication messages -->
-    <logger name="py4j" level="WARN" />
+    <logger name="py4j.java_gateway" level="WARN" />
 
     <logger name="org.apache.zookeeper.ClientCnxn" level="ERROR" />
     <logger name="org.apache.zookeeper.server.NIOServerCnxn" level="ERROR" />


### PR DESCRIPTION
# Summary

[NIFI-14323](https://issues.apache.org/jira/browse/NIFI-14323) Adds optional support for using [Astral uv](https://docs.astral.sh/uv/) to install dependencies for Python Processors.

Astral uv is a modern, Apache 2-licensed, Python package manager with a [pip interface](https://docs.astral.sh/uv/pip/) that offers much better performance for loading Python dependencies.

The changes to the Python `ExtensionManager` use the `uv` command discovery to determine whether `uv` is installed. `ExtensionManager` prefers Astral uv when available and falls back to current Python pip behavior when uv is not found. This approach provides compatibility with existing installations, and supports opting in to Astral uv by installing it and making it available to the operating system user that runs NiFi.

Updates to the NiFi Docker image include [installing  uv](https://docs.astral.sh/uv/getting-started/installation/) using the standard method as part of the build, and removing the `python3-pip` package from the build.

Updates to the `system-tests` workflow add the [setup-uv](https://github.com/astral-sh/setup-uv) action to make it available for Python-based tests. Current tests include installing Python Processors with dependencies, so the system test workflow verifies working behavior with Astral uv.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
