### PR TITLE
NIFI-14542 Remove System.getProperty() from FetchFile Description

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/FetchFile.java
@@ -170,7 +170,7 @@ public class FetchFile extends AbstractProcessor {
         .build();
     static final PropertyDescriptor PERM_DENIED_LOG_LEVEL = new PropertyDescriptor.Builder()
         .name("Log level when permission denied")
-        .description("Log level to use in case user " + System.getProperty("user.name") + " does not have sufficient permissions to read the file")
+        .description("Log level to use if the current application user does not have sufficient permissions to read the file")
         .allowableValues(LogLevel.values())
         .defaultValue(LogLevel.ERROR.toString())
         .required(true)


### PR DESCRIPTION
# Summary

[NIFI-14542](https://issues.apache.org/jira/browse/NIFI-14542) Removes `System.getProperty("user.name")` from description of the `Log level when permission denied` property in the `FetchFile` Processor.

Using `System.getProperty()` in the property description results in reflecting the build username in the Runtime Manifest property description, breaking reproducible builds and unnecessarily associating the Runtime Manifest with the build user.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
