### PR TITLE
NIFI-14545 Remove casting for PublishKafka to BufferedInputStream

### DIFF
--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaIT.java
@@ -20,11 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.header.Header;
-import org.apache.nifi.json.JsonRecordSetWriter;
-import org.apache.nifi.json.JsonTreeReader;
 import org.apache.nifi.reporting.InitializationException;
-import org.apache.nifi.schema.access.SchemaAccessUtils;
-import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.MethodOrderer;
@@ -32,16 +28,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Properties;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @TestMethodOrder(MethodOrderer.MethodName.class)
@@ -50,10 +42,6 @@ public class PublishKafkaIT extends AbstractPublishKafkaIT {
     private static final String TEST_KEY_ATTRIBUTE_EL = "${my-key}";
     private static final String TEST_KEY_VALUE = "some-key-value";
     private static final String TEST_RECORD_VALUE = "value-" + System.currentTimeMillis();
-
-    private static final int EXPECTED_RECORD_COUNT = 20000; // Expect 20,000 records
-    private static final int MAX_MESSAGE_SIZE = 2 * 1024 * 1024; // 2MB
-    private static final byte[] LARGE_SAMPLE_INPUT = new byte[MAX_MESSAGE_SIZE];
 
     @Test
     public void test_1_KafkaTestContainerProduceOne() throws InitializationException {
@@ -89,90 +77,5 @@ public class PublishKafkaIT extends AbstractPublishKafkaIT {
             assertEquals("a1", header.key());
             assertEquals("valueA1", new String(header.value(), StandardCharsets.UTF_8));
         }
-    }
-
-    @Test
-    public void test_3_KafkaTestContainerProduceOneLargeFlowFile() throws InitializationException {
-        final TestRunner runner = TestRunners.newTestRunner(PublishKafka.class);
-
-        final JsonTreeReader jsonTreeReader = new JsonTreeReader();
-
-        runner.addControllerService("jsonTreeReader", jsonTreeReader);
-        runner.setProperty(jsonTreeReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, "infer-schema");
-        runner.enableControllerService(jsonTreeReader);
-
-        final JsonRecordSetWriter jsonRecordSetWriter = new JsonRecordSetWriter();
-
-        runner.addControllerService("jsonRecordSetWriter", jsonRecordSetWriter);
-        runner.setProperty(jsonRecordSetWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.INHERIT_RECORD_SCHEMA);
-        runner.setProperty(jsonRecordSetWriter, "output-grouping", "output-oneline");
-        runner.enableControllerService(jsonRecordSetWriter);
-
-        runner.setValidateExpressionUsage(false);
-        runner.setProperty(PublishKafka.CONNECTION_SERVICE, addKafkaConnectionService(runner));
-        runner.setProperty(PublishKafka.TOPIC_NAME, getClass().getName());
-        runner.setProperty(PublishKafka.ATTRIBUTE_HEADER_PATTERN, "a.*");
-        runner.setProperty(PublishKafka.KAFKA_KEY, TEST_KEY_ATTRIBUTE_EL);
-        runner.setProperty(PublishKafka.RECORD_READER, "jsonTreeReader");
-        runner.setProperty(PublishKafka.RECORD_WRITER, "jsonRecordSetWriter");
-
-        final Map<String, String> attributes = new HashMap<>();
-        attributes.put("a1", "valueA1");
-        attributes.put("b1", "valueB1");
-        attributes.put(TEST_KEY_ATTRIBUTE, TEST_KEY_VALUE);
-
-        populateSampleInput();
-        runner.enqueue(LARGE_SAMPLE_INPUT, attributes);
-        runner.run();
-        runner.assertAllFlowFilesTransferred(PublishKafka.REL_SUCCESS, 1);
-
-        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PublishKafka.REL_SUCCESS).getFirst();
-        assertEquals(Integer.toString(EXPECTED_RECORD_COUNT), flowFile.getAttribute("msg.count"));
-    }
-
-    @Test
-    public void test_4_KafkaTestContainerConsumeLargeFlowFileBatch() {
-        final Properties kafkaConsumerProperties = getKafkaConsumerProperties();
-        kafkaConsumerProperties.setProperty(MAX_POLL_RECORDS_CONFIG, Integer.toString(EXPECTED_RECORD_COUNT * 2));
-
-        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(kafkaConsumerProperties)) {
-            consumer.subscribe(Collections.singletonList(getClass().getName()));
-
-            final List<ConsumerRecord<String, String>> records = new ArrayList<>();
-            for (int i = 0; (i < 5); ++i) {
-                final ConsumerRecords<String, String> recordsPoll = consumer.poll(Duration.ofSeconds(1));
-                recordsPoll.forEach(records::add);
-            }
-            assertEquals(EXPECTED_RECORD_COUNT, records.size());
-        }
-    }
-
-    // Create sample data with multiple records
-    private static void populateSampleInput() {
-        StringBuilder sb = new StringBuilder();
-        int recordCount = EXPECTED_RECORD_COUNT;
-        int approximateRecordSize = MAX_MESSAGE_SIZE / recordCount;
-
-        for (int i = 0; i < recordCount; i++) {
-            sb.append("{\"key\": \"").append(i).append("\",\"value\":\"");
-            int payloadSize = approximateRecordSize - 30;
-            for (int j = 0; j < payloadSize; j++) {
-                sb.append((char) ('A' + (j % 26)));
-            }
-            sb.append("\"}");
-            if (i < recordCount - 1) {
-                sb.append("\n");
-            }
-            if (sb.length() >= MAX_MESSAGE_SIZE - 100) {
-                break;
-            }
-        }
-
-        byte[] stringBytes = sb.toString().getBytes();
-
-        Arrays.fill(LARGE_SAMPLE_INPUT, (byte) ' '); // Fill with spaces instead of NULL
-
-        int copyLength = Math.min(stringBytes.length, LARGE_SAMPLE_INPUT.length);
-        System.arraycopy(stringBytes, 0, LARGE_SAMPLE_INPUT, 0, copyLength);
     }
 }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaIT.java
