### PR TITLE
NIFI-14352: Add MQTT nar to MiNiFi java

### DIFF
--- a/minifi/minifi-assembly/pom.xml
+++ b/minifi/minifi-assembly/pom.xml
@@ -297,6 +297,12 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mqtt-nar</artifactId>
+            <version>${project.version}</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-python-framework</artifactId>
             <version>2.3.0-SNAPSHOT</version>
             <scope>compile</scope>

--- a/minifi/minifi-assembly/src/main/assembly/dependencies-windows-service.xml
+++ b/minifi/minifi-assembly/src/main/assembly/dependencies-windows-service.xml
@@ -55,6 +55,7 @@
                 <include>org.apache.nifi.minifi:minifi-framework-api</include>
                 <include>org.apache.nifi.minifi:minifi-runtime</include>
                 <include>org.apache.nifi.minifi:*:nar</include>
+                <include>org.apache.nifi:nifi-mqtt:nar</include>
                 <!-- Unfortunately minifi-runtime depends on jackson databind and annotations
                 so for now this pollutes the root classloader. -->
                 <include>com.fasterxml.jackson.core:jackson-databind</include>

--- a/minifi/minifi-assembly/src/main/assembly/dependencies.xml
+++ b/minifi/minifi-assembly/src/main/assembly/dependencies.xml
@@ -56,6 +56,7 @@
                 <include>org.apache.nifi.minifi:minifi-framework-api</include>
                 <include>org.apache.nifi.minifi:minifi-runtime</include>
                 <include>org.apache.nifi.minifi:*:nar</include>
+                <include>org.apache.nifi:nifi-mqtt:nar</include>
                 <!-- Unfortunately minifi-runtime depends on jackson databind and annotations
                 so for now this pollutes the root classloader. -->
                 <include>com.fasterxml.jackson.core:jackson-databind</include>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14352](https://issues.apache.org/jira/browse/NIFI-14352)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-14352`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-14352`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
