### PR TITLE
NIFI-14445: Creating processor to fetch specific metadata instance for box file

### DIFF
--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/utils/BoxMetadataUtils.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/utils/BoxMetadataUtils.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.box.utils;
+
+import com.box.sdk.Metadata;
+import com.eclipsesource.json.JsonValue;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public class BoxMetadataUtils {
+
+    /**
+     * Parses a JsonValue and returns the appropriate Java object.
+     * Box does not allow exponential notation in metadata values, so we need to handle
+     * special number formats. For numbers containing decimal points or exponents, we try to
+     * convert them to BigDecimal first for precise representation. If that fails, we
+     * fall back to double, which might lose precision but allows the processing to continue.
+     *
+     * @param jsonValue The JsonValue to parse.
+     * @return The parsed Java object.
+     */
+    public static Object parseJsonValue(final JsonValue jsonValue) {
+        if (jsonValue == null) {
+            return null;
+        }
+        if (jsonValue.isString()) {
+            return jsonValue.asString();
+        } else if (jsonValue.isNumber()) {
+            final String numberString = jsonValue.toString();
+            if (numberString.contains(".") || numberString.toLowerCase().contains("e")) {
+                try {
+                    return (new BigDecimal(numberString)).toPlainString();
+                } catch (final NumberFormatException e) {
+                    return jsonValue.asDouble();
+                }
+            } else {
+                try {
+                    return jsonValue.asLong();
+                } catch (final NumberFormatException e) {
+                    return (new BigDecimal(numberString)).toPlainString();
+                }
+            }
+        } else if (jsonValue.isBoolean()) {
+            return jsonValue.asBoolean();
+        }
+        // Fallback: return the string representation.
+        return jsonValue.toString();
+    }
+
+    /**
+     * Processes Box metadata instance and populates the provided map with the default fields.
+     *
+     * @param fileId         The ID of the file.
+     * @param metadata       The Box metadata instance.
+     * @param instanceFields The map to populate with metadata fields.
+     */
+    public static void processBoxMetadataInstance(final String fileId,
+                                                  final Metadata metadata,
+                                                  final Map<String, Object> instanceFields) {
+        instanceFields.put("$id", metadata.getID());
+        instanceFields.put("$type", metadata.getTypeName());
+        instanceFields.put("$parent", "file_" + fileId); // match the Box API format
+        instanceFields.put("$template", metadata.getTemplateName());
+        instanceFields.put("$scope", metadata.getScope());
+
+        for (final String fieldName : metadata.getPropertyPaths()) {
+            final JsonValue jsonValue = metadata.getValue(fieldName);
+            if (jsonValue != null) {
+                final String cleanFieldName = fieldName.startsWith("/") ? fieldName.substring(1) : fieldName;
+                final Object fieldValue = parseJsonValue(jsonValue);
+                instanceFields.put(cleanFieldName, fieldValue);
+            }
+        }
+    }
+}

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -20,6 +20,7 @@ org.apache.nifi.processors.box.CreateBoxFileMetadataInstance
 org.apache.nifi.processors.box.ExtractStructuredBoxFileMetadata
 org.apache.nifi.processors.box.FetchBoxFile
 org.apache.nifi.processors.box.FetchBoxFileInfo
