### PR TITLE
NIFI-14456: Adding processor to delete metadata instance from box file

### DIFF
--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/DeleteBoxFileMetadataInstance.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/DeleteBoxFileMetadataInstance.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.box;
+
+import com.box.sdk.BoxAPIConnection;
+import com.box.sdk.BoxAPIResponseException;
+import com.box.sdk.BoxFile;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.box.controllerservices.BoxClientService;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.lang.String.valueOf;
+import static org.apache.nifi.processors.box.BoxFileAttributes.ERROR_CODE;
+import static org.apache.nifi.processors.box.BoxFileAttributes.ERROR_CODE_DESC;
+import static org.apache.nifi.processors.box.BoxFileAttributes.ERROR_MESSAGE;
+import static org.apache.nifi.processors.box.BoxFileAttributes.ERROR_MESSAGE_DESC;
+
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+@Tags({"box", "storage", "metadata", "templates", "delete"})
+@CapabilityDescription("Deletes a metadata instance from a Box file using the specified template key")
+@SeeAlso({CreateBoxFileMetadataInstance.class, FetchBoxFileMetadataInstance.class, UpdateBoxFileMetadataInstance.class})
+@WritesAttributes({
+        @WritesAttribute(attribute = "box.id", description = "The ID of the file from which metadata was deleted"),
+        @WritesAttribute(attribute = "box.template.key", description = "The template key used for metadata deletion"),
+        @WritesAttribute(attribute = ERROR_CODE, description = ERROR_CODE_DESC),
+        @WritesAttribute(attribute = ERROR_MESSAGE, description = ERROR_MESSAGE_DESC)
+})
+public class DeleteBoxFileMetadataInstance extends AbstractProcessor {
+
+    public static final PropertyDescriptor FILE_ID = new PropertyDescriptor.Builder()
+            .name("File ID")
+            .description("The ID of the file from which to delete metadata.")
+            .required(true)
+            .defaultValue("${box.id}")
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor TEMPLATE_KEY = new PropertyDescriptor.Builder()
+            .name("Template Key")
+            .description("The key of the metadata template instance to delete.")
+            .required(true)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("A FlowFile is routed to this relationship after metadata has been successfully deleted.")
+            .build();
+
+    public static final Relationship REL_FAILURE = new Relationship.Builder()
+            .name("failure")
+            .description("A FlowFile is routed to this relationship if an error occurs during metadata deletion.")
+            .build();
+
+    public static final Relationship REL_FILE_NOT_FOUND = new Relationship.Builder()
+            .name("file not found")
+            .description("FlowFiles for which the specified Box file was not found will be routed to this relationship.")
+            .build();
+
+    public static final Relationship REL_TEMPLATE_NOT_FOUND = new Relationship.Builder()
+            .name("template not found")
+            .description("FlowFiles for which the specified metadata template was not found will be routed to this relationship.")
+            .build();
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_FILE_NOT_FOUND,
+            REL_TEMPLATE_NOT_FOUND
+    );
+
+    private static final List<PropertyDescriptor> PROPERTY_DESCRIPTORS = List.of(
+            BoxClientService.BOX_CLIENT_SERVICE,
+            FILE_ID,
+            TEMPLATE_KEY
+    );
+
+    private volatile BoxAPIConnection boxAPIConnection;
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return RELATIONSHIPS;
+    }
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        final BoxClientService boxClientService = context.getProperty(BoxClientService.BOX_CLIENT_SERVICE)
+                .asControllerService(BoxClientService.class);
+        boxAPIConnection = boxClientService.getBoxApiConnection();
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        final String fileId = context.getProperty(FILE_ID).evaluateAttributeExpressions(flowFile).getValue();
+        final String templateKey = context.getProperty(TEMPLATE_KEY).evaluateAttributeExpressions(flowFile).getValue();
+
+        try {
+            final BoxFile boxFile = getBoxFile(fileId);
+            boxFile.deleteMetadata(templateKey);
+
+            final Map<String, String> attributes = Map.of(
+                    "box.id", fileId,
+                    "box.template.key", templateKey);
+            flowFile = session.putAllAttributes(flowFile, attributes);
+
+            session.getProvenanceReporter().invokeRemoteProcess(flowFile,
+                    "%s%s/metadata/%s".formatted(BoxFileUtils.BOX_URL, fileId, templateKey),
+                    "Deleted metadata instance using template key: " + templateKey);
+            session.transfer(flowFile, REL_SUCCESS);
+
+        } catch (final BoxAPIResponseException e) {
+            flowFile = session.putAttribute(flowFile, ERROR_CODE, valueOf(e.getResponseCode()));
+            flowFile = session.putAttribute(flowFile, ERROR_MESSAGE, e.getMessage());
+
+            if (e.getResponseCode() == 404) {
+                final String errorBody = e.getResponse();
+
+                if (errorBody != null && errorBody.toLowerCase().contains("specified metadata template not found")) {
+                    getLogger().warn("Box metadata instance with template key {} was not found for file ID {}.", templateKey, fileId);
+                    session.transfer(flowFile, REL_TEMPLATE_NOT_FOUND);
+                } else {
+                    getLogger().warn("Box file with ID {} was not found.", fileId);
+                    session.transfer(flowFile, REL_FILE_NOT_FOUND);
+                }
+            } else {
+                getLogger().error("Couldn't delete metadata for file with id [{}]", fileId, e);
+                session.transfer(flowFile, REL_FAILURE);
+            }
+        } catch (Exception e) {
+            getLogger().error("Error processing metadata deletion for Box file [{}]", fileId, e);
+            flowFile = session.putAttribute(flowFile, ERROR_MESSAGE, e.getMessage());
+            session.transfer(flowFile, REL_FAILURE);
+        }
+    }
+
+    /**
+     * Returns a BoxFile object for the given file ID.
+     *
+     * @param fileId The ID of the file.
+     * @return A BoxFile object for the given file ID.
+     */
+    BoxFile getBoxFile(final String fileId) {
+        return new BoxFile(boxAPIConnection, fileId);
+    }
+}

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -17,6 +17,7 @@ org.apache.nifi.processors.box.ConsumeBoxEnterpriseEvents
 org.apache.nifi.processors.box.ConsumeBoxEvents
 org.apache.nifi.processors.box.CreateBoxMetadataTemplate
 org.apache.nifi.processors.box.CreateBoxFileMetadataInstance
