### PR TITLE
NIFI-14463 Standardize SSL Context Service Property Name

### DIFF
--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessorTest.java
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/src/test/java/org/apache/nifi/amqp/processors/AbstractAMQPProcessorTest.java
@@ -68,7 +68,7 @@ public class AbstractAMQPProcessorTest {
     public void testNotValidBothUserPasswordAndClientCertAuth() throws Exception {
         testRunner.setProperty(AbstractAMQPProcessor.USER, "user");
         testRunner.setProperty(AbstractAMQPProcessor.PASSWORD, "password");
-        testRunner.setProperty(AbstractAMQPProcessor.USE_CERT_AUTHENTICATION, "true");
+        testRunner.setProperty(AbstractAMQPProcessor.CLIENT_CERTIFICATE_AUTHENTICATION_ENABLED, "true");
         configureSSLContextService();
 
         testRunner.assertNotValid();
@@ -76,7 +76,7 @@ public class AbstractAMQPProcessorTest {
 
     @Test
     public void testValidClientCertAuth() throws Exception {
-        testRunner.setProperty(AbstractAMQPProcessor.USE_CERT_AUTHENTICATION, "true");
+        testRunner.setProperty(AbstractAMQPProcessor.CLIENT_CERTIFICATE_AUTHENTICATION_ENABLED, "true");
         configureSSLContextService();
 
         testRunner.assertValid();
@@ -84,7 +84,7 @@ public class AbstractAMQPProcessorTest {
 
     @Test
     public void testNotValidClientCertAuthButNoSSLContextService() throws Exception {
-        testRunner.setProperty(AbstractAMQPProcessor.USE_CERT_AUTHENTICATION, "true");
+        testRunner.setProperty(AbstractAMQPProcessor.CLIENT_CERTIFICATE_AUTHENTICATION_ENABLED, "true");
 
         testRunner.assertNotValid();
     }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/AmazonGlueSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/AmazonGlueSchemaRegistry.java
@@ -27,6 +27,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.processors.aws.credentials.provider.service.AWSCredentialsProviderService;
 import org.apache.nifi.proxy.ProxyConfiguration;
@@ -70,16 +71,14 @@ public class AmazonGlueSchemaRegistry extends AbstractControllerService implemen
             SchemaField.SCHEMA_TEXT_FORMAT, SchemaField.SCHEMA_IDENTIFIER, SchemaField.SCHEMA_VERSION);
 
     static final PropertyDescriptor SCHEMA_REGISTRY_NAME = new PropertyDescriptor.Builder()
-            .name("schema-registry-name")
-            .displayName("Schema Registry Name")
+            .name("Schema Registry Name")
             .description("The name of the Schema Registry")
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .required(true)
             .build();
 
     public static final PropertyDescriptor REGION = new PropertyDescriptor.Builder()
-            .name("region")
-            .displayName("Region")
+            .name("Region")
             .description("The region of the cloud resources")
             .required(true)
             .allowableValues(getAvailableRegions())
@@ -87,8 +86,7 @@ public class AmazonGlueSchemaRegistry extends AbstractControllerService implemen
             .build();
 
     static final PropertyDescriptor CACHE_SIZE = new PropertyDescriptor.Builder()
-            .name("cache-size")
-            .displayName("Cache Size")
+            .name("Cache Size")
             .description("Specifies how many Schemas should be cached from the Schema Registry")
             .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
             .defaultValue("1000")
@@ -96,8 +94,7 @@ public class AmazonGlueSchemaRegistry extends AbstractControllerService implemen
             .build();
 
     static final PropertyDescriptor CACHE_EXPIRATION = new PropertyDescriptor.Builder()
-            .name("cache-expiration")
-            .displayName("Cache Expiration")
+            .name("Cache Expiration")
             .description("Specifies how long a Schema that is cached should remain in the cache. Once this time period elapses, a "
                     + "cached version of a schema will no longer be used, and the service will have to communicate with the "
                     + "Schema Registry again in order to obtain the schema.")
@@ -107,8 +104,7 @@ public class AmazonGlueSchemaRegistry extends AbstractControllerService implemen
             .build();
 
     static final PropertyDescriptor COMMUNICATIONS_TIMEOUT = new PropertyDescriptor.Builder()
-            .name("communications-timeout")
-            .displayName("Communications Timeout")
+            .name("Communications Timeout")
             .description("Specifies how long to wait to receive data from the Schema Registry before considering the communications a failure")
             .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.NONE)
@@ -117,16 +113,14 @@ public class AmazonGlueSchemaRegistry extends AbstractControllerService implemen
             .build();
 
     public static final PropertyDescriptor AWS_CREDENTIALS_PROVIDER_SERVICE = new PropertyDescriptor.Builder()
-            .name("aws-credentials-provider-service")
-            .displayName("AWS Credentials Provider Service")
+            .name("AWS Credentials Provider Service")
             .description("The Controller Service that is used to obtain AWS credentials provider")
             .required(false)
             .identifiesControllerService(AWSCredentialsProviderService.class)
             .build();
 
     public static final PropertyDescriptor SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
-            .name("ssl-context-service")
-            .displayName("SSL Context Service")
+            .name("SSL Context Service")
             .description("Specifies an optional SSL Context Service that, if provided, will be used to create connections")
             .required(false)
             .identifiesControllerService(SSLContextProvider.class)
@@ -147,6 +141,16 @@ public class AmazonGlueSchemaRegistry extends AbstractControllerService implemen
             SSL_CONTEXT_SERVICE
     );
 
+    @Override
+    public void migrateProperties(final PropertyConfiguration propertyConfiguration) {
+        propertyConfiguration.renameProperty("schema-registry-name", SCHEMA_REGISTRY_NAME.getName());
+        propertyConfiguration.renameProperty("region", REGION.getName());
+        propertyConfiguration.renameProperty("communications-timeout", COMMUNICATIONS_TIMEOUT.getName());
+        propertyConfiguration.renameProperty("cache-size", CACHE_SIZE.getName());
+        propertyConfiguration.renameProperty("cache-expiration", CACHE_EXPIRATION.getName());
+        propertyConfiguration.renameProperty("aws-credentials-provider-service", AWS_CREDENTIALS_PROVIDER_SERVICE.getName());
+        propertyConfiguration.renameProperty("ssl-context-service", SSL_CONTEXT_SERVICE.getName());
+    }
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-client-service-api/src/main/java/org/apache/nifi/mongodb/MongoDBClientService.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-client-service-api/src/main/java/org/apache/nifi/mongodb/MongoDBClientService.java
@@ -70,8 +70,7 @@ public interface MongoDBClientService extends ControllerService, VerifiableContr
             "Write operations that use this write concern will wait for acknowledgement from three members");
 
      PropertyDescriptor URI = new PropertyDescriptor.Builder()
-            .name("mongo-uri")
-            .displayName("Mongo URI")
+            .name("Mongo URI")
             .description("MongoURI, typically of the form: mongodb://host1[:port1][,host2[:port2],...]")
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -79,7 +78,6 @@ public interface MongoDBClientService extends ControllerService, VerifiableContr
             .build();
      PropertyDescriptor DB_USER = new PropertyDescriptor.Builder()
             .name("Database User")
-            .displayName("Database User")
             .description("Database user name")
             .required(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
@@ -87,7 +85,6 @@ public interface MongoDBClientService extends ControllerService, VerifiableContr
             .build();
      PropertyDescriptor DB_PASSWORD = new PropertyDescriptor.Builder()
             .name("Password")
-            .displayName("Password")
             .description("The password for the database user")
             .required(false)
             .sensitive(true)
@@ -95,8 +92,7 @@ public interface MongoDBClientService extends ControllerService, VerifiableContr
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
             .build();
      PropertyDescriptor SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
-            .name("ssl-context-service")
-            .displayName("SSL Context Service")
+            .name("SSL Context Service")
             .description("The SSL Context Service used to provide client certificate information for TLS/SSL "
                     + "connections.")
             .required(false)
@@ -104,8 +100,7 @@ public interface MongoDBClientService extends ControllerService, VerifiableContr
             .build();
 
      PropertyDescriptor WRITE_CONCERN = new PropertyDescriptor.Builder()
-            .name("mongo-write-concern")
-            .displayName("Write Concern")
+            .name("Write Concern")
             .description("The write concern to use")
             .required(true)
             .allowableValues(WRITE_CONCERN_ACKNOWLEDGED_VALUE, WRITE_CONCERN_UNACKNOWLEDGED_VALUE, WRITE_CONCERN_FSYNCED_VALUE,

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
@@ -71,6 +71,10 @@ public class MongoDBControllerService extends AbstractControllerService implemen
     @Override
     public void migrateProperties(final PropertyConfiguration propertyConfiguration) {
         propertyConfiguration.removeProperty("ssl-client-auth");
+
+        propertyConfiguration.renameProperty("mongo-uri", URI.getName());
+        propertyConfiguration.renameProperty("ssl-context-service", SSL_CONTEXT_SERVICE.getName());
+        propertyConfiguration.renameProperty("mongo-write-concern", WRITE_CONCERN.getName());
     }
 
     // TODO: Remove duplicate code by refactoring shared method to accept PropertyContext

--- a/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/service/TestRedisConnectionPoolService.java
+++ b/nifi-extension-bundles/nifi-redis-bundle/nifi-redis-extensions/src/test/java/org/apache/nifi/redis/service/TestRedisConnectionPoolService.java
@@ -20,6 +20,7 @@ import org.apache.nifi.redis.RedisConnectionPool;
 import org.apache.nifi.redis.util.RedisUtils;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.ssl.SSLContextProvider;
+import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.MockConfigurationContext;
 import org.apache.nifi.util.MockProcessContext;
 import org.apache.nifi.util.StandardProcessorTestRunner;
@@ -39,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestRedisConnectionPoolService {
 
-    public static final String SSL_CONTEXT_IDENTIFIER = "ssl-context-service";
+    public static final String SSL_CONTEXT_IDENTIFIER = SSLContextService.class.getSimpleName();
     private TestRunner testRunner;
     private FakeRedisProcessor proc;
     private RedisConnectionPool redisService;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-rules/src/main/java/org/apache/nifi/flowanalysis/rules/RequireServerSSLContextService.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-rules/src/main/java/org/apache/nifi/flowanalysis/rules/RequireServerSSLContextService.java
@@ -42,7 +42,7 @@ import java.util.List;
 )
 public class RequireServerSSLContextService extends AbstractFlowAnalysisRule {
 
-    private final static List<String> COMPONENT_TYPES = List.of(
+    private static final List<String> COMPONENT_TYPES = List.of(
             "org.apache.nifi.processors.standard.ListenFTP",
             "org.apache.nifi.processors.standard.ListenHTTP",
             "org.apache.nifi.processors.standard.ListenTCP",
@@ -51,24 +51,23 @@ public class RequireServerSSLContextService extends AbstractFlowAnalysisRule {
             "org.apache.nifi.websocket.jetty.JettyWebSocketServer"
     );
 
+    private static final String SERVICE_PROPERTY_NAME = "SSL Context Service";
+
     @Override
     public Collection<ComponentAnalysisResult> analyzeComponent(VersionedComponent component, FlowAnalysisRuleContext context) {
-        Collection<ComponentAnalysisResult> results = new HashSet<>();
+        final Collection<ComponentAnalysisResult> results = new HashSet<>();
 
         if (component instanceof VersionedConfigurableExtension versionedConfigurableExtension) {
-
-            String encounteredComponentType = versionedConfigurableExtension.getType();
+            final String encounteredComponentType = versionedConfigurableExtension.getType();
 
             if (COMPONENT_TYPES.contains(encounteredComponentType)) {
                 // Loop over the properties for this component looking for an SSLContextService
                 versionedConfigurableExtension.getProperties().forEach((propertyName, propertyValue) -> {
 
                     // If the SSL Context property exists and the value is not set, report a violation
-                    if (("SSL Context Service".equalsIgnoreCase(propertyName) || "ssl-context-service".equalsIgnoreCase(propertyName))
-                            && StringUtils.isEmpty(propertyValue)) {
-
-                        String encounteredSimpleComponentType = encounteredComponentType.substring(encounteredComponentType.lastIndexOf(".") + 1);
-                        ComponentAnalysisResult result = new ComponentAnalysisResult(
+                    if (SERVICE_PROPERTY_NAME.equals(propertyName) && StringUtils.isEmpty(propertyValue)) {
+                        final String encounteredSimpleComponentType = encounteredComponentType.substring(encounteredComponentType.lastIndexOf(".") + 1);
+                        final ComponentAnalysisResult result = new ComponentAnalysisResult(
                                 component.getInstanceIdentifier(),
                                 "'" + encounteredSimpleComponentType + "' must specify an SSL Context Service"
                         );

--- a/nifi-extension-bundles/nifi-standard-services/nifi-web-client-provider-bundle/nifi-web-client-provider-service/src/main/java/org/apache/nifi/web/client/provider/service/StandardWebClientServiceProvider.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-web-client-provider-bundle/nifi-web-client-provider-service/src/main/java/org/apache/nifi/web/client/provider/service/StandardWebClientServiceProvider.java
@@ -24,6 +24,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.proxy.ProxyConfiguration;
 import org.apache.nifi.proxy.ProxyConfigurationService;
@@ -55,8 +56,7 @@ import static org.apache.nifi.proxy.ProxyConfigurationService.PROXY_CONFIGURATIO
 public class StandardWebClientServiceProvider extends AbstractControllerService implements WebClientServiceProvider {
 
     static final PropertyDescriptor CONNECT_TIMEOUT = new PropertyDescriptor.Builder()
-            .name("connect-timeout")
-            .displayName("Connect Timeout")
+            .name("Connect Timeout")
             .description("Maximum amount of time to wait before failing during initial socket connection")
             .required(true)
             .defaultValue("10 secs")
@@ -64,8 +64,7 @@ public class StandardWebClientServiceProvider extends AbstractControllerService 
             .build();
 
     static final PropertyDescriptor READ_TIMEOUT = new PropertyDescriptor.Builder()
-            .name("read-timeout")
-            .displayName("Read Timeout")
+            .name("Read Timeout")
             .description("Maximum amount of time to wait before failing while reading socket responses")
             .required(true)
             .defaultValue("10 secs")
@@ -73,8 +72,7 @@ public class StandardWebClientServiceProvider extends AbstractControllerService 
             .build();
 
     static final PropertyDescriptor WRITE_TIMEOUT = new PropertyDescriptor.Builder()
-            .name("write-timeout")
-            .displayName("Write Timeout")
+            .name("Write Timeout")
             .description("Maximum amount of time to wait before failing while writing socket requests")
             .required(true)
             .defaultValue("10 secs")
@@ -82,8 +80,7 @@ public class StandardWebClientServiceProvider extends AbstractControllerService 
             .build();
 
     static final PropertyDescriptor REDIRECT_HANDLING_STRATEGY = new PropertyDescriptor.Builder()
-            .name("redirect-handling-strategy")
-            .displayName("Redirect Handling Strategy")
+            .name("Redirect Handling Strategy")
             .description("Handling strategy for responding to HTTP 301 or 302 redirects received with a Location header")
             .required(true)
             .defaultValue(RedirectHandling.FOLLOWED.name())
@@ -91,8 +88,7 @@ public class StandardWebClientServiceProvider extends AbstractControllerService 
             .build();
 
     static final PropertyDescriptor SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
-            .name("ssl-context-service")
-            .displayName("SSL Context Service")
+            .name("SSL Context Service")
             .description("SSL Context Service overrides system default TLS settings for HTTPS communication")
             .required(false)
             .identifiesControllerService(SSLContextProvider.class)
@@ -108,6 +104,15 @@ public class StandardWebClientServiceProvider extends AbstractControllerService 
     );
 
     private StandardWebClientService webClientService;
+
+    @Override
+    public void migrateProperties(final PropertyConfiguration propertyConfiguration) {
+        propertyConfiguration.renameProperty("connect-timeout", CONNECT_TIMEOUT.getName());
+        propertyConfiguration.renameProperty("read-timeout", READ_TIMEOUT.getName());
+        propertyConfiguration.renameProperty("write-timeout", WRITE_TIMEOUT.getName());
+        propertyConfiguration.renameProperty("redirect-handling-strategy", REDIRECT_HANDLING_STRATEGY.getName());
+        propertyConfiguration.renameProperty("ssl-context-service", SSL_CONTEXT_SERVICE.getName());
+    }
 
     @OnEnabled
     public void onEnabled(final ConfigurationContext context) {

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/test/java/org/apache/nifi/processors/websocket/TestConnectWebSocket.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-processors/src/test/java/org/apache/nifi/processors/websocket/TestConnectWebSocket.java
@@ -130,7 +130,7 @@ class TestConnectWebSocket extends TestListenWebSocket {
         final String serverId = "ws-server-service";
         JettyWebSocketServer server = new JettyWebSocketServer();
         webSocketListener.addControllerService(serverId, server);
-        webSocketListener.setProperty(server, JettyWebSocketServer.LISTEN_PORT, "0");
+        webSocketListener.setProperty(server, JettyWebSocketServer.PORT, "0");
         webSocketListener.enableControllerService(server);
 
         webSocketListener.setProperty(ListenWebSocket.PROP_WEBSOCKET_SERVER_SERVICE, serverId);
@@ -208,7 +208,7 @@ class TestConnectWebSocket extends TestListenWebSocket {
         final String serverId = "ws-server-service";
         JettyWebSocketServer server = new JettyWebSocketServer();
         webSocketListener.addControllerService(serverId, server);
-        webSocketListener.setProperty(server, JettyWebSocketServer.LISTEN_PORT, "0");
+        webSocketListener.setProperty(server, JettyWebSocketServer.PORT, "0");
         webSocketListener.enableControllerService(server);
 
         webSocketListener.setProperty(ListenWebSocket.PROP_WEBSOCKET_SERVER_SERVICE, serverId);

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/WebSocketService.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-api/src/main/java/org/apache/nifi/websocket/WebSocketService.java
@@ -28,9 +28,8 @@ import java.io.IOException;
  */
 public interface WebSocketService extends ControllerService {
 
-    PropertyDescriptor SSL_CONTEXT = new PropertyDescriptor.Builder()
-            .name("ssl-context-service")
-            .displayName("SSL Context Service")
+    PropertyDescriptor SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
+            .name("SSL Context Service")
             .description("The SSL Context Service to use in order to secure the server. If specified, the server will accept only WSS requests; "
                     + "otherwise, the server will accept only WS requests")
             .required(false)

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/AbstractJettyWebSocketService.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/AbstractJettyWebSocketService.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.websocket.jetty;
 
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.websocket.AbstractWebSocketService;
 
@@ -25,8 +26,7 @@ import java.util.List;
 public abstract class AbstractJettyWebSocketService extends AbstractWebSocketService {
 
     public static final PropertyDescriptor INPUT_BUFFER_SIZE = new PropertyDescriptor.Builder()
-            .name("input-buffer-size")
-            .displayName("Input Buffer Size")
+            .name("Input Buffer Size")
             .description("The size of the input (read from network layer) buffer size.")
             .required(true)
             .defaultValue("4 kb")
@@ -34,8 +34,7 @@ public abstract class AbstractJettyWebSocketService extends AbstractWebSocketSer
             .build();
 
     public static final PropertyDescriptor MAX_TEXT_MESSAGE_SIZE = new PropertyDescriptor.Builder()
-            .name("max-text-message-size")
-            .displayName("Max Text Message Size")
+            .name("Max Text Message Size")
             .description("The maximum size of a text message during parsing/generating.")
             .required(true)
             .defaultValue("64 kb")
@@ -43,8 +42,7 @@ public abstract class AbstractJettyWebSocketService extends AbstractWebSocketSer
             .build();
 
     public static final PropertyDescriptor MAX_BINARY_MESSAGE_SIZE = new PropertyDescriptor.Builder()
-            .name("max-binary-message-size")
-            .displayName("Max Binary Message Size")
+            .name("Max Binary Message Size")
             .description("The maximum size of a binary message during parsing/generating.")
             .required(true)
             .defaultValue("64 kb")
@@ -59,5 +57,13 @@ public abstract class AbstractJettyWebSocketService extends AbstractWebSocketSer
 
     static List<PropertyDescriptor> getAbstractPropertyDescriptors() {
         return PROPERTY_DESCRIPTORS;
+    }
+
+    @Override
+    public void migrateProperties(final PropertyConfiguration propertyConfiguration) {
+        super.migrateProperties(propertyConfiguration);
+        propertyConfiguration.renameProperty("input-buffer-size", INPUT_BUFFER_SIZE.getName());
+        propertyConfiguration.renameProperty("max-text-message-size", MAX_TEXT_MESSAGE_SIZE.getName());
+        propertyConfiguration.renameProperty("max-binary-message-size", MAX_BINARY_MESSAGE_SIZE.getName());
     }
 }

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketClient.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketClient.java
@@ -27,6 +27,7 @@ import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
@@ -75,8 +76,7 @@ import java.util.stream.Stream;
 public class JettyWebSocketClient extends AbstractJettyWebSocketService implements WebSocketClientService {
 
     public static final PropertyDescriptor WS_URI = new PropertyDescriptor.Builder()
-            .name("websocket-uri")
-            .displayName("WebSocket URI")
+            .name("WebSocket URI")
             .description("The WebSocket URI this client connects to.")
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
@@ -98,8 +98,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
             .build();
 
     public static final PropertyDescriptor CONNECTION_TIMEOUT = new PropertyDescriptor.Builder()
-            .name("connection-timeout")
-            .displayName("Connection Timeout")
+            .name("Connection Timeout")
             .description("The timeout to connect the WebSocket URI.")
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -108,8 +107,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
             .build();
 
     public static final PropertyDescriptor CONNECTION_ATTEMPT_COUNT = new PropertyDescriptor.Builder()
-            .name("connection-attempt-timeout")
-            .displayName("Connection Attempt Count")
+            .name("Connection Attempt Count")
             .description("The number of times to try and establish a connection.")
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -118,8 +116,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
             .build();
 
     public static final PropertyDescriptor SESSION_MAINTENANCE_INTERVAL = new PropertyDescriptor.Builder()
-            .name("session-maintenance-interval")
-            .displayName("Session Maintenance Interval")
+            .name("Session Maintenance Interval")
             .description("The interval between session maintenance activities." +
                     " A WebSocket session established with a WebSocket server can be terminated due to different reasons" +
                     " including restarting the WebSocket server or timing out inactive sessions." +
@@ -133,8 +130,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
             .build();
 
     public static final PropertyDescriptor USER_NAME = new PropertyDescriptor.Builder()
-            .name("user-name")
-            .displayName("User Name")
+            .name("Username")
             .description("The user name for Basic Authentication.")
             .required(false)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -142,8 +138,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
             .build();
 
     public static final PropertyDescriptor USER_PASSWORD = new PropertyDescriptor.Builder()
-            .name("user-password")
-            .displayName("User Password")
+            .name("Password")
             .description("The user password for Basic Authentication.")
             .required(false)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -152,8 +147,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
             .build();
 
     public static final PropertyDescriptor AUTH_CHARSET = new PropertyDescriptor.Builder()
-            .name("authentication-charset")
-            .displayName("Authentication Header Charset")
+            .name("Authentication Header Charset")
             .description("The charset for Basic Authentication header base64 string.")
             .required(true)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -162,8 +156,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
             .build();
 
     public static final PropertyDescriptor CUSTOM_AUTH = new PropertyDescriptor.Builder()
-            .name("custom-authorization")
-            .displayName("Custom Authorization")
+            .name("Custom Authorization")
             .description(
                     "Configures a custom HTTP Authorization Header as described in RFC 7235 Section 4.2." +
                             " Setting a custom Authorization Header excludes configuring the User Name and User Password properties for Basic Authentication.")
@@ -175,8 +168,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
 
 
     public static final PropertyDescriptor PROXY_HOST = new PropertyDescriptor.Builder()
-            .name("proxy-host")
-            .displayName("HTTP Proxy Host")
+            .name("HTTP Proxy Host")
             .description("The host name of the HTTP Proxy.")
             .required(false)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -184,8 +176,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
             .build();
 
     public static final PropertyDescriptor PROXY_PORT = new PropertyDescriptor.Builder()
-            .name("proxy-port")
-            .displayName("HTTP Proxy Port")
+            .name("HTTP Proxy Port")
             .description("The port number of the HTTP Proxy.")
             .required(false)
             .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
@@ -199,7 +190,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
             getAbstractPropertyDescriptors().stream(),
             Stream.of(
                     WS_URI,
-                    SSL_CONTEXT,
+                    SSL_CONTEXT_SERVICE,
                     CONNECTION_TIMEOUT,
                     CONNECTION_ATTEMPT_COUNT,
                     SESSION_MAINTENANCE_INTERVAL,
@@ -222,6 +213,23 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
     private ConfigurationContext configurationContext;
     protected String authorizationHeader;
 
+
+    @Override
+    public void migrateProperties(final PropertyConfiguration propertyConfiguration) {
+        super.migrateProperties(propertyConfiguration);
+        propertyConfiguration.renameProperty("websocket-uri", WS_URI.getName());
+        propertyConfiguration.renameProperty("ssl-context-service", SSL_CONTEXT_SERVICE.getName());
+        propertyConfiguration.renameProperty("connection-timeout", CONNECTION_TIMEOUT.getName());
+        propertyConfiguration.renameProperty("connection-attempt-count", CONNECTION_ATTEMPT_COUNT.getName());
+        propertyConfiguration.renameProperty("session-maintenance-interval", SESSION_MAINTENANCE_INTERVAL.getName());
+        propertyConfiguration.renameProperty("user-name", USER_NAME.getName());
+        propertyConfiguration.renameProperty("user-password", USER_PASSWORD.getName());
+        propertyConfiguration.renameProperty("authentication-charset", AUTH_CHARSET.getName());
+        propertyConfiguration.renameProperty("custom-authorization", CUSTOM_AUTH.getName());
+        propertyConfiguration.renameProperty("proxy-host", PROXY_HOST.getName());
+        propertyConfiguration.renameProperty("proxy-port", PROXY_PORT.getName());
+    }
+
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return PROPERTY_DESCRIPTORS;
@@ -235,7 +243,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
         connectCount = configurationContext.getProperty(CONNECTION_ATTEMPT_COUNT).evaluateAttributeExpressions().asInteger();
 
         final HttpClient httpClient;
-        final SSLContextProvider sslContextProvider = context.getProperty(SSL_CONTEXT).asControllerService(SSLContextProvider.class);
+        final SSLContextProvider sslContextProvider = context.getProperty(SSL_CONTEXT_SERVICE).asControllerService(SSLContextProvider.class);
         if (sslContextProvider == null) {
             httpClient = new HttpClient();
         } else {

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketServer.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/test/java/org/apache/nifi/websocket/jetty/TestJettyWebSocketServer.java
@@ -61,7 +61,7 @@ public class TestJettyWebSocketServer {
     public void testValidationHashLoginService() throws Exception {
         final JettyWebSocketServer server = new JettyWebSocketServer();
         runner.addControllerService(IDENTIFIER, server);
-        runner.setProperty(server, JettyWebSocketServer.LISTEN_PORT, Integer.toString(MAX_PORT));
+        runner.setProperty(server, JettyWebSocketServer.PORT, Integer.toString(MAX_PORT));
         runner.setProperty(server, JettyWebSocketServer.LOGIN_SERVICE, JettyWebSocketServer.LOGIN_SERVICE_HASH.getValue());
         runner.setProperty(server, JettyWebSocketServer.BASIC_AUTH, Boolean.TRUE.toString());
         runner.assertNotValid();
@@ -71,7 +71,7 @@ public class TestJettyWebSocketServer {
     public void testValidationSuccess() throws Exception {
         final JettyWebSocketServer server = new JettyWebSocketServer();
         runner.addControllerService(IDENTIFIER, server);
-        runner.setProperty(server, JettyWebSocketServer.LISTEN_PORT, Integer.toString(MAX_PORT));
+        runner.setProperty(server, JettyWebSocketServer.PORT, Integer.toString(MAX_PORT));
         runner.assertValid(server);
     }
 
@@ -81,7 +81,7 @@ public class TestJettyWebSocketServer {
         final String identifier = JettyWebSocketServer.class.getSimpleName();
         final JettyWebSocketServer server = new JettyWebSocketServer();
         runner.addControllerService(identifier, server);
-        runner.setProperty(server, JettyWebSocketServer.LISTEN_PORT, "0");
+        runner.setProperty(server, JettyWebSocketServer.PORT, "0");
         runner.enableControllerService(server);
 
         server.registerProcessor(ROOT_ENDPOINT_ID, runner.getProcessor());


### PR DESCRIPTION
# Summary

[NIFI-14463](https://issues.apache.org/jira/browse/NIFI-14463) Standardizes the component property name for the `SSLContextService` and `SSLContextProvider` Controller Service as `SSL Context Service`, migrating other uses of `ssl-context-service` to the standard naming convention.

Additional changes include migrating other properties in updated components to reflect the current convention of using human-readable labels for the `name()` field without the need for the `displayName()`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
