### PR TITLE
NIFI-14449 - Fixed nifi.cmd to work with paths with spaces

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.cmd
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.cmd
@@ -16,7 +16,7 @@ rem    See the License for the specific language governing permissions and
 rem    limitations under the License.
 rem
 
-call %~dp0\nifi-env.cmd
+call "%~dp0\nifi-env.cmd"
 
 if exist "%JAVA_HOME%\bin\java.exe" (
   set JAVA_EXE=%JAVA_HOME%\bin\java.exe
@@ -33,15 +33,15 @@ set CONFIG_FILE_PROPERTY=-Dorg.apache.nifi.bootstrap.config.file=%CONF_DIR%\boot
 set PROPERTIES_FILE_PROPERTY=-Dnifi.properties.file.path=%CONF_DIR%\nifi.properties
 set BOOTSTRAP_HEAP_SIZE=48m
 
-set JAVA_ARGS=%LOG_DIR_PROPERTY% %CONFIG_FILE_PROPERTY%
-set JAVA_PARAMS=-cp %BOOTSTRAP_LIB_DIR%\*;%CONF_DIR% %JAVA_ARGS%
+set JAVA_ARGS="%LOG_DIR_PROPERTY%" "%CONFIG_FILE_PROPERTY%"
+set JAVA_PARAMS=-cp "%BOOTSTRAP_LIB_DIR%\*;%CONF_DIR%" %JAVA_ARGS%
 set JAVA_MEMORY=-Xms%BOOTSTRAP_HEAP_SIZE% -Xmx%BOOTSTRAP_HEAP_SIZE%
 
 echo JAVA_HOME=%JAVA_HOME%
 echo NIFI_HOME=%NIFI_HOME%
 echo.
 
-pushd %NIFI_HOME%
+pushd "%NIFI_HOME%"
 
 set RUN_COMMAND="%~1"
 if %RUN_COMMAND% == "set-single-user-credentials" (


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14449](https://issues.apache.org/jira/browse/NIFI-14449) fixes a bug with nifi.cmd where it fails when NIFI_HOME has a space in the path on Windows.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [NIFI-14449 ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-1449) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
- [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
