### PR TITLE
NIFI-14505 - Fix migrate properties in JettyWebSocketClient

### DIFF
--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketClient.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketClient.java
@@ -49,6 +49,7 @@ import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 
 import javax.net.ssl.SSLContext;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -220,7 +221,7 @@ public class JettyWebSocketClient extends AbstractJettyWebSocketService implemen
         propertyConfiguration.renameProperty("websocket-uri", WS_URI.getName());
         propertyConfiguration.renameProperty("ssl-context-service", SSL_CONTEXT_SERVICE.getName());
         propertyConfiguration.renameProperty("connection-timeout", CONNECTION_TIMEOUT.getName());
-        propertyConfiguration.renameProperty("connection-attempt-count", CONNECTION_ATTEMPT_COUNT.getName());
+        propertyConfiguration.renameProperty("connection-attempt-timeout", CONNECTION_ATTEMPT_COUNT.getName());
         propertyConfiguration.renameProperty("session-maintenance-interval", SESSION_MAINTENANCE_INTERVAL.getName());
         propertyConfiguration.renameProperty("user-name", USER_NAME.getName());
         propertyConfiguration.renameProperty("user-password", USER_PASSWORD.getName());


### PR DESCRIPTION
# Summary

[NIFI-14505](https://issues.apache.org/jira/browse/NIFI-14505) - Fix migrate properties in JettyWebSocketClient

See: https://github.com/apache/nifi/commit/87800b0a3684f051cbde043afca93373220cf1f3#diff-fb3881e91ff195e7fd700d9de72815d39d7d191d70e913ffb968ca7f8e882c64L111

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
