### PR TITLE
NIFI-14490 Deprecate OCSP Certificate Validation for Removal

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/pom.xml
@@ -78,6 +78,11 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-deprecation-log</artifactId>
+            <version>2.4.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi.registry</groupId>
             <artifactId>nifi-registry-security-utils</artifactId>
             <version>2.4.0-SNAPSHOT</version>

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/ocsp/OcspCertificateValidator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/x509/ocsp/OcspCertificateValidator.java
@@ -41,6 +41,8 @@ import jakarta.ws.rs.core.Response;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.deprecation.log.DeprecationLogger;
+import org.apache.nifi.deprecation.log.DeprecationLoggerFactory;
 import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.util.NiFiProperties;
 import org.apache.nifi.web.security.x509.ocsp.OcspStatus.ValidationStatus;
@@ -75,6 +77,8 @@ public class OcspCertificateValidator {
 
     private static final Logger logger = LoggerFactory.getLogger(OcspCertificateValidator.class);
 
+    private static final DeprecationLogger deprecationLogger = DeprecationLoggerFactory.getLogger(OcspCertificateValidator.class);
+
     private static final String OCSP_REQUEST_CONTENT_TYPE = "application/ocsp-request";
 
     private static final int CONNECT_TIMEOUT = 10000;
@@ -92,6 +96,8 @@ public class OcspCertificateValidator {
 
         // set properties when appropriate
         if (StringUtils.isNotBlank(rawValidationAuthorityUrl)) {
+            deprecationLogger.warn("OCSP Certificate Validation with Responder URL [{}] is deprecated for removal", NiFiProperties.SECURITY_OCSP_RESPONDER_URL);
+
             try {
                 // attempt to parse the specified va url
                 validationAuthorityURI = URI.create(rawValidationAuthorityUrl);


### PR DESCRIPTION
# Summary

[NIFI-14490](https://issues.apache.org/jira/browse/NIFI-14490) Deprecates [Online Certificate Status Protocol](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) certificate validation for removal from the application security configuration.

Major certificate authorities such as Let's Encrypt are in the process of [ending support for OCSP](https://letsencrypt.org/2024/12/05/ending-ocsp/) and articles such as [The Slow Death of OCSP](https://www.feistyduck.com/newsletter/issue_121_the_slow_death_of_ocsp) describe the technical issues and adoption shortcomings.

The deprecation writes a warning log when the application is configured with a property value for `nifi.security.ocsp.responder.url`, which enables OCSP checking for mutual TLS client certificate authentication. Standard certificate validation still applies during the TLS handshake process, regardless of the OCSP configuration.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
