### PR TITLE
NIFI-14435 - FlowComparator should offer deep recursive comparison

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowComparatorVersionedStrategy.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowComparatorVersionedStrategy.java
@@ -26,12 +26,6 @@ public enum FlowComparatorVersionedStrategy {
      */
     DEEP,
     /**
-     * The whole versioned process group is considered and every component change
-     * should appear as a difference. This also includes the list of changes within
-     * a newly added process group. Version information is included as well.
-     */
-    DEEP_WITH_RECURSIVE_PG,
-    /**
      * The comparator should disregard individual changes but only look for changes
      * in the version information.
      */

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowComparatorVersionedStrategy.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowComparatorVersionedStrategy.java
@@ -26,7 +26,14 @@ public enum FlowComparatorVersionedStrategy {
      */
     DEEP,
     /**
-     * The comparator should disregard individual changes but only look for changes in the version information.
+     * The whole versioned process group is considered and every component change
+     * should appear as a difference. This also includes the list of changes within
+     * a newly added process group. Version information is included as well.
+     */
+    DEEP_WITH_RECURSIVE_PG,
+    /**
+     * The comparator should disregard individual changes but only look for changes
+     * in the version information.
      */
     SHALLOW
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
@@ -148,7 +148,7 @@ public class StandardFlowComparator implements FlowComparator {
         if (componentA == null) {
             differences.add(difference(DifferenceType.COMPONENT_ADDED, componentA, componentB, componentA, componentB));
 
-            if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP_WITH_RECURSIVE_PG
+            if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP
                     && componentB instanceof VersionedProcessGroup groupB) {
                 // we want to also add the differences of the sub process groups
                 // to do that we create an empty process group to simulate groupA
@@ -161,6 +161,15 @@ public class StandardFlowComparator implements FlowComparator {
 
         if (componentB == null) {
             differences.add(difference(DifferenceType.COMPONENT_REMOVED, componentA, componentB, componentA, componentB));
+
+            if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP
+                    && componentA instanceof VersionedProcessGroup groupA) {
+                // we want to also add the differences of the sub process groups
+                // to do that we create an empty process group to simulate groupA
+                // and compare it to groupB
+                compare(groupA, new VersionedProcessGroup(), differences, comparePos);
+            }
+
             return true;
         }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
@@ -147,6 +147,15 @@ public class StandardFlowComparator implements FlowComparator {
         final boolean compareName, final boolean comparePos, final boolean compareComments) {
         if (componentA == null) {
             differences.add(difference(DifferenceType.COMPONENT_ADDED, componentA, componentB, componentA, componentB));
+
+            if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP_WITH_RECURSIVE_PG
+                    && componentB instanceof VersionedProcessGroup groupB) {
+                // we want to also add the differences of the sub process groups
+                // to do that we create an empty process group to simulate groupA
+                // and compare it to groupB
+                compare(new VersionedProcessGroup(), groupB, differences, comparePos);
+            }
+
             return true;
         }
 
@@ -526,16 +535,6 @@ public class StandardFlowComparator implements FlowComparator {
 
     private void compare(final VersionedProcessGroup groupA, final VersionedProcessGroup groupB, final Set<FlowDifference> differences, final boolean compareNamePos) {
         if (compareComponents(groupA, groupB, differences, compareNamePos, compareNamePos, true)) {
-            return;
-        }
-
-        if (groupA == null) {
-            differences.add(difference(DifferenceType.COMPONENT_ADDED, groupA, groupB, groupA, groupB));
-            return;
-        }
-
-        if (groupB == null) {
-            differences.add(difference(DifferenceType.COMPONENT_REMOVED, groupA, groupB, groupA, groupB));
             return;
         }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/test/java/org/apache/nifi/registry/flow/diff/TestStandardFlowComparator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/test/java/org/apache/nifi/registry/flow/diff/TestStandardFlowComparator.java
@@ -17,11 +17,14 @@
 
 package org.apache.nifi.registry.flow.diff;
 
+import org.apache.nifi.flow.ComponentType;
 import org.apache.nifi.flow.VersionedAsset;
 import org.apache.nifi.flow.VersionedComponent;
+import org.apache.nifi.flow.VersionedControllerService;
 import org.apache.nifi.flow.VersionedParameter;
 import org.apache.nifi.flow.VersionedParameterContext;
 import org.apache.nifi.flow.VersionedProcessGroup;
+import org.apache.nifi.flow.VersionedProcessor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestStandardFlowComparator {
     private Map<String, String> decryptedToEncrypted;
@@ -174,6 +178,60 @@ public class TestStandardFlowComparator {
         comparator.compare(contextA, contextB, differences);
 
         assertEquals(4, differences.size());
+    }
+
+    @Test
+    public void testEmbeddedProcessGroupWithDeepRecursiveStrategy() {
+        final Function<String, String> decryptor = encryptedToDecrypted::get;
+
+        final VersionedProcessGroup rootPGA = new VersionedProcessGroup();
+        rootPGA.setIdentifier("rootPG");
+
+        final VersionedProcessGroup rootPGB = new VersionedProcessGroup();
+        rootPGB.setIdentifier("rootPG");
+        final VersionedProcessGroup childPG = new VersionedProcessGroup();
+        childPG.setIdentifier("childPG");
+        rootPGB.getProcessGroups().add(childPG);
+        final VersionedProcessGroup subChildPG = new VersionedProcessGroup();
+        subChildPG.setIdentifier("subChildPG");
+        childPG.getProcessGroups().add(subChildPG);
+        final VersionedProcessor processor = new VersionedProcessor();
+        processor.setIdentifier("processor");
+        childPG.getProcessors().add(processor);
+        final VersionedControllerService controllerService = new VersionedControllerService();
+        controllerService.setIdentifier("controllerService");
+        subChildPG.getControllerServices().add(controllerService);
+
+        final ComparableDataFlow flowA = new StandardComparableDataFlow("Flow A", rootPGA);
+        final ComparableDataFlow flowB = new StandardComparableDataFlow("Flow B", rootPGB);
+
+        comparator = new StandardFlowComparator(flowA, flowB, Collections.emptySet(),
+                new StaticDifferenceDescriptor(), decryptor, VersionedComponent::getIdentifier, FlowComparatorVersionedStrategy.DEEP);
+
+        final Set<FlowDifference> differencesDeep = comparator.compare().getDifferences();
+        assertEquals(1, differencesDeep.size());
+        assertTrue(differencesDeep.stream()
+                .anyMatch(difference -> difference.getDifferenceType() == DifferenceType.COMPONENT_ADDED
+                        && difference.getComponentB().getComponentType() == ComponentType.PROCESS_GROUP));
+
+        comparator = new StandardFlowComparator(flowA, flowB, Collections.emptySet(),
+                new StaticDifferenceDescriptor(), decryptor, VersionedComponent::getIdentifier, FlowComparatorVersionedStrategy.DEEP_WITH_RECURSIVE_PG);
+        final Set<FlowDifference> differencesDeepRecursive = comparator.compare().getDifferences();
+        assertEquals(4, differencesDeepRecursive.size());
+        assertTrue(differencesDeepRecursive.stream()
+                .anyMatch(difference -> difference.getDifferenceType() == DifferenceType.COMPONENT_ADDED
+                        && difference.getComponentB().getComponentType() == ComponentType.PROCESS_GROUP
+                        && difference.getComponentB().getIdentifier().equals("childPG")));
+        assertTrue(differencesDeepRecursive.stream()
+                .anyMatch(difference -> difference.getDifferenceType() == DifferenceType.COMPONENT_ADDED
+                        && difference.getComponentB().getComponentType() == ComponentType.PROCESS_GROUP
+                        && difference.getComponentB().getIdentifier().equals("subChildPG")));
+        assertTrue(differencesDeepRecursive.stream()
+                .anyMatch(difference -> difference.getDifferenceType() == DifferenceType.COMPONENT_ADDED
+                        && difference.getComponentB().getComponentType() == ComponentType.PROCESSOR));
+        assertTrue(differencesDeepRecursive.stream()
+                .anyMatch(difference -> difference.getDifferenceType() == DifferenceType.COMPONENT_ADDED
+                        && difference.getComponentB().getComponentType() == ComponentType.CONTROLLER_SERVICE));
     }
 
     private VersionedParameter createParameter(final String name, final String value, final boolean sensitive) {


### PR DESCRIPTION
# Summary

[NIFI-14435](https://issues.apache.org/jira/browse/NIFI-14435) - FlowComparator should offer deep recursive comparison

> Consider a versioned process group PG.
> Add a new child process group inside of PG.
> Do many modifications in the child PG (add processors, etc).
> If showing local changes for PG, it'll only say that a process group childPG has been added but nothing about what has been done in childPG.
> This JIRA is to add a new Flow Comparator Versioned Strategy in order to offer the option for a full exhaustive listing of the differences to also include the list of what is being added inside a newly added process group.
> There is no intent with this work to change what is returned to the UI when showing local changes as it should be further evaluated in terms of side effects.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
