### PR TITLE
NIFI-14413 - Add User Agent to NiFi User Model

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
@@ -20,6 +20,7 @@ import org.apache.nifi.authorization.user.NiFiUserUtils;
 import org.apache.nifi.util.NiFiProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
@@ -46,6 +47,7 @@ public abstract class NiFiAuthenticationFilter extends GenericFilterBean {
 
     private AuthenticationManager authenticationManager;
     private NiFiProperties properties;
+    protected AuthenticationDetailsSource<HttpServletRequest, NiFiWebAuthenticationDetails> authenticationDetailsSource;
 
     @Override
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
@@ -161,6 +163,10 @@ public abstract class NiFiAuthenticationFilter extends GenericFilterBean {
 
     public void setAuthenticationManager(AuthenticationManager authenticationManager) {
         this.authenticationManager = authenticationManager;
+    }
+
+    public void setAuthenticationDetailsSource(final AuthenticationDetailsSource<HttpServletRequest, NiFiWebAuthenticationDetails> authenticationDetailsSource) {
+        this.authenticationDetailsSource = authenticationDetailsSource;
     }
 
     public void setProperties(NiFiProperties properties) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationRequestToken.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationRequestToken.java
@@ -26,11 +26,13 @@ public abstract class NiFiAuthenticationRequestToken extends AbstractAuthenticat
     private final String clientAddress;
 
     /**
-     * @param clientAddress   The address of the client making the request
+     * @param clientAddress The address of the client making the request
+     * @param authenticationDetails The authentication details of the client making the request
      */
-    public NiFiAuthenticationRequestToken(final String clientAddress) {
+    public NiFiAuthenticationRequestToken(final String clientAddress, final Object authenticationDetails) {
         super(null);
         setAuthenticated(false);
+        setDetails(authenticationDetails);
         this.clientAddress = clientAddress;
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiWebAuthenticationDetails.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiWebAuthenticationDetails.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.web.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+
+import java.util.Objects;
+
+/**
+ * Authentication details for NiFi web. Stores the user agent in addition to the remote address and session id.
+ */
+public class NiFiWebAuthenticationDetails extends WebAuthenticationDetails {
+    private final String userAgent;
+
+    public NiFiWebAuthenticationDetails(final HttpServletRequest request) {
+        super(request);
+        this.userAgent = request.getHeader(HttpHeaders.USER_AGENT);
+    }
+
+    public NiFiWebAuthenticationDetails(final String remoteAddress, final String sessionId, String userAgent) {
+        super(remoteAddress, sessionId);
+        this.userAgent = userAgent;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        final NiFiWebAuthenticationDetails that = (NiFiWebAuthenticationDetails) o;
+        return Objects.equals(userAgent, that.userAgent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), userAgent);
+    }
+
+    @Override
+    public String toString() {
+        return "NiFiWebAuthenticationDetails{" +
+            "userAgent='" + userAgent + '\'' +
+            ", remoteIpAddress='" + getRemoteAddress() + '\'' +
+            ", sessionId='" + getSessionId() + '\'' +
+            "} ";
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiWebAuthenticationDetailsSource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiWebAuthenticationDetailsSource.java
@@ -14,21 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.nifi.web.security.anonymous;
-
-import org.apache.nifi.web.security.NiFiAuthenticationFilter;
-import org.springframework.security.core.Authentication;
+package org.apache.nifi.web.security;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 
 /**
- * Extracts an anonymous authentication request from a specified servlet request.
+ * AuthenticationDetailsSource implementation for NiFi Web.
  */
-public class NiFiAnonymousAuthenticationFilter extends NiFiAuthenticationFilter {
-
+public class NiFiWebAuthenticationDetailsSource implements AuthenticationDetailsSource<HttpServletRequest, NiFiWebAuthenticationDetails> {
     @Override
-    public Authentication attemptAuthentication(final HttpServletRequest request) {
-        // return the anonymous authentication request for this http request
-        return new NiFiAnonymousAuthenticationRequestToken(request.isSecure(), request.getRemoteAddr(), authenticationDetailsSource.buildDetails(request));
+    public NiFiWebAuthenticationDetails buildDetails(HttpServletRequest context) {
+        return new NiFiWebAuthenticationDetails(context);
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/anonymous/NiFiAnonymousAuthenticationProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/anonymous/NiFiAnonymousAuthenticationProvider.java
@@ -46,7 +46,7 @@ public class NiFiAnonymousAuthenticationProvider extends NiFiAuthenticationProvi
             throw new InvalidAuthenticationException("Anonymous authentication has not been configured.");
         }
 
-        return new NiFiAuthenticationToken(new NiFiUserDetails(StandardNiFiUser.populateAnonymousUser(null, request.getClientAddress())));
+        return new NiFiAuthenticationToken(new NiFiUserDetails(StandardNiFiUser.populateAnonymousUser(null, request.getClientAddress())), null, request.getDetails());
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/anonymous/NiFiAnonymousAuthenticationRequestToken.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/anonymous/NiFiAnonymousAuthenticationRequestToken.java
@@ -31,9 +31,10 @@ public class NiFiAnonymousAuthenticationRequestToken extends NiFiAuthenticationR
      * Creates a representation of the anonymous authentication request for a user.
      *
      * @param clientAddress the address of the client making the request
+     * @param authenticationDetails the authentication details of teh client making the request
      */
-    public NiFiAnonymousAuthenticationRequestToken(final boolean secureRequest, final String clientAddress) {
-        super(clientAddress);
+    public NiFiAnonymousAuthenticationRequestToken(final boolean secureRequest, final String clientAddress, final Object authenticationDetails) {
+        super(clientAddress, authenticationDetails);
         setAuthenticated(false);
         this.secureRequest = secureRequest;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/AuthenticationSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/AuthenticationSecurityConfiguration.java
@@ -16,9 +16,12 @@
  */
 package org.apache.nifi.web.security.configuration;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.nifi.authorization.Authorizer;
 import org.apache.nifi.nar.ExtensionManager;
 import org.apache.nifi.util.NiFiProperties;
+import org.apache.nifi.web.security.NiFiWebAuthenticationDetails;
+import org.apache.nifi.web.security.NiFiWebAuthenticationDetailsSource;
 import org.apache.nifi.web.security.anonymous.NiFiAnonymousAuthenticationFilter;
 import org.apache.nifi.web.security.anonymous.NiFiAnonymousAuthenticationProvider;
 import org.apache.nifi.web.security.logout.LogoutRequestManager;
@@ -27,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 
 /**
@@ -65,6 +69,7 @@ public class AuthenticationSecurityConfiguration {
         final NiFiAnonymousAuthenticationFilter anonymousAuthenticationFilter = new NiFiAnonymousAuthenticationFilter();
         anonymousAuthenticationFilter.setProperties(niFiProperties);
         anonymousAuthenticationFilter.setAuthenticationManager(authenticationManager);
+        anonymousAuthenticationFilter.setAuthenticationDetailsSource(authenticationDetailsSource());
         return anonymousAuthenticationFilter;
     }
 
@@ -89,5 +94,10 @@ public class AuthenticationSecurityConfiguration {
     @Bean
     public NiFiAnonymousAuthenticationProvider anonymousAuthenticationProvider() {
         return new NiFiAnonymousAuthenticationProvider(niFiProperties, authorizer);
+    }
+
+    @Bean
+    public AuthenticationDetailsSource<HttpServletRequest, NiFiWebAuthenticationDetails> authenticationDetailsSource() {
+        return new NiFiWebAuthenticationDetailsSource();
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtAuthenticationSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/JwtAuthenticationSecurityConfiguration.java
@@ -16,8 +16,10 @@
  */
 package org.apache.nifi.web.security.configuration;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.nifi.authorization.Authorizer;
 import org.apache.nifi.util.NiFiProperties;
+import org.apache.nifi.web.security.NiFiWebAuthenticationDetails;
 import org.apache.nifi.web.security.jwt.converter.StandardJwtAuthenticationConverter;
 import org.apache.nifi.web.security.StandardAuthenticationEntryPoint;
 import org.apache.nifi.web.security.jwt.jws.StandardJwsSignerProvider;
@@ -38,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
@@ -93,8 +96,10 @@ public class JwtAuthenticationSecurityConfiguration {
      * @return Bearer Token Authentication Filter
      */
     @Bean
-    public BearerTokenAuthenticationFilter bearerTokenAuthenticationFilter(final AuthenticationManager authenticationManager) {
+    public BearerTokenAuthenticationFilter bearerTokenAuthenticationFilter(final AuthenticationManager authenticationManager,
+        final AuthenticationDetailsSource<HttpServletRequest, NiFiWebAuthenticationDetails> authenticationDetailsSource) {
         final BearerTokenAuthenticationFilter bearerTokenAuthenticationFilter = new BearerTokenAuthenticationFilter(authenticationManager);
+        bearerTokenAuthenticationFilter.setAuthenticationDetailsSource(authenticationDetailsSource);
         bearerTokenAuthenticationFilter.setBearerTokenResolver(bearerTokenResolver());
         bearerTokenAuthenticationFilter.setAuthenticationEntryPoint(authenticationEntryPoint());
         return bearerTokenAuthenticationFilter;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
@@ -18,10 +18,12 @@ package org.apache.nifi.web.security.configuration;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.nifi.authorization.util.IdentityMappingUtil;
 import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.util.StringUtils;
+import org.apache.nifi.web.security.NiFiWebAuthenticationDetails;
 import org.apache.nifi.web.security.jwt.provider.BearerTokenProvider;
 import org.apache.nifi.web.security.logout.LogoutRequestManager;
 import org.apache.nifi.web.security.saml2.SamlUrlPath;
@@ -41,6 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.saml2.provider.service.authentication.AbstractSaml2AuthenticationRequest;
 import org.springframework.security.saml2.provider.service.authentication.OpenSaml5AuthenticationProvider;
@@ -142,9 +145,11 @@ public class SamlAuthenticationSecurityConfiguration {
      * @return SAML 2 Authentication Filter
      */
     @Bean
-    public Saml2WebSsoAuthenticationFilter saml2WebSsoAuthenticationFilter(final AuthenticationManager authenticationManager) {
+    public Saml2WebSsoAuthenticationFilter saml2WebSsoAuthenticationFilter(final AuthenticationManager authenticationManager,
+        final AuthenticationDetailsSource<HttpServletRequest, NiFiWebAuthenticationDetails> authenticationDetailsSource) {
         final Saml2AuthenticationTokenConverter authenticationTokenConverter = new Saml2AuthenticationTokenConverter(relyingPartyRegistrationResolver());
         final Saml2WebSsoAuthenticationFilter filter = new Saml2WebSsoAuthenticationFilter(authenticationTokenConverter, SamlUrlPath.LOGIN_RESPONSE_REGISTRATION_ID.getPath());
+        filter.setAuthenticationDetailsSource(authenticationDetailsSource);
         filter.setAuthenticationManager(authenticationManager);
         filter.setAuthenticationSuccessHandler(getAuthenticationSuccessHandler());
         filter.setAuthenticationRequestRepository(saml2AuthenticationRequestRepository());

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/X509AuthenticationSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/X509AuthenticationSecurityConfiguration.java
@@ -16,8 +16,10 @@
  */
 package org.apache.nifi.web.security.configuration;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.nifi.authorization.Authorizer;
 import org.apache.nifi.util.NiFiProperties;
+import org.apache.nifi.web.security.NiFiWebAuthenticationDetails;
 import org.apache.nifi.web.security.x509.SubjectDnX509PrincipalExtractor;
 import org.apache.nifi.web.security.x509.X509AuthenticationFilter;
 import org.apache.nifi.web.security.x509.X509AuthenticationProvider;
@@ -28,6 +30,7 @@ import org.apache.nifi.web.security.x509.ocsp.OcspCertificateValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.web.authentication.preauth.x509.X509PrincipalExtractor;
 
@@ -50,12 +53,14 @@ public class X509AuthenticationSecurityConfiguration {
     }
 
     @Bean
-    public X509AuthenticationFilter x509AuthenticationFilter(final AuthenticationManager authenticationManager) {
+    public X509AuthenticationFilter x509AuthenticationFilter(final AuthenticationManager authenticationManager,
+        final AuthenticationDetailsSource<HttpServletRequest, NiFiWebAuthenticationDetails> authenticationDetailsSource) {
         final X509AuthenticationFilter x509AuthenticationFilter = new X509AuthenticationFilter();
         x509AuthenticationFilter.setProperties(niFiProperties);
         x509AuthenticationFilter.setCertificateExtractor(certificateExtractor());
         x509AuthenticationFilter.setPrincipalExtractor(principalExtractor());
         x509AuthenticationFilter.setAuthenticationManager(authenticationManager);
+        x509AuthenticationFilter.setAuthenticationDetailsSource(authenticationDetailsSource);
         return x509AuthenticationFilter;
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/converter/StandardJwtAuthenticationConverter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/converter/StandardJwtAuthenticationConverter.java
@@ -56,7 +56,8 @@ public class StandardJwtAuthenticationConverter implements Converter<Jwt, NiFiAu
     @Override
     public NiFiAuthenticationToken convert(final Jwt jwt) {
         final NiFiUser user = getUser(jwt);
-        return new NiFiAuthenticationToken(new NiFiUserDetails(user), jwt);
+        //authentication details should be null as it'll be set later by the {@link JwtAuthenticationProvider#authenticate(Authentication)} method
+        return new NiFiAuthenticationToken(new NiFiUserDetails(user), jwt, null);
     }
 
     private NiFiUser getUser(final Jwt jwt) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/token/NiFiAuthenticationToken.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/token/NiFiAuthenticationToken.java
@@ -34,7 +34,7 @@ public class NiFiAuthenticationToken extends AbstractAuthenticationToken {
      * @param userDetails Spring Security User Details
      */
     public NiFiAuthenticationToken(final UserDetails userDetails) {
-        this(userDetails, userDetails.getPassword());
+        this(userDetails, userDetails.getPassword(), null);
     }
 
     /**
@@ -42,11 +42,12 @@ public class NiFiAuthenticationToken extends AbstractAuthenticationToken {
      *
      * @param userDetails Spring Security User Details
      * @param credentials Optional credentials from authentication processing
+     * @param authenticationDetails  Optional authentication details from authentication processing
      */
-    public NiFiAuthenticationToken(final UserDetails userDetails, final Object credentials) {
+    public NiFiAuthenticationToken(final UserDetails userDetails, final Object credentials, final Object authenticationDetails) {
         super(userDetails.getAuthorities());
         super.setAuthenticated(true);
-        setDetails(userDetails);
+        setDetails(authenticationDetails);
         this.nifiUserDetails = userDetails;
         this.credentials = credentials;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/X509AuthenticationFilter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/X509AuthenticationFilter.java
@@ -55,7 +55,13 @@ public class X509AuthenticationFilter extends NiFiAuthenticationFilter {
         final String proxiedEntityIdpGroups = request.getHeader(ProxiedEntitiesUtils.PROXY_ENTITY_GROUPS);
         logger.debug("Raw {} - {}", ProxiedEntitiesUtils.PROXY_ENTITY_GROUPS, proxiedEntityIdpGroups);
 
-        return new X509AuthenticationRequestToken(proxiedEntitiesChain, proxiedEntityIdpGroups, principalExtractor, certificates, request.getRemoteAddr());
+        return new X509AuthenticationRequestToken(
+            proxiedEntitiesChain,
+            proxiedEntityIdpGroups,
+            principalExtractor,
+            certificates,
+            request.getRemoteAddr(),
+            authenticationDetailsSource.buildDetails(request));
     }
 
     /* setters */

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/X509AuthenticationProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/X509AuthenticationProvider.java
@@ -92,7 +92,7 @@ public class X509AuthenticationProvider extends NiFiAuthenticationProvider {
         if (StringUtils.isBlank(request.getProxiedEntitiesChain())) {
             final String mappedIdentity = mapIdentity(authenticationResponse.getIdentity());
             final NiFiUser user = new Builder().identity(mappedIdentity).groups(getUserGroups(mappedIdentity)).clientAddress(request.getClientAddress()).build();
-            return new NiFiAuthenticationToken(new NiFiUserDetails(user), certificates);
+            return new NiFiAuthenticationToken(new NiFiUserDetails(user), certificates, request.getDetails());
         } else {
             // get the idp groups for the end-user that were sent over in the X-ProxiedEntityGroups header
             final Set<String> endUserIdpGroups = ProxiedEntitiesUtils.tokenizeProxiedEntityGroups(request.getProxiedEntityGroups());
@@ -142,7 +142,7 @@ public class X509AuthenticationProvider extends NiFiAuthenticationProvider {
                 logProxyChain(proxy);
             }
 
-            return new NiFiAuthenticationToken(new NiFiUserDetails(proxy), certificates);
+            return new NiFiAuthenticationToken(new NiFiUserDetails(proxy), certificates, request.getDetails());
         }
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/X509AuthenticationRequestToken.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/X509AuthenticationRequestToken.java
@@ -37,11 +37,12 @@ public class X509AuthenticationRequestToken extends NiFiAuthenticationRequestTok
      *
      * @param proxiedEntitiesChain   The http servlet request
      * @param certificates  The certificate chain
+     * @param authenticationDetails The authentication details of the client making the request
      */
     public X509AuthenticationRequestToken(final String proxiedEntitiesChain, final String proxiedEntityGroups,
                                           final X509PrincipalExtractor principalExtractor, final X509Certificate[] certificates,
-                                          final String clientAddress) {
-        super(clientAddress);
+                                          final String clientAddress, final Object authenticationDetails) {
+        super(clientAddress, authenticationDetails);
         setAuthenticated(false);
         this.proxiedEntitiesChain = proxiedEntitiesChain;
         this.proxiedEntityGroups = proxiedEntityGroups;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/anonymous/NiFiAnonymousAuthenticationProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/anonymous/NiFiAnonymousAuthenticationProviderTest.java
@@ -21,6 +21,7 @@ import org.apache.nifi.authorization.user.NiFiUserDetails;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.util.StringUtils;
 import org.apache.nifi.web.security.InvalidAuthenticationException;
+import org.apache.nifi.web.security.NiFiWebAuthenticationDetails;
 import org.apache.nifi.web.security.token.NiFiAuthenticationToken;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -39,10 +40,13 @@ public class NiFiAnonymousAuthenticationProviderTest {
 
         final NiFiAnonymousAuthenticationProvider anonymousAuthenticationProvider = new NiFiAnonymousAuthenticationProvider(nifiProperties, mock(Authorizer.class));
 
-        final NiFiAnonymousAuthenticationRequestToken authenticationRequest = new NiFiAnonymousAuthenticationRequestToken(false, StringUtils.EMPTY);
+        final NiFiAnonymousAuthenticationRequestToken authenticationRequest = new NiFiAnonymousAuthenticationRequestToken(
+            false,
+            StringUtils.EMPTY,
+            new NiFiWebAuthenticationDetails("127.0.0.1", "someSessionId", "someUserAgent"));
 
         final NiFiAuthenticationToken authentication = (NiFiAuthenticationToken) anonymousAuthenticationProvider.authenticate(authenticationRequest);
-        final NiFiUserDetails userDetails = (NiFiUserDetails) authentication.getDetails();
+        final NiFiUserDetails userDetails = (NiFiUserDetails) authentication.getPrincipal();
         assertTrue(userDetails.getNiFiUser().isAnonymous());
     }
 
@@ -53,10 +57,13 @@ public class NiFiAnonymousAuthenticationProviderTest {
 
         final NiFiAnonymousAuthenticationProvider anonymousAuthenticationProvider = new NiFiAnonymousAuthenticationProvider(nifiProperties, mock(Authorizer.class));
 
-        final NiFiAnonymousAuthenticationRequestToken authenticationRequest = new NiFiAnonymousAuthenticationRequestToken(false, StringUtils.EMPTY);
+        final NiFiAnonymousAuthenticationRequestToken authenticationRequest = new NiFiAnonymousAuthenticationRequestToken(
+            false,
+            StringUtils.EMPTY,
+            new NiFiWebAuthenticationDetails("127.0.0.1", "someSessionId", "someUserAgent"));
 
         final NiFiAuthenticationToken authentication = (NiFiAuthenticationToken) anonymousAuthenticationProvider.authenticate(authenticationRequest);
-        final NiFiUserDetails userDetails = (NiFiUserDetails) authentication.getDetails();
+        final NiFiUserDetails userDetails = (NiFiUserDetails) authentication.getPrincipal();
         assertTrue(userDetails.getNiFiUser().isAnonymous());
     }
 
@@ -67,7 +74,10 @@ public class NiFiAnonymousAuthenticationProviderTest {
 
         final NiFiAnonymousAuthenticationProvider anonymousAuthenticationProvider = new NiFiAnonymousAuthenticationProvider(nifiProperties, mock(Authorizer.class));
 
-        final NiFiAnonymousAuthenticationRequestToken authenticationRequest = new NiFiAnonymousAuthenticationRequestToken(true, StringUtils.EMPTY);
+        final NiFiAnonymousAuthenticationRequestToken authenticationRequest = new NiFiAnonymousAuthenticationRequestToken(
+            true,
+            StringUtils.EMPTY,
+            new NiFiWebAuthenticationDetails("127.0.0.1", "someSessionId", "someUserAgent"));
 
         assertThrows(InvalidAuthenticationException.class, () -> anonymousAuthenticationProvider.authenticate(authenticationRequest));
     }
@@ -79,10 +89,13 @@ public class NiFiAnonymousAuthenticationProviderTest {
 
         final NiFiAnonymousAuthenticationProvider anonymousAuthenticationProvider = new NiFiAnonymousAuthenticationProvider(nifiProperties, mock(Authorizer.class));
 
-        final NiFiAnonymousAuthenticationRequestToken authenticationRequest = new NiFiAnonymousAuthenticationRequestToken(true, StringUtils.EMPTY);
+        final NiFiAnonymousAuthenticationRequestToken authenticationRequest = new NiFiAnonymousAuthenticationRequestToken(
+            true,
+            StringUtils.EMPTY,
+            new NiFiWebAuthenticationDetails("127.0.0.1", "someSessionId", "someUserAgent"));
 
         final NiFiAuthenticationToken authentication = (NiFiAuthenticationToken) anonymousAuthenticationProvider.authenticate(authenticationRequest);
-        final NiFiUserDetails userDetails = (NiFiUserDetails) authentication.getDetails();
+        final NiFiUserDetails userDetails = (NiFiUserDetails) authentication.getPrincipal();
         assertTrue(userDetails.getNiFiUser().isAnonymous());
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/converter/StandardJwtAuthenticationConverterTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/converter/StandardJwtAuthenticationConverterTest.java
@@ -106,7 +106,7 @@ public class StandardJwtAuthenticationConverterTest {
         assertNotNull(authenticationToken);
         assertEquals(USERNAME, authenticationToken.toString());
 
-        final NiFiUserDetails details = (NiFiUserDetails) authenticationToken.getDetails();
+        final NiFiUserDetails details = (NiFiUserDetails) authenticationToken.getPrincipal();
         final NiFiUser user = details.getNiFiUser();
 
         final Set<String> expectedGroups = Collections.singleton(AUTHORIZER_GROUP);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14413](https://issues.apache.org/jira/browse/NIFI-14413)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
