### PR TITLE
NIFI-14379 Fix frontend HTTP redirect for paths without trailing slash

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/StandardServerProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/StandardServerProvider.java
@@ -51,6 +51,8 @@ class StandardServerProvider implements ServerProvider {
 
     private static final String FRONTEND_CONTEXT_PATH = "/nifi";
 
+    private static final String FRONTEND_CONTEXT_PATH_DIRECTORY = "/nifi/";
+
     private final SSLContext sslContext;
 
     StandardServerProvider(final SSLContext sslContext) {
@@ -69,10 +71,7 @@ class StandardServerProvider implements ServerProvider {
         final Handler standardHandler = getStandardHandler();
         server.setHandler(standardHandler);
 
-        final RewriteHandler defaultRewriteHandler = new RewriteHandler();
-        final List<String> allowedContextPaths = properties.getAllowedContextPathsAsList();
-        final RedirectPatternRule redirectDefault = new ContextPathRedirectPatternRule(ALL_PATHS_PATTERN, FRONTEND_CONTEXT_PATH, allowedContextPaths);
-        defaultRewriteHandler.addRule(redirectDefault);
+        final RewriteHandler defaultRewriteHandler = getDefaultRewriteHandler(properties);
         server.setDefaultHandler(defaultRewriteHandler);
 
         final String requestLogFormat = properties.getProperty(NiFiProperties.WEB_REQUEST_LOG_FORMAT);
@@ -81,6 +80,16 @@ class StandardServerProvider implements ServerProvider {
         server.setRequestLog(requestLog);
 
         return server;
+    }
+
+    private RewriteHandler getDefaultRewriteHandler(final NiFiProperties properties) {
+        final RewriteHandler defaultRewriteHandler = new RewriteHandler();
+        final List<String> allowedContextPaths = properties.getAllowedContextPathsAsList();
+        final RedirectPatternRule redirectFrontend = new ContextPathRedirectPatternRule(FRONTEND_CONTEXT_PATH, FRONTEND_CONTEXT_PATH_DIRECTORY, allowedContextPaths);
+        defaultRewriteHandler.addRule(redirectFrontend);
+        final RedirectPatternRule redirectDefault = new ContextPathRedirectPatternRule(ALL_PATHS_PATTERN, FRONTEND_CONTEXT_PATH_DIRECTORY, allowedContextPaths);
+        defaultRewriteHandler.addRule(redirectDefault);
+        return defaultRewriteHandler;
     }
 
     private void addConnectors(final Server server, final NiFiProperties properties, final SSLContext sslContext) {


### PR DESCRIPTION
# Summary

[NIFI-14379](https://issues.apache.org/jira/browse/NIFI-14379) Corrects the behavior of HTTP redirects from the NiFi Server when running behind a reverse proxy with a custom context path.

The correction adds a Jetty Redirect Pattern Rule from `/nifi` to `/nifi/` using the Context Path implementation introduced in 
[NIFI-14165](https://issues.apache.org/jira/browse/NIFI-14165). The Context Path Redirect Pattern Rule handles supported context paths that a reverse sets using HTTP request headers.

Changes include additional unit test methods to verify that the redirected `Location` header has the expected path with the trailing slash included.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
