### PR TITLE
NIFI-14440 - Bump Netty to 4.2.0.Final, Jetty to 12.0.19, GCP BOM to 26.59.0 and others

### DIFF
--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.58.0</google.libraries.version>
+        <google.libraries.version>26.59.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-media-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-media-bundle/pom.xml
@@ -24,7 +24,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <poi.version>5.4.0</poi.version>
+        <poi.version>5.4.1</poi.version>
         <mime4j.version>0.8.12</mime4j.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-poi-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-poi-bundle/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>nifi-poi-bundle</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <poi.version>5.4.0</poi.version>
+        <poi.version>5.4.1</poi.version>
     </properties>
     <modules>
         <module>nifi-poi-nar</module>

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-salesforce</artifactId>
-            <version>4.10.3</version>
+            <version>4.11.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-snowflake-bundle/pom.xml
@@ -40,7 +40,7 @@
                 <groupId>net.snowflake</groupId>
                 <artifactId>snowflake-jdbc</artifactId>
                 <!-- please check snowflake-ingest-sdk compatibility before upgrade -->
-                <version>3.23.1</version>
+                <version>3.23.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -408,7 +408,7 @@
         <dependency>
             <groupId>net.datafaker</groupId>
             <artifactId>datafaker</artifactId>
-            <version>2.4.2</version>
+            <version>2.4.3</version>
             <exclusions>
                 <!-- Exclude snakeyaml with android qualifier -->
                 <exclusion>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -169,7 +169,7 @@
             <dependency>
                 <groupId>com.github.wnameless.json</groupId>
                 <artifactId>json-flattener</artifactId>
-                <version>0.17.2</version>
+                <version>0.17.3</version>
             </dependency>
             <dependency>
                 <groupId>io.krakens</groupId>

--- a/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
@@ -121,7 +121,7 @@
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
-                <version>3.49.1</version>
+                <version>3.49.2</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>3.4.4</spring.boot.version>
-        <flyway.version>11.5.0</flyway.version>
+        <flyway.version>11.6.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.2.0.202503040940-r</jgit.version>
@@ -226,12 +226,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>3.21</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.782</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.31.11</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.31.16</software.amazon.awssdk.version>
         <gson.version>2.12.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.1.0</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.1.20</kotlin.version>
@@ -133,7 +133,7 @@
         <org.slf4j.version>2.0.17</org.slf4j.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <derby.version>10.17.1.0</derby.version>
-        <jetty.version>12.0.18</jetty.version>
+        <jetty.version>12.0.19</jetty.version>
         <jackson.bom.version>2.18.3</jackson.bom.version>
         <avro.version>1.11.4</avro.version>
         <jaxb.runtime.version>4.0.5</jaxb.runtime.version>
@@ -150,14 +150,14 @@
         <jersey.bom.version>3.1.10</jersey.bom.version>
         <log4j2.version>2.24.3</log4j2.version>
         <logback.version>1.5.18</logback.version>
-        <mockito.version>5.16.1</mockito.version>
+        <mockito.version>5.17.0</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.4</snakeyaml.version>
-        <netty.4.version>4.1.119.Final</netty.4.version>
+        <netty.4.version>4.2.0.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.version>6.2.5</spring.version>
         <spring.security.version>6.4.4</spring.security.version>
-        <swagger.annotations.version>2.2.29</swagger.annotations.version>
+        <swagger.annotations.version>2.2.30</swagger.annotations.version>
         <h2.version>2.3.232</h2.version>
         <zookeeper.version>3.9.3</zookeeper.version>
         <caffeine.version>3.2.0</caffeine.version>
@@ -671,7 +671,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>jaxb2-maven-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                     <configuration>
                         <noGeneratedHeaderComments>true</noGeneratedHeaderComments>
                     </configuration>
@@ -723,7 +723,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.45.1</version>
+                    <version>0.46.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -778,12 +778,12 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.12</version>
+                    <version>0.8.13</version>
                 </plugin>
                 <plugin>
                     <groupId>io.swagger.core.v3</groupId>
                     <artifactId>swagger-maven-plugin-jakarta</artifactId>
-                    <version>2.2.28</version>
+                    <version>2.2.30</version>
                 </plugin>
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>


### PR DESCRIPTION
# Summary

[NIFI-14440](https://issues.apache.org/jira/browse/NIFI-14440) - Bump Netty to 4.2.0.Final, Jetty to 12.0.19, GCP BOM to 26.59.0 and others

- GCP BOM from 26.58.0 to 26.59.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.59.0
- Apache POI from 5.4.0 to 5.4.1 - https://poi.apache.org/changes.html
- Camel Salesforce from 4.10.3 to 4.11.0 - https://github.com/apache/camel/releases/tag/camel-4.11.0
- Snowflake JDBC from 3.23.1 to 3.23.2 - https://docs.snowflake.com/en/release-notes/clients-drivers/jdbc-2025#version-3-23-2-april-3-2025
- DataFaker from 2.4.2 to 2.4.3 - https://github.com/datafaker-net/datafaker/releases/tag/2.4.3
- JSON Flattener from 0.17.2 to 0.17.3 - https://github.com/wnameless/json-flattener/releases/tag/json-flattener-0.17.3
- checker-qual from 3.49.1 to 3.49.2 - https://github.com/typetools/checker-framework/blob/master/docs/CHANGELOG.md
- FlywayDB from 11.5.0 to 11.6.0 - https://github.com/flyway/flyway/releases/tag/flyway-11.6.0
- Maven Source Plugin from 3.3.0 to 3.3.1 - https://github.com/apache/maven-source-plugin/releases/tag/maven-source-plugin-3.3.1
- Maven Site Plugin  from 3.4 to 3.21 - https://github.com/apache/maven-site-plugin/releases/tag/maven-site-plugin-3.21.0
- AWS SDK v2 from 2.31.11 to 2.31.16 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md#23116-2025-04-04
- Jetty from 12.0.18 to 12.0.19 - https://github.com/jetty/jetty.project/releases/tag/jetty-12.0.19
- Mockito from 5.16.1 to 5.17.0 - https://github.com/mockito/mockito/releases/tag/v5.17.0
- Netty from 4.1.119.Final to 4.2.0.Final - https://netty.io/news/2025/04/03/4-2-0.html
- Swagger Annotations from 2.2.29 to 2.2.30 - https://github.com/swagger-api/swagger-core/releases/tag/v2.2.30
- JAXB2 Maven Plugin from 3.2.0 to 3.3.0 - https://github.com/mojohaus/jaxb2-maven-plugin/releases/tag/jaxb2-maven-plugin-3.3.0
- Docker Maven Plugin from 0.45.1 to 0.46.0 - https://github.com/fabric8io/docker-maven-plugin/blob/master/doc/changelog.md
- Swagger Maven Plugin from 2.2.28 to 2.2.30 - https://github.com/swagger-api/swagger-core/releases/tag/v2.2.30

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
