### PR TITLE
NIFI-14491 Support other types in CreateBoxFileMetadataInstance

### DIFF
--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/utils/BoxDate.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/utils/BoxDate.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.box.utils;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * A wrapper class for formatting {@link LocalDate} to a string that is accepted by Box Metadata API.
+ */
+public final class BoxDate {
+
+    // The time part is always set to 0. https://developer.box.com/guides/metadata/fields/date/
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T00:00:00.000Z'");
+
+    private final LocalDate date;
+
+    private BoxDate(final LocalDate date) {
+        this.date = date;
+    }
+
+    public static BoxDate of(final LocalDate date) {
+        return new BoxDate(date);
+    }
+
+    public String format() {
+        return DATE_FORMATTER.format(date);
+    }
+}

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/UpdateBoxFileMetadataInstanceTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/UpdateBoxFileMetadataInstanceTest.java
@@ -91,6 +91,7 @@ public class UpdateBoxFileMetadataInstanceTest extends AbstractBoxFileTest {
     private void configureJsonRecordReader(TestRunner runner) throws InitializationException {
         final JsonTreeReader readerService = new JsonTreeReader();
         runner.addControllerService("json-reader", readerService);
+        runner.setProperty(readerService, "Date Format", "yyyy-MM-dd");
         runner.enableControllerService(readerService);
     }
 
@@ -290,7 +291,8 @@ public class UpdateBoxFileMetadataInstanceTest extends AbstractBoxFileTest {
                   "doubleField": 42.5,
                   "booleanField": true,
                   "listField": ["item1", "item2", "item3"],
-                  "emptyListField": []
+                  "emptyListField": [],
+                  "date": "2025-01-01"
                 }""";
 
         testRunner.enqueue(inputJson);
@@ -301,6 +303,7 @@ public class UpdateBoxFileMetadataInstanceTest extends AbstractBoxFileTest {
         verify(mockMetadata).add("/numberField", 42.0); // Numbers are stored as doubles
         verify(mockMetadata).add("/doubleField", 42.5);
         verify(mockMetadata).add("/booleanField", "true"); // Booleans are stored as strings
+        verify(mockMetadata).add("/date", "2025-01-01T00:00:00.000Z"); // Dates have a specific format.
         // We need to use doAnswer/when to capture and verify list fields being added, but this is simpler
 
         verify(mockBoxFile).updateMetadata(any(Metadata.class));

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/utils/BoxDateTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/utils/BoxDateTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.box.utils;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BoxDateTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "2025-01-01, 2025-01-01T00:00:00.000Z",
+            "2025-02-25, 2025-02-25T00:00:00.000Z",
+            "2025-11-10, 2025-11-10T00:00:00.000Z",
+            })
+    void format(final LocalDate date, final String expected) {
+        final BoxDate boxDate = BoxDate.of(date);
+        final String formatted = boxDate.format();
+
+        assertEquals(expected, formatted);
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14491](https://issues.apache.org/jira/browse/NIFI-14491)
Adding support for numeric, date and array types in `CreateBoxFileMetadataInstance`.
Adding support for date type in `UpdateBoxFileMetadataInstance`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
