### PR TITLE
NIFI-14394 ConsumeKinesisStream add Sub Seq Num to metadata

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterWrapper.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/record/converter/RecordConverterWrapper.java
@@ -38,16 +38,20 @@ public class RecordConverterWrapper implements RecordConverter {
     private static final String STREAM = "stream";
     private static final String SHARD_ID = "shardId";
     private static final String SEQUENCE_NUMBER = "sequenceNumber";
+    private static final String SUB_SEQUENCE_NUMBER = "subSequenceNumber";
+    private static final String SHARDED_SEQUENCE_NUMBER = "shardedSequenceNumber";
     private static final String PARTITION_KEY = "partitionKey";
     private static final String APPROX_ARRIVAL_TIMESTAMP = "approximateArrival";
 
     private static final RecordField FIELD_STREAM = new RecordField(STREAM, RecordFieldType.STRING.getDataType());
     private static final RecordField FIELD_SHARD_ID = new RecordField(SHARD_ID, RecordFieldType.STRING.getDataType());
     private static final RecordField FIELD_SEQUENCE_NUMBER = new RecordField(SEQUENCE_NUMBER, RecordFieldType.STRING.getDataType());
+    private static final RecordField FIELD_SUB_SEQUENCE_NUMBER = new RecordField(SUB_SEQUENCE_NUMBER, RecordFieldType.LONG.getDataType());
+    private static final RecordField FIELD_SHARDED_SEQUENCE_NUMBER = new RecordField(SHARDED_SEQUENCE_NUMBER, RecordFieldType.STRING.getDataType());
     private static final RecordField FIELD_PARTITION_KEY = new RecordField(PARTITION_KEY, RecordFieldType.STRING.getDataType());
     private static final RecordField FIELD_APPROX_ARRIVAL_TIMESTAMP = new RecordField(APPROX_ARRIVAL_TIMESTAMP, RecordFieldType.TIMESTAMP.getDataType());
     private static final RecordSchema SCHEMA_METADATA = new SimpleRecordSchema(Arrays.asList(
-            FIELD_STREAM, FIELD_SHARD_ID, FIELD_SEQUENCE_NUMBER, FIELD_PARTITION_KEY, FIELD_APPROX_ARRIVAL_TIMESTAMP));
+            FIELD_STREAM, FIELD_SHARD_ID, FIELD_SEQUENCE_NUMBER, FIELD_SUB_SEQUENCE_NUMBER, FIELD_SHARDED_SEQUENCE_NUMBER, FIELD_PARTITION_KEY, FIELD_APPROX_ARRIVAL_TIMESTAMP));
 
     public static final RecordField FIELD_METADATA = new RecordField(METADATA, RecordFieldType.RECORD.getRecordDataType(SCHEMA_METADATA));
 
@@ -57,7 +61,12 @@ public class RecordConverterWrapper implements RecordConverter {
         final Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put(STREAM, streamName);
         metadata.put(SHARD_ID, shardId);
-        metadata.put(SEQUENCE_NUMBER, kinesisRecord.sequenceNumber());
+        final String sequenceNumber = kinesisRecord.sequenceNumber();
+        metadata.put(SEQUENCE_NUMBER, sequenceNumber);
+        final long subSequenceNumber = kinesisRecord.subSequenceNumber();
+        metadata.put(SUB_SEQUENCE_NUMBER, subSequenceNumber);
+        final String shardedSequenceNumber = String.format("%s%020d", sequenceNumber, subSequenceNumber);
+        metadata.put(SHARDED_SEQUENCE_NUMBER, shardedSequenceNumber);
         metadata.put(PARTITION_KEY, kinesisRecord.partitionKey());
         final Instant approxArrivalTimestamp = kinesisRecord.approximateArrivalTimestamp();
         metadata.put(APPROX_ARRIVAL_TIMESTAMP, approxArrivalTimestamp == null ? null : approxArrivalTimestamp.toEpochMilli());

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/docs/org.apache.nifi.processors.aws.kinesis.stream.ConsumeKinesisStream/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/docs/org.apache.nifi.processors.aws.kinesis.stream.ConsumeKinesisStream/additionalDetails.md
@@ -40,5 +40,7 @@ processed in the batch of messages constituting the content of the FlowFile.
 
 Once a Record Writer is set the Output Strategy can be set to `Use Wrapper` or `Use Content`. When `Use Wrapper` is 
 picked the original content of the Kinesis Record will be wrapped under `value` key and an additional `metadata`
-key will be populated with Stream Name, Shard ID, Partition Key, Sequence Number and Approximate Arrival Timestamp. 
+key will be populated with Stream Name, Shard ID, Partition Key, Sequence Number, Sub Sequence Number, Approximate 
+Arrival Timestamp and a Sharded Sequence Number that is a concatenation of Sequence and Sub Sequence Numbers that allows
+a single comparison record ordering. 
 When `Use Content` is picked the original content of the Kinesis Record will be used as is.

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/test/java/org/apache/nifi/processors/aws/kinesis/stream/record/TestKinesisRecordProcessorRecord.java
@@ -220,14 +220,14 @@ public class TestKinesisRecordProcessorRecord {
 
     private String expectRecordContentWrapper() {
         return """
-                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"1","partitionKey":"partition-1",\
-                "approximateArrival":1609459140000},"value":{"record":"1"}}
-                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"1","partitionKey":"partition-1",\
-                "approximateArrival":1609459140000},"value":{"record":"1b"}}
-                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"no-date","partitionKey":"partition-no-date",\
-                "approximateArrival":null},"value":{"record":"no-date"}}
-                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"2","partitionKey":"partition-2",\
-                "approximateArrival":1609459200000},"value":{"record":"2"}}""";
+                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"1","subSequenceNumber":0,\
+                "shardedSequenceNumber":"100000000000000000000","partitionKey":"partition-1","approximateArrival":1609459140000},"value":{"record":"1"}}
+                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"1","subSequenceNumber":0,\
+                "shardedSequenceNumber":"100000000000000000000","partitionKey":"partition-1","approximateArrival":1609459140000},"value":{"record":"1b"}}
+                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"no-date","subSequenceNumber":0,\
+                "shardedSequenceNumber":"no-date00000000000000000000","partitionKey":"partition-no-date","approximateArrival":null},"value":{"record":"no-date"}}
+                {"metadata":{"stream":"kinesis-test","shardId":"another-shard","sequenceNumber":"2","subSequenceNumber":0,\
+                "shardedSequenceNumber":"200000000000000000000","partitionKey":"partition-2","approximateArrival":1609459200000},"value":{"record":"2"}}""";
     }
 
     @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14394](https://issues.apache.org/jira/browse/NIFI-14394)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-14394`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-14394`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] (no new) New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] (no new) New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
