### PR TITLE
NIFI-14356 Add missing YearMonth and Year queries to DateTimeFormatter

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java
@@ -24,6 +24,8 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Year;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -242,11 +244,13 @@ public class FormatUtils {
             throw new IllegalArgumentException("Text cannot be null");
         }
 
-        TemporalAccessor parsed = formatter.parseBest(text, Instant::from, LocalDateTime::from, LocalDate::from, LocalTime::from);
+        TemporalAccessor parsed = formatter.parseBest(text, Instant::from, LocalDateTime::from, LocalDate::from, YearMonth::from, Year::from, LocalTime::from);
         return switch (parsed) {
             case Instant instant -> instant;
             case LocalDateTime localDateTime -> toInstantInSystemDefaultTimeZone(localDateTime);
             case LocalDate localDate -> toInstantInSystemDefaultTimeZone(localDate.atTime(0, 0));
+            case YearMonth yearMonth -> toInstantInSystemDefaultTimeZone(yearMonth.atDay(1).atTime(0, 0));
+            case Year year -> toInstantInSystemDefaultTimeZone(year.atDay(1).atTime(0, 0));
             case null, default -> toInstantInSystemDefaultTimeZone(((LocalTime) parsed).atDate(EPOCH_INITIAL_DATE));
         };
     }

--- a/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/TestFormatUtils.java
+++ b/nifi-commons/nifi-utils/src/test/java/org/apache/nifi/util/TestFormatUtils.java
@@ -48,16 +48,22 @@ public class TestFormatUtils {
         return Stream.of(/*GMT-*/
             Arguments.of("yyyy-MM-dd HH:mm:ss", "2020-01-01 02:00:00", NEW_YORK_TIME_ZONE_ID, "2020-01-01T07:00:00"),
             Arguments.of("yyyy-MM-dd", "2020-01-01", NEW_YORK_TIME_ZONE_ID, "2020-01-01T05:00:00"),
+            Arguments.of("yyyy-MM", "2020-01", NEW_YORK_TIME_ZONE_ID, "2020-01-01T05:00:00"),
+            Arguments.of("yyyy", "2020", NEW_YORK_TIME_ZONE_ID, "2020-01-01T05:00:00"),
             Arguments.of("HH:mm:ss", "03:00:00", NEW_YORK_TIME_ZONE_ID, "1970-01-01T08:00:00"),
             Arguments.of("yyyy-MMM-dd", "2020-may-01", NEW_YORK_TIME_ZONE_ID, "2020-05-01T04:00:00"),
             /*GMT+*/
             Arguments.of("yyyy-MM-dd HH:mm:ss", "2020-01-01 02:00:00", KIEV_TIME_ZONE_ID, "2020-01-01T00:00:00"),
             Arguments.of("yyyy-MM-dd", "2020-01-01", KIEV_TIME_ZONE_ID, "2019-12-31T22:00:00"),
+            Arguments.of("yyyy-MM", "2020-01", KIEV_TIME_ZONE_ID, "2019-12-31T22:00:00"),
+            Arguments.of("yyyy", "2020", KIEV_TIME_ZONE_ID, "2019-12-31T22:00:00"),
             Arguments.of("HH:mm:ss", "03:00:00", KIEV_TIME_ZONE_ID, "1970-01-01T00:00:00"),
             Arguments.of("yyyy-MMM-dd", "2020-may-01", KIEV_TIME_ZONE_ID, "2020-04-30T21:00:00"),
             /*UTC*/
             Arguments.of("yyyy-MM-dd HH:mm:ss", "2020-01-01 02:00:00", ZoneOffset.UTC.getId(), "2020-01-01T02:00:00"),
             Arguments.of("yyyy-MM-dd", "2020-01-01", ZoneOffset.UTC.getId(), "2020-01-01T00:00:00"),
+            Arguments.of("yyyy-MM", "2020-01", ZoneOffset.UTC.getId(), "2020-01-01T00:00:00"),
+            Arguments.of("yyyy", "2020", ZoneOffset.UTC.getId(), "2020-01-01T00:00:00"),
             Arguments.of("HH:mm:ss", "03:00:00", ZoneOffset.UTC.getId(), "1970-01-01T03:00:00"),
             Arguments.of("yyyy-MMM-dd", "2020-may-01", ZoneOffset.UTC.getId(), "2020-05-01T00:00:00"));
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14356](https://issues.apache.org/jira/browse/NIFI-14356)

Adding YearMonth and Year temporal queries to [DateTimeFormatter parser](https://github.com/apache/nifi/blob/fc04d49057d5208d70342c15ee1e18ea545b14aa/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/FormatUtils.java#L245C45-L245C54) which is used in the date functions of the expression language. Patterns like 'yyyy' and 'yyyyMM' will work with this fix ([like the toDate example of the expression language documentation which is currently throwing an exception](https://nifi.apache.org/nifi-docs/expression-language-guide.html#todate)). 

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
- [x] JDK 21

### Licensing

no new dependencies
- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
