### PR TITLE
NIFI-14478 Changing version controlled Process Group sync

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -517,7 +517,7 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
                     .storageLocation(storageLocation)
                     .flowName(flowId)
                     .version(version)
-                    .flowSnapshot(syncOptions.isUpdateGroupVersionControlSnapshot() ? proposed : null)
+                    .flowSnapshot(null)
                     .status(new StandardVersionedFlowStatus(flowState, flowState.getDescription()))
                     .build();
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -3836,7 +3836,6 @@ public final class StandardProcessGroup implements ProcessGroup {
             .ignoreLocalModifications(!verifyNotDirty)
             .updateDescendantVersionedFlows(updateDescendantVersionedFlows)
             .updateGroupSettings(updateSettings)
-            .updateGroupVersionControlSnapshot(true)
             .updateRpgUrls(false)
             .propertyDecryptor(value -> null)
             .build();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/FlowSynchronizationOptions.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/FlowSynchronizationOptions.java
@@ -30,7 +30,6 @@ public class FlowSynchronizationOptions {
     private final boolean ignoreLocalModifications;
     private final boolean updateSettings;
     private final boolean updateDescendantVersionedFlows;
-    private final boolean updateGroupVersionControlSnapshot;
     private final boolean updateRpgUrls;
     private final Duration componentStopTimeout;
     private final ComponentStopTimeoutAction timeoutAction;
@@ -45,7 +44,6 @@ public class FlowSynchronizationOptions {
         this.ignoreLocalModifications = builder.ignoreLocalModifications;
         this.updateSettings = builder.updateSettings;
         this.updateDescendantVersionedFlows = builder.updateDescendantVersionedFlows;
-        this.updateGroupVersionControlSnapshot = builder.updateGroupVersionControlSnapshot;
         this.updateRpgUrls = builder.updateRpgUrls;
         this.componentStopTimeout = builder.componentStopTimeout;
         this.timeoutAction = builder.timeoutAction;
@@ -75,10 +73,6 @@ public class FlowSynchronizationOptions {
 
     public boolean isUpdateDescendantVersionedFlows() {
         return updateDescendantVersionedFlows;
-    }
-
-    public boolean isUpdateGroupVersionControlSnapshot() {
-        return updateGroupVersionControlSnapshot;
     }
 
     public boolean isUpdateRpgUrls() {
@@ -112,7 +106,6 @@ public class FlowSynchronizationOptions {
         private boolean ignoreLocalModifications = false;
         private boolean updateSettings = true;
         private boolean updateDescendantVersionedFlows = true;
-        private boolean updateGroupVersionControlSnapshot = true;
         private boolean updateRpgUrls = false;
         private ScheduledStateChangeListener scheduledStateChangeListener;
         private PropertyDecryptor propertyDecryptor = value -> value;
@@ -180,20 +173,6 @@ public class FlowSynchronizationOptions {
          */
         public Builder updateDescendantVersionedFlows(final boolean updateDescendantVersionedFlows) {
             this.updateDescendantVersionedFlows = updateDescendantVersionedFlows;
-            return this;
-        }
-
-        /**
-         * When a Process Group is version controlled, it tracks whether or not there are any local modifications by comparing the current dataflow
-         * to a snapshot of what the Versioned Flow looks like. If this value is set to <code>true</code>, when the Process Group is synchronized
-         * with a VersionedProcessGroup, that VersionedProcessGroup will become the snapshot of what the Versioned Flow looks like. If <code>false</code>,
-         * the snapshot is not updated.
-         *
-         * @param updateGroupVersionControlSnapshot <code>true</code> to update the snapshot, <code>false</code> otherwise
-         * @return the builder
-         */
-        public Builder updateGroupVersionControlSnapshot(final boolean updateGroupVersionControlSnapshot) {
-            this.updateGroupVersionControlSnapshot = updateGroupVersionControlSnapshot;
             return this;
         }
 
@@ -285,7 +264,6 @@ public class FlowSynchronizationOptions {
             builder.ignoreLocalModifications = options.isIgnoreLocalModifications();
             builder.updateSettings = options.isUpdateSettings();
             builder.updateDescendantVersionedFlows = options.isUpdateDescendantVersionedFlows();
-            builder.updateGroupVersionControlSnapshot = options.isUpdateGroupVersionControlSnapshot();
             builder.updateRpgUrls = options.isUpdateRpgUrls();
             builder.propertyDecryptor = options.getPropertyDecryptor();
             builder.componentStopTimeout = options.getComponentStopTimeout();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardStatelessGroupNodeFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/flow/StandardStatelessGroupNodeFactory.java
@@ -288,7 +288,6 @@ public class StandardStatelessGroupNodeFactory implements StatelessGroupNodeFact
             .topLevelGroupId(group.getIdentifier())
             .updateDescendantVersionedFlows(true)
             .updateGroupSettings(true)
-            .updateGroupVersionControlSnapshot(false)
             .updateRpgUrls(true)
             .ignoreLocalModifications(true)
             .build();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
@@ -429,7 +429,6 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
                     .ignoreLocalModifications(true)
                     .updateGroupSettings(true)
                     .updateDescendantVersionedFlows(true)
-                    .updateGroupVersionControlSnapshot(false)
                     .updateRpgUrls(true)
                     .propertyDecryptor(encryptor::decrypt)
                     .build();

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/pg/CopyPasteIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/pg/CopyPasteIT.java
@@ -402,4 +402,31 @@ public class CopyPasteIT extends NiFiSystemIT {
         assertNotEquals(terminate1.getComponent().getId(), terminate2.getComponent().getId());
         assertEquals(terminate1.getComponent().getVersionedComponentId(), terminate2.getComponent().getVersionedComponentId());
     }
+
+    @Test
+    public void testCopyPasteVersionControlledProcessGroupWithLocalChanges()  throws NiFiClientException, IOException, InterruptedException {
+        // Create a top-level PG and version it with nothing in it.
+        final FlowRegistryClientEntity clientEntity = registerClient();
+        final ProcessGroupEntity topLevel1 = getClientUtil().createProcessGroup("Top Level 1", "root");
+
+        // Create a lower level PG and add a Processor.  Commit as Version 1 of the PG.
+        final ProcessGroupEntity innerGroup = getClientUtil().createProcessGroup("Inner 1", topLevel1.getId());
+        ProcessorEntity terminate1 = getClientUtil().createProcessor("TerminateFlowFile", innerGroup.getId());
+        VersionControlInformationEntity vciEntity = getClientUtil().startVersionControl(innerGroup, clientEntity, TEST_FLOWS_BUCKET, FIRST_FLOW_ID);
+        assertEquals("1", vciEntity.getVersionControlInformation().getVersion());
+
+        // Modify the processor and wait for the group to show it has local changes
+        getClientUtil().updateProcessorSchedulingPeriod(terminate1, "2 mins");
+        waitFor(() -> VersionControlInformationDTO.LOCALLY_MODIFIED.equals(getClientUtil().getVersionControlState(innerGroup.getId())));
+
+        // Copy the versioned and modified process group and paste it to a new PG.
+        final ProcessGroupEntity topLevel2 = getClientUtil().createProcessGroup("Top Level 2", "root");
+        final CopyRequestEntity copyRequestEntity = new CopyRequestEntity();
+        copyRequestEntity.setProcessGroups(Set.of(innerGroup.getId()));
+        final FlowDTO flowDto = getClientUtil().copyAndPaste(topLevel1.getId(), copyRequestEntity, topLevel2.getRevision(), topLevel2.getId());
+
+        // The new PG should also show as being locally modified from Version 1 of the PG
+        final String pastedGroupId = flowDto.getProcessGroups().iterator().next().getId();
+        waitFor(() -> VersionControlInformationDTO.LOCALLY_MODIFIED.equals(getClientUtil().getVersionControlState(pastedGroupId)));
+    }
 }


### PR DESCRIPTION
# Summary

[NIFI-14478](https://issues.apache.org/jira/browse/NIFI-14478)

This PR removes a capability where a version controlled Process Groups could replace, in memory, what it thought was in the FlowRegistry.  The capability causes some non-intuitive effects on Versioned Process Group, by appearing to be "In Sync" with the FlowRegistry when in reality they are not.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [n/a] Documentation formatting appears as expected in rendered files