+org.apache.nifi.processors.box.FetchBoxFileMetadataInstance
 org.apache.nifi.processors.box.FetchBoxFileRepresentation
 org.apache.nifi.processors.box.GetBoxFileCollaborators
 org.apache.nifi.processors.box.GetBoxGroupMembers

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/BoxParseJsonTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/BoxParseJsonTest.java
@@ -20,21 +20,22 @@ import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
+import org.apache.nifi.processors.box.utils.BoxMetadataUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ListBoxFileMetadataInstancesParseJsonTest {
+public class BoxParseJsonTest {
 
     @Test
     void testParseString() {
         String expected = "test string";
-        Object result = ListBoxFileMetadataInstances.parseJsonValue(Json.value(expected));
+        Object result = BoxMetadataUtils.parseJsonValue(Json.value(expected));
         assertEquals(expected, result);
 
         // Empty string
         expected = "";
-        result = ListBoxFileMetadataInstances.parseJsonValue(Json.value(expected));
+        result = BoxMetadataUtils.parseJsonValue(Json.value(expected));
         assertEquals(expected, result);
     }
 
@@ -42,12 +43,12 @@ public class ListBoxFileMetadataInstancesParseJsonTest {
     void testParseBoolean() {
         // Test true
         boolean expected = true;
-        Object result = ListBoxFileMetadataInstances.parseJsonValue(Json.value(expected));
+        Object result = BoxMetadataUtils.parseJsonValue(Json.value(expected));
         assertEquals(expected, result);
 
         // Test false
         expected = false;
-        result = ListBoxFileMetadataInstances.parseJsonValue(Json.value(expected));
+        result = BoxMetadataUtils.parseJsonValue(Json.value(expected));
         assertEquals(expected, result);
     }
 
@@ -55,17 +56,17 @@ public class ListBoxFileMetadataInstancesParseJsonTest {
     void testParseIntegerNumber() {
         // Integer value
         long expected = 42;
-        Object result = ListBoxFileMetadataInstances.parseJsonValue(Json.value(expected));
+        Object result = BoxMetadataUtils.parseJsonValue(Json.value(expected));
         assertEquals(expected, result);
 
         // Max long value
         expected = Long.MAX_VALUE;
-        result = ListBoxFileMetadataInstances.parseJsonValue(Json.value(expected));
+        result = BoxMetadataUtils.parseJsonValue(Json.value(expected));
         assertEquals(expected, result);
 
         // Min long value
         expected = Long.MIN_VALUE;
-        result = ListBoxFileMetadataInstances.parseJsonValue(Json.value(expected));
+        result = BoxMetadataUtils.parseJsonValue(Json.value(expected));
         assertEquals(expected, result);
     }
 
@@ -74,19 +75,19 @@ public class ListBoxFileMetadataInstancesParseJsonTest {
         // Double without exponent
         String input = "3.14159";
         JsonValue jsonValue = Json.parse(input);
-        Object result = ListBoxFileMetadataInstances.parseJsonValue(jsonValue);
+        Object result = BoxMetadataUtils.parseJsonValue(jsonValue);
         assertEquals(input, result);
 
         // Very small number that should be preserved
         input = "0.0000000001";
         jsonValue = Json.parse(input);
-        result = ListBoxFileMetadataInstances.parseJsonValue(jsonValue);
+        result = BoxMetadataUtils.parseJsonValue(jsonValue);
         assertEquals(input, result);
 
         // Very large number that should be preserved
         input = "9999999999999999.9999";
         jsonValue = Json.parse(input);
-        result = ListBoxFileMetadataInstances.parseJsonValue(jsonValue);
+        result = BoxMetadataUtils.parseJsonValue(jsonValue);
         assertEquals(input, result);
     }
 
@@ -95,19 +96,19 @@ public class ListBoxFileMetadataInstancesParseJsonTest {
         // Scientific notation is converted to plain string format
         String input = "1.234e5";
         JsonValue jsonValue = Json.parse(input);
-        Object result = ListBoxFileMetadataInstances.parseJsonValue(jsonValue);
+        Object result = BoxMetadataUtils.parseJsonValue(jsonValue);
         assertEquals("123400", result);
 
         // large exponent
         input = "1.234e20";
         jsonValue = Json.parse(input);
-        result = ListBoxFileMetadataInstances.parseJsonValue(jsonValue);
+        result = BoxMetadataUtils.parseJsonValue(jsonValue);
         assertEquals("123400000000000000000", result);
 
         // Negative exponent
         input = "1.234e-5";
         jsonValue = Json.parse(input);
-        result = ListBoxFileMetadataInstances.parseJsonValue(jsonValue);
+        result = BoxMetadataUtils.parseJsonValue(jsonValue);
         assertEquals("0.00001234", result);
     }
 
@@ -115,12 +116,12 @@ public class ListBoxFileMetadataInstancesParseJsonTest {
     void testParseObjectAndArray() {
         // JSON objects return their string representation
         JsonObject jsonObject = Json.object().add("key", "value");
-        Object result = ListBoxFileMetadataInstances.parseJsonValue(jsonObject);
+        Object result = BoxMetadataUtils.parseJsonValue(jsonObject);
         assertEquals(jsonObject.toString(), result);
 
         // JSON arrays return their string representation
         JsonArray jsonArray = Json.array().add("item1").add("item2");
-        result = ListBoxFileMetadataInstances.parseJsonValue(jsonArray);
+        result = BoxMetadataUtils.parseJsonValue(jsonArray);
         assertEquals(jsonArray.toString(), result);
     }
 
@@ -128,11 +129,11 @@ public class ListBoxFileMetadataInstancesParseJsonTest {
     void testParseNumberFormatException() {
         String largeIntegerString = "9999999999999999999"; // Beyond Long.MAX_VALUE
         JsonValue jsonValue = Json.parse(largeIntegerString);
-        Object result = ListBoxFileMetadataInstances.parseJsonValue(jsonValue);
+        Object result = BoxMetadataUtils.parseJsonValue(jsonValue);
         assertEquals(largeIntegerString, result);
 
         double doubleValue = 123.456;
-        result = ListBoxFileMetadataInstances.parseJsonValue(Json.value(doubleValue));
+        result = BoxMetadataUtils.parseJsonValue(Json.value(doubleValue));
         assertEquals(String.valueOf(doubleValue), result);
     }
 }

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/FetchBoxFileMetadataInstanceTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/FetchBoxFileMetadataInstanceTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.box;
+
+import com.box.sdk.BoxAPIException;
+import com.box.sdk.BoxAPIResponseException;
+import com.box.sdk.BoxFile;
+import com.box.sdk.Metadata;
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonObject;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class FetchBoxFileMetadataInstanceTest extends AbstractBoxFileTest {
+
+    private static final String TEMPLATE_KEY = "fileMetadata";
+    private static final String TEMPLATE_SCOPE = "enterprise_123";
+    private static final String TEMPLATE_ID = "12345";
+
+    @Mock
+    private BoxFile mockBoxFile;
+
+    @Override
+    @BeforeEach
+    void setUp() throws Exception {
+        final FetchBoxFileMetadataInstance testSubject = new FetchBoxFileMetadataInstance() {
+            @Override
+            BoxFile getBoxFile(String fileId) {
+                return mockBoxFile;
+            }
+        };
+
+        testRunner = TestRunners.newTestRunner(testSubject);
+        super.setUp();
+    }
+
+    @Test
+    void testSuccessfulMetadataRetrieval() {
+        final JsonObject metadataJson = Json.object()
+                .add("$id", TEMPLATE_ID)
+                .add("$type", "fileMetadata-123")
+                .add("$parent", "file_" + TEST_FILE_ID)
+                .add("$template", TEMPLATE_KEY)
+                .add("$scope", TEMPLATE_SCOPE)
+                .add("fileName", "document.pdf")
+                .add("fileExtension", "pdf");
+        final Metadata metadata = new Metadata(metadataJson);
+
+        when(mockBoxFile.getMetadata(TEMPLATE_KEY, TEMPLATE_SCOPE)).thenReturn(metadata);
+
+        testRunner.setProperty(FetchBoxFileMetadataInstance.FILE_ID, TEST_FILE_ID);
+        testRunner.setProperty(FetchBoxFileMetadataInstance.TEMPLATE_KEY, TEMPLATE_KEY);
+        testRunner.setProperty(FetchBoxFileMetadataInstance.TEMPLATE_SCOPE, TEMPLATE_SCOPE);
+        testRunner.enqueue(new byte[0]);
+        testRunner.run();
+        testRunner.assertAllFlowFilesTransferred(FetchBoxFileMetadataInstance.REL_SUCCESS, 1);
+
+        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(FetchBoxFileMetadataInstance.REL_SUCCESS).getFirst();
+        flowFile.assertAttributeEquals("box.id", TEST_FILE_ID);
+        flowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), "application/json");
+        flowFile.assertAttributeEquals("box.metadata.template.key", TEMPLATE_KEY);
+        flowFile.assertAttributeEquals("box.metadata.template.scope", TEMPLATE_SCOPE);
+
+        final String content = new String(flowFile.toByteArray());
+        assertTrue(content.contains("\"$id\":\"" + TEMPLATE_ID + "\""));
+        assertTrue(content.contains("\"$template\":\"" + TEMPLATE_KEY + "\""));
+        assertTrue(content.contains("\"$scope\":\"" + TEMPLATE_SCOPE + "\""));
+        assertTrue(content.contains("\"$parent\":\"file_" + TEST_FILE_ID + "\""));
+        assertTrue(content.contains("\"fileName\":\"document.pdf\""));
+        assertTrue(content.contains("\"fileExtension\":\"pdf\""));
+    }
+
+    @Test
+    void testMetadataNotFound() {
+        when(mockBoxFile.getMetadata(anyString(), anyString())).thenThrow(
+                new BoxAPIResponseException("instance_not_found - Template not found", 404, "instance_not_found", null));
+
+        testRunner.setProperty(FetchBoxFileMetadataInstance.FILE_ID, TEST_FILE_ID);
+        testRunner.setProperty(FetchBoxFileMetadataInstance.TEMPLATE_KEY, TEMPLATE_KEY);
+        testRunner.setProperty(FetchBoxFileMetadataInstance.TEMPLATE_SCOPE, TEMPLATE_SCOPE);
+        testRunner.enqueue(new byte[0]);
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(FetchBoxFileMetadataInstance.REL_TEMPLATE_NOT_FOUND, 1);
+        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(FetchBoxFileMetadataInstance.REL_TEMPLATE_NOT_FOUND).getFirst();
+        flowFile.assertAttributeExists(BoxFileAttributes.ERROR_MESSAGE);
+    }
+
+    @Test
+    void testFileNotFound() {
+        final BoxAPIResponseException mockException = new BoxAPIResponseException("API Error", 404, "Box File Not Found", null);
+        doThrow(mockException).when(mockBoxFile).getMetadata(anyString(), anyString());
+
+        testRunner.setProperty(FetchBoxFileMetadataInstance.FILE_ID, TEST_FILE_ID);
+        testRunner.setProperty(FetchBoxFileMetadataInstance.TEMPLATE_KEY, TEMPLATE_KEY);
+        testRunner.setProperty(FetchBoxFileMetadataInstance.TEMPLATE_SCOPE, TEMPLATE_SCOPE);
+        testRunner.enqueue(new byte[0]);
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(FetchBoxFileMetadataInstance.REL_FILE_NOT_FOUND, 1);
+        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(FetchBoxFileMetadataInstance.REL_FILE_NOT_FOUND).getFirst();
+        flowFile.assertAttributeEquals(BoxFileAttributes.ERROR_CODE, "404");
+        flowFile.assertAttributeEquals(BoxFileAttributes.ERROR_MESSAGE, "API Error [404]");
+    }
+
+    @Test
+    void testBoxApiException() {
+        final BoxAPIException mockException = new BoxAPIException("General API Error", 500, "Unexpected Error");
+        doThrow(mockException).when(mockBoxFile).getMetadata(anyString(), anyString());
+
+        testRunner.setProperty(FetchBoxFileMetadataInstance.FILE_ID, TEST_FILE_ID);
+        testRunner.setProperty(FetchBoxFileMetadataInstance.TEMPLATE_KEY, TEMPLATE_KEY);
+        testRunner.setProperty(FetchBoxFileMetadataInstance.TEMPLATE_SCOPE, TEMPLATE_SCOPE);
+        testRunner.enqueue(new byte[0]);
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(FetchBoxFileMetadataInstance.REL_FAILURE, 1);
+        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(FetchBoxFileMetadataInstance.REL_FAILURE).getFirst();
+        flowFile.assertAttributeEquals(BoxFileAttributes.ERROR_MESSAGE, "General API Error\nUnexpected Error");
+    }
+}


### PR DESCRIPTION
NIFI-14445:
- Creating processor to fetch metadata template for specific Box file
- Moving common methods to shared class

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
