### PR TITLE
NIFI-14432 MiNiFi Update resource path validation pattern

### DIFF
--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/command/syncresource/DefaultSyncResourceStrategy.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/command/syncresource/DefaultSyncResourceStrategy.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultSyncResourceStrategy implements SyncResourceStrategy {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultSyncResourceStrategy.class);
-    private static final Pattern ALLOWED_RESOURCE_PATH_PATTERN = compile("^(?:(?:.[/\\\\])?[^~<>:\\|\\\"\\?\\*\\./\\\\]+(?:(?!(\\.\\.))[^~<>:\\|\\\"\\?\\*])*)?$");
+    private static final Pattern ALLOWED_RESOURCE_PATH_PATTERN = compile("^(?:[^~<>:\\|\\\"\\?\\*\\.\\/\\\\]+(?:[/\\\\][^~<>:\\|\\\"\\?\\*\\.\\/\\\\]+)*)?$");
 
     private static final Set<Entry<OperationState, OperationState>> SUCCESS_RESULT_PAIRS = Set.of(
         entry(NO_OPERATION, NO_OPERATION),

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/syncresource/DefaultSyncResourceStrategyTest.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/syncresource/DefaultSyncResourceStrategyTest.java
@@ -348,20 +348,8 @@ public class DefaultSyncResourceStrategyTest {
                 null,
                 "",
                 "sub-folder",
-                "sub-folder/",
-                "sub-folder\\",
-                "./sub-folder",
-                "./sub-folder/",
-                ".\\sub-folder",
-                ".\\sub-folder\\",
-                "./sub-folder/sub-sub-folder",
-                "./sub-folder/sub-sub-folder/",
-                ".\\sub-folder\\sub-sub-folder",
-                ".\\sub-folder\\sub-sub-folder\\",
-                "./sub-folder/sub-sub-folder/sub-sub-sub-folder",
-                "./sub-folder/sub-sub-folder/sub-sub-sub-folder/",
-                ".\\sub-folder\\sub-sub-folder\\sub-sub-sub-folder",
-                ".\\sub-folder\\sub-sub-folder\\sub-sub-sub-folder\\"
+                "sub-folder/sub-sub-folder",
+                "sub-folder\\sub-sub-folder"
             )
             .map(Arguments::of);
     }
@@ -406,9 +394,24 @@ public class DefaultSyncResourceStrategyTest {
                 "\\absolute-path\\..",
                 "\\absolute-path\\invalid-char-in-path-~",
                 "C:\\",
-                "C:\\path",
-                "C:/",
-                "C:/path"
+                "C:\\relative-path",
+                "C:\\relative-path\\",
+                "C:\\relative-path\\sub-folder",
+                "C:\\relative-path\\sub-folder\\",
+                "./sub-folder",
+                "./sub-folder/",
+                "sub-folder/",
+                "sub-folder\\",
+                ".\\sub-folder",
+                ".\\sub-folder\\",
+                "./sub-folder/sub-sub-folder",
+                "./sub-folder/sub-sub-folder/",
+                ".\\sub-folder\\sub-sub-folder",
+                ".\\sub-folder\\sub-sub-folder\\",
+                "./sub-folder/sub-sub-folder/sub-sub-sub-folder",
+                "./sub-folder/sub-sub-folder/sub-sub-sub-folder/",
+                ".\\sub-folder\\sub-sub-folder\\sub-sub-sub-folder",
+                ".\\sub-folder\\sub-sub-folder\\sub-sub-sub-folder\\"
             )
             .map(Arguments::of);
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14432](https://issues.apache.org/jira/browse/NIFI-14432)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ x ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ x ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ x ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ x ] Pull Request based on current revision of the `main` branch
- [ x ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ x ] Build completed using `mvn clean install -P contrib-check`
  - [ x ] JDK 21

### Licensing

- [ x ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ x ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ x ] Documentation formatting appears as expected in rendered files
