### PR TITLE
NIFI:14326: Reverting 'REMOTE_POLL_BATCH_SIZE property for ListSFTP'

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/ListFileTransfer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/ListFileTransfer.java
@@ -31,6 +31,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -123,7 +124,13 @@ public abstract class ListFileTransfer extends AbstractListProcessor<FileInfo> {
             return listing;
         }
 
-        listing.removeIf(file -> file.getLastModifiedTime() < minTimestamp);
+        final Iterator<FileInfo> itr = listing.iterator();
+        while (itr.hasNext()) {
+            final FileInfo next = itr.next();
+            if (next.getLastModifiedTime() < minTimestamp) {
+                itr.remove();
+            }
+        }
 
         return listing;
     }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
@@ -127,6 +127,7 @@ public class ListSFTP extends ListFileTransfer {
     public void migrateProperties(PropertyConfiguration config) {
         super.migrateProperties(config);
         FTPTransfer.migrateProxyProperties(config);
+        config.removeProperty(FileTransfer.REMOTE_POLL_BATCH_SIZE.getName());
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
@@ -178,7 +178,7 @@ public class ListSFTP extends ListFileTransfer {
         final Long maxAge = context.getProperty(ListFile.MAX_AGE).asTimePeriod(TimeUnit.MILLISECONDS);
 
         return (attributes) -> {
-            if(attributes.isDirectory()) {
+            if (attributes.isDirectory()) {
                 return true;
             }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListSFTP.java
@@ -95,7 +95,6 @@ public class ListSFTP extends ListFileTransfer {
             SFTPTransfer.FILE_FILTER_REGEX,
             SFTPTransfer.PATH_FILTER_REGEX,
             SFTPTransfer.IGNORE_DOTTED_FILES,
-            SFTPTransfer.REMOTE_POLL_BATCH_SIZE,
             SFTPTransfer.STRICT_HOST_KEY_CHECKING,
             SFTPTransfer.HOST_KEY_FILE,
             SFTPTransfer.CONNECTION_TIMEOUT,
@@ -179,7 +178,7 @@ public class ListSFTP extends ListFileTransfer {
         final Long maxAge = context.getProperty(ListFile.MAX_AGE).asTimePeriod(TimeUnit.MILLISECONDS);
 
         return (attributes) -> {
-            if (attributes.isDirectory()) {
+            if(attributes.isDirectory()) {
                 return true;
             }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListSFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestListSFTP.java
@@ -16,6 +16,16 @@
  */
 package org.apache.nifi.processors.standard;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
 import org.apache.nifi.components.ConfigVerificationResult;
 import org.apache.nifi.components.ConfigVerificationResult.Outcome;
 import org.apache.nifi.distributed.cache.client.DistributedMapCacheClient;
@@ -34,16 +44,6 @@ import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -94,7 +94,7 @@ public class TestListSFTP {
         runner.assertAllFlowFilesContainAttribute(ListFile.FILE_PERMISSIONS_ATTRIBUTE);
         runner.assertAllFlowFilesContainAttribute(ListFile.FILE_SIZE_ATTRIBUTE);
         runner.assertAllFlowFilesContainAttribute(ListFile.FILE_LAST_MODIFY_TIME_ATTRIBUTE);
-        runner.assertAllFlowFilesContainAttribute("filename");
+        runner.assertAllFlowFilesContainAttribute( "filename");
 
         final MockFlowFile retrievedFile = runner.getFlowFilesForRelationship(ListSFTP.REL_SUCCESS).get(0);
         retrievedFile.assertAttributeEquals("sftp.listing.user", sshServer.getUsername());
@@ -176,21 +176,6 @@ public class TestListSFTP {
         runner.run(2);
 
         runner.assertTransferCount(ListSFTP.REL_SUCCESS, 0);
-    }
-
-    @Test
-    public void testRemotePollBatchSizeEnforced() {
-        runner.setProperty(AbstractListProcessor.LISTING_STRATEGY, AbstractListProcessor.NO_TRACKING);
-        runner.setProperty(SFTPTransfer.REMOTE_POLL_BATCH_SIZE, "1");
-
-        runner.run();
-        // Of 3 items only 1 returned due to batch size
-        runner.assertTransferCount(ListSFTP.REL_SUCCESS, 1);
-
-        runner.setProperty(SFTPTransfer.REMOTE_POLL_BATCH_SIZE, "2");
-
-        runner.run();
-        runner.assertTransferCount(ListSFTP.REL_SUCCESS, 3);
     }
 
     @Test


### PR DESCRIPTION
# Summary

This reverts #8390, allowing ListSFTP to return more than just the configured batch size.

[NIFI-14326](https://issues.apache.org/jira/browse/NIFI-14326)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
