### PR TITLE
NIFI-14389 - Provide the option to force refresh Access Token in OAuth2AccessTokenProvider

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -1238,7 +1238,7 @@ public class InvokeHTTP extends AbstractProcessor {
                 // we are using oauth2 and we got a 401 response
                 // it may be because the token has been revoked even though it has not expired
                 // yet, so we force the token to be refreshed if configured to do so
-                oauth2AccessTokenProviderOptional.get().getAccessDetails(true);
+                oauth2AccessTokenProviderOptional.get().refreshAccessDetails();
             }
 
             if (request != null) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -1233,7 +1233,7 @@ public class InvokeHTTP extends AbstractProcessor {
         } else {
             final TokenRefreshStrategy tokenRefreshStrategy = context.getProperty(REQUEST_OAUTH2_REFRESH_TOKEN).asAllowableValue(TokenRefreshStrategy.class);
             if (oauth2AccessTokenProviderOptional.isPresent()
-                    && TokenRefreshStrategy.ON_NON_AUTHORIZED_REQUEST == tokenRefreshStrategy
+                    && TokenRefreshStrategy.ON_UNAUTHORIZED_RESPONSE == tokenRefreshStrategy
                     && statusCode == 401) {
                 // we are using oauth2 and we got a 401 response
                 // it may be because the token has been revoked even though it has not expired

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/InvokeHTTPTest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/InvokeHTTPTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.oauth2.OAuth2AccessTokenProvider;
+import org.apache.nifi.oauth2.TokenRefreshStrategy;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.util.URLValidator;
 import org.apache.nifi.processors.standard.http.ContentEncodingStrategy;
@@ -977,7 +978,7 @@ public class InvokeHTTPTest {
         runner.addControllerService(oauth2AccessTokenProviderId, oauth2AccessTokenProvider);
         runner.enableControllerService(oauth2AccessTokenProvider);
         runner.setProperty(InvokeHTTP.REQUEST_OAUTH2_ACCESS_TOKEN_PROVIDER, oauth2AccessTokenProviderId);
-        runner.setProperty(InvokeHTTP.REQUEST_OAUTH2_REFRESH_TOKEN, "true");
+        runner.setProperty(InvokeHTTP.REQUEST_OAUTH2_REFRESH_TOKEN, TokenRefreshStrategy.ON_NON_AUTHORIZED_REQUEST.name());
 
         enqueueResponseCodeAndRun(HTTP_UNAUTHORIZED);
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/InvokeHTTPTest.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/InvokeHTTPTest.java
@@ -978,7 +978,7 @@ public class InvokeHTTPTest {
         runner.addControllerService(oauth2AccessTokenProviderId, oauth2AccessTokenProvider);
         runner.enableControllerService(oauth2AccessTokenProvider);
         runner.setProperty(InvokeHTTP.REQUEST_OAUTH2_ACCESS_TOKEN_PROVIDER, oauth2AccessTokenProviderId);
-        runner.setProperty(InvokeHTTP.REQUEST_OAUTH2_REFRESH_TOKEN, TokenRefreshStrategy.ON_NON_AUTHORIZED_REQUEST.name());
+        runner.setProperty(InvokeHTTP.REQUEST_OAUTH2_REFRESH_TOKEN, TokenRefreshStrategy.ON_UNAUTHORIZED_RESPONSE.name());
 
         enqueueResponseCodeAndRun(HTTP_UNAUTHORIZED);
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/OAuth2AccessTokenProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/OAuth2AccessTokenProvider.java
@@ -29,9 +29,10 @@ public interface OAuth2AccessTokenProvider extends ControllerService {
     AccessToken getAccessDetails();
 
     /**
-     * Refreshes the access token even if it has not expired yet
+     * Request a new Access Token based on configured properties regardless of
+     * current expiration status. The default implementation does not perform any
+     * action.
      */
     default void refreshAccessDetails() {
-        // no default implementation
     }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/OAuth2AccessTokenProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/OAuth2AccessTokenProvider.java
@@ -29,12 +29,9 @@ public interface OAuth2AccessTokenProvider extends ControllerService {
     AccessToken getAccessDetails();
 
     /**
-     * @param forceAccessTokenRefresh true if the access token should be refreshed
-     *                                even if it is not expired
-     * @return A valid access token (refreshed automatically if needed) and
-     *         additional metadata (provided by the OAuth2 access server)
+     * Refreshes the access token even if it has not expired yet
      */
-    default AccessToken getAccessDetails(final boolean forceAccessTokenRefresh) {
-        return getAccessDetails();
+    default void refreshAccessDetails() {
+        // no default implementation
     }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/OAuth2AccessTokenProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/OAuth2AccessTokenProvider.java
@@ -27,4 +27,14 @@ public interface OAuth2AccessTokenProvider extends ControllerService {
      * @return A valid access token (refreshed automatically if needed) and additional metadata (provided by the OAuth2 access server)
      */
     AccessToken getAccessDetails();
+
+    /**
+     * @param forceAccessTokenRefresh true if the access token should be refreshed
+     *                                even if it is not expired
+     * @return A valid access token (refreshed automatically if needed) and
+     *         additional metadata (provided by the OAuth2 access server)
+     */
+    default AccessToken getAccessDetails(final boolean forceAccessTokenRefresh) {
+        return getAccessDetails();
+    }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/TokenRefreshStrategy.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/TokenRefreshStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.oauth2;
+
+import org.apache.nifi.components.DescribedValue;
+
+public enum TokenRefreshStrategy implements DescribedValue {
+
+    ON_TOKEN_EXPIRATION("The token will be refreshed based on its expiration time and the configured refresh window"),
+
+    ON_NON_AUTHORIZED_REQUEST("A new token will be requested in case of a non-authorized request (HTTP 401) even if the current token has not expired");
+
+    private final String description;
+
+    TokenRefreshStrategy(final String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return name();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return name();
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+}

--- a/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/TokenRefreshStrategy.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-api/src/main/java/org/apache/nifi/oauth2/TokenRefreshStrategy.java
@@ -22,7 +22,7 @@ public enum TokenRefreshStrategy implements DescribedValue {
 
     ON_TOKEN_EXPIRATION("The token will be refreshed based on its expiration time and the configured refresh window"),
 
-    ON_NON_AUTHORIZED_REQUEST("A new token will be requested in case of a non-authorized request (HTTP 401) even if the current token has not expired");
+    ON_UNAUTHORIZED_RESPONSE("A new token will be requested in case of a non-authorized request (HTTP 401) even if the current token has not expired");
 
     private final String description;
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
@@ -342,27 +342,25 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
 
     @Override
     public void refreshAccessDetails() {
-
         if (this.accessDetails == null || this.accessDetails.getRefreshToken() == null) {
             acquireAccessDetails();
-            return;
+        } else {
+            getLogger().debug("Refresh Access Token request started [{}]", authorizationServerUrl);
+
+            FormBody.Builder refreshTokenBuilder = new FormBody.Builder()
+                    .add("grant_type", "refresh_token")
+                    .add("refresh_token", this.accessDetails.getRefreshToken());
+
+            addFormData(refreshTokenBuilder);
+
+            AccessToken newAccessDetails = requestToken(refreshTokenBuilder);
+
+            if (newAccessDetails.getRefreshToken() == null) {
+                newAccessDetails.setRefreshToken(this.accessDetails.getRefreshToken());
+            }
+
+            this.accessDetails = newAccessDetails;
         }
-
-        getLogger().debug("Refresh Access Token request started [{}]", authorizationServerUrl);
-
-        FormBody.Builder refreshTokenBuilder = new FormBody.Builder()
-                .add("grant_type", "refresh_token")
-                .add("refresh_token", this.accessDetails.getRefreshToken());
-
-        addFormData(refreshTokenBuilder);
-
-        AccessToken newAccessDetails = requestToken(refreshTokenBuilder);
-
-        if (newAccessDetails.getRefreshToken() == null) {
-            newAccessDetails.setRefreshToken(this.accessDetails.getRefreshToken());
-        }
-
-        this.accessDetails = newAccessDetails;
     }
 
     private void getProperties(ConfigurationContext context) {

--- a/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-oauth2-provider-bundle/nifi-oauth2-provider-service/src/main/java/org/apache/nifi/oauth2/StandardOauth2AccessTokenProvider.java
@@ -48,6 +48,7 @@ import org.apache.nifi.ssl.SSLContextProvider;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.Proxy;
@@ -337,6 +338,16 @@ public class StandardOauth2AccessTokenProvider extends AbstractControllerService
         }
 
         return accessDetails;
+    }
+
+    @Override
+    public AccessToken getAccessDetails(boolean forceAccessTokenRefresh) {
+        if (forceAccessTokenRefresh) {
+            acquireAccessDetails();
+            return accessDetails;
+        } else {
+            return getAccessDetails();
+        }
     }
 
     private void getProperties(ConfigurationContext context) {


### PR DESCRIPTION
# Summary

[NIFI-14389](https://issues.apache.org/jira/browse/NIFI-14389) - Provide the option to force refresh Access Token in OAuth2AccessTokenProvider

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
