### PR TITLE
NIFI-14410 Upgrade Apache NiFi API from 2.0.0 to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <node.version>v22.1.0</node.version>
         <frontend.mvn.plugin.version>1.15.1</frontend.mvn.plugin.version>
         <nifi.nar.maven.plugin.version>2.1.0</nifi.nar.maven.plugin.version>
-        <nifi-api.version>2.0.0</nifi-api.version>
+        <nifi-api.version>2.1.0</nifi-api.version>
         <project.build.outputTimestamp>1741688885</project.build.outputTimestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
# Summary

[NIFI-14410](https://issues.apache.org/jira/browse/NIFI-14410) Upgrades the Apache NiFi API dependency from 2.0.0 to [2.1.0](https://cwiki.apache.org/confluence/display/NIFI/Release+Notes#ReleaseNotes-NiFiAPIVersion2.1.0) introducing support for the `DisallowRunOnce` annotation and improving the behavior of Runtime Manifest generation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
