### PR TITLE
NIFI-14511 Updated additionalDetails.md to indicate when coercing an Excel number to a string for large numbers will result in a string representation of the number in scientific notation.

### DIFF
--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/resources/docs/org.apache.nifi.excel.ExcelReader/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/resources/docs/org.apache.nifi.excel.ExcelReader/additionalDetails.md
@@ -36,7 +36,7 @@ type, an Exception will be thrown.
 
 The following rules apply when attempting to coerce a field value from one data type to another:
 
-* Any data type can be coerced into a String type. Please note Excel stores all numbers as a double. A large number coerced to a string will result in a string representation of the number in scientific notation. If this is not desired, then coerce the number to a long numeric type.
+* Any data type can be coerced into a String type. Please note Excel stores all numbers as a Double. A large number coerced to a String will result in a string representation of the number in scientific notation. If this is not desired, then coerce the number to a Long numeric type.
 * Any numeric data type (Byte, Short, Int, Long, Float, Double) can be coerced into any other numeric data type.
 * Any numeric value can be coerced into a Date, Time, or Timestamp type, by assuming that the Long value is the number
   of milliseconds since epoch (Midnight GMT, January 1, 1970).

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/resources/docs/org.apache.nifi.excel.ExcelReader/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/resources/docs/org.apache.nifi.excel.ExcelReader/additionalDetails.md
@@ -36,7 +36,7 @@ type, an Exception will be thrown.
 
 The following rules apply when attempting to coerce a field value from one data type to another:
 
-* Any data type can be coerced into a String type.
+* Any data type can be coerced into a String type. Please note Excel stores all numbers as a double. A large number coerced to a string will result in a string representation of the number in scientific notation. If this is not desired, then coerce the number to a long numeric type.
 * Any numeric data type (Byte, Short, Int, Long, Float, Double) can be coerced into any other numeric data type.
 * Any numeric value can be coerced into a Date, Time, or Timestamp type, by assuming that the Long value is the number
   of milliseconds since epoch (Midnight GMT, January 1, 1970).

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/resources/docs/org.apache.nifi.excel.ExcelReader/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/resources/docs/org.apache.nifi.excel.ExcelReader/additionalDetails.md
@@ -36,8 +36,8 @@ type, an Exception will be thrown.
 
 The following rules apply when attempting to coerce a field value from one data type to another:
 
-* Any data type can be coerced into a String type. Please note Excel stores all numbers as a Double. A large number coerced to a String will result in a string representation of the number in scientific notation. If this is not desired, then coerce the number to a Long numeric type.
-* Any numeric data type (Byte, Short, Int, Long, Float, Double) can be coerced into any other numeric data type.
+* Excel stores all numeric types as a Double which can be coerced to any other numeric data type (Byte, Short, Int, Long, Float).
+* Any data type can be coerced into a String type. Please note since Excel stores all numbers as a Double, a large number coerced to a String will result in a string representation of the number in scientific notation. If this is not desired, then coerce the number to a Long numeric type.
 * Any numeric value can be coerced into a Date, Time, or Timestamp type, by assuming that the Long value is the number
   of milliseconds since epoch (Midnight GMT, January 1, 1970).
 * A String value can be coerced into a Date, Time, or Timestamp type, if its format matches the configured "Date

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelRecordReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelRecordReader.java
@@ -361,8 +361,9 @@ public class TestExcelRecordReader {
         final ExcelRecordReader recordReader = new ExcelRecordReader(configuration, workbook, logger);
         final List<Record> records = getRecords(recordReader, true, true);
         final Record firstRecord = records.getFirst();
+        final String scientificNotationNumber = "9.87654321E9";
 
-        assertEquals("9.87654321E9", firstRecord.getAsString(fieldName));
+        assertEquals(scientificNotationNumber, firstRecord.getAsString(fieldName));
     }
 
     private static InputStream createWorkbook(Object[][] data) throws Exception {

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelRecordReader.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelRecordReader.java
@@ -349,6 +349,22 @@ public class TestExcelRecordReader {
         assertDoesNotThrow(() -> getRecords(recordReader, true, true));
     }
 
+    @Test
+    void testWhereLongSpecifiedInSchemaAsString() throws Exception {
+        final String fieldName = "Phone";
+        final RecordSchema schema = new SimpleRecordSchema(List.of(new RecordField(fieldName, RecordFieldType.STRING.getDataType())));
+        final ExcelRecordReaderConfiguration configuration = new ExcelRecordReaderConfiguration.Builder()
+                .withSchema(schema)
+                .build();
+        final Object[][] data = {{9876543210L}};
+        final InputStream workbook = createWorkbook(data);
+        final ExcelRecordReader recordReader = new ExcelRecordReader(configuration, workbook, logger);
+        final List<Record> records = getRecords(recordReader, true, true);
+        final Record firstRecord = records.getFirst();
+
+        assertEquals("9.87654321E9", firstRecord.getAsString(fieldName));
+    }
+
     private static InputStream createWorkbook(Object[][] data) throws Exception {
         final ByteArrayOutputStream workbookOutputStream = new ByteArrayOutputStream();
         try (XSSFWorkbook workbook = new XSSFWorkbook()) {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14511](https://issues.apache.org/jira/browse/NIFI-14511)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
