### PR TITLE
NIFI-13531 ExecuteSQLRecord not honouring FlowFile attributes for con…

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-mock-record-utils/src/main/java/org/apache/nifi/serialization/record/MockCsvRecordWriter.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-mock-record-utils/src/main/java/org/apache/nifi/serialization/record/MockCsvRecordWriter.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.serialization.record;
+
+import org.apache.nifi.serialization.RecordSetWriterFactory;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * {@code MockCsvRecordWriter} is a concrete implementation of a {@link RecordSetWriterFactory}
+ * that produces CSV-formatted output. It extends the {@link MockRecordWriter} and provides a
+ * fluent {@link Builder} to configure properties such as header inclusion, value quoting,
+ * output buffering, and schema specification.
+ * <p>
+ * This class is suitable for use in testing scenarios or simple serialization tasks where
+ * CSV output is needed and full schema compliance is not required.
+ *
+ * <p><strong>Example usage:</strong></p>
+ * <pre>{@code
+ * RecordSchema schema = ...; // define schema as needed
+ * MockCsvRecordWriter writer = MockCsvRecordWriter.builder()
+ *     .withHeader("id,name,age")
+ *     .quoteValues(true)
+ *     .bufferOutput(true)
+ *     .withSchema(schema)
+ *     .withSeparator(attributes -> attributes.getOrDefault("csv.separator", ","))
+ *     .build();
+ * }</pre>
+ */
+public final class MockCsvRecordWriter extends MockRecordWriter {
+
+    /**
+     * Returns a new {@link Builder} instance for constructing a {@code MockCsvRecordWriter}.
+     *
+     * @return builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Constructs a MockCsvRecordWriter with the specified configuration.
+     *
+     * @param header optional CSV header line (e.g., "id,name,age"), may be {@code null}
+     * @param quoteValues whether to quote individual field values (useful for text fields)
+     * @param failAfterN if positive, causes writer to throw IOException after writing N records (used in testing)
+     * @param bufferOutput whether to wrap output stream in a {@link java.io.BufferedOutputStream}
+     * @param schema optional {@link RecordSchema} used for field name and type resolution
+     * @param mapToSeparator a function to dynamically resolve the field separator based on FlowFile attributes
+     */
+    private MockCsvRecordWriter(
+            String header,
+            boolean quoteValues,
+            int failAfterN,
+            boolean bufferOutput,
+            RecordSchema schema,
+            Function<Map<String, String>, String> mapToSeparator) {
+        super(header, quoteValues, failAfterN, bufferOutput, schema, mapToSeparator);
+    }
+
+    /**
+     * Builder class for fluent construction of {@link MockCsvRecordWriter} instances.
+     */
+    public static class Builder {
+        private String header = null;
+        private boolean quoteValues = true;
+        private int failAfterN = -1;
+        private boolean bufferOutput = false;
+        private RecordSchema schema = null;
+        private Function<Map<String, String>, String> mapToSeparator = attributes -> DEFAULT_SEPARATOR;
+
+        private Builder() {
+        }
+
+        /**
+         * Specifies a header line to be written before the CSV data.
+         *
+         * @param header the header line (e.g., "id,name,age"); can be {@code null} to omit header
+         * @return the current {@code Builder} instance
+         */
+        public Builder withHeader(String header) {
+            this.header = header;
+            return this;
+        }
+
+        /**
+         * Specifies whether field values should be enclosed in double quotes.
+         *
+         * @param quoteValues {@code true} to quote values, {@code false} otherwise
+         * @return the current {@code Builder} instance
+         */
+        public Builder quoteValues(boolean quoteValues) {
+            this.quoteValues = quoteValues;
+            return this;
+        }
+
+        /**
+         * Configures the writer to throw an {@link java.io.IOException} after writing a given number of records.
+         * Primarily used for testing failure scenarios.
+         *
+         * @param failAfterN the number of records after which to fail; use -1 to disable
+         * @return the current {@code Builder} instance
+         */
+        public Builder failAfterN(int failAfterN) {
+            this.failAfterN = failAfterN;
+            return this;
+        }
+
+        /**
+         * Specifies whether the output stream should be wrapped in a {@link java.io.BufferedOutputStream}.
+         *
+         * @param bufferOutput {@code true} to enable buffering, {@code false} to write directly
+         * @return the current {@code Builder} instance
+         */
+        public Builder bufferOutput(boolean bufferOutput) {
+            this.bufferOutput = bufferOutput;
+            return this;
+        }
+
+        /**
+         * Sets the schema to be used for writing records.
+         *
+         * @param schema the {@link RecordSchema}; can be {@code null} if schema inference is acceptable
+         * @return the current {@code Builder} instance
+         */
+        public Builder withSchema(RecordSchema schema) {
+            this.schema = schema;
+            return this;
+        }
+
+        /**
+         * Specifies a function to dynamically resolve the field separator based on FlowFile attributes.
+         * <p><strong>Example usage:</strong></p>
+         * <pre>{@code
+         *     builder.withSeparator(attributes -> attributes.getOrDefault("csv.separator", ","));
+         * }</pre>
+         *
+         * @param mapToSeparator a function that maps FlowFile attributes to a separator string
+         * @return the current {@code Builder} instance
+         */
+        public Builder withSeparator(Function<Map<String, String>, String> mapToSeparator) {
+            this.mapToSeparator = mapToSeparator;
+            return this;
+        }
+
+
+        /**
+         * Constructs a new {@link MockCsvRecordWriter} instance using the configured parameters.
+         *
+         * @return a fully initialized {@link MockCsvRecordWriter}
+         */
+        public MockCsvRecordWriter build() {
+            return new MockCsvRecordWriter(header, quoteValues, failAfterN, bufferOutput, schema, mapToSeparator);
+        }
+    }
+}

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/RecordSqlWriter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/RecordSqlWriter.java
@@ -78,7 +78,7 @@ public class RecordSqlWriter implements SqlWriter {
         } catch (final SQLException | SchemaNotFoundException | IOException e) {
             throw new ProcessException(e);
         }
