### PR TITLE
NIFI-12952 Add Amazon MSK Connection Service and NAR

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -311,6 +311,12 @@ language governing permissions and limitations under the License. -->
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-kafka-service-aws-nar</artifactId>
+            <version>2.4.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-kafka-nar</artifactId>
             <version>2.4.0-SNAPSHOT</version>
             <type>nar</type>

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws-nar/pom.xml
@@ -22,19 +22,19 @@
         <version>2.4.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>nifi-kafka-service-api-nar</artifactId>
+    <artifactId>nifi-kafka-service-aws-nar</artifactId>
     <packaging>nar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-kafka-service-api</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <artifactId>nifi-kafka-service-aws</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-standard-shared-nar</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <artifactId>nifi-kafka-service-api-nar</artifactId>
+            <version>${project.version}</version>
             <type>nar</type>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/pom.xml
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/pom.xml
@@ -22,20 +22,40 @@
         <version>2.4.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>nifi-kafka-service-api-nar</artifactId>
-    <packaging>nar</packaging>
+    <artifactId>nifi-kafka-service-aws</artifactId>
+    <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-kafka-service-api</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Kafka Service implementation required for extending the Controller Service class -->
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-kafka-3-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- Controller Service API modules required for extending Kafka3ConnectionService -->
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-kerberos-user-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-standard-shared-nar</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
-            <type>nar</type>
+            <artifactId>nifi-ssl-context-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>3.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.msk</groupId>
+            <artifactId>aws-msk-iam-auth</artifactId>
+            <version>2.3.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionService.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kafka.service.aws;
+
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.kafka.service.Kafka3ConnectionService;
+import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
+import org.apache.nifi.kafka.shared.property.SaslMechanism;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
+@Tags({"AWS", "MSK", "streaming", "kafka"})
+@CapabilityDescription("Provides and manages connections to AWS MSK Kafka Brokers for producer or consumer operations.")
+public class AmazonMSKConnectionService extends Kafka3ConnectionService {
+
+    public static final PropertyDescriptor AWS_SASL_MECHANISM = new PropertyDescriptor.Builder()
+            .fromPropertyDescriptor(SASL_MECHANISM)
+            .allowableValues(
+                    SaslMechanism.AWS_MSK_IAM,
+                    SaslMechanism.SCRAM_SHA_512
+            )
+            .defaultValue(SaslMechanism.AWS_MSK_IAM)
+            .build();
+
+    private final List<PropertyDescriptor> supportedPropertyDescriptors;
+
+    public AmazonMSKConnectionService() {
+        final List<PropertyDescriptor> propertyDescriptors = new ArrayList<>(super.getSupportedPropertyDescriptors());
+
+        final ListIterator<PropertyDescriptor> descriptors = propertyDescriptors.listIterator();
+        while (descriptors.hasNext()) {
+            final PropertyDescriptor propertyDescriptor = descriptors.next();
+            if (SASL_MECHANISM.equals(propertyDescriptor)) {
+                descriptors.remove();
+                // Add AWS MSK properties
+                descriptors.add(AWS_SASL_MECHANISM);
+                descriptors.add(KafkaClientComponent.AWS_PROFILE_NAME);
+            }
+        }
+
+        supportedPropertyDescriptors = propertyDescriptors;
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return supportedPropertyDescriptors;
+    }
+}

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.kafka.service.aws.AmazonMSKConnectionService

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/test/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionServiceTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/test/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionServiceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kafka.service.aws;
+
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.NoOpProcessor;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AmazonMSKConnectionServiceTest {
+
+    private static final String SERVICE_ID = AmazonMSKConnectionService.class.getName();
+
+    private static final String BOOTSTRAP_SERVERS = "localhost:9092";
+
+    private TestRunner runner;
+
+    @BeforeEach
+    void setRunner() {
+        runner = TestRunners.newTestRunner(NoOpProcessor.class);
+    }
+
+    @Test
+    void testValidProperties() throws InitializationException {
+        final AmazonMSKConnectionService service = new AmazonMSKConnectionService();
+        runner.addControllerService(SERVICE_ID, service);
+
+        runner.setProperty(service, AmazonMSKConnectionService.BOOTSTRAP_SERVERS, BOOTSTRAP_SERVERS);
+
+        runner.assertValid(service);
+
+        runner.enableControllerService(service);
+    }
+}

--- a/nifi-extension-bundles/nifi-kafka-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-kafka-bundle/pom.xml
@@ -16,9 +16,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.nifi</groupId>
-        <artifactId>nifi-standard-services-api-bom</artifactId>
+        <artifactId>nifi-standard-shared-bom</artifactId>
         <version>2.4.0-SNAPSHOT</version>
-        <relativePath>../nifi-standard-services-api-bom</relativePath>
+        <relativePath>../nifi-standard-shared-bundle/nifi-standard-shared-bom</relativePath>
     </parent>
     <artifactId>nifi-kafka-bundle</artifactId>
     <packaging>pom</packaging>
@@ -37,6 +37,8 @@
         <module>nifi-kafka-processors</module>
         <module>nifi-kafka-service-api-nar</module>
         <module>nifi-kafka-service-api</module>
+        <module>nifi-kafka-service-aws</module>
+        <module>nifi-kafka-service-aws-nar</module>
         <module>nifi-kafka-shared</module>
     </modules>
 


### PR DESCRIPTION
# Summary

[NIFI-12952](https://issues.apache.org/jira/browse/NIFI-12952) Adds an [Amazon MSK](https://aws.amazon.com/msk/) implementation of the Kafka Connection Service supporting [IAM Access Control](https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html) based on the AWS MSK IAM library.

The implementation extends the standard `Kafka3ConnectionService` and modifies the `SASL Mechanism` property to include and default to AWS MSK IAM. The implementation also adds the optional `AWS Profile` property.

The service class builds on existing SASL handling in the `nifi-kafka-shared` library where the `AwsMskIamLoginConfigProvider` builds the required SASL configuration.

The implementation is packaged in a `nifi-kafka-service-aws-nar`, apart from the `nifi-kafka-3-service-nar` as the Amazon MSK class has a number of additional transitive dependencies.

Additional changes include adjusting the parent NAR of the `nifi-kafka-service-api-nar` to `nifi-standard-shared-nar` in order to avoid including duplicate copies of standard libraries in the service NAR bundles.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
