### PR TITLE
NIFI-14357 Write path and owner attributes in FetchBoxFileInfo

### DIFF
--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/BoxFileUtils.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/BoxFileUtils.java
@@ -16,25 +16,31 @@
  */
 package org.apache.nifi.processors.box;
 
-import static java.lang.String.valueOf;
-
 import com.box.sdk.BoxFile;
 import com.box.sdk.BoxFolder;
 import com.box.sdk.BoxItem;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
-import org.apache.nifi.flowfile.attributes.CoreAttributes;
+
+import static java.lang.String.valueOf;
+import static java.util.stream.Collectors.joining;
 
 public final class BoxFileUtils {
 
     public static final String BOX_URL = "https://app.box.com/file/";
 
+    public static String getParentIds(final BoxItem.Info info) {
+        return info.getPathCollection().stream()
+                .map(BoxItem.Info::getID)
+                .collect(joining(","));
+    }
     public static String getParentPath(BoxItem.Info info) {
         return "/" + info.getPathCollection().stream()
                 .filter(pathItemInfo -> !pathItemInfo.getID().equals("0"))
                 .map(BoxItem.Info::getName)
-                .collect(Collectors.joining("/"));
+                .collect(joining("/"));
     }
 
     public static String getFolderPath(BoxFolder.Info folderInfo) {

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/FetchBoxFileInfoTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/FetchBoxFileInfoTest.java
@@ -47,6 +47,8 @@ public class FetchBoxFileInfoTest extends AbstractBoxFileTest {
     private static final String TEST_ITEM_STATUS = "active";
     private static final String TEST_SEQUENCE_ID = "1";
     private static final String TEST_OWNER_NAME = "Test User";
+    private static final String TEST_OWNER_ID = "123456";
+    private static final String TEST_OWNER_LOGIN = "Test.User@mail.org";
     private static final String TEST_SHARED_LINK_URL = "https://app.box.com/s/abcdef123456";
     private static final Date TEST_CREATED_AT = new Date(12345678L);
     private static final Date TEST_CONTENT_CREATED_AT = new Date(12345600L);
@@ -173,7 +175,10 @@ public class FetchBoxFileInfoTest extends AbstractBoxFileTest {
         when(mockFileInfo.getPurgedAt()).thenReturn(TEST_PURGED_AT);
 
         when(mockBoxUser.getName()).thenReturn(TEST_OWNER_NAME);
+        when(mockBoxUser.getID()).thenReturn(TEST_OWNER_ID);
+        when(mockBoxUser.getLogin()).thenReturn(TEST_OWNER_LOGIN);
         when(mockFileInfo.getOwnedBy()).thenReturn(mockBoxUser);
+
         when(mockSharedLink.getURL()).thenReturn(TEST_SHARED_LINK_URL);
         when(mockFileInfo.getSharedLink()).thenReturn(mockSharedLink);
 
@@ -193,6 +198,10 @@ public class FetchBoxFileInfoTest extends AbstractBoxFileTest {
         flowFile.assertAttributeEquals("box.content.created.at", TEST_CONTENT_CREATED_AT.toString());
         flowFile.assertAttributeEquals("box.content.modified.at", TEST_CONTENT_MODIFIED_AT.toString());
         flowFile.assertAttributeEquals("box.owner", TEST_OWNER_NAME);
+        flowFile.assertAttributeEquals("box.owner.id", TEST_OWNER_ID);
+        flowFile.assertAttributeEquals("box.owner.login", TEST_OWNER_LOGIN);
         flowFile.assertAttributeEquals("box.shared.link", TEST_SHARED_LINK_URL);
+        flowFile.assertAttributeEquals("box.path.folder.ids", mockBoxFolderInfo.getID());
+        flowFile.assertAttributeEquals("path", "/" + mockBoxFolderInfo.getName());
     }
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14357](https://issues.apache.org/jira/browse/NIFI-14357)

Adding `box.path.folder.ids`, `box.owner.id` and `box.owner.login` attributes to `FetchBoxFileInfo` processor.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
