### PR TITLE
NIFI-14477: Add the ability to configure jetty http compliance

### DIFF
--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -208,6 +208,7 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String WEB_HTTPS_NETWORK_INTERFACE_PREFIX = "nifi.web.https.network.interface.";
     public static final String WEB_WORKING_DIR = "nifi.web.jetty.working.directory";
     public static final String WEB_THREADS = "nifi.web.jetty.threads";
+    public static final String WEB_HTTP_COMPLIANCE = "nifi.web.jetty.http.compliance";
     public static final String WEB_MAX_HEADER_SIZE = "nifi.web.max.header.size";
     public static final String WEB_PROXY_CONTEXT_PATH = "nifi.web.proxy.context.path";
     public static final String WEB_PROXY_HOST = "nifi.web.proxy.host";

--- a/nifi-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/administration-guide.adoc
@@ -3529,7 +3529,7 @@ The CustomRequestLog writes formatted messages using the following SLF4J logger:
 `org.apache.nifi.web.server.RequestLog`
 |`nifi.web.jmx.metrics.allowed.filter.pattern`|The regular expression controlling the JMX MBean names that the REST API
 is allowed to return. The default value is empty, blocking all MBeans. Configuring `.*` allows all registered MBeans.
-|====
+|nifi.web.jetty.http.compliance| You can configure link:https://jetty.org/docs/jetty/12/programming-guide/server/compliance.html[jetty http compliance]. This way you can allow some http violation if you need compatibility with older http clients. Example value: RFC7230,TRANSFER_ENCODING_WITH_CONTENT_LENGTH |====
 
 [[security_properties]]
 === Security Properties

--- a/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -135,6 +135,7 @@
         <nifi.web.proxy.context.path />
         <nifi.web.proxy.host />
         <nifi.web.max.content.size />
+        <nifi.web.jetty.http.compliance />
         <nifi.web.max.requests.per.second>30000</nifi.web.max.requests.per.second>
         <nifi.web.max.access.token.requests.per.second>25</nifi.web.max.access.token.requests.per.second>
         <nifi.web.request.timeout>60 secs</nifi.web.request.timeout>

--- a/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -168,6 +168,7 @@ nifi.web.max.header.size=${nifi.web.max.header.size}
 nifi.web.proxy.context.path=${nifi.web.proxy.context.path}
 nifi.web.proxy.host=${nifi.web.proxy.host}
 nifi.web.max.content.size=${nifi.web.max.content.size}
+nifi.web.jetty.http.compliance=${nifi.web.jetty.http.compliance}
 nifi.web.max.requests.per.second=${nifi.web.max.requests.per.second}
 nifi.web.max.access.token.requests.per.second=${nifi.web.max.access.token.requests.per.second}
 nifi.web.request.timeout=${nifi.web.request.timeout}

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
@@ -23,6 +23,7 @@ import org.apache.nifi.jetty.configuration.connector.StandardServerConnectorFact
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.security.util.TlsPlatform;
 import org.apache.nifi.util.NiFiProperties;
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.server.HostHeaderCustomizer;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Server;
@@ -56,6 +57,8 @@ public class FrameworkServerConnectorFactory extends StandardServerConnectorFact
 
     private final Set<Integer> validPorts;
 
+    private final String httpCompliance;
+
     private SslContextFactory.Server sslContextFactory;
 
     /**
@@ -69,6 +72,7 @@ public class FrameworkServerConnectorFactory extends StandardServerConnectorFact
 
         includeCipherSuites = properties.getProperty(NiFiProperties.WEB_HTTPS_CIPHERSUITES_INCLUDE);
         excludeCipherSuites = properties.getProperty(NiFiProperties.WEB_HTTPS_CIPHERSUITES_EXCLUDE);
+        httpCompliance = properties.getProperty(NiFiProperties.WEB_HTTP_COMPLIANCE);
         headerSize = DataUnit.parseDataSize(properties.getWebMaxHeaderSize(), DataUnit.B).intValue();
         validPorts = getValidPorts(properties);
 
@@ -104,6 +108,9 @@ public class FrameworkServerConnectorFactory extends StandardServerConnectorFact
 
         final HostPortValidatorCustomizer hostPortValidatorCustomizer = new HostPortValidatorCustomizer(validPorts);
         httpConfiguration.addCustomizer(hostPortValidatorCustomizer);
+        if (StringUtils.isNotEmpty(httpCompliance)) {
+            httpConfiguration.setHttpCompliance(HttpCompliance.from(httpCompliance));
+        }
 
         return httpConfiguration;
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
