### PR TITLE
NIFI-14555 - Option to empty parameter values in git registry clients

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
@@ -358,10 +358,11 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
         flowSnapshot.getSnapshotMetadata().setTimestamp(0);
 
         // remove all parameter values if configured to do so
-        if (ParameterContextValuesStrategy.REMOVE.equals(context.getProperty(PARAMETER_CONTEXT_VALUES).asAllowableValue(ParameterContextValuesStrategy.class))) {
-            flowSnapshot.getParameterContexts().forEach((name, parameterContext) -> {
-                parameterContext.getParameters().forEach(parameter -> parameter.setValue(null));
-            });
+        final ParameterContextValuesStrategy parameterContextValuesStrategy = context.getProperty(PARAMETER_CONTEXT_VALUES).asAllowableValue(ParameterContextValuesStrategy.class);
+        if (ParameterContextValuesStrategy.REMOVE.equals(parameterContextValuesStrategy)) {
+            flowSnapshot.getParameterContexts().forEach((name, parameterContext) ->
+                parameterContext.getParameters().forEach(parameter -> parameter.setValue(null))
+            );
         }
 
         // replace the id of the top level group and all of its references with a constant value prior to serializing to avoid
@@ -675,22 +676,20 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
     }
 
     enum ParameterContextValuesStrategy implements DescribedValue {
-        RETAIN("retain", "Retain", "Will not modify the parameter values"),
-        REMOVE("remove", "Remove", "Will remove the parameter values");
+        RETAIN("Retain", "Retain Values in Parameter Contexts without modifications"),
+        REMOVE("Remove", "Remove Values from Parameter Context");
 
-        private final String value;
         private final String displayName;
         private final String description;
 
-        ParameterContextValuesStrategy(final String value, final String displayName, final String description) {
-            this.value = value;
+        ParameterContextValuesStrategy(final String displayName, final String description) {
             this.displayName = displayName;
             this.description = description;
         }
 
         @Override
         public String getValue() {
-            return value;
+            return name();
         }
 
         @Override

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/test/java/org/apache/nifi/github/GitHubFlowRegistryClientTest.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/test/java/org/apache/nifi/github/GitHubFlowRegistryClientTest.java
@@ -180,6 +180,9 @@ public class GitHubFlowRegistryClientTest {
 
         final PropertyValue filterPropertyValue = createMockPropertyValue(DEFAULT_FILTER);
         when(clientConfigurationContext.getProperty(GitHubFlowRegistryClient.DIRECTORY_FILTER_EXCLUDE)).thenReturn(filterPropertyValue);
+
+        final PropertyValue parametersPropertyValue = createMockPropertyValue("Retain");
+        when(clientConfigurationContext.getProperty(GitHubFlowRegistryClient.PARAMETER_CONTEXT_VALUES)).thenReturn(parametersPropertyValue);
     }
 
     private void setupClientConfigurationContextWithDefaults() {


### PR DESCRIPTION
# Summary

[NIFI-14555](https://issues.apache.org/jira/browse/NIFI-14555) - Option to empty parameter values in git registry clients

The goal of this PR is to add an optional property for all Git based registry clients. The property "Empty Parameters" will default to false to retain current behavior. If set to true, all values of all parameters will be removed before the flow is being versioned and stored in the git repo.

Parameters are usually environment dependent and it might not be desirable to include in the versioned flow the parameters values that have been set in a lower/dev environment while designing the flow.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
