### PR TITLE
Revert "NIFI-14409 Replaced use of deprecated method authorizeRequests in orgspringframework.security.config.annotation.web.builders.HttpSecurity with method authorizeHttpRequests."

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
@@ -110,7 +110,7 @@ public class NiFiRegistrySecurityConfig {
                         .httpStrictTransportSecurity(hstsConfig -> hstsConfig.maxAgeInSeconds(31540000))
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
                 )
-                .authorizeHttpRequests((authorize) -> authorize
+                .authorizeRequests((authorize) -> authorize
                         .requestMatchers(
                                 antMatcher("/access/token"),
                                 antMatcher("/access/token/identity-provider"),


### PR DESCRIPTION
Reverts apache/nifi#9833