### PR TITLE
NIFI-14470 - PublishKafka; compatibility with PublishKafka26 keys

### DIFF
--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaExpressionKeyIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaExpressionKeyIT.java
@@ -19,7 +19,6 @@ package org.apache.nifi.kafka.processors;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.header.Header;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
@@ -27,21 +26,18 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 @TestMethodOrder(MethodOrderer.MethodName.class)
-public class PublishKafkaIT extends AbstractPublishKafkaIT {
-    private static final String TEST_KEY_ATTRIBUTE = "my-key";
-    private static final String TEST_KEY_ATTRIBUTE_EL = "${my-key}";
+public class PublishKafkaExpressionKeyIT extends AbstractPublishKafkaIT {
+    private static final String TEST_KEY = "some-key";
+    private static final String TEST_KEY_EL = "${some-key}";
     private static final String TEST_KEY_VALUE = "some-key-value";
-    private static final String TEST_RECORD_VALUE = "value-" + System.currentTimeMillis();
+    private static final String TEST_VALUE = "some-value-" + System.currentTimeMillis();
 
     @Test
     public void test_1_KafkaTestContainerProduceOne() throws InitializationException {
@@ -49,15 +45,12 @@ public class PublishKafkaIT extends AbstractPublishKafkaIT {
         runner.setValidateExpressionUsage(false);
         runner.setProperty(PublishKafka.CONNECTION_SERVICE, addKafkaConnectionService(runner));
         runner.setProperty(PublishKafka.TOPIC_NAME, getClass().getName());
-        runner.setProperty(PublishKafka.ATTRIBUTE_HEADER_PATTERN, "a.*");
-        runner.setProperty(PublishKafka.KAFKA_KEY, TEST_KEY_ATTRIBUTE_EL);
+        runner.setProperty(PublishKafka.KAFKA_KEY, TEST_KEY_EL);
 
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("a1", "valueA1");
-        attributes.put("b1", "valueB1");
-        attributes.put(TEST_KEY_ATTRIBUTE, TEST_KEY_VALUE);
+        attributes.put(TEST_KEY, TEST_KEY_VALUE);
 
-        runner.enqueue(TEST_RECORD_VALUE, attributes);
+        runner.enqueue(TEST_VALUE, attributes);
         runner.run();
         runner.assertAllFlowFilesTransferred(PublishKafka.REL_SUCCESS, 1);
     }
@@ -70,12 +63,7 @@ public class PublishKafkaIT extends AbstractPublishKafkaIT {
             assertEquals(1, records.count());
             final ConsumerRecord<String, String> record = records.iterator().next();
             assertEquals(TEST_KEY_VALUE, record.key());
-            assertEquals(TEST_RECORD_VALUE, record.value());
-            final List<Header> headers = Arrays.asList(record.headers().toArray());
-            assertEquals(1, headers.size());
-            final Header header = record.headers().iterator().next();
-            assertEquals("a1", header.key());
-            assertEquals("valueA1", new String(header.value(), StandardCharsets.UTF_8));
+            assertEquals(TEST_VALUE, record.value());
         }
     }
 }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaRecordIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaRecordIT.java
@@ -46,6 +46,7 @@ public class PublishKafkaRecordIT extends AbstractPublishKafkaIT {
     private static final String TEST_RESOURCE = "org/apache/nifi/kafka/processors/publish/ff.json";
 
     private static final String KEY_ATTRIBUTE_KEY = "keyAttribute";
+    private static final String KEY_ATTRIBUTE_KEY_EL = "${keyAttribute}";
     private static final String KEY_ATTRIBUTE_VALUE = "keyAttributeValue";
 
     private static final int TEST_RECORD_COUNT = 3;
@@ -59,7 +60,7 @@ public class PublishKafkaRecordIT extends AbstractPublishKafkaIT {
         addRecordWriterService(runner);
 
         runner.setProperty(PublishKafka.TOPIC_NAME, getClass().getName());
-        runner.setProperty(PublishKafka.KAFKA_KEY, KEY_ATTRIBUTE_KEY);
+        runner.setProperty(PublishKafka.KAFKA_KEY, KEY_ATTRIBUTE_KEY_EL);
         runner.setProperty(PublishKafka.ATTRIBUTE_HEADER_PATTERN, "a.*");
 
         final Map<String, String> attributes = new HashMap<>();

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaTombstoneIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaTombstoneIT.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class PublishKafkaTombstoneIT extends AbstractPublishKafkaIT {
     private static final String TEST_KEY_ATTRIBUTE = "my-key";
+    private static final String TEST_KEY_ATTRIBUTE_EL = "${my-key}";
     private static final String TEST_KEY_VALUE = "some-key-value";
     private static final byte[] TEST_RECORD_VALUE = new byte[0];
 
@@ -51,7 +52,7 @@ public class PublishKafkaTombstoneIT extends AbstractPublishKafkaIT {
         runner.setProperty(PublishKafka.CONNECTION_SERVICE, addKafkaConnectionService(runner));
         runner.setProperty(PublishKafka.TOPIC_NAME, getClass().getName());
         runner.setProperty(PublishKafka.ATTRIBUTE_HEADER_PATTERN, "a.*");
-        runner.setProperty(PublishKafka.KAFKA_KEY, TEST_KEY_ATTRIBUTE);
+        runner.setProperty(PublishKafka.KAFKA_KEY, TEST_KEY_ATTRIBUTE_EL);
 
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("a1", "valueA1");

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/producer/key/AttributeKeyFactoryTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/producer/key/AttributeKeyFactoryTest.java
@@ -16,12 +16,15 @@
  */
 package org.apache.nifi.kafka.processors.producer.key;
 
+import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.serialization.SimpleRecordSchema;
 import org.apache.nifi.serialization.record.MapRecord;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.MockPropertyValue;
 import org.junit.jupiter.api.Test;
 
 import java.io.UnsupportedEncodingException;
@@ -31,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class AttributeKeyFactoryTest {
@@ -39,8 +43,9 @@ public class AttributeKeyFactoryTest {
     void testNullKeyAttribute() throws UnsupportedEncodingException {
         final Map<String, String> attributes = new HashMap<>();
         final Record record = fabricateRecord();
+        final PropertyValue propertyValue = new MockPropertyValue(null);
 
-        final AttributeKeyFactory attributeKeyFactory = new AttributeKeyFactory(null, null);
+        final AttributeKeyFactory attributeKeyFactory = new AttributeKeyFactory(null, propertyValue, null);
         assertNull(attributeKeyFactory.getKey(attributes, record));
     }
 
@@ -48,9 +53,12 @@ public class AttributeKeyFactoryTest {
     void testNullKeyAttributeValue() throws UnsupportedEncodingException {
         final Map<String, String> attributes = new HashMap<>();
         final Record record = fabricateRecord();
+        final MockFlowFile flowFile = new MockFlowFile(1L);
+        flowFile.putAttributes(attributes);
+        final PropertyValue propertyValue = new MockPropertyValue("${A}");
 
-        final AttributeKeyFactory attributeKeyFactory = new AttributeKeyFactory("A", null);
-        assertNull(attributeKeyFactory.getKey(attributes, record));
+        final AttributeKeyFactory attributeKeyFactory = new AttributeKeyFactory(flowFile, propertyValue, null);
+        assertEquals("".length(), attributeKeyFactory.getKey(attributes, record).length);
     }
 
     @Test
@@ -59,8 +67,11 @@ public class AttributeKeyFactoryTest {
         attributes.put("A", "valueA");
         attributes.put("B", "valueB");
         final Record record = fabricateRecord();
+        final MockFlowFile flowFile = new MockFlowFile(1L);
+        flowFile.putAttributes(attributes);
+        final PropertyValue propertyValue = new MockPropertyValue("${A}");
 
-        final AttributeKeyFactory attributeKeyFactory = new AttributeKeyFactory("A", null);
+        final AttributeKeyFactory attributeKeyFactory = new AttributeKeyFactory(flowFile, propertyValue, null);
         assertArrayEquals("valueA".getBytes(StandardCharsets.UTF_8), attributeKeyFactory.getKey(attributes, record));
     }
 


### PR DESCRIPTION
The JIRA notes a difference in the handling of the `kafka.key` setting in the new `PublishKafka` processor, when
compared to the deprecated `PublishKafka_2_6` processor.

* as expression language is noted as supported in the component property, the code should honor that
* the expression language resolved value should be used as is, rather than as a lookup into the FlowFile attribute set

There were a couple of other component properties that employ the expression language evaluation, so those
PropertyDescriptors have been updated to reflect the code usage.

As NiFi 2.0 was released in October 2024, there might be significant uptake of the processor (with its incompatible behavior).  Weighing this against the compatibility expectations of the community, this seems like the best path forward, but it is also a reasonable point of discussion.


# Summary

[NIFI-14470](https://issues.apache.org/jira/browse/NIFI-14470)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
