### PR TITLE
NIFI-14313 JoinEnrichment processor; failure to close result sets

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/enrichment/SqlJoinStrategy.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/enrichment/SqlJoinStrategy.java
@@ -74,13 +74,13 @@ public class SqlJoinStrategy implements RecordJoinStrategy {
             throw t;
         }
 
-        final RecordSet recordSet = new ResultSetRecordSet(rs, outputSchema, defaultPrecision, defaultScale, true);
+        final ResultSetRecordSet recordSet = new ResultSetRecordSet(rs, outputSchema, defaultPrecision, defaultScale, true);
 
         // Create a RecordJoinResult that allows us to return our RecordSet and also close all resources when they are no longer needed
         return new RecordJoinResult() {
             @Override
             public void close() {
-                closeQuietly(originalTable, enrichmentTable);
+                closeQuietly(originalTable, enrichmentTable, recordSet);
                 cache.returnCalciteParameters(sql, outputSchema, calciteParameters);
             }
 


### PR DESCRIPTION
contributes to excess memory usage

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14313](https://issues.apache.org/jira/browse/NIFI-14313)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-14313) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-14313`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-14313`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

I ran the UI with a flow which used the JoinEnrichment processor and watched using IntelliJ JVM remote debug mode to confirm that the result set was correctly closed and released its memory after the resultset was finished being used.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [X] No new dependencies

### Documentation

- [X] No documentation changes needed
