### PR TITLE
NIFI-14541 Add Scoped Authorization for Flow Registry Clients

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/main/java/org/apache/nifi/authorization/resource/ResourceFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/main/java/org/apache/nifi/authorization/resource/ResourceFactory.java
@@ -553,6 +553,7 @@ public final class ResourceFactory {
                     case InputPort -> "Input Port";
                     case OutputPort -> "Output Port";
                     case Processor -> "Processor";
+                    case RegistryClient -> "Registry Client";
                     case RemoteProcessGroup -> "Remote Process Group";
                     case ReportingTask -> "Reporting Task";
                     case FlowAnalysisRule -> "Flow Analysis Rule";

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/main/java/org/apache/nifi/authorization/resource/ResourceType.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/main/java/org/apache/nifi/authorization/resource/ResourceType.java
@@ -35,6 +35,7 @@ public enum ResourceType {
     RemoteProcessGroup("/remote-process-groups"),
     ReportingTask("/reporting-tasks"),
     FlowAnalysisRule("/controller/flow-analysis-rules"),
+    RegistryClient("/controller/registry-clients"),
     Resource("/resources"),
     SiteToSite("/site-to-site"),
     DataTransfer("/data-transfer"),

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardFlowRegistryClientNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/registry/flow/StandardFlowRegistryClientNode.java
@@ -99,7 +99,7 @@ public final class StandardFlowRegistryClientNode extends AbstractComponentNode 
 
     @Override
     public Resource getResource() {
-        return ResourceFactory.getComponentResource(ResourceType.Controller, getIdentifier(), getName());
+        return ResourceFactory.getComponentResource(ResourceType.RegistryClient, getIdentifier(), getName());
     }
 
     @Override

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/StandardAuthorizableLookup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/StandardAuthorizableLookup.java
@@ -644,6 +644,9 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
             case ProcessGroup:
                 authorizable = getProcessGroup(componentId).getAuthorizable();
                 break;
+            case RegistryClient:
+                authorizable = getFlowRegistryClient(componentId).getAuthorizable();
+                break;
             case RemoteProcessGroup:
                 authorizable = getRemoteProcessGroup(componentId);
                 break;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ControllerResource.java
@@ -1443,7 +1443,7 @@ public class ControllerResource extends ApplicationResource {
                     @ApiResponse(responseCode = "409", description = "The request was valid but NiFi was not in the appropriate state to process it.")
             },
             security = {
-                    @SecurityRequirement(name = "Read - /flow")
+                    @SecurityRequirement(name = "Read - /controller")
             }
     )
     public Response getFlowRegistryClients() {
@@ -1481,6 +1481,7 @@ public class ControllerResource extends ApplicationResource {
                     @ApiResponse(responseCode = "409", description = "The request was valid but NiFi was not in the appropriate state to process it.")
             },
             security = {
+                    @SecurityRequirement(name = "Read - /controller"),
                     @SecurityRequirement(name = "Write - /controller")
             }
     )
@@ -1569,7 +1570,7 @@ public class ControllerResource extends ApplicationResource {
                     @ApiResponse(responseCode = "409", description = "The request was valid but NiFi was not in the appropriate state to process it.")
             },
             security = {
-                    @SecurityRequirement(name = "Read - /controller")
+                    @SecurityRequirement(name = "Read - /controller/registry-clients/{id}")
             }
     )
     public Response getFlowRegistryClient(
@@ -1584,7 +1585,10 @@ public class ControllerResource extends ApplicationResource {
         }
 
         // authorize access
-        authorizeController(RequestAction.READ);
+        serviceFacade.authorizeAccess(lookup -> {
+            final Authorizable authorizable = lookup.getFlowRegistryClient(id).getAuthorizable();
+            authorizable.authorize(authorizer, RequestAction.READ, NiFiUserUtils.getNiFiUser());
+        });
 
         // get the flow registry client
         final FlowRegistryClientEntity entity = serviceFacade.getRegistryClient(id);
@@ -1613,7 +1617,7 @@ public class ControllerResource extends ApplicationResource {
                     @ApiResponse(responseCode = "409", description = "The request was valid but NiFi was not in the appropriate state to process it.")
             },
             security = {
-                    @SecurityRequirement(name = "Write - /controller")
+                    @SecurityRequirement(name = "Write - /controller/registry-clients/{id}")
             }
     )
     public Response updateFlowRegistryClient(
@@ -1635,8 +1639,11 @@ public class ControllerResource extends ApplicationResource {
             throw new IllegalArgumentException("Revision must be specified.");
         }
 
-        // authorize access
-        authorizeController(RequestAction.WRITE);
+        // Authorize Read before Write Action
+        serviceFacade.authorizeAccess(lookup -> {
+            final Authorizable authorizable = lookup.getFlowRegistryClient(id).getAuthorizable();
+            authorizable.authorize(authorizer, RequestAction.READ, NiFiUserUtils.getNiFiUser());
+        });
 
         // ensure the ids are the same
         final FlowRegistryClientDTO requestRegistryClient = requestFlowRegistryClientEntity.getComponent();
@@ -1662,7 +1669,8 @@ public class ControllerResource extends ApplicationResource {
                 requestFlowRegistryClientEntity,
                 requestRevision,
                 lookup -> {
-                    authorizeController(RequestAction.WRITE);
+                    final Authorizable authorizable = lookup.getFlowRegistryClient(id).getAuthorizable();
+                    authorizable.authorize(authorizer, RequestAction.WRITE, NiFiUserUtils.getNiFiUser());
                 },
                 null,
                 (revision, registryClientEntity) -> {
@@ -1702,7 +1710,7 @@ public class ControllerResource extends ApplicationResource {
                     @ApiResponse(responseCode = "409", description = "The request was valid but NiFi was not in the appropriate state to process it.")
             },
             security = {
-                    @SecurityRequirement(name = "Write - /controller")
+                    @SecurityRequirement(name = "Write - /controller/registry-clients/{id}")
             }
     )
     public Response deleteFlowRegistryClient(
@@ -1731,7 +1739,10 @@ public class ControllerResource extends ApplicationResource {
         }
 
         // authorize access
-        authorizeController(RequestAction.WRITE);
+        serviceFacade.authorizeAccess(lookup -> {
+            final Authorizable authorizable = lookup.getFlowRegistryClient(id).getAuthorizable();
+            authorizable.authorize(authorizer, RequestAction.WRITE, NiFiUserUtils.getNiFiUser());
+        });
 
         final FlowRegistryClientEntity requestFlowRegistryClientEntity = new FlowRegistryClientEntity();
         requestFlowRegistryClientEntity.setId(id);
@@ -1743,7 +1754,8 @@ public class ControllerResource extends ApplicationResource {
                 requestFlowRegistryClientEntity,
                 requestRevision,
                 lookup -> {
-                    authorizeController(RequestAction.WRITE);
+                    final Authorizable authorizable = lookup.getFlowRegistryClient(id).getAuthorizable();
+                    authorizable.authorize(authorizer, RequestAction.WRITE, NiFiUserUtils.getNiFiUser());
                 },
                 () -> serviceFacade.verifyDeleteRegistry(id),
                 (revision, registryClientEntity) -> {
@@ -1776,7 +1788,7 @@ public class ControllerResource extends ApplicationResource {
                     @ApiResponse(responseCode = "409", description = "The request was valid but NiFi was not in the appropriate state to process it.")
             },
             security = {
-                    @SecurityRequirement(name = "Read - /controller/registry-clients/{uuid}")
+                    @SecurityRequirement(name = "Read - /controller/registry-clients/{id}")
             }
     )
     public Response getPropertyDescriptor(
@@ -1804,7 +1816,10 @@ public class ControllerResource extends ApplicationResource {
         }
 
         // authorize access
-        authorizeController(RequestAction.READ);
+        serviceFacade.authorizeAccess(lookup -> {
+            final Authorizable authorizable = lookup.getFlowRegistryClient(id).getAuthorizable();
+            authorizable.authorize(authorizer, RequestAction.READ, NiFiUserUtils.getNiFiUser());
+        });
 
         // get the property descriptor
         final PropertyDescriptorDTO descriptor = serviceFacade.getRegistryClientPropertyDescriptor(id, propertyName, sensitive);
@@ -1837,7 +1852,7 @@ public class ControllerResource extends ApplicationResource {
                     @ApiResponse(responseCode = "409", description = "The request was valid but NiFi was not in the appropriate state to process it.")
             },
             security = {
-                    @SecurityRequirement(name = "Read - /flow")
+                    @SecurityRequirement(name = "Read - /controller")
             }
     )
     public Response getRegistryClientTypes() {


### PR DESCRIPTION
# Summary

[NIFI-14541](https://issues.apache.org/jira/browse/NIFI-14541) Adds scoped authorization for listing, adding, modifying, and removing Flow Registry Clients.

The changes are compatible with existing authorization policies based on the read and write access to the Controller resource. Introducing a new Registry Client Resource Type aligns with other component authorization, and enables authorization checking for operations on Flow Registry Clients nested under the Controller resource.

The `StandardFlowRegistryClientNode` already returns the Controller resource as the parent authorizable object, supporting nested authorization checking.

Enabling the standard Managed Authorizer and configuring a Flow Registry Client exercises new authorization checking against existing policies at the Controller level.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
