### PR TITLE
NIFI-14450: Setting Max retry to static value to FetchBoxFileRepresentation

### DIFF
--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/FetchBoxFileRepresentation.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/FetchBoxFileRepresentation.java
@@ -120,6 +120,13 @@ public class FetchBoxFileRepresentation extends AbstractProcessor implements Ver
             REL_REPRESENTATION_NOT_FOUND
     );
 
+    /*
+     * The maximum number of retries for polling the status of the generated representation.
+     * Each retry waits for 100 milliseconds before the next attempt, set in the Box SDK.
+     * Total wait time is 5 seconds.
+     */
+    private static final int MAX_RETRIES = 50;
+
     private volatile BoxAPIConnection boxAPIConnection;
 
     @Override
@@ -156,7 +163,7 @@ public class FetchBoxFileRepresentation extends AbstractProcessor implements Ver
 
             flowFile = session.write(flowFile, outputStream ->
                     // Download the file representation, box sdk handles a request to create representation if it doesn't exist
-                    boxFile.getRepresentationContent("[" + representationType + "]", outputStream)
+                    boxFile.getRepresentationContent("[" + representationType + "]", "", outputStream, MAX_RETRIES)
             );
 
             flowFile = session.putAllAttributes(flowFile, Map.of(

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/FetchBoxFileRepresentationTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/FetchBoxFileRepresentationTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -88,10 +89,11 @@ class FetchBoxFileRepresentationTest extends AbstractBoxFileTest {
         when(mockFileInfo.getType()).thenReturn(TEST_FILE_TYPE);
 
         doAnswer(invocation -> {
-            final OutputStream outputStream = invocation.getArgument(1);
+            final OutputStream outputStream = invocation.getArgument(2);
             outputStream.write(TEST_CONTENT);
             return null;
-        }).when(mockBoxFile).getRepresentationContent(eq("[" + TEST_REPRESENTATION_TYPE + "]"), any(OutputStream.class));
+        }).when(mockBoxFile).getRepresentationContent(eq("[" + TEST_REPRESENTATION_TYPE + "]"), anyString(), any(OutputStream.class), anyInt());
+
 
         testRunner.enqueue("");
         testRunner.run();
@@ -139,7 +141,7 @@ class FetchBoxFileRepresentationTest extends AbstractBoxFileTest {
         when(repNotFoundException.getMessage()).thenReturn("No matching representations found for requested hint");
         when(repNotFoundException.getResponseCode()).thenReturn(400);
 
-        doThrow(repNotFoundException).when(mockBoxFile).getRepresentationContent(anyString(), any(OutputStream.class));
+        doThrow(repNotFoundException).when(mockBoxFile).getRepresentationContent(eq("[" + TEST_REPRESENTATION_TYPE + "]"), anyString(), any(OutputStream.class), anyInt());
 
         testRunner.enqueue("");
         testRunner.run();
@@ -157,7 +159,7 @@ class FetchBoxFileRepresentationTest extends AbstractBoxFileTest {
         when(generalException.getMessage()).thenReturn("API error occurred");
         when(generalException.getResponseCode()).thenReturn(500);
 
-        doThrow(generalException).when(mockBoxFile).getRepresentationContent(anyString(), any(OutputStream.class));
+        doThrow(generalException).when(mockBoxFile).getRepresentationContent(eq("[" + TEST_REPRESENTATION_TYPE + "]"), anyString(), any(OutputStream.class), anyInt());
 
         testRunner.enqueue("");
         testRunner.run();
@@ -178,10 +180,10 @@ class FetchBoxFileRepresentationTest extends AbstractBoxFileTest {
         testRunner.setProperty(FetchBoxFileRepresentation.FILE_ID, "${box.id}");
 
         doAnswer(invocation -> {
-            final OutputStream outputStream = invocation.getArgument(1);
+            final OutputStream outputStream = invocation.getArgument(2);
             outputStream.write(TEST_CONTENT);
             return null;
-        }).when(mockBoxFile).getRepresentationContent(anyString(), any(OutputStream.class));
+        }).when(mockBoxFile).getRepresentationContent(eq("[" + TEST_REPRESENTATION_TYPE + "]"), anyString(), any(OutputStream.class), anyInt());
 
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("box.id", TEST_FILE_ID);


### PR DESCRIPTION
NIFI-14450:

Edge case has been occurring once in a while were Box API gets stuck and goes in a loop. The box service which generates the representation gets stuck and the default method sets the default max retries to Integer.MAX_VALUE
```
public void getRepresentationContent(String representationHint, String assetPath, OutputStream output) {
        this.getRepresentationContent(representationHint, assetPath, output, Integer.MAX_VALUE);
    }
```

- setting a static value for the retry count 

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14450](https://issues.apache.org/jira/browse/NIFI-14450)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
