### PR TITLE
NIFI-14448 nifi-cdc: Fix integer serialization to respect SQL UNSIGNED type semantics

### DIFF
--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/ColumnDefinition.java
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-api/src/main/java/org/apache/nifi/cdc/event/ColumnDefinition.java
@@ -24,14 +24,16 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 public class ColumnDefinition {
 
     private int type;
+    private Boolean isSigned;
     private String name = "";
 
-    public ColumnDefinition(int type) {
+    public ColumnDefinition(Boolean isSigned, int type) {
         this.type = type;
+        this.isSigned = isSigned;
     }
 
-    public ColumnDefinition(int type, String name) {
-        this(type);
+    public ColumnDefinition(Boolean isSigned, int type, String name) {
+        this(isSigned, type);
         this.name = name;
     }
 
@@ -41,6 +43,14 @@ public class ColumnDefinition {
 
     public void setType(int type) {
         this.type = type;
+    }
+
+    public Boolean getIsSigned() {
+        return isSigned;
+    }
+
+    public void setIsSigned(boolean isSigned) {
+        this.isSigned = isSigned;
     }
 
     public String getName() {

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DeleteRowsWriter.java
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/DeleteRowsWriter.java
@@ -79,17 +79,11 @@ public class DeleteRowsWriter extends AbstractBinlogTableEventWriter<DeleteRowsE
             jsonGenerator.writeStartObject();
             jsonGenerator.writeNumberField("id", i + 1);
             ColumnDefinition columnDefinition = event.getColumnByIndex(i);
-            Integer columnType = null;
             if (columnDefinition != null) {
                 jsonGenerator.writeStringField("name", columnDefinition.getName());
-                columnType = columnDefinition.getType();
-                jsonGenerator.writeNumberField("column_type", columnType);
+                jsonGenerator.writeNumberField("column_type", columnDefinition.getType());
             }
-            if (row[i] == null) {
-                jsonGenerator.writeNullField("value");
-            } else {
-                jsonGenerator.writeObjectField("value", getWritableObject(columnType, row[i]));
-            }
+            writeObjectAsValueField(jsonGenerator, "value", columnDefinition, row[i]);
             jsonGenerator.writeEndObject();
             i = includedColumns.nextSetBit(i + 1);
         }

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/InsertRowsWriter.java
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/InsertRowsWriter.java
@@ -80,17 +80,11 @@ public class InsertRowsWriter extends AbstractBinlogTableEventWriter<InsertRowsE
             jsonGenerator.writeStartObject();
             jsonGenerator.writeNumberField("id", i + 1);
             ColumnDefinition columnDefinition = event.getColumnByIndex(i);
-            Integer columnType = null;
             if (columnDefinition != null) {
                 jsonGenerator.writeStringField("name", columnDefinition.getName());
-                columnType = columnDefinition.getType();
-                jsonGenerator.writeNumberField("column_type", columnType);
+                jsonGenerator.writeNumberField("column_type", columnDefinition.getType());
             }
-            if (row[i] == null) {
-                jsonGenerator.writeNullField("value");
-            } else {
-                jsonGenerator.writeObjectField("value", getWritableObject(columnType, row[i]));
-            }
+            writeObjectAsValueField(jsonGenerator, "value", columnDefinition, row[i]);
             jsonGenerator.writeEndObject();
             i = includedColumns.nextSetBit(i + 1);
         }

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/UpdateRowsWriter.java
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/event/io/UpdateRowsWriter.java
@@ -82,26 +82,15 @@ public class UpdateRowsWriter extends AbstractBinlogTableEventWriter<UpdateRowsE
             jsonGenerator.writeStartObject();
             jsonGenerator.writeNumberField("id", i + 1);
             ColumnDefinition columnDefinition = event.getColumnByIndex(i);
-            Integer columnType = null;
             if (columnDefinition != null) {
                 jsonGenerator.writeStringField("name", columnDefinition.getName());
-                columnType = columnDefinition.getType();
-                jsonGenerator.writeNumberField("column_type", columnType);
+                jsonGenerator.writeNumberField("column_type", columnDefinition.getType());
             }
             Serializable[] oldRow = row.getKey();
             Serializable[] newRow = row.getValue();
 
-            if (oldRow[i] == null) {
-                jsonGenerator.writeNullField("last_value");
-            } else {
-                jsonGenerator.writeObjectField("last_value", getWritableObject(columnType, oldRow[i]));
-            }
-
-            if (newRow[i] == null) {
-                jsonGenerator.writeNullField("value");
-            } else {
-                jsonGenerator.writeObjectField("value", getWritableObject(columnType, newRow[i]));
-            }
+            writeObjectAsValueField(jsonGenerator, "last_value", columnDefinition, oldRow[i]);
+            writeObjectAsValueField(jsonGenerator, "value", columnDefinition, newRow[i]);
             jsonGenerator.writeEndObject();
             i = includedColumns.nextSetBit(i + 1);
         }

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/main/java/org/apache/nifi/cdc/mysql/processors/CaptureChangeMySQL.java
@@ -1253,7 +1253,9 @@ public class CaptureChangeMySQL extends AbstractSessionFactoryProcessor {
                 for (int i = 1; i <= numCols; i++) {
                     // Use the column label if it exists, otherwise use the column name. We're not doing aliasing here, but it's better practice.
                     String columnLabel = rsmd.getColumnLabel(i);
-                    columnDefinitions.add(new ColumnDefinition(rsmd.getColumnType(i), columnLabel != null ? columnLabel : rsmd.getColumnName(i)));
+                    columnDefinitions.add(new ColumnDefinition(
+                            rsmd.isSigned(i), rsmd.getColumnType(i), columnLabel != null ? columnLabel : rsmd.getColumnName(i)
+                    ));
                 }
 
                 tableInfo = new TableInfo(key.getDatabaseName(), key.getTableName(), key.getTableId(), columnDefinitions);

--- a/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/test/java/org/apache/nifi/cdc/mysql/event/io/TestInsertRowsWriter.java
+++ b/nifi-extension-bundles/nifi-cdc/nifi-cdc-mysql-bundle/nifi-cdc-mysql-processors/src/test/java/org/apache/nifi/cdc/mysql/event/io/TestInsertRowsWriter.java
@@ -17,22 +17,77 @@
 package org.apache.nifi.cdc.mysql.event.io;
 
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.nifi.cdc.event.ColumnDefinition;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.sql.Types;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 class TestInsertRowsWriter {
 
     @Test
-    public void testGetWritableObject() {
+    public void testGetWritableObject() throws IOException {
         InsertRowsWriter insertRowsWriter = new InsertRowsWriter();
-        assertNull(insertRowsWriter.getWritableObject(null, null));
-        assertNull(insertRowsWriter.getWritableObject(Types.INTEGER, null));
-        assertEquals((byte) 1, insertRowsWriter.getWritableObject(Types.INTEGER, (byte) 1));
-        assertEquals("Hello", insertRowsWriter.getWritableObject(Types.VARCHAR, "Hello".getBytes()));
+        try (JsonGenerator g = mock(JsonGenerator.class)) {
+            insertRowsWriter.writeObjectAsValueField(g, "fieldName", null, null); //null
+            verify(g).writeNullField("fieldName");
+            verifyNoMoreInteractions(g);
+        }
+        try (JsonGenerator g = mock(JsonGenerator.class)) {
+            insertRowsWriter.writeObjectAsValueField(g, "fieldName", new ColumnDefinition(true, Types.INTEGER), null); //null
+            verify(g).writeNullField("fieldName");
+            verifyNoMoreInteractions(g);
+        }
+        try (JsonGenerator g = mock(JsonGenerator.class)) {
+            insertRowsWriter.writeObjectAsValueField(g, "fieldName", new ColumnDefinition(false, Types.BIGINT), (int) -77); //null
+            verify(g).writeFieldName("fieldName");
+            verify(g).writeRawValue("18446744073709551539");
+            verifyNoMoreInteractions(g);
+        }
+        try (JsonGenerator g = mock(JsonGenerator.class)) {
+            insertRowsWriter.writeObjectAsValueField(g, "fieldName", new ColumnDefinition(false, Types.INTEGER), (int) -77); //null
+            verify(g).writeFieldName("fieldName");
+            verify(g).writeRawValue("4294967219");
+            verifyNoMoreInteractions(g);
+        }
+        try (JsonGenerator g = mock(JsonGenerator.class)) {
+            insertRowsWriter.writeObjectAsValueField(g, "fieldName", new ColumnDefinition(false, Types.SMALLINT), (int) -77); //null
+            verify(g).writeFieldName("fieldName");
+            verify(g).writeRawValue("65459");
+            verifyNoMoreInteractions(g);
+        }
+        try (JsonGenerator g = mock(JsonGenerator.class)) {
+            insertRowsWriter.writeObjectAsValueField(g, "fieldName", new ColumnDefinition(false, Types.TINYINT), (int) -77); //null
+            verify(g).writeFieldName("fieldName");
+            verify(g).writeRawValue("179");
+            verifyNoMoreInteractions(g);
+        }
+        try (JsonGenerator g = mock(JsonGenerator.class)) {
+            insertRowsWriter.writeObjectAsValueField(g, "fieldName", new ColumnDefinition(true, Types.TINYINT), (int) -77); //null
+            verify(g).writeObjectField("fieldName", -77);
+            verifyNoMoreInteractions(g);
+        }
+        try (JsonGenerator g = mock(JsonGenerator.class)) {
+            insertRowsWriter.writeObjectAsValueField(g, "fieldName", new ColumnDefinition(false, Types.TINYINT), (byte) 1); //null
+            verify(g).writeFieldName("fieldName");
+            verify(g).writeRawValue( "1");
+            verifyNoMoreInteractions(g);
+        }
+        try (JsonGenerator g = mock(JsonGenerator.class)) {
+            insertRowsWriter.writeObjectAsValueField(g, "fieldName", new ColumnDefinition(true, Types.TINYINT), (byte) 1); //null
+            verify(g).writeObjectField("fieldName", (byte) 1);
+            verifyNoMoreInteractions(g);
+        }
+        try (JsonGenerator g = mock(JsonGenerator.class)) {
+            insertRowsWriter.writeObjectAsValueField(g, "fieldName", new ColumnDefinition(null, Types.VARCHAR), "Hello".getBytes()); //null
+            verify(g).writeObjectField("fieldName", "Hello");
+            verifyNoMoreInteractions(g);
+        }
     }
 
 }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14448](https://issues.apache.org/jira/browse/NIFI-14448)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

There are no new dependencies.

### Documentation

- [x] Documentation formatting appears as expected in rendered files

The documentation didnt change.