### PR TITLE
NIFI-14346 PutDatabaseRecord fails to do upsert on MySQL due to too few parameters bound

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -971,8 +971,8 @@ public class PutDatabaseRecord extends AbstractProcessor {
                                 setParameter(ps, ++deleteIndex, currentValue, fieldSqlType, sqlType);
                             }
                         } else if (UPSERT_TYPE.equalsIgnoreCase(statementType)) {
-                            // Calculate the number of times to set the parameter based on fields divided by parameters
-                            final int timesToAddObjects = fieldIndexes.size() / preparedSqlAndColumns.parameterCount;
+                            // Calculate the number of times to set the parameter based on parameters divided by number of field indexes
+                            final int timesToAddObjects =  preparedSqlAndColumns.parameterCount / fieldIndexes.size();
                             for (int j = 0; j < timesToAddObjects; j++) {
                                 setParameter(ps, i + (fieldIndexes.size() * j) + 1, currentValue, fieldSqlType, sqlType);
                             }


### PR DESCRIPTION
This change addresses an issue in the PutDatabaseRecord processor when the Statement Type is set to UPSERT and connected to a MySQL database. The original code for binding parameters to the UPSERT SQL statement was incorrectly calculating the number of repetitions for parameter setting, leading to the error: java.sql.SQLException: No value specified for parameter 1.

# Summary

[NIFI-14346](https://issues.apache.org/jira/browse/NIFI-14346)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as NIFI-00000
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such NIFI-00000

### Pull Request Formatting

- [ ] Pull Request based on current revision of the main branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using mvn clean install -P contrib-check
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable LICENSE and NOTICE files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files