### PR TITLE
NIFI-14365 Filter collaboration by actual json value in GetBoxFileCollaborators

### DIFF
--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/GetBoxFileCollaborators.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/GetBoxFileCollaborators.java
@@ -267,7 +267,7 @@ public class GetBoxFileCollaborators extends AbstractProcessor {
             count++;
 
             final String status = collab.getStatus().toString().toLowerCase();
-            final String role = collab.getRole().toString().toLowerCase();
+            final String role = roleToJsonValue(collab.getRole());
 
             // Skip if not in allowed roles or statuses
             if ((allowedRoles != null && !allowedRoles.contains(role))
@@ -332,5 +332,19 @@ public class GetBoxFileCollaborators extends AbstractProcessor {
         if (values != null && !values.isEmpty()) {
             attributes.put(key, String.join(",", values));
         }
+    }
+
+    private static String roleToJsonValue(final BoxCollaboration.Role role) {
+        // BoxCollaboration.Role::toJSONString() is package-private, so we have to duplicate the mapping.
+        return switch (role) {
+            case EDITOR -> "editor";
+            case VIEWER -> "viewer";
+            case PREVIEWER -> "previewer";
+            case UPLOADER -> "uploader";
+            case PREVIEWER_UPLOADER -> "previewer uploader";
+            case VIEWER_UPLOADER -> "viewer uploader";
+            case CO_OWNER -> "co-owner";
+            case OWNER -> "owner";
+        };
     }
 }


### PR DESCRIPTION


<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14365](https://issues.apache.org/jira/browse/NIFI-14365)

Instead of lower case enum names, the processor should filter collaborations by their json values.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
