### PR TITLE
NIFI-14499 - Override httpclient5 5.4.1 from calcite-core

### DIFF
--- a/nifi-commons/nifi-calcite-utils/pom.xml
+++ b/nifi-commons/nifi-calcite-utils/pom.xml
@@ -71,6 +71,12 @@
             <artifactId>protobuf-java</artifactId>
             <version>3.25.6</version>
         </dependency>
+        <!-- Override httpclient5 5.4.1 from calcite-core -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.4.4</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -203,6 +203,12 @@
                 <artifactId>commons-compiler</artifactId>
                 <version>3.1.12</version>
             </dependency>
+            <!-- Override httpclient5 5.4.1 from calcite-core -->
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>5.4.4</version>
+            </dependency>
             <dependency>
                 <groupId>org.codehaus.janino</groupId>
                 <artifactId>janino</artifactId>


### PR DESCRIPTION
# Summary

[NIFI-14499](https://issues.apache.org/jira/browse/NIFI-14499) - Override httpclient5 5.4.1 from calcite-core

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
