### PR TITLE
NIFI-14455 Unbind MiNiFi asset repository parent directory from c2.asset.directory

### DIFF
--- a/c2/c2-client-bundle/c2-client-base/src/main/java/org/apache/nifi/c2/client/C2ClientConfig.java
+++ b/c2/c2-client-bundle/c2-client-base/src/main/java/org/apache/nifi/c2/client/C2ClientConfig.java
@@ -57,6 +57,7 @@ public class C2ClientConfig {
     private final long keepAliveDuration;
     private final String c2RequestCompression;
     private final String c2AssetDirectory;
+    private final String c2AssetRepositoryDirectory;
     private final long bootstrapAcknowledgeTimeout;
     private final int c2FlowInfoProcessorBulletinLimit;
     private final boolean c2FlowInfoProcessorStatusEnabled;
@@ -89,6 +90,7 @@ public class C2ClientConfig {
         this.keepAliveDuration = builder.keepAliveDuration;
         this.c2RequestCompression = builder.c2RequestCompression;
         this.c2AssetDirectory = builder.c2AssetDirectory;
+        this.c2AssetRepositoryDirectory = builder.c2AssetRepositoryDirectory;
         this.bootstrapAcknowledgeTimeout = builder.bootstrapAcknowledgeTimeout;
         this.c2FlowInfoProcessorBulletinLimit = builder.c2FlowInfoProcessorBulletinLimit;
         this.c2FlowInfoProcessorStatusEnabled = builder.c2FlowInfoProcessorStatusEnabled;
@@ -194,6 +196,10 @@ public class C2ClientConfig {
         return c2AssetDirectory;
     }
 
+    public String getC2AssetRepositoryDirectory() {
+        return c2AssetRepositoryDirectory;
+    }
+
     public int getMaxIdleConnections() {
         return maxIdleConnections;
     }
@@ -248,6 +254,7 @@ public class C2ClientConfig {
         private long keepAliveDuration;
         private String c2RequestCompression;
         private String c2AssetDirectory;
+        private String c2AssetRepositoryDirectory;
         private long bootstrapAcknowledgeTimeout;
         private int c2FlowInfoProcessorBulletinLimit;
         private boolean c2FlowInfoProcessorStatusEnabled;
@@ -394,6 +401,11 @@ public class C2ClientConfig {
 
         public Builder c2AssetDirectory(String c2AssetDirectory) {
             this.c2AssetDirectory = c2AssetDirectory;
+            return this;
+        }
+
+        public Builder c2AssetRepositoryDirectory(String c2AssetRepositoryDirectory) {
+            this.c2AssetRepositoryDirectory = c2AssetRepositoryDirectory;
             return this;
         }
 

--- a/minifi/minifi-commons/minifi-commons-api/src/main/java/org/apache/nifi/minifi/commons/api/MiNiFiProperties.java
+++ b/minifi/minifi-commons/minifi-commons-api/src/main/java/org/apache/nifi/minifi/commons/api/MiNiFiProperties.java
@@ -84,6 +84,7 @@ public enum MiNiFiProperties {
     C2_RUNTIME_MANIFEST_IDENTIFIER("c2.runtime.manifest.identifier", "minifi", false, true, VALID),
     C2_RUNTIME_TYPE("c2.runtime.type", "minifi-java", false, true, VALID),
     C2_ASSET_DIRECTORY("c2.asset.directory", "./asset", false, true, VALID),
+    C2_ASSET_REPOSITORY_DIRECTORY("c2.asset.repository.directory", "./asset/repository", false, false, VALID),
     C2_SECURITY_TRUSTSTORE_LOCATION("c2.security.truststore.location", "", false, false, VALID),
     C2_SECURITY_TRUSTSTORE_PASSWORD("c2.security.truststore.password", "", true, false, VALID),
     C2_SECURITY_TRUSTSTORE_TYPE("c2.security.truststore.type", "JKS", false, false, VALID),

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/C2NifiClientService.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/C2NifiClientService.java
@@ -31,6 +31,7 @@ import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.C2_AGENT_CLASS
 import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.C2_AGENT_HEARTBEAT_PERIOD;
 import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.C2_AGENT_IDENTIFIER;
 import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.C2_ASSET_DIRECTORY;
+import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.C2_ASSET_REPOSITORY_DIRECTORY;
 import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.C2_BOOTSTRAP_ACKNOWLEDGE_TIMEOUT;
 import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.C2_CONFIG_DIRECTORY;
 import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.C2_FLOW_INFO_PROCESSOR_STATUS_ENABLED;
@@ -170,7 +171,7 @@ public class C2NifiClientService {
         this.flowController = flowController;
         C2Serializer c2Serializer = new C2JacksonSerializer();
         ResourceRepository resourceRepository =
-            new FileResourceRepository(Path.of(clientConfig.getC2AssetDirectory()), niFiProperties.getNarAutoLoadDirectory().toPath(),
+            new FileResourceRepository(Path.of(clientConfig.getC2AssetRepositoryDirectory()), niFiProperties.getNarAutoLoadDirectory().toPath(),
                 niFiProperties.getFlowConfigurationFileDir().toPath(), c2Serializer);
         C2HttpClient client = C2HttpClient.create(clientConfig, c2Serializer);
         FlowIdHolder flowIdHolder = new FlowIdHolder(clientConfig.getConfDirectory());
@@ -209,6 +210,7 @@ public class C2NifiClientService {
             .httpHeaders(properties.getProperty(C2_REST_HTTP_HEADERS.getKey(), C2_REST_HTTP_HEADERS.getDefaultValue()))
             .c2RequestCompression(properties.getProperty(C2_REQUEST_COMPRESSION.getKey(), C2_REQUEST_COMPRESSION.getDefaultValue()))
             .c2AssetDirectory(properties.getProperty(C2_ASSET_DIRECTORY.getKey(), C2_ASSET_DIRECTORY.getDefaultValue()))
+            .c2AssetRepositoryDirectory(properties.getProperty(C2_ASSET_REPOSITORY_DIRECTORY.getKey(), C2_ASSET_REPOSITORY_DIRECTORY.getDefaultValue()))
             .confDirectory(properties.getProperty(C2_CONFIG_DIRECTORY.getKey(), C2_CONFIG_DIRECTORY.getDefaultValue()))
             .runtimeManifestIdentifier(properties.getProperty(C2_RUNTIME_MANIFEST_IDENTIFIER.getKey(), C2_RUNTIME_MANIFEST_IDENTIFIER.getDefaultValue()))
             .runtimeType(properties.getProperty(C2_RUNTIME_TYPE.getKey(), C2_RUNTIME_TYPE.getDefaultValue()))

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/command/syncresource/FileResourceRepository.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/command/syncresource/FileResourceRepository.java
@@ -58,7 +58,6 @@ import org.slf4j.LoggerFactory;
 
 public class FileResourceRepository implements ResourceRepository {
 
-    static final String ASSET_REPOSITORY_DIRECTORY = "repository";
     static final String RESOURCE_REPOSITORY_FILE_NAME = "resources.json";
 
     private static final Logger LOG = LoggerFactory.getLogger(FileResourceRepository.class);
@@ -71,10 +70,10 @@ public class FileResourceRepository implements ResourceRepository {
 
     private ResourceRepositoryDescriptor resourceRepositoryDescriptor;
 
-    public FileResourceRepository(Path assetDirectory, Path extensionDirectory, Path configDirectory, C2Serializer c2Serializer) {
+    public FileResourceRepository(Path assetRepositoryDirectory, Path extensionDirectory, Path configDirectory, C2Serializer c2Serializer) {
         this.resourceRepositoryFile = configDirectory.resolve(RESOURCE_REPOSITORY_FILE_NAME);
         this.c2Serializer = c2Serializer;
-        this.assetRepositoryDirectory = assetDirectory.resolve(ASSET_REPOSITORY_DIRECTORY);
+        this.assetRepositoryDirectory = assetRepositoryDirectory;
         this.extensionDirectory = extensionDirectory;
         initialize();
     }

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/syncresource/FileResourceRepositoryTest.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/syncresource/FileResourceRepositoryTest.java
@@ -30,7 +30,6 @@ import static org.apache.commons.codec.digest.DigestUtils.sha512Hex;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.nifi.c2.protocol.api.ResourceType.ASSET;
 import static org.apache.nifi.c2.protocol.api.ResourceType.EXTENSION;
-import static org.apache.nifi.minifi.c2.command.syncresource.FileResourceRepository.ASSET_REPOSITORY_DIRECTORY;
 import static org.apache.nifi.minifi.c2.command.syncresource.FileResourceRepository.RESOURCE_REPOSITORY_FILE_NAME;
 import static org.apache.nifi.util.StringUtils.EMPTY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -72,7 +71,6 @@ public class FileResourceRepositoryTest {
 
     private C2Serializer c2Serializer;
 
-    private Path assetDirectory;
     private Path assetRepositoryDirectory;
     private Path extensionDirectory;
     private Path repositoryFile;
@@ -83,8 +81,7 @@ public class FileResourceRepositoryTest {
         c2Serializer = new C2JacksonSerializer();
         configDirectoryPath = testBaseDirectory.resolve("conf");
         createDirectories(configDirectoryPath);
-        assetDirectory = testBaseDirectory.resolve("assets");
-        assetRepositoryDirectory = assetDirectory.resolve(ASSET_REPOSITORY_DIRECTORY);
+        assetRepositoryDirectory = testBaseDirectory.resolve("assets").resolve("repository");
         createDirectories(assetRepositoryDirectory);
         extensionDirectory = testBaseDirectory.resolve("extensions");
         createDirectories(extensionDirectory);
@@ -390,7 +387,7 @@ public class FileResourceRepositoryTest {
     }
 
     private FileResourceRepository createTestRepository() {
-        return new FileResourceRepository(assetDirectory, extensionDirectory, configDirectoryPath, c2Serializer);
+        return new FileResourceRepository(assetRepositoryDirectory, extensionDirectory, configDirectoryPath, c2Serializer);
     }
 
     private ResourcesGlobalHash resourcesGlobalHash(String digest, String hashType) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14455](https://issues.apache.org/jira/browse/NIFI-14455)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
