### PR TITLE
NIFI-14452 Add X-Content-Type-Options Header to HTTP Responses

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/handler/HeaderWriterHandler.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/handler/HeaderWriterHandler.java
@@ -30,6 +30,9 @@ public class HeaderWriterHandler extends Handler.Wrapper {
     private static final String CONTENT_SECURITY_POLICY_HEADER = "Content-Security-Policy";
     private static final String CONTENT_SECURITY_POLICY = "frame-ancestors 'self'";
 
+    private static final String CONTENT_TYPE_OPTIONS_HEADER = "X-Content-Type-Options";
+    private static final String CONTENT_TYPE_OPTIONS = "nosniff";
+
     private static final String FRAME_OPTIONS_HEADER = "X-Frame-Options";
     private static final String FRAME_OPTIONS = "SAMEORIGIN";
 
@@ -52,6 +55,7 @@ public class HeaderWriterHandler extends Handler.Wrapper {
     public boolean handle(final Request request, final Response response, final Callback callback) throws Exception {
         final HttpFields.Mutable responseHeaders = response.getHeaders();
         responseHeaders.put(CONTENT_SECURITY_POLICY_HEADER, CONTENT_SECURITY_POLICY);
+        responseHeaders.put(CONTENT_TYPE_OPTIONS_HEADER, CONTENT_TYPE_OPTIONS);
         responseHeaders.put(FRAME_OPTIONS_HEADER, FRAME_OPTIONS);
         responseHeaders.put(XSS_PROTECTION_HEADER, XSS_PROTECTION);
 


### PR DESCRIPTION
# Summary

[NIFI-14452](https://issues.apache.org/jira/browse/NIFI-14452) Adds the [X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options) HTTP header to framework responses from the Jetty server.

This response header was present in NiFi 2.1.0 and earlier, but refactoring the implementation did not carry over the header in the Jetty `HeaderWriterHandler`.

The changes include unit test updates to check for the presence of standard HTTP response headers from the framework Jetty server.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