-        try (final RecordSetWriter resultSetWriter = recordSetWriterFactory.createWriter(logger, writeSchema, outputStream, Collections.emptyMap())) {
+        try (final RecordSetWriter resultSetWriter = recordSetWriterFactory.createWriter(logger, writeSchema, outputStream, originalAttributes)) {
             writeResultRef.set(resultSetWriter.write(recordSet));
             if (mimeType == null) {
                 mimeType = resultSetWriter.getMimeType();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteSQLRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestExecuteSQLRecord.java
@@ -31,6 +31,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.provenance.ProvenanceEventType;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.schema.access.SchemaAccessUtils;
+import org.apache.nifi.serialization.record.MockCsvRecordWriter;
 import org.apache.nifi.serialization.record.MockRecordWriter;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
@@ -178,6 +179,51 @@ public class TestExecuteSQLRecord {
     public void testAutoCommitTrue() throws InitializationException, ClassNotFoundException, SQLException, IOException {
         runner.setProperty(ExecuteSQL.AUTO_COMMIT, "true");
         invokeOnTriggerRecords(null, QUERY_WITHOUT_EL, true, null, false);
+    }
+
+    @Test
+    public void testFlowFileAttributeResolution() throws InitializationException, SQLException {
+        // remove previous test database, if any
+        final File dbLocation = new File(DB_LOCATION);
+        dbLocation.delete();
+
+        // load test data to database
+        final Connection con = ((DBCPService) runner.getControllerService("dbcp")).getConnection();
+        Statement stmt = con.createStatement();
+
+        try {
+            stmt.execute("drop table TEST_NULL_INT");
+        } catch (final SQLException ignored) {
+        }
+
+        stmt.execute("create table TEST_NULL_INT (id integer not null, val1 integer, val2 integer, constraint my_pk primary key (id))");
+
+        for (int i = 0; i < 2; i++) {
+            stmt.execute("insert into TEST_NULL_INT (id, val1, val2) VALUES (" + i + ", 1, 1)");
+        }
+
+        MockRecordWriter recordWriter = MockCsvRecordWriter.builder()
+                .withHeader("foo|bar|baz")
+                .quoteValues(false)
+                .withSeparator(attr -> attr.getOrDefault("csv.separator", ","))
+                .build();
+
+        runner.addControllerService("writer", recordWriter);
+        runner.setProperty(ExecuteSQLRecord.RECORD_WRITER_FACTORY, "writer");
+        runner.enableControllerService(recordWriter);
+
+        runner.setIncomingConnection(true);
+        runner.setProperty(ExecuteSQLRecord.SQL_QUERY, "SELECT * FROM TEST_NULL_INT");
+        runner.enqueue("", Map.of("csv.separator", "|"));
+        runner.run();
+
+        runner.assertAllFlowFilesTransferred(ExecuteSQLRecord.REL_SUCCESS, 1);
+        MockFlowFile out = runner.getFlowFilesForRelationship(ExecuteSQLRecord.REL_SUCCESS).getFirst();
+        out.assertContentEquals("""
+                foo|bar|baz
+                0|1|1
+                1|1|1
+                """);
     }
 
     @Test
@@ -463,7 +509,7 @@ public class TestExecuteSQLRecord {
             Object imageObj = avroRecord.get("IMAGE");
             assertNotNull(imageObj);
             assertInstanceOf(ByteBuffer.class, imageObj);
-            assertArrayEquals(new byte[] {(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF}, ((ByteBuffer) imageObj).array());
+            assertArrayEquals(new byte[]{(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF}, ((ByteBuffer) imageObj).array());
 
             Object wordsObj = avroRecord.get("WORDS");
             assertNotNull(wordsObj);


### PR DESCRIPTION
…figured RecordWriter.

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-13531](https://issues.apache.org/jira/browse/NIFI-13531)

These are the following changes:

- New MockCsvRecordWriter utility class with a fluent builder and an option to configure a dynamic separator.
- Changes to existing MockRecordWriter class to support dynamic separators.
- Bugfix in the RecordSqlWriter class that was providing an empty Map instead of the original attributes when constructing a RecordSetWriter.

One thing to note here is that this could (in theory) break some existing flows if the users are aware of the issue and made some workarounds for it. This is in fact a breaking change if the users are not relying on this behavior.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
- [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
