### PR TITLE
NIFI-14497: Restore support for ExpressionLanguageScope to InvokeScriptedProcessor

### DIFF
--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
@@ -63,8 +63,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-extension-manifest-model</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <artifactId>nifi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.ivy</groupId>

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>nifi-record-sink-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-extension-manifest-model</artifactId>
+            <version>2.4.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.ivy</groupId>
             <artifactId>ivy</artifactId>
             <version>2.5.3</version>

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/groovy/test_reader.groovy
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/test/resources/groovy/test_reader.groovy
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.apache.nifi.expression.ExpressionLanguageScope
+
 class GroovyProcessor implements Processor {
 
     def REL_TEST = new Relationship.Builder()
@@ -22,7 +24,10 @@ class GroovyProcessor implements Processor {
             .build();
 
     def descriptor = new PropertyDescriptor.Builder()
-            .name("test-attribute").addValidator(StandardValidators.NON_EMPTY_VALIDATOR).build()
+            .name("test-attribute")
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .build()
 
     def logger
 


### PR DESCRIPTION
# Summary

[NIFI-14497](https://issues.apache.org/jira/browse/NIFI-14497) This PR restores support for ExpressionLanguageScope to InvokeScriptedProcessor by including `nifi-extension-manifest-model` as a dependency. Unit tests were updated to exercise this

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
