### PR TITLE
NIFI-14504 Fix Record Field Conversion from Array to String

### DIFF
--- a/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverter.java
+++ b/nifi-commons/nifi-record/src/main/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverter.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
 
@@ -98,14 +99,19 @@ class ObjectStringFieldConverter implements FieldConverter<Object, String> {
             }
             case Object[] objectArray -> {
                 if (objectArray.length > 0) {
-                    final byte[] converted = new byte[objectArray.length];
-                    for (int i = 0; i < objectArray.length; i++) {
-                        converted[i] = (byte) objectArray[i];
+                    final Object firstElement = objectArray[0];
+
+                    if (firstElement instanceof Byte) {
+                        final byte[] converted = new byte[objectArray.length];
+                        for (int i = 0; i < objectArray.length; i++) {
+                            converted[i] = (byte) objectArray[i];
+                        }
+                        return new String(converted, StandardCharsets.UTF_8);
+                    } else {
+                        return Arrays.toString(objectArray);
                     }
-                    return new String(converted, StandardCharsets.UTF_8);
                 } else {
-                    // Handle an empty array as an empty string
-                    return "";
+                    return Arrays.toString(objectArray);
                 }
             }
             default -> {

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverterTest.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/field/ObjectStringFieldConverterTest.java
@@ -46,7 +46,11 @@ class ObjectStringFieldConverterTest {
 
     private static final String DATE_TIME_ZONE_OFFSET_PATTERN = "yyyy-MM-dd HH:mm:ssZZZZZ";
 
-    private static final String EMPTY_STRING = "";
+    private static final String EMPTY_ARRAY_STRING = "[]";
+
+    private static final String ARRAY_STRING_ELEMENT = String.class.getSimpleName();
+
+    private static final String ARRAY_STRING = "[String, String, String]";
 
     @Test
     void testConvertFieldNull() {
@@ -124,7 +128,7 @@ class ObjectStringFieldConverterTest {
     }
 
     @Test
-    void testConvertFieldObjectArray() {
+    void testConvertFieldObjectArrayOfBytes() {
         final String expected = String.class.getSimpleName();
         final byte[] bytes = expected.getBytes(StandardCharsets.UTF_8);
 
@@ -138,11 +142,20 @@ class ObjectStringFieldConverterTest {
     }
 
     @Test
+    void testConvertFieldObjectArrayOfStrings() {
+        final Object[] objectArray = new Object[]{ARRAY_STRING_ELEMENT, ARRAY_STRING_ELEMENT, ARRAY_STRING_ELEMENT};
+
+        final String string = CONVERTER.convertField(objectArray, Optional.empty(), FIELD_NAME);
+
+        assertEquals(ARRAY_STRING, string);
+    }
+
+    @Test
     void testConvertFieldObjectArrayEmpty() {
         final Object[] objectArray = new Object[0];
 
         final String string = CONVERTER.convertField(objectArray, Optional.empty(), FIELD_NAME);
-        assertEquals(EMPTY_STRING, string);
+        assertEquals(EMPTY_ARRAY_STRING, string);
     }
 
     private String getDateTimeZoneOffset() {

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
@@ -760,6 +760,35 @@ class TestJsonTreeRowRecordReader {
     }
 
     @Test
+    public void testArrayOfStringsToString() throws Exception {
+        final String inputJson = """
+            [{
+              "labels": [
+                "first", "second", "third"
+              ]
+            }]""";
+
+        final String labelsFieldName = "labels";
+        final RecordSchema recordSchema = new SimpleRecordSchema(List.of(
+                new RecordField(labelsFieldName, RecordFieldType.STRING.getDataType())
+        ));
+
+        final StringBuilder labelsRead = new StringBuilder();
+        try (final InputStream in = new ByteArrayInputStream(inputJson.getBytes(StandardCharsets.UTF_8));
+             final JsonTreeRowRecordReader reader = createJsonTreeRowRecordReader(in, recordSchema, dateFormat, timeFormat, timestampFormat,
+                     StartingFieldStrategy.ROOT_NODE, null, SchemaApplicationStrategy.SELECTED_PART, null, false, null)
+        ) {
+            final Record record = reader.nextRecord();
+            assertNotNull(record, "Record not found");
+
+            final String labels = record.getAsString(labelsFieldName);
+            labelsRead.append(labels);
+        }
+
+        assertEquals("[first, second, third]", labelsRead.toString());
+    }
+
+    @Test
     public void testMultipleInputRecordsWithStartingFieldSingleObject() throws Exception {
         final String inputJson = """
             {"book": {"id": 1,"title": "Book 1"}}


### PR DESCRIPTION
# Summary

[NIFI-14504](https://issues.apache.org/jira/browse/NIFI-14504) Fixes Record field conversion from an array of Objects to a String for JSON Record processing.

[NIFI-14496](https://issues.apache.org/jira/browse/NIFI-14496) Updated field conversion for an array of Java Objects to String, casting each array element to a `byte` primitive for conversion to a String. This change results in a `ClassCastException` when attempting to convert an array of other typed Objects to a String through the `JsonTreeReader`.

The updated conversion process checks the type of the first array element, retaining the `byte` array to String conversion, and handling other types using `java.util.Arrays.toString()`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
