### PR TITLE
NIFI-14458 - Added run command to nifi.cmd

### DIFF
--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -58,7 +58,9 @@ NOTE: Under sustained and extremely high throughput the CodeCache settings may n
 *** `start`: starts NiFi in the background
 *** `stop`: stops NiFi that is running in the background
 *** `status`: provides the current status of NiFi
+*** `run`: runs NiFi in the foreground and waits for a Ctrl-C to initiate shutdown of NiFi.
 
+NOTE: When using Ctrl-C to initiate shutdown of NiFi on Windows, it is recommended to answer `N` to the `Terminate batch job (Y/N)?` prompt to allow the nifi.cmd to exit cleanly and restore the current working directory.  Alternatively, a `.\nifi.cmd stop` can be run from another console.
 
 When NiFi first starts up, the following files and directories are created:
 

--- a/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.cmd
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.cmd
@@ -55,6 +55,9 @@ if %RUN_COMMAND% == "set-single-user-credentials" (
 ) else if %RUN_COMMAND% == "start" (
   rem Start bootstrap process in new minimized window
   call start /MIN "Apache NiFi" "%JAVA_EXE%" %JAVA_MEMORY% %JAVA_PARAMS% org.apache.nifi.bootstrap.BootstrapProcess %RUN_COMMAND%
+) else if %RUN_COMMAND% == "run" (
+  rem Start bootstrap process in the foreground
+  call "%JAVA_EXE%" %JAVA_MEMORY% %JAVA_PARAMS% org.apache.nifi.bootstrap.BootstrapProcess start
 ) else (
   call "%JAVA_EXE%" %JAVA_MEMORY% %JAVA_PARAMS% org.apache.nifi.bootstrap.BootstrapProcess %RUN_COMMAND%
 )


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14458](https://issues.apache.org/jira/browse/NIFI-14458)
Added run command to nifi.cmd to allow NiFi to run in the foreground and be used with Apache ProcRun

# Tracking

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
