### PR TITLE
NIFI-14396 Fix Default Value for security.autoreload.interval

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/framework/configuration/SslContextConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/framework/configuration/SslContextConfiguration.java
@@ -104,7 +104,7 @@ public class SslContextConfiguration {
         final WatchServiceMonitorCommand command;
 
         if (isReloadEnabled()) {
-            final String reloadIntervalProperty = properties.getProperty(SECURITY_AUTO_RELOAD_INTERVAL);
+            final String reloadIntervalProperty = properties.getProperty(SECURITY_AUTO_RELOAD_INTERVAL, NiFiProperties.DEFAULT_SECURITY_AUTO_RELOAD_INTERVAL);
             final long reloadIntervalSeconds = Math.round(FormatUtils.getPreciseTimeDuration(reloadIntervalProperty, TimeUnit.SECONDS));
             final Duration reloadDuration = Duration.ofSeconds(reloadIntervalSeconds);
 


### PR DESCRIPTION
# Summary

[NIFI-14396](https://issues.apache.org/jira/browse/NIFI-14396) Corrects handling of the `nifi.security.autoreload.interval` property when it is not defined in `nifi.properties`. The correction uses standard `Properties.getProperty()` behavior to return the default value.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
