### PR TITLE
NIFI-14435 - FlowComparator should offer deep recursive comparison

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -25,6 +25,7 @@ on:
       - 'nifi-framework-api/**'
       - 'nifi-framework-bundle/**'
       - 'nifi-extension-bundles/nifi-py4j-extension-bundle/**'
+      - 'nifi-registry/nifi-registry-core/nifi-registry-flow-diff/**'
       - 'nifi-stateless/**'
       - 'nifi-mock/**'
   pull_request:
@@ -36,6 +37,7 @@ on:
       - 'nifi-framework-api/**'
       - 'nifi-framework-bundle/**'
       - 'nifi-extension-bundles/nifi-py4j-extension-bundle/**'
+      - 'nifi-registry/nifi-registry-core/nifi-registry-flow-diff/**'
       - 'nifi-stateless/**'
       - 'nifi-mock/**'
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/AffectedComponentSet.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/AffectedComponentSet.java
@@ -402,7 +402,8 @@ public class AffectedComponentSet {
 
     private void addComponentsForInheritedParameterContextChange(final FlowDifference difference) {
         // If the inherited parameter contexts have changed, any component referencing a parameter in that context is affected.
-        final String parameterContextId = difference.getComponentA().getInstanceIdentifier();
+        final VersionedComponent vc = difference.getComponentA() == null ? difference.getComponentB() : difference.getComponentA();
+        final String parameterContextId = vc.getInstanceIdentifier();
         final ParameterContext context = flowManager.getParameterContextManager().getParameterContext(parameterContextId);
         if (context == null) {
             return;
@@ -428,7 +429,8 @@ public class AffectedComponentSet {
 
     private void addComponentsForParameterContextChange(final FlowDifference difference) {
         // When the parameter context that a PG is bound to is updated, any component referencing a parameter is affected.
-        final String groupId = difference.getComponentA().getInstanceIdentifier();
+        final VersionedComponent vc = difference.getComponentA() == null ? difference.getComponentB() : difference.getComponentA();
+        final String groupId = vc.getInstanceIdentifier();
         final ProcessGroup group = flowManager.getGroup(groupId);
         if (group == null) {
             return;

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowComparatorVersionedStrategy.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowComparatorVersionedStrategy.java
@@ -26,12 +26,6 @@ public enum FlowComparatorVersionedStrategy {
      */
     DEEP,
     /**
-     * The whole versioned process group is considered and every component change
-     * should appear as a difference. This also includes the list of changes within
-     * a newly added process group. Version information is included as well.
-     */
-    DEEP_WITH_RECURSIVE_PG,
-    /**
      * The comparator should disregard individual changes but only look for changes
      * in the version information.
      */

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowComparatorVersionedStrategy.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowComparatorVersionedStrategy.java
@@ -26,8 +26,7 @@ public enum FlowComparatorVersionedStrategy {
      */
     DEEP,
     /**
-     * The comparator should disregard individual changes but only look for changes
-     * in the version information.
+     * The comparator should disregard individual changes but only look for changes in the version information.
      */
     SHALLOW
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowComparatorVersionedStrategy.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/FlowComparatorVersionedStrategy.java
@@ -26,7 +26,14 @@ public enum FlowComparatorVersionedStrategy {
      */
     DEEP,
     /**
-     * The comparator should disregard individual changes but only look for changes in the version information.
+     * The whole versioned process group is considered and every component change
+     * should appear as a difference. This also includes the list of changes within
+     * a newly added process group. Version information is included as well.
+     */
+    DEEP_WITH_RECURSIVE_PG,
+    /**
+     * The comparator should disregard individual changes but only look for changes
+     * in the version information.
      */
     SHALLOW
 }

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
@@ -151,9 +151,15 @@ public class StandardFlowComparator implements FlowComparator {
             if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP
                     && componentB instanceof VersionedProcessGroup groupB) {
                 // we want to also add the differences of the sub process groups
-                // to do that we create an empty process group to simulate groupA
-                // and compare it to groupB
-                compare(new VersionedProcessGroup(), groupB, differences, comparePos);
+                differences.addAll(compareComponents(Set.of(), groupB.getConnections(), this::compare));
+                differences.addAll(compareComponents(Set.of(), groupB.getProcessors(), this::compare));
+                differences.addAll(compareComponents(Set.of(), groupB.getControllerServices(), this::compare));
+                differences.addAll(compareComponents(Set.of(), groupB.getFunnels(), this::compare));
+                differences.addAll(compareComponents(Set.of(), groupB.getInputPorts(), this::compare));
+                differences.addAll(compareComponents(Set.of(), groupB.getLabels(), this::compare));
+                differences.addAll(compareComponents(Set.of(), groupB.getOutputPorts(), this::compare));
+                differences.addAll(compareComponents(Set.of(), groupB.getProcessGroups(), (a, b, diffs) -> compare(a, b, diffs, true)));
+                differences.addAll(compareComponents(Set.of(), groupB.getRemoteProcessGroups(), this::compare));
             }
 
             return true;
@@ -165,9 +171,15 @@ public class StandardFlowComparator implements FlowComparator {
             if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP
                     && componentA instanceof VersionedProcessGroup groupA) {
                 // we want to also add the differences of the sub process groups
-                // to do that we create an empty process group to simulate groupA
-                // and compare it to groupB
-                compare(groupA, new VersionedProcessGroup(), differences, comparePos);
+                differences.addAll(compareComponents(groupA.getConnections(), Set.of(), this::compare));
+                differences.addAll(compareComponents(groupA.getProcessors(), Set.of(), this::compare));
+                differences.addAll(compareComponents(groupA.getControllerServices(), Set.of(), this::compare));
+                differences.addAll(compareComponents(groupA.getFunnels(), Set.of(), this::compare));
+                differences.addAll(compareComponents(groupA.getInputPorts(), Set.of(), this::compare));
+                differences.addAll(compareComponents(groupA.getLabels(), Set.of(), this::compare));
+                differences.addAll(compareComponents(groupA.getOutputPorts(), Set.of(), this::compare));
+                differences.addAll(compareComponents(groupA.getProcessGroups(), Set.of(), (a, b, diffs) -> compare(a, b, diffs, true)));
+                differences.addAll(compareComponents(groupA.getRemoteProcessGroups(), Set.of(), this::compare));
             }
 
             return true;

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
@@ -150,16 +150,9 @@ public class StandardFlowComparator implements FlowComparator {
 
             if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP
                     && componentB instanceof VersionedProcessGroup groupB) {
-                // we want to also add the differences of the sub process groups
-                differences.addAll(compareComponents(Set.of(), groupB.getConnections(), this::compare));
-                differences.addAll(compareComponents(Set.of(), groupB.getProcessors(), this::compare));
-                differences.addAll(compareComponents(Set.of(), groupB.getControllerServices(), this::compare));
-                differences.addAll(compareComponents(Set.of(), groupB.getFunnels(), this::compare));
-                differences.addAll(compareComponents(Set.of(), groupB.getInputPorts(), this::compare));
-                differences.addAll(compareComponents(Set.of(), groupB.getLabels(), this::compare));
-                differences.addAll(compareComponents(Set.of(), groupB.getOutputPorts(), this::compare));
-                differences.addAll(compareComponents(Set.of(), groupB.getProcessGroups(), (a, b, diffs) -> compare(a, b, diffs, true)));
-                differences.addAll(compareComponents(Set.of(), groupB.getRemoteProcessGroups(), this::compare));
+                // we want to also add the differences of the added sub process groups
+                extractPGConfigDifferences(null, groupB, differences);
+                extractPGComponentsDifferences(null, groupB, differences);
             }
 
             return true;
@@ -170,16 +163,8 @@ public class StandardFlowComparator implements FlowComparator {
 
             if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP
                     && componentA instanceof VersionedProcessGroup groupA) {
-                // we want to also add the differences of the sub process groups
-                differences.addAll(compareComponents(groupA.getConnections(), Set.of(), this::compare));
-                differences.addAll(compareComponents(groupA.getProcessors(), Set.of(), this::compare));
-                differences.addAll(compareComponents(groupA.getControllerServices(), Set.of(), this::compare));
-                differences.addAll(compareComponents(groupA.getFunnels(), Set.of(), this::compare));
-                differences.addAll(compareComponents(groupA.getInputPorts(), Set.of(), this::compare));
-                differences.addAll(compareComponents(groupA.getLabels(), Set.of(), this::compare));
-                differences.addAll(compareComponents(groupA.getOutputPorts(), Set.of(), this::compare));
-                differences.addAll(compareComponents(groupA.getProcessGroups(), Set.of(), (a, b, diffs) -> compare(a, b, diffs, true)));
-                differences.addAll(compareComponents(groupA.getRemoteProcessGroups(), Set.of(), this::compare));
+                // we want to also add the differences of the removed sub process groups
+                extractPGComponentsDifferences(groupA, null, differences);
             }
 
             return true;
@@ -566,20 +551,7 @@ public class StandardFlowComparator implements FlowComparator {
         compareFlowCoordinates(groupA, groupB, flowCoordinateDifferences);
         differences.addAll(flowCoordinateDifferences);
 
-        addIfDifferent(differences, DifferenceType.FLOWFILE_CONCURRENCY_CHANGED, groupA, groupB, VersionedProcessGroup::getFlowFileConcurrency,
-            true, DEFAULT_FLOW_FILE_CONCURRENCY);
-        addIfDifferent(differences, DifferenceType.FLOWFILE_OUTBOUND_POLICY_CHANGED, groupA, groupB, VersionedProcessGroup::getFlowFileOutboundPolicy,
-            true, DEFAULT_OUTBOUND_FLOW_FILE_POLICY);
-
-        addIfDifferent(differences, DifferenceType.DEFAULT_BACKPRESSURE_DATA_SIZE_CHANGED, groupA, groupB, VersionedProcessGroup::getDefaultBackPressureDataSizeThreshold, true, "1 GB");
-        addIfDifferent(differences, DifferenceType.DEFAULT_BACKPRESSURE_OBJECT_COUNT_CHANGED, groupA, groupB, VersionedProcessGroup::getDefaultBackPressureObjectThreshold, true, 10_000L);
-        addIfDifferent(differences, DifferenceType.DEFAULT_FLOWFILE_EXPIRATION_CHANGED, groupA, groupB, VersionedProcessGroup::getDefaultFlowFileExpiration, true, "0 sec");
-        addIfDifferent(differences, DifferenceType.PARAMETER_CONTEXT_CHANGED, groupA, groupB, VersionedProcessGroup::getParameterContextName, true, null);
-        addIfDifferent(differences, DifferenceType.LOG_FILE_SUFFIX_CHANGED, groupA, groupB, VersionedProcessGroup::getLogFileSuffix, true, null);
-        addIfDifferent(differences, DifferenceType.EXECUTION_ENGINE_CHANGED, groupA, groupB, VersionedProcessGroup::getExecutionEngine, true, ExecutionEngine.INHERITED);
-        addIfDifferent(differences, DifferenceType.SCHEDULED_STATE_CHANGED, groupA, groupB, VersionedProcessGroup::getScheduledState, true, org.apache.nifi.flow.ScheduledState.ENABLED);
-        addIfDifferent(differences, DifferenceType.CONCURRENT_TASKS_CHANGED, groupA, groupB, VersionedProcessGroup::getMaxConcurrentTasks, true, 1);
-        addIfDifferent(differences, DifferenceType.TIMEOUT_CHANGED, groupA, groupB, VersionedProcessGroup::getStatelessFlowTimeout, false, "1 min");
+        extractPGConfigDifferences(groupA, groupB, differences);
 
         final VersionedFlowCoordinates groupACoordinates = groupA.getVersionedFlowCoordinates();
         final VersionedFlowCoordinates groupBCoordinates = groupB.getVersionedFlowCoordinates();
@@ -597,16 +569,55 @@ public class StandardFlowComparator implements FlowComparator {
 
 
         if (compareGroupContents) {
-            differences.addAll(compareComponents(groupA.getConnections(), groupB.getConnections(), this::compare));
-            differences.addAll(compareComponents(groupA.getProcessors(), groupB.getProcessors(), this::compare));
-            differences.addAll(compareComponents(groupA.getControllerServices(), groupB.getControllerServices(), this::compare));
-            differences.addAll(compareComponents(groupA.getFunnels(), groupB.getFunnels(), this::compare));
-            differences.addAll(compareComponents(groupA.getInputPorts(), groupB.getInputPorts(), this::compare));
-            differences.addAll(compareComponents(groupA.getLabels(), groupB.getLabels(), this::compare));
-            differences.addAll(compareComponents(groupA.getOutputPorts(), groupB.getOutputPorts(), this::compare));
-            differences.addAll(compareComponents(groupA.getProcessGroups(), groupB.getProcessGroups(), (a, b, diffs) -> compare(a, b, diffs, true)));
-            differences.addAll(compareComponents(groupA.getRemoteProcessGroups(), groupB.getRemoteProcessGroups(), this::compare));
+            extractPGComponentsDifferences(groupA, groupB, differences);
         }
+    }
+
+    private void extractPGConfigDifferences(final VersionedProcessGroup groupA, final VersionedProcessGroup groupB, final Set<FlowDifference> differences) {
+        addIfDifferent(differences, DifferenceType.FLOWFILE_CONCURRENCY_CHANGED, groupA, groupB, VersionedProcessGroup::getFlowFileConcurrency,
+            true, DEFAULT_FLOW_FILE_CONCURRENCY);
+        addIfDifferent(differences, DifferenceType.FLOWFILE_OUTBOUND_POLICY_CHANGED, groupA, groupB, VersionedProcessGroup::getFlowFileOutboundPolicy,
+            true, DEFAULT_OUTBOUND_FLOW_FILE_POLICY);
+
+        addIfDifferent(differences, DifferenceType.DEFAULT_BACKPRESSURE_DATA_SIZE_CHANGED, groupA, groupB, VersionedProcessGroup::getDefaultBackPressureDataSizeThreshold, true, "1 GB");
+        addIfDifferent(differences, DifferenceType.DEFAULT_BACKPRESSURE_OBJECT_COUNT_CHANGED, groupA, groupB, VersionedProcessGroup::getDefaultBackPressureObjectThreshold, true, 10_000L);
+        addIfDifferent(differences, DifferenceType.DEFAULT_FLOWFILE_EXPIRATION_CHANGED, groupA, groupB, VersionedProcessGroup::getDefaultFlowFileExpiration, true, "0 sec");
+        addIfDifferent(differences, DifferenceType.PARAMETER_CONTEXT_CHANGED, groupA, groupB, VersionedProcessGroup::getParameterContextName, true, null);
+        addIfDifferent(differences, DifferenceType.LOG_FILE_SUFFIX_CHANGED, groupA, groupB, VersionedProcessGroup::getLogFileSuffix, true, null);
+        addIfDifferent(differences, DifferenceType.EXECUTION_ENGINE_CHANGED, groupA, groupB, VersionedProcessGroup::getExecutionEngine, true, ExecutionEngine.INHERITED);
+        addIfDifferent(differences, DifferenceType.SCHEDULED_STATE_CHANGED, groupA, groupB, VersionedProcessGroup::getScheduledState, true, org.apache.nifi.flow.ScheduledState.ENABLED);
+        addIfDifferent(differences, DifferenceType.CONCURRENT_TASKS_CHANGED, groupA, groupB, VersionedProcessGroup::getMaxConcurrentTasks, true, 1);
+        addIfDifferent(differences, DifferenceType.TIMEOUT_CHANGED, groupA, groupB, VersionedProcessGroup::getStatelessFlowTimeout, false, "1 min");
+    }
+
+    private void extractPGComponentsDifferences(final VersionedProcessGroup groupA, final VersionedProcessGroup groupB, final Set<FlowDifference> differences) {
+        differences.addAll(compareComponents(groupA == null ? Set.of() : groupA.getConnections(),
+                groupB == null ? Set.of() : groupB.getConnections(),
+                this::compare));
+        differences.addAll(compareComponents(groupA == null ? Set.of() : groupA.getProcessors(),
+                groupB == null ? Set.of() : groupB.getProcessors(),
+                this::compare));
+        differences.addAll(compareComponents(groupA == null ? Set.of() : groupA.getControllerServices(),
+                groupB == null ? Set.of() : groupB.getControllerServices(),
+                this::compare));
+        differences.addAll(compareComponents(groupA == null ? Set.of() : groupA.getFunnels(),
+                groupB == null ? Set.of() : groupB.getFunnels(),
+                this::compare));
+        differences.addAll(compareComponents(groupA == null ? Set.of() : groupA.getInputPorts(),
+                groupB == null ? Set.of() : groupB.getInputPorts(),
+                this::compare));
+        differences.addAll(compareComponents(groupA == null ? Set.of() : groupA.getLabels(),
+                groupB == null ? Set.of() : groupB.getLabels(),
+                this::compare));
+        differences.addAll(compareComponents(groupA == null ? Set.of() : groupA.getOutputPorts(),
+                groupB == null ? Set.of() : groupB.getOutputPorts(),
+                this::compare));
+        differences.addAll(compareComponents(groupA == null ? Set.of() : groupA.getProcessGroups(),
+                groupB == null ? Set.of() : groupB.getProcessGroups(),
+                (a, b, diffs) -> compare(a, b, diffs, true)));
+        differences.addAll(compareComponents(groupA == null ? Set.of() : groupA.getRemoteProcessGroups(),
+                groupB == null ? Set.of() : groupB.getRemoteProcessGroups(),
+                this::compare));
     }
 
 
@@ -690,12 +701,12 @@ public class StandardFlowComparator implements FlowComparator {
     private <T extends VersionedComponent> void addIfDifferent(final Set<FlowDifference> differences, final DifferenceType type, final T componentA, final T componentB,
         final Function<T, Object> transform, final boolean differentiateNullAndEmptyString, final Object defaultValue) {
 
-        Object valueA = transform.apply(componentA);
+        Object valueA = componentA == null ? null : transform.apply(componentA);
         if (valueA == null) {
             valueA = defaultValue;
         }
 
-        Object valueB = transform.apply(componentB);
+        Object valueB = componentB == null ? null : transform.apply(componentB);
         if (valueB == null) {
             valueB = defaultValue;
         }

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
@@ -148,7 +148,7 @@ public class StandardFlowComparator implements FlowComparator {
         if (componentA == null) {
             differences.add(difference(DifferenceType.COMPONENT_ADDED, componentA, componentB, componentA, componentB));
 
-            if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP_WITH_RECURSIVE_PG
+            if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP
                     && componentB instanceof VersionedProcessGroup groupB) {
                 // we want to also add the differences of the sub process groups
                 // to do that we create an empty process group to simulate groupA
@@ -161,6 +161,15 @@ public class StandardFlowComparator implements FlowComparator {
 
         if (componentB == null) {
             differences.add(difference(DifferenceType.COMPONENT_REMOVED, componentA, componentB, componentA, componentB));
+
+            if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP
+                    && componentA instanceof VersionedProcessGroup groupA) {
+                // we want to also add the differences of the sub process groups
+                // to do that we create an empty process group to simulate groupA
+                // and compare it to groupB
+                compare(groupA, new VersionedProcessGroup(), differences, comparePos);
+            }
+
             return true;
         }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StandardFlowComparator.java
@@ -147,6 +147,15 @@ public class StandardFlowComparator implements FlowComparator {
         final boolean compareName, final boolean comparePos, final boolean compareComments) {
         if (componentA == null) {
             differences.add(difference(DifferenceType.COMPONENT_ADDED, componentA, componentB, componentA, componentB));
+
+            if (flowComparatorVersionedStrategy == FlowComparatorVersionedStrategy.DEEP_WITH_RECURSIVE_PG
+                    && componentB instanceof VersionedProcessGroup groupB) {
+                // we want to also add the differences of the sub process groups
+                // to do that we create an empty process group to simulate groupA
+                // and compare it to groupB
+                compare(new VersionedProcessGroup(), groupB, differences, comparePos);
+            }
+
             return true;
         }
 
@@ -526,16 +535,6 @@ public class StandardFlowComparator implements FlowComparator {
 
     private void compare(final VersionedProcessGroup groupA, final VersionedProcessGroup groupB, final Set<FlowDifference> differences, final boolean compareNamePos) {
         if (compareComponents(groupA, groupB, differences, compareNamePos, compareNamePos, true)) {
-            return;
-        }
-
-        if (groupA == null) {
-            differences.add(difference(DifferenceType.COMPONENT_ADDED, groupA, groupB, groupA, groupB));
-            return;
-        }
-
-        if (groupB == null) {
-            differences.add(difference(DifferenceType.COMPONENT_REMOVED, groupA, groupB, groupA, groupB));
             return;
         }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StaticDifferenceDescriptor.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/main/java/org/apache/nifi/registry/flow/diff/StaticDifferenceDescriptor.java
@@ -63,7 +63,9 @@ public class StaticDifferenceDescriptor implements DifferenceDescriptor {
                 description = String.format("Property '%s' is a parameter reference in %s but not in %s", fieldName, flowBName, flowAName);
                 break;
             case SCHEDULED_STATE_CHANGED:
-                description = String.format("%s %s has a Scheduled State of %s in %s but %s in %s", componentA.getComponentType(), getId(componentA), valueA, flowAName, valueB, flowBName);
+                description = String.format("%s %s has a Scheduled State of %s in %s but %s in %s",
+                        componentA == null ? componentB.getComponentType().getTypeName() : componentA.getComponentType().getTypeName(),
+                        componentA == null ? getId(componentB) : getId(componentA), valueA, flowAName, valueB, flowBName);
                 break;
             case VERSIONED_FLOW_COORDINATES_CHANGED:
                 if (valueA instanceof VersionedFlowCoordinates && valueB instanceof VersionedFlowCoordinates) {
@@ -84,9 +86,9 @@ public class StaticDifferenceDescriptor implements DifferenceDescriptor {
                     flowAName, valueA, flowBName, valueB);
                 break;
             default:
-                description = String.format("%s for %s with ID %s; flow '%s' has value %s; flow '%s' has value %s",
-                    type.getDescription(), componentA.getComponentType().getTypeName(), getId(componentA),
-                    flowAName, valueA, flowBName, valueB);
+                description = String.format("%s for %s with ID %s; flow '%s' has value %s; flow '%s' has value %s", type.getDescription(),
+                        componentA == null ? componentB.getComponentType().getTypeName() : componentA.getComponentType().getTypeName(),
+                        componentA == null ? getId(componentB) : getId(componentA), flowAName, valueA, flowBName, valueB);
                 break;
         }
 

--- a/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/test/java/org/apache/nifi/registry/flow/diff/TestStandardFlowComparator.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-flow-diff/src/test/java/org/apache/nifi/registry/flow/diff/TestStandardFlowComparator.java
@@ -17,11 +17,14 @@
 
 package org.apache.nifi.registry.flow.diff;
 
+import org.apache.nifi.flow.ComponentType;
 import org.apache.nifi.flow.VersionedAsset;
 import org.apache.nifi.flow.VersionedComponent;
+import org.apache.nifi.flow.VersionedControllerService;
 import org.apache.nifi.flow.VersionedParameter;
 import org.apache.nifi.flow.VersionedParameterContext;
 import org.apache.nifi.flow.VersionedProcessGroup;
+import org.apache.nifi.flow.VersionedProcessor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestStandardFlowComparator {
     private Map<String, String> decryptedToEncrypted;
@@ -174,6 +178,60 @@ public class TestStandardFlowComparator {
         comparator.compare(contextA, contextB, differences);
 
         assertEquals(4, differences.size());
+    }
+
+    @Test
+    public void testEmbeddedProcessGroupWithDeepRecursiveStrategy() {
+        final Function<String, String> decryptor = encryptedToDecrypted::get;
+
+        final VersionedProcessGroup rootPGA = new VersionedProcessGroup();
+        rootPGA.setIdentifier("rootPG");
+
+        final VersionedProcessGroup rootPGB = new VersionedProcessGroup();
+        rootPGB.setIdentifier("rootPG");
+        final VersionedProcessGroup childPG = new VersionedProcessGroup();
+        childPG.setIdentifier("childPG");
+        rootPGB.getProcessGroups().add(childPG);
+        final VersionedProcessGroup subChildPG = new VersionedProcessGroup();
+        subChildPG.setIdentifier("subChildPG");
+        childPG.getProcessGroups().add(subChildPG);
+        final VersionedProcessor processor = new VersionedProcessor();
+        processor.setIdentifier("processor");
+        childPG.getProcessors().add(processor);
+        final VersionedControllerService controllerService = new VersionedControllerService();
+        controllerService.setIdentifier("controllerService");
+        subChildPG.getControllerServices().add(controllerService);
+
+        final ComparableDataFlow flowA = new StandardComparableDataFlow("Flow A", rootPGA);
+        final ComparableDataFlow flowB = new StandardComparableDataFlow("Flow B", rootPGB);
+
+        comparator = new StandardFlowComparator(flowA, flowB, Collections.emptySet(),
+                new StaticDifferenceDescriptor(), decryptor, VersionedComponent::getIdentifier, FlowComparatorVersionedStrategy.DEEP);
+
+        final Set<FlowDifference> differencesDeep = comparator.compare().getDifferences();
+        assertEquals(1, differencesDeep.size());
+        assertTrue(differencesDeep.stream()
+                .anyMatch(difference -> difference.getDifferenceType() == DifferenceType.COMPONENT_ADDED
+                        && difference.getComponentB().getComponentType() == ComponentType.PROCESS_GROUP));
+
+        comparator = new StandardFlowComparator(flowA, flowB, Collections.emptySet(),
+                new StaticDifferenceDescriptor(), decryptor, VersionedComponent::getIdentifier, FlowComparatorVersionedStrategy.DEEP_WITH_RECURSIVE_PG);
+        final Set<FlowDifference> differencesDeepRecursive = comparator.compare().getDifferences();
+        assertEquals(4, differencesDeepRecursive.size());
+        assertTrue(differencesDeepRecursive.stream()
+                .anyMatch(difference -> difference.getDifferenceType() == DifferenceType.COMPONENT_ADDED
+                        && difference.getComponentB().getComponentType() == ComponentType.PROCESS_GROUP
+                        && difference.getComponentB().getIdentifier().equals("childPG")));
+        assertTrue(differencesDeepRecursive.stream()
+                .anyMatch(difference -> difference.getDifferenceType() == DifferenceType.COMPONENT_ADDED
+                        && difference.getComponentB().getComponentType() == ComponentType.PROCESS_GROUP
+                        && difference.getComponentB().getIdentifier().equals("subChildPG")));
+        assertTrue(differencesDeepRecursive.stream()
+                .anyMatch(difference -> difference.getDifferenceType() == DifferenceType.COMPONENT_ADDED
+                        && difference.getComponentB().getComponentType() == ComponentType.PROCESSOR));
+        assertTrue(differencesDeepRecursive.stream()
+                .anyMatch(difference -> difference.getDifferenceType() == DifferenceType.COMPONENT_ADDED
+                        && difference.getComponentB().getComponentType() == ComponentType.CONTROLLER_SERVICE));
     }
 
     private VersionedParameter createParameter(final String name, final String value, final boolean sensitive) {


### PR DESCRIPTION
# Summary

[NIFI-14435](https://issues.apache.org/jira/browse/NIFI-14435) - FlowComparator should offer deep recursive comparison

Follow up of reverted PR #9848.

Instead of instantiating an empty versioned process group which causes a class cast exception, we just call the compare methods for the components as well as for the configuration of the PG (only in the case of a newly added PG) to check if the defaults have changed.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
