### PR TITLE
[NIFI-10304] [NIFI-14351] Added a config item to SearchElasticsearch processor to control if the processor restarts on query finish. Also removed query expiration for SEARCH_AFTER pagination type

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractJsonQueryElasticsearch.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/AbstractJsonQueryElasticsearch.java
@@ -205,6 +205,10 @@ public abstract class AbstractJsonQueryElasticsearch<Q extends JsonQueryParamete
         try {
             final Q queryJsonParameters = buildJsonQueryParameters(input, context, session);
 
+            if (queryJsonParameters == null) {
+                context.yield();
+                return;
+            }
             List<FlowFile> hitsFlowFiles = new ArrayList<>();
             final StopWatch stopWatch = new StopWatch(true);
             final SearchResponse response = doQuery(queryJsonParameters, hitsFlowFiles, session, context, input, stopWatch);

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/ConsumeElasticsearch.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/ConsumeElasticsearch.java
@@ -188,7 +188,7 @@ public class ConsumeElasticsearch extends SearchElasticsearch {
     private static final List<PropertyDescriptor> propertyDescriptors = Stream.concat(
             Stream.of(RANGE_FIELD, RANGE_FIELD_SORT_ORDER, RANGE_INITIAL_VALUE, RANGE_DATE_FORMAT, RANGE_TIME_ZONE, ADDITIONAL_FILTERS),
             scrollPropertyDescriptors.stream()
-                    .filter(pd -> !QUERY.equals(pd) && !QUERY_CLAUSE.equals(pd) && !QUERY_DEFINITION_STYLE.equals(pd))
+                    .filter(pd -> !QUERY.equals(pd) && !QUERY_CLAUSE.equals(pd) && !QUERY_DEFINITION_STYLE.equals(pd) && !RESTART_ON_FINISH.equals(pd))
                     .map(property -> {
                         if (property == ElasticsearchRestProcessor.SIZE) return SIZE;
                         if (property == ElasticsearchRestProcessor.AGGREGATIONS) return AGGREGATIONS;

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PaginatedJsonQueryElasticsearch.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PaginatedJsonQueryElasticsearch.java
@@ -82,10 +82,8 @@ public class PaginatedJsonQueryElasticsearch extends AbstractPaginatedJsonQueryE
     }
 
     @Override
-    boolean isExpired(final PaginatedJsonQueryParameters paginatedQueryJsonParameters, final ProcessContext context,
-                      final SearchResponse response) {
-        // queries using input FlowFiles don't expire, they run until completion
-        return false;
+    void resetQueryParamsIfRequired(final PaginatedJsonQueryParameters paginatedQueryJsonParameters, final ProcessContext context) {
+        // Noting to reset. Queries using input FlowFiles don't expire, they run until completion
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/SearchElasticsearch.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/SearchElasticsearch.java
@@ -110,7 +110,7 @@ public class SearchElasticsearch extends AbstractPaginatedJsonQueryElasticsearch
     static final PropertyDescriptor RESTART_ON_FINISH = new PropertyDescriptor.Builder()
             .name("restart-on-finish")
             .displayName("Restart On Finish?")
-            .description("Whether the should processor start another search with the same query once a paginated search has completed.")
+            .description("Whether the processor should start another search with the same query once a paginated search has completed.")
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .allowableValues(Boolean.TRUE.toString(), Boolean.FALSE.toString())
             .defaultValue(Boolean.TRUE.toString())
@@ -152,7 +152,7 @@ public class SearchElasticsearch extends AbstractPaginatedJsonQueryElasticsearch
     @OnScheduled
     public void onScheduled(final ProcessContext context) {
         super.onScheduled(context);
-        if (context.getProperty(RESTART_ON_FINISH) != null) {
+        if (context.getProperty(RESTART_ON_FINISH).isSet()) {
             this.restartOnFinish = context.getProperty(RESTART_ON_FINISH).asBoolean();
         }
     }
@@ -161,7 +161,7 @@ public class SearchElasticsearch extends AbstractPaginatedJsonQueryElasticsearch
     PaginatedJsonQueryParameters buildJsonQueryParameters(final FlowFile input, final ProcessContext context, final ProcessSession session) throws IOException {
         final StateMap stateMap = context.getStateManager().getState(getStateScope());
 
-        final boolean finished = stateMap.get(STATE_FINISHED) != null && Boolean.parseBoolean(stateMap.get(STATE_FINISHED))
+        final boolean finished = stateMap.get(STATE_FINISHED) != null && Boolean.parseBoolean(stateMap.get(STATE_FINISHED));
 
         if (finished && !this.restartOnFinish) {
             return null;

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/SearchElasticsearch.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/SearchElasticsearch.java
@@ -110,10 +110,10 @@ public class SearchElasticsearch extends AbstractPaginatedJsonQueryElasticsearch
     static final PropertyDescriptor RESTART_ON_FINISH = new PropertyDescriptor.Builder()
             .name("restart-on-finish")
             .displayName("Restart On Finish?")
-            .description("Should the processor start from the beginning when the query finishes?")
+            .description("Whether the should processor start another search with the same query once a paginated search has completed.")
             .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
             .allowableValues(Boolean.TRUE.toString(), Boolean.FALSE.toString())
-            .defaultValue(Boolean.TRUE.toString()) // maintain existing behavior
+            .defaultValue(Boolean.TRUE.toString())
             .required(true)
             .build();
 
@@ -152,7 +152,7 @@ public class SearchElasticsearch extends AbstractPaginatedJsonQueryElasticsearch
     @OnScheduled
     public void onScheduled(final ProcessContext context) {
         super.onScheduled(context);
-        if (context.getProperty(RESTART_ON_FINISH).asBoolean() != null) {
+        if (context.getProperty(RESTART_ON_FINISH) != null) {
             this.restartOnFinish = context.getProperty(RESTART_ON_FINISH).asBoolean();
         }
     }
@@ -161,7 +161,7 @@ public class SearchElasticsearch extends AbstractPaginatedJsonQueryElasticsearch
     PaginatedJsonQueryParameters buildJsonQueryParameters(final FlowFile input, final ProcessContext context, final ProcessSession session) throws IOException {
         final StateMap stateMap = context.getStateManager().getState(getStateScope());
 
-        final boolean finished = stateMap.get(STATE_FINISHED) == null ? false : Boolean.parseBoolean(stateMap.get(STATE_FINISHED));
+        final boolean finished = stateMap.get(STATE_FINISHED) != null && Boolean.parseBoolean(stateMap.get(STATE_FINISHED))
 
         if (finished && !this.restartOnFinish) {
             return null;

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/api/PaginatedJsonQueryParameters.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/api/PaginatedJsonQueryParameters.java
@@ -25,6 +25,7 @@ public class PaginatedJsonQueryParameters extends JsonQueryParameters {
     private String pageExpirationTimestamp = null;
     private String keepAlive;
     private String trackingRangeValue;
+    private boolean finished = false;
 
     public int getPageCount() {
         return pageCount;
@@ -84,5 +85,13 @@ public class PaginatedJsonQueryParameters extends JsonQueryParameters {
 
     public void setTrackingRangeValue(String trackingRangeValue) {
         this.trackingRangeValue = trackingRangeValue;
+    }
+
+    public boolean isFinished() {
+        return finished;
+    }
+
+    public void setFinished(boolean finished) {
+        this.finished = finished;
     }
 }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/api/PaginationType.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/api/PaginationType.java
@@ -20,17 +20,19 @@ package org.apache.nifi.processors.elasticsearch.api;
 import org.apache.nifi.components.DescribedValue;
 
 public enum PaginationType implements DescribedValue {
-    SCROLL("pagination-scroll", "Use Elasticsearch \"_scroll\" API to page results. Does not accept additional query parameters."),
-    SEARCH_AFTER("pagination-search_after", "Use Elasticsearch \"search_after\" _search API to page sorted results."),
+    SCROLL("pagination-scroll", "Use Elasticsearch \"_scroll\" API to page results. Does not accept additional query parameters.", true),
+    SEARCH_AFTER("pagination-search_after", "Use Elasticsearch \"search_after\" _search API to page sorted results.", false),
     POINT_IN_TIME("pagination-pit", "Use Elasticsearch (7.10+ with XPack) \"point in time\" _search API to page sorted results. " +
-            "Not available for use with AWS OpenSearch.");
+            "Not available for use with AWS OpenSearch.", true);
 
     private final String value;
     private final String description;
+    private final boolean hasExpiry;
 
-    PaginationType(final String value, final String description) {
+    PaginationType(final String value, final String description, final boolean hasExpiry) {
         this.value = value;
         this.description = description;
+        this.hasExpiry = hasExpiry;
     }
 
     @Override
@@ -46,5 +48,9 @@ public enum PaginationType implements DescribedValue {
     @Override
     public String getDescription() {
         return description;
+    }
+
+    public boolean hasExpiry() {
+        return this.hasExpiry;
     }
 }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/ConsumeElasticsearchTest.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/test/java/org/apache/nifi/processors/elasticsearch/ConsumeElasticsearchTest.java
@@ -23,6 +23,7 @@ import com.jayway.jsonpath.JsonPath;
 import org.apache.nifi.components.state.Scope;
 import org.apache.nifi.elasticsearch.SearchResponse;
 import org.apache.nifi.processors.elasticsearch.api.PaginatedJsonQueryParameters;
+import org.apache.nifi.processors.elasticsearch.api.PaginationType;
 import org.apache.nifi.util.StringUtils;
 import org.apache.nifi.util.TestRunner;
 import org.junit.jupiter.api.BeforeAll;
@@ -151,6 +152,7 @@ public class ConsumeElasticsearchTest extends SearchElasticsearchTest {
         paginatedJsonQueryParameters.setPageCount(pageCount);
         paginatedJsonQueryParameters.setTrackingRangeValue(defaultUnset);
 
+        ((ConsumeElasticsearch) runner.getProcessor()).paginationType = PaginationType.SCROLL;
         ((ConsumeElasticsearch) runner.getProcessor()).updateQueryParameters(paginatedJsonQueryParameters, response);
 
         if ("asc".equals(sortOrder)) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-10304](https://issues.apache.org/jira/browse/NIFI-10304)
[NIFI-14351](https://issues.apache.org/jira/browse/NIFI-14351)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-10304) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
- [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
