### PR TITLE
NIFI-14348 - Bump Azure, AWS, Salesforce, Google Drive dependencies

### DIFF
--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -28,8 +28,8 @@
 
     <properties>
         <!-- when changing the Azure SDK version, also update msal4j to the version that is required by azure-identity -->
-        <azure.sdk.bom.version>1.2.31</azure.sdk.bom.version>
-        <msal4j.version>1.17.3</msal4j.version>
+        <azure.sdk.bom.version>1.2.32</azure.sdk.bom.version>
+        <msal4j.version>1.19.0</msal4j.version>
         <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20250216-2.0.0</version>
+            <version>v3-rev20250220-2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.tdunning</groupId>

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-salesforce</artifactId>
-            <version>4.10.1</version>
+            <version>4.10.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.782</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.30.33</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.30.36</software.amazon.awssdk.version>
         <gson.version>2.12.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.1.0</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.1.10</kotlin.version>


### PR DESCRIPTION
# Summary

[NIFI-14348](https://issues.apache.org/jira/browse/NIFI-14348) - Bump Azure, AWS, Salesforce, Google Drive dependencies

- Azure BOM from 1.2.31 to 1.2.32 (this updates azure-identity allowing us to upgrade MSAL4J to 1.19.0)
- Google Drive from v3-rev20250216-2.0.0 to v3-rev20250220-2.0.0
- Salesforce from 4.10.1 to 4.10.2
- AWS SDK from 2.30.33 to 2.30.36

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