@@ -147,7 +147,7 @@ public class PublishKafkaIT extends AbstractPublishKafkaIT {
         }
     }
 
-    // Create 5MB of sample data with multiple records
+    // Create sample data with multiple records
     private static void populateSampleInput() {
         StringBuilder sb = new StringBuilder();
         int recordCount = EXPECTED_RECORD_COUNT;

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaIT.java
@@ -20,7 +20,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.header.Header;
+import org.apache.nifi.json.JsonRecordSetWriter;
+import org.apache.nifi.json.JsonTreeReader;
 import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.schema.access.SchemaAccessUtils;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.MethodOrderer;
@@ -42,6 +45,10 @@ public class PublishKafkaIT extends AbstractPublishKafkaIT {
     private static final String TEST_KEY_ATTRIBUTE_EL = "${my-key}";
     private static final String TEST_KEY_VALUE = "some-key-value";
     private static final String TEST_RECORD_VALUE = "value-" + System.currentTimeMillis();
+
+    private static final int EXPECTED_RECORD_COUNT = 50000; // Expect 50,000 records
+    private static final int MAX_MESSAGE_SIZE = 5 * 1024 * 1024; // 5MB
+    private static final byte[] LARGE_SAMPLE_INPUT = new byte[MAX_MESSAGE_SIZE];
 
     @Test
     public void test_1_KafkaTestContainerProduceOne() throws InitializationException {
@@ -77,5 +84,70 @@ public class PublishKafkaIT extends AbstractPublishKafkaIT {
             assertEquals("a1", header.key());
             assertEquals("valueA1", new String(header.value(), StandardCharsets.UTF_8));
         }
+    }
+
+    @Test
+    public void test_3_KafkaTestContainerProduceOneLargeFlowFile() throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(PublishKafka.class);
+
+        final JsonTreeReader jsonTreeReader = new JsonTreeReader();
+
+        runner.addControllerService("jsonTreeReader", jsonTreeReader);
+        runner.setProperty(jsonTreeReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, "infer-schema");
+        runner.enableControllerService(jsonTreeReader);
+
+        final JsonRecordSetWriter jsonRecordSetWriter = new JsonRecordSetWriter();
+
+        runner.addControllerService("jsonRecordSetWriter", jsonRecordSetWriter);
+        runner.setProperty(jsonRecordSetWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.INHERIT_RECORD_SCHEMA);
+        runner.setProperty(jsonRecordSetWriter, "output-grouping", "output-oneline");
+        runner.enableControllerService(jsonRecordSetWriter);
+
+        runner.setValidateExpressionUsage(false);
+        runner.setProperty(PublishKafka.CONNECTION_SERVICE, addKafkaConnectionService(runner));
+        runner.setProperty(PublishKafka.TOPIC_NAME, getClass().getName());
+        runner.setProperty(PublishKafka.ATTRIBUTE_HEADER_PATTERN, "a.*");
+        runner.setProperty(PublishKafka.KAFKA_KEY, TEST_KEY_ATTRIBUTE_EL);
+        runner.setProperty(PublishKafka.RECORD_READER, "jsonTreeReader");
+        runner.setProperty(PublishKafka.RECORD_WRITER, "jsonRecordSetWriter");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("a1", "valueA1");
+        attributes.put("b1", "valueB1");
+        attributes.put(TEST_KEY_ATTRIBUTE, TEST_KEY_VALUE);
+
+        populateSampleInput();
+        runner.enqueue(LARGE_SAMPLE_INPUT, attributes);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PublishKafka.REL_SUCCESS, 1);
+    }
+
+    // Create 5MB of sample data with multiple records
+    private static void populateSampleInput() {
+        StringBuilder sb = new StringBuilder();
+        int recordCount = EXPECTED_RECORD_COUNT;
+        int approximateRecordSize = MAX_MESSAGE_SIZE / recordCount;
+
+        for (int i = 0; i < recordCount; i++) {
+            sb.append("{\"key\": \"").append(i).append("\",\"value\":\"");
+            int payloadSize = approximateRecordSize - 30;
+            for (int j = 0; j < payloadSize; j++) {
+                sb.append((char) ('A' + (j % 26)));
+            }
+            sb.append("\"}");
+            if (i < recordCount - 1) {
+                sb.append("\n");
+            }
+            if (sb.length() >= MAX_MESSAGE_SIZE - 100) {
+                break;
+            }
+        }
+
+        byte[] stringBytes = sb.toString().getBytes();
+
+        Arrays.fill(LARGE_SAMPLE_INPUT, (byte) ' '); // Fill with spaces instead of NULL
+
+        int copyLength = Math.min(stringBytes.length, LARGE_SAMPLE_INPUT.length);
+        System.arraycopy(stringBytes, 0, LARGE_SAMPLE_INPUT, 0, copyLength);
     }
 }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaLargePayloadIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/PublishKafkaLargePayloadIT.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kafka.processors;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.nifi.json.JsonRecordSetWriter;
