### PR TITLE
NIFI-13015: Support sensitive dynamic properties in ExecuteGroovyScript

### DIFF
--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/main/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScript.java
@@ -33,6 +33,7 @@ import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.Restricted;
 import org.apache.nifi.annotation.behavior.Restriction;
 import org.apache.nifi.annotation.behavior.Stateful;
+import org.apache.nifi.annotation.behavior.SupportsSensitiveDynamicProperties;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -80,16 +81,15 @@ import org.codehaus.groovy.runtime.StackTraceUtils;
 @Stateful(scopes = {Scope.LOCAL, Scope.CLUSTER},
         description = "Scripts can store and retrieve state using the State Management APIs. Consult the State Manager section of the Developer's Guide for more details.")
 @SeeAlso(classNames = {"org.apache.nifi.processors.script.ExecuteScript"})
+@SupportsSensitiveDynamicProperties
 @DynamicProperty(name = "A script engine property to update",
         value = "The value to set it to",
         expressionLanguageScope = ExpressionLanguageScope.FLOWFILE_ATTRIBUTES,
         description = "Updates a script engine property specified by the Dynamic Property's key with the value specified by the Dynamic Property's value. "
                 + "Use `CTL.` to access any controller services, `SQL.` to access any DBCPServices, `RecordReader.` to access RecordReaderFactory instances, or "
-                + "`RecordWriter.` to access any RecordSetWriterFactory instances. Use `SENSITIVE.` to mark the property as sensitive.")
+                + "`RecordWriter.` to access any RecordSetWriterFactory instances.")
 public class ExecuteGroovyScript extends AbstractProcessor {
     public static final String GROOVY_CLASSPATH = "${groovy.classes.path}";
-
-    protected static final String SENSITIVE_PROPERTY_PREFIX = "SENSITIVE.";
 
     private static final String PRELOADS = "import org.apache.nifi.components.*;" + "import org.apache.nifi.flowfile.FlowFile;" + "import org.apache.nifi.processor.*;"
             + "import org.apache.nifi.processor.FlowFileFilter.FlowFileFilterResult;" + "import org.apache.nifi.processor.exception.*;" + "import org.apache.nifi.processor.io.*;"
@@ -545,18 +545,13 @@ public class ExecuteGroovyScript extends AbstractProcessor {
                     .build();
         }
 
-        final PropertyDescriptor.Builder builder = new PropertyDescriptor.Builder()
+        return new PropertyDescriptor.Builder()
                 .name(propertyDescriptorName)
                 .required(false)
                 .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
                 .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
-                .dynamic(true);
-
-        if (propertyDescriptorName.startsWith(SENSITIVE_PROPERTY_PREFIX)) {
-            builder.sensitive(true);
-        }
-
-        return builder.build();
+                .dynamic(true)
+                .build();
     }
 
     /** simple HashMap with exception on access of non-existent key */

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScriptTest.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScriptTest.java
@@ -19,9 +19,12 @@ package org.apache.nifi.processors.groovyx;
 import groovy.json.JsonOutput;
 import groovy.json.JsonSlurper;
 import org.apache.commons.io.FileUtils;
+import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.dbcp.DBCPService;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.serialization.RecordSetWriterFactory;
 import org.apache.nifi.serialization.record.MockRecordParser;
 import org.apache.nifi.serialization.record.MockRecordWriter;
@@ -556,9 +559,17 @@ public class ExecuteGroovyScriptTest {
 
     @Test
     public void test_sensitive_dynamic_property() throws Exception {
-        runner.setProperty("SENSITIVE.password", "MyP@ssW0rd!");
+        new PropertyDescriptor.Builder()
+                .name("password")
+                .required(false)
+                .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+                .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+                .dynamic(true)
+                .sensitive(true)
+                .build();
+        runner.setProperty("password", "MyP@ssW0rd!");
         runner.setProperty(ExecuteGroovyScript.SCRIPT_BODY,
-                "assert context.getProperties().find {k,v -> k.name == 'SENSITIVE.password'}.key.sensitive");
+                "assert context.getProperties().find {k,v -> k.name == 'password'}.key.sensitive");
         runner.assertValid();
         runner.run();
     }


### PR DESCRIPTION
# Summary

[NIFI-13015](https://issues.apache.org/jira/browse/NIFI-13015) This PR adds support to ExecuteGroovyScript for sensitive dynamic properties. The same pattern was employed as is in DBCPConnectionPool.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
