### PR TITLE
NIFI-14404 Clear Sensitive Dynamic Property Names on Migration

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/controller/AbstractComponentNode.java
@@ -238,13 +238,14 @@ public abstract class AbstractComponentNode implements ComponentNode {
      * @param properties Map of Property Name to Value
      */
     protected void overwriteProperties(final Map<String, String> properties) {
-        // Update properties.
         final Map<String, String> updatedProperties = new HashMap<>(properties);
-        final Set<String> sensitiveDynamicPropNames = new HashSet<>();
+
+        // Build set of Sensitive Dynamic Property Names based on updated Properties
+        final Set<String> updatedSensitiveDynamicPropertyNames = new HashSet<>();
         for (final String propertyName : updatedProperties.keySet()) {
             final PropertyDescriptor descriptor = getPropertyDescriptor(propertyName);
             if (descriptor != null && descriptor.isDynamic() && descriptor.isSensitive()) {
-                sensitiveDynamicPropNames.add(propertyName);
+                updatedSensitiveDynamicPropertyNames.add(propertyName);
             }
         }
 
@@ -253,7 +254,10 @@ public abstract class AbstractComponentNode implements ComponentNode {
             updatedProperties.putIfAbsent(descriptor.getName(), null);
         }
 
-        setProperties(updatedProperties, true, sensitiveDynamicPropNames);
+        // Clear existing Sensitive Dynamic Property Names to avoid cases where a sensitive property name has been changed or removed
+        sensitiveDynamicPropertyNames.getAndSet(Set.of());
+
+        setProperties(updatedProperties, true, updatedSensitiveDynamicPropertyNames);
     }
 
     /**

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/test/java/org/apache/nifi/controller/TestAbstractComponentNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/test/java/org/apache/nifi/controller/TestAbstractComponentNode.java
@@ -78,6 +78,10 @@ public class TestAbstractComponentNode {
 
     private static final String PROPERTY_VALUE = "abstract-property-value";
 
+    private static final String SECOND_PROPERTY_NAME = "Second Property";
+
+    private static final String SECOND_PROPERTY_VALUE = "2";
+
     @Timeout(5)
     @Test
     public void testGetValidationStatusWithTimeout() {
@@ -397,6 +401,27 @@ public class TestAbstractComponentNode {
         final PropertyDescriptor removedPropertyDescriptor = node.getPropertyDescriptor(PROPERTY_NAME);
         assertTrue(removedPropertyDescriptor.isDynamic());
         assertFalse(removedPropertyDescriptor.isSensitive());
+    }
+
+    @Test
+    public void testOverwritePropertiesSensitiveDynamicPropertyNames() {
+        final AbstractComponentNode node = new LocalComponentNode();
+
+        final Map<String, String> properties = Map.of(PROPERTY_NAME, PROPERTY_VALUE);
+        final Set<String> sensitiveDynamicPropertyNames = Collections.singleton(PROPERTY_NAME);
+        node.setProperties(properties, false, sensitiveDynamicPropertyNames);
+
+        final PropertyDescriptor propertyDescriptor = node.getPropertyDescriptor(PROPERTY_NAME);
+        assertTrue(propertyDescriptor.isDynamic());
+        assertTrue(propertyDescriptor.isSensitive());
+
+        // Overwrite Properties which clears existing Sensitive Dynamic Property Names
+        final Map<String, String> secondProperties = Map.of(SECOND_PROPERTY_NAME, SECOND_PROPERTY_VALUE);
+        node.overwriteProperties(secondProperties);
+
+        final PropertyDescriptor updatedPropertyDescriptor = node.getPropertyDescriptor(PROPERTY_NAME);
+        assertTrue(updatedPropertyDescriptor.isDynamic());
+        assertFalse(updatedPropertyDescriptor.isSensitive());
     }
 
     private ValidationContext getServiceValidationContext(final ControllerServiceState serviceState, final ControllerServiceProvider serviceProvider) {


### PR DESCRIPTION
# Summary

[NIFI-14404](https://issues.apache.org/jira/browse/NIFI-14404) Clears the internal set of Sensitive Dynamic Property Names when overwriting component properties during configuration migration.

The `AbstractComponentNode.overwriteProperties()` method is used exclusively when migrating configuration settings, such as renaming or removing historical property names.

In cases where a registered property was designated as sensitive, such as a password, the framework loads the component configuration and adds the property name to the set of sensitive dynamic property names. This occurs because the flow definition property descriptor designates the property as sensitive, and the property is considered dynamic because the current version of the component no longer knows about the previous property name. This scenario occurred with the `Http Proxy Password` property of SFTP Processors, which existed in NiFi 1, but no longer exists in NiFi 2. As a result of this behavior, the component considered the historical property name as a sensitive dynamic property when loading the flow definition. The configuration migration occurs after flow definition loading, and updating the set of sensitive properties does not remove existing property names. For this reason, it is necessary to clear the existing set of sensitive dynamic property names when overwriting properties as a result of the migration process.

The new unit test method confirms the sensitive and dynamic status of a named property before and after calling the `overwriteProperties()` method, verifying the expected behavior.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