+import org.apache.nifi.json.JsonTreeReader;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.schema.access.SchemaAccessUtils;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class PublishKafkaLargePayloadIT extends AbstractPublishKafkaIT {
+    private static final String TEST_KEY_ATTRIBUTE = "my-key";
+    private static final String TEST_KEY_ATTRIBUTE_EL = "${my-key}";
+    private static final String TEST_KEY_VALUE = "some-key-value";
+
+    private static final int EXPECTED_RECORD_COUNT = 20000; // Expect 20,000 records
+    private static final int MAX_MESSAGE_SIZE = 2 * 1024 * 1024; // 2MB
+    private static final byte[] LARGE_SAMPLE_INPUT = new byte[MAX_MESSAGE_SIZE];
+
+    @Test
+    public void test_1_KafkaTestContainerProduceOneLargeFlowFile() throws InitializationException {
+        final TestRunner runner = TestRunners.newTestRunner(PublishKafka.class);
+
+        final JsonTreeReader jsonTreeReader = new JsonTreeReader();
+
+        runner.addControllerService("jsonTreeReader", jsonTreeReader);
+        runner.setProperty(jsonTreeReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, "infer-schema");
+        runner.enableControllerService(jsonTreeReader);
+
+        final JsonRecordSetWriter jsonRecordSetWriter = new JsonRecordSetWriter();
+
+        runner.addControllerService("jsonRecordSetWriter", jsonRecordSetWriter);
+        runner.setProperty(jsonRecordSetWriter, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaAccessUtils.INHERIT_RECORD_SCHEMA);
+        runner.setProperty(jsonRecordSetWriter, "output-grouping", "output-oneline");
+        runner.enableControllerService(jsonRecordSetWriter);
+
+        runner.setValidateExpressionUsage(false);
+        runner.setProperty(PublishKafka.CONNECTION_SERVICE, addKafkaConnectionService(runner));
+        runner.setProperty(PublishKafka.TOPIC_NAME, getClass().getName());
+        runner.setProperty(PublishKafka.ATTRIBUTE_HEADER_PATTERN, "a.*");
+        runner.setProperty(PublishKafka.KAFKA_KEY, TEST_KEY_ATTRIBUTE_EL);
+        runner.setProperty(PublishKafka.RECORD_READER, "jsonTreeReader");
+        runner.setProperty(PublishKafka.RECORD_WRITER, "jsonRecordSetWriter");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("a1", "valueA1");
+        attributes.put("b1", "valueB1");
+        attributes.put(TEST_KEY_ATTRIBUTE, TEST_KEY_VALUE);
+
+        populateSampleInput();
+        runner.enqueue(LARGE_SAMPLE_INPUT, attributes);
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PublishKafka.REL_SUCCESS, 1);
+
+        MockFlowFile flowFile = runner.getFlowFilesForRelationship(PublishKafka.REL_SUCCESS).getFirst();
+        assertEquals(Integer.toString(EXPECTED_RECORD_COUNT), flowFile.getAttribute("msg.count"));
+    }
+
+    @Test
+    public void test_2_KafkaTestContainerConsumeLargeFlowFileBatch() {
+        final Properties kafkaConsumerProperties = getKafkaConsumerProperties();
+        kafkaConsumerProperties.setProperty(MAX_POLL_RECORDS_CONFIG, Integer.toString(EXPECTED_RECORD_COUNT * 2));
+
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(kafkaConsumerProperties)) {
+            consumer.subscribe(Collections.singletonList(getClass().getName()));
+
+            final List<ConsumerRecord<String, String>> records = new ArrayList<>();
+            for (int i = 0; (i < 5); ++i) {
+                final ConsumerRecords<String, String> recordsPoll = consumer.poll(Duration.ofSeconds(1));
+                recordsPoll.forEach(records::add);
+            }
+            assertEquals(EXPECTED_RECORD_COUNT, records.size());
+        }
+    }
+
+    // Create sample data with multiple records
+    private static void populateSampleInput() {
+        StringBuilder sb = new StringBuilder();
+        int recordCount = EXPECTED_RECORD_COUNT;
+        int approximateRecordSize = MAX_MESSAGE_SIZE / recordCount;
+
+        for (int i = 0; i < recordCount; i++) {
+            sb.append("{\"key\": \"").append(i).append("\",\"value\":\"");
+            int payloadSize = approximateRecordSize - 30;
+            for (int j = 0; j < payloadSize; j++) {
+                sb.append((char) ('A' + (j % 26)));
+            }
+            sb.append("\"}");
+            if (i < recordCount - 1) {
+                sb.append("\n");
+            }
+            if (sb.length() >= MAX_MESSAGE_SIZE - 100) {
+                break;
+            }
+        }
+
+        byte[] stringBytes = sb.toString().getBytes();
+
+        Arrays.fill(LARGE_SAMPLE_INPUT, (byte) ' '); // Fill with spaces instead of NULL
+
+        int copyLength = Math.min(stringBytes.length, LARGE_SAMPLE_INPUT.length);
+        System.arraycopy(stringBytes, 0, LARGE_SAMPLE_INPUT, 0, copyLength);
+    }
+}

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/PublishKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/PublishKafka.java
@@ -610,7 +610,7 @@ public class PublishKafka extends AbstractProcessor implements KafkaPublishCompo
 
         @Override
         public void process(final InputStream in) {
-            try (final InputStream is = new BufferedInputStream(in)) {
+            try (final InputStream is = in) {
                 final Iterator<KafkaRecord> records = kafkaConverter.convert(attributes, is, inputLength);
                 producerService.send(records, publishContext);
             } catch (final Exception e) {

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/PublishKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/PublishKafka.java
@@ -609,8 +609,8 @@ public class PublishKafka extends AbstractProcessor implements KafkaPublishCompo
 
         @Override
         public void process(final InputStream in) {
-            try (final InputStream is = in) {
-                final Iterator<KafkaRecord> records = kafkaConverter.convert(attributes, is, inputLength);
+            try {
+                final Iterator<KafkaRecord> records = kafkaConverter.convert(attributes, in, inputLength);
                 producerService.send(records, publishContext);
             } catch (final Exception e) {
                 publishContext.setException(e); // on data pre-process failure, indicate this to controller service

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/PublishKafka.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/PublishKafka.java
@@ -72,7 +72,6 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.serialization.RecordReaderFactory;
 import org.apache.nifi.serialization.RecordSetWriterFactory;
 
-import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
This PR aims to avoids restriction on mark() supplied length, currently set to around 1MB, when publishing payloads to Kafka. This fix seems to have been lost during the Kafka Refactor, as part of [NIFI-14375](https://issues.apache.org/jira/browse/NIFI-14375).

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14545](https://issues.apache.org/jira/browse/NIFI-14545)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