+org.apache.nifi.processors.box.DeleteBoxFileMetadataInstance
 org.apache.nifi.processors.box.ExtractStructuredBoxFileMetadata
 org.apache.nifi.processors.box.FetchBoxFile
 org.apache.nifi.processors.box.FetchBoxFileInfo

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/DeleteBoxFileMetadataInstanceTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/DeleteBoxFileMetadataInstanceTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.box;
+
+import com.box.sdk.BoxAPIResponseException;
+import com.box.sdk.BoxFile;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteBoxFileMetadataInstanceTest extends AbstractBoxFileTest {
+
+    private static final String TEMPLATE_KEY = "fileProperties";
+
+    @Mock
+    private BoxFile mockBoxFile;
+
+    @Override
+    @BeforeEach
+    void setUp() throws Exception {
+        final DeleteBoxFileMetadataInstance testSubject = new DeleteBoxFileMetadataInstance() {
+            @Override
+            BoxFile getBoxFile(String fileId) {
+                return mockBoxFile;
+            }
+        };
+
+        testRunner = TestRunners.newTestRunner(testSubject);
+        super.setUp();
+
+        testRunner.setProperty(DeleteBoxFileMetadataInstance.FILE_ID, TEST_FILE_ID);
+        testRunner.setProperty(DeleteBoxFileMetadataInstance.TEMPLATE_KEY, TEMPLATE_KEY);
+    }
+
+    @Test
+    void testSuccessfulMetadataDeletion() {
+        testRunner.enqueue("test content");
+        testRunner.run();
+
+        verify(mockBoxFile).deleteMetadata(TEMPLATE_KEY);
+
+        testRunner.assertAllFlowFilesTransferred(DeleteBoxFileMetadataInstance.REL_SUCCESS, 1);
+        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(DeleteBoxFileMetadataInstance.REL_SUCCESS).getFirst();
+
+        flowFile.assertAttributeEquals("box.id", TEST_FILE_ID);
+        flowFile.assertAttributeEquals("box.template.key", TEMPLATE_KEY);
+    }
+
+    @Test
+    void testFileNotFound() {
+        final BoxAPIResponseException mockException = new BoxAPIResponseException("API Error", 404, "Box File Not Found", null);
+        doThrow(mockException).when(mockBoxFile).deleteMetadata(TEMPLATE_KEY);
+
+        testRunner.enqueue("test content");
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(DeleteBoxFileMetadataInstance.REL_FILE_NOT_FOUND, 1);
+        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(DeleteBoxFileMetadataInstance.REL_FILE_NOT_FOUND).getFirst();
+        flowFile.assertAttributeEquals(BoxFileAttributes.ERROR_CODE, "404");
+        flowFile.assertAttributeEquals(BoxFileAttributes.ERROR_MESSAGE, "API Error [404]");
+    }
+
+    @Test
+    void testMetadataNotFound() {
+        final BoxAPIResponseException mockException = new BoxAPIResponseException("instance_not_found - Template not found", 404, "instance_not_found", null);
+        doThrow(mockException).when(mockBoxFile).deleteMetadata(TEMPLATE_KEY);
+
+        testRunner.enqueue("test content");
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(DeleteBoxFileMetadataInstance.REL_TEMPLATE_NOT_FOUND, 1);
+        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(DeleteBoxFileMetadataInstance.REL_TEMPLATE_NOT_FOUND).getFirst();
+        flowFile.assertAttributeEquals(BoxFileAttributes.ERROR_CODE, "404");
+        flowFile.assertAttributeEquals(BoxFileAttributes.ERROR_MESSAGE, "instance_not_found - Template not found [404]");
+    }
+
+    @Test
+    void testGeneralError() {
+        final BoxAPIResponseException mockException = new BoxAPIResponseException("API Error", 500, "Internal Server Error", null);
+        doThrow(mockException).when(mockBoxFile).deleteMetadata(TEMPLATE_KEY);
+
+        testRunner.enqueue("test content");
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(DeleteBoxFileMetadataInstance.REL_FAILURE, 1);
+        final MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(DeleteBoxFileMetadataInstance.REL_FAILURE).getFirst();
+        flowFile.assertAttributeEquals(BoxFileAttributes.ERROR_CODE, "500");
+        flowFile.assertAttributeEquals(BoxFileAttributes.ERROR_MESSAGE, "API Error [500]");
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14456](https://issues.apache.org/jira/browse/NIFI-14456)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
