### PR TITLE
NIFI-14071: Labels not rendering lines starting with spaces

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
@@ -1484,7 +1484,7 @@ export class CanvasUtils {
 
             // Split words normally, letting internal whitespace collapse
             const words = trimmedLine.split(/\s+/).reverse();
-            if (words.length > 0) {
+            if (leadingWhitespace.length > 0 && words.length > 0) {
                 words[words.length - 1] = leadingWhitespace + words[words.length - 1]; // Prepend leading space to the first word
             }
 

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
@@ -1478,16 +1478,20 @@ export class CanvasUtils {
         let lineHeight = height;
 
         for (const fullLine of lines) {
-            // Preserve leading spaces per word
-            const words: string[] = fullLine.match(/(\s*\S+)/g)?.reverse() || [];
+            // Extract and preserve only the leading whitespace at the start of the line
+            const trimmedLine = fullLine.trimStart();
+            const leadingWhitespace = fullLine.slice(0, fullLine.length - trimmedLine.length);
+
+            // Split words normally, letting internal whitespace collapse
+            const words = trimmedLine.split(/\s+/).reverse();
+            if (words.length > 0) {
+                words[words.length - 1] = leadingWhitespace + words[words.length - 1]; // Prepend leading space to the first word
+            }
 
             let newLine = true;
             let line: string[] = [];
 
-            let tspan = selection.append('tspan')
-                .attr('x', x)
-                .attr('width', width)
-                .attr('xml:space', 'preserve'); // preserve leading spaces
+            let tspan = selection.append('tspan').attr('x', x).attr('width', width).attr('xml:space', 'preserve');
 
             // go through each word
             let word = words.pop();
@@ -1495,9 +1499,8 @@ export class CanvasUtils {
             while (word) {
                 // add the current word
                 line.push(word);
-
                 // update the label text
-                tspan.text(line.join(''));
+                tspan.text(line.join(' '));
 
                 if (!lineCountCalculated) {
                     const bbox = tspan.node().getBoundingClientRect();
@@ -1519,10 +1522,11 @@ export class CanvasUtils {
                     line.pop();
 
                     // update the label text
-                    tspan.text(line.join(''));
+                    tspan.text(line.join(' '));
 
-                     // create the tspan for the next line
-                    tspan = selection.append('tspan')
+                    // create the tspan for the next line
+                    tspan = selection
+                        .append('tspan')
                         .attr('x', x)
                         .attr('dy', '1.2em')
                         .attr('width', width)
@@ -1535,7 +1539,7 @@ export class CanvasUtils {
                         const remainder = [word].concat(words.reverse());
 
                         // apply ellipsis to the last line
-                        this.ellipsis(tspan, remainder.join(''), cacheName);
+                        this.ellipsis(tspan, remainder.join(' '), cacheName);
 
                         // we've reached the line count
                         return;
@@ -1552,10 +1556,8 @@ export class CanvasUtils {
             }
 
             if (newLine) {
-
                 // set the label height
                 tspan.attr('y', lineHeight * i++);
-                newLine = false;
             }
 
             if (i >= lineCount) {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/service/canvas-utils.service.ts
@@ -1489,48 +1489,71 @@ export class CanvasUtils {
                 .attr('width', width)
                 .attr('xml:space', 'preserve'); // preserve leading spaces
 
+            // go through each word
             let word = words.pop();
 
             while (word) {
+                // add the current word
                 line.push(word);
+
+                // update the label text
                 tspan.text(line.join(''));
 
                 if (!lineCountCalculated) {
                     const bbox = tspan.node().getBoundingClientRect();
                     lineHeight = bbox.height / this.scale;
+
                     lineCount = Math.floor(height / lineHeight);
                     lineCountCalculated = true;
                 }
 
                 if (newLine) {
+                    // set the label height
                     tspan.attr('y', lineHeight * i++);
                     newLine = false;
                 }
 
+                // if this word caused us to go too far
                 if (tspan.node().getComputedTextLength() > width) {
-                    line.pop(); // remove word that caused overflow
+                    // remove the current word
+                    line.pop();
+
+                    // update the label text
                     tspan.text(line.join(''));
 
+                     // create the tspan for the next line
                     tspan = selection.append('tspan')
                         .attr('x', x)
                         .attr('dy', '1.2em')
                         .attr('width', width)
                         .attr('xml:space', 'preserve');
 
+                    // if we've reached the last line, use single line ellipsis
                     if (i++ >= lineCount) {
+                        // get the remainder using the current word and
+                        // reversing whats left
                         const remainder = [word].concat(words.reverse());
+
+                        // apply ellipsis to the last line
                         this.ellipsis(tspan, remainder.join(''), cacheName);
+
+                        // we've reached the line count
                         return;
                     } else {
                         tspan.text(word);
+
+                        // prep the line for the next iteration
                         line = [word];
                     }
                 }
 
+                // get the next word
                 word = words.pop();
             }
 
             if (newLine) {
+
+                // set the label height
                 tspan.attr('y', lineHeight * i++);
                 newLine = false;
             }


### PR DESCRIPTION
🛠️ Fix: Label rendering issue in boundedMultilineEllipsis
This MR addresses a bug where SVG labels using boundedMultilineEllipsis were not displaying correctly when rendered via D3, especially during interactions like dragging or viewport changes.

✅ Root Cause:
The issue stemmed from inaccurate line height and line count calculations, which affected label wrapping and positioning. In some cases, the initial tspan was not receiving the proper y attribute, causing the entire label to be misaligned or not visible.

🔧 Fix Details:
Reordered the logic inside the while (word) loop to:

1. Assign y position immediately on first word append, ensuring the tspan gets positioned correctly even for single-word lines.
2. Calculate lineHeight and lineCount using getBoundingClientRect() only once (on the first word of the first line), improving performance and consistency.
3. Preserve leading spaces using xml:space="preserve" to match label formatting.
4. Ensure all wrapped lines are properly positioned using dy="1.2em" and line limit logic.

📷 Screenshots:
Before (Broken Labels):
![Screenshot from 2025-04-21 22-23-15](https://github.com/user-attachments/assets/26fb795e-8038-4840-a535-958919e89ce7)

After (Fixed Labels):
![Screenshot from 2025-04-22 10-02-05](https://github.com/user-attachments/assets/d3ff4ff5-2e9a-41d8-9203-26d3bc6eca69)


🔬 Validation:
Tested rendering behavior on:
1. Long and short label strings
2. Multi-line wrapping scenarios
3. Resizing, dragging, zooming, and panning

All scenarios now render correctly as expected.

📌 Note:
This fix improves layout consistency and ensures robust label handling across different canvas states and screen sizes.

