### PR TITLE
NIFI-14550 Allow setting version control info on a non-versioned proc…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/flow/synchronization/StandardVersionedComponentSynchronizer.java
@@ -486,7 +486,7 @@ public class StandardVersionedComponentSynchronizer implements VersionedComponen
 
         final VersionedFlowCoordinates remoteCoordinates = proposed.getVersionedFlowCoordinates();
         if (remoteCoordinates == null) {
-            group.disconnectVersionControl(false);
+            group.disconnectVersionControl();
         } else {
             final String registryId = determineRegistryId(remoteCoordinates);
             final String branch = remoteCoordinates.getBranch();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/groups/StandardProcessGroup.java
@@ -3642,15 +3642,10 @@ public final class StandardProcessGroup implements ProcessGroup {
     }
 
     @Override
-    public void disconnectVersionControl(final boolean removeVersionedComponentIds) {
+    public void disconnectVersionControl() {
         writeLock.lock();
         try {
             this.versionControlInfo.set(null);
-
-            if (removeVersionedComponentIds) {
-                // remove version component ids from each component (until another versioned PG is encountered)
-                applyVersionedComponentIds(this, id -> null);
-            }
         } finally {
             writeLock.unlock();
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/ProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core-api/src/main/java/org/apache/nifi/groups/ProcessGroup.java
@@ -1039,7 +1039,7 @@ public interface ProcessGroup extends ComponentAuthorizable, Positionable, Versi
     /**
      * Disconnects this Process Group from version control. If not currently under version control, this method does nothing.
      */
-    void disconnectVersionControl(boolean removeVersionedComponentIds);
+    void disconnectVersionControl();
 
     /**
      * Synchronizes the Process Group with the given Flow Registry, determining whether or not the local flow

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/MockProcessGroup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/mock/MockProcessGroup.java
@@ -725,7 +725,7 @@ public class MockProcessGroup implements ProcessGroup {
     }
 
     @Override
-    public void disconnectVersionControl(final boolean removeVersionedComponentIds) {
+    public void disconnectVersionControl() {
         this.versionControlInfo = null;
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -1279,6 +1279,16 @@ public interface NiFiServiceFacade {
     ProcessGroupEntity updateProcessGroup(Revision revision, ProcessGroupDTO processGroupDTO);
 
     /**
+     * Sets the version control info of an unversioned process group.
+     *
+     * @param revision Revision to compare with the current base version
+     * @param processGroupDTO The ProcessGroupDTO
+     * @param flowSnapshot The flow snapshot matching the given version control info
+     * @return the updated process group entity
+     */
+    ProcessGroupEntity setVersionControlInformation(Revision revision, ProcessGroupDTO processGroupDTO, RegisteredFlowSnapshot flowSnapshot);
+
+    /**
      * Verifies that the Process Group identified by the given DTO can be updated in the manner appropriate according
      * to the DTO
      *

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -1822,6 +1822,21 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
     }
 
     @Override
+    public ProcessGroupEntity setVersionControlInformation(final Revision revision, final ProcessGroupDTO processGroupDTO, final RegisteredFlowSnapshot flowSnapshot) {
+        final ProcessGroup processGroupNode = processGroupDAO.getProcessGroup(processGroupDTO.getId());
+        final RevisionUpdate<ProcessGroupDTO> snapshot = updateComponent(revision,
+            processGroupNode,
+            () -> processGroupDAO.setVersionControlInformation(processGroupDTO, flowSnapshot),
+            processGroup -> dtoFactory.createProcessGroupDto(processGroup));
+
+        final PermissionsDTO permissions = dtoFactory.createPermissionsDto(processGroupNode);
+        final RevisionDTO updatedRevision = dtoFactory.createRevisionDTO(snapshot.getLastModification());
+        final ProcessGroupStatusDTO status = dtoFactory.createConciseProcessGroupStatusDto(controllerFacade.getProcessGroupStatus(processGroupNode.getIdentifier()));
+        final List<BulletinEntity> bulletinEntities = getProcessGroupBulletins(processGroupNode);
+        return entityFactory.createProcessGroupEntity(snapshot.getComponent(), updatedRevision, permissions, status, bulletinEntities);
+    }
+
+    @Override
     public void verifyUpdateProcessGroup(ProcessGroupDTO processGroupDTO) {
         if (processGroupDAO.hasProcessGroup(processGroupDTO.getId())) {
             processGroupDAO.verifyUpdate(processGroupDTO);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -2928,7 +2928,6 @@ public final class DtoFactory {
        return mapping;
    }
 
-
    /**
     * Creates a ProcessGroupContentDTO from the specified ProcessGroup.
     *

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ProcessGroupDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/ProcessGroupDAO.java
@@ -23,6 +23,7 @@ import org.apache.nifi.flow.VersionedExternalFlow;
 import org.apache.nifi.groups.ComponentAdditions;
 import org.apache.nifi.groups.ProcessGroup;
 import org.apache.nifi.groups.VersionedComponentAdditions;
+import org.apache.nifi.registry.flow.RegisteredFlowSnapshot;
 import org.apache.nifi.web.api.dto.ProcessGroupDTO;
 import org.apache.nifi.web.api.dto.VersionControlInformationDTO;
 import org.apache.nifi.web.api.entity.ProcessGroupRecursivity;
@@ -135,6 +136,15 @@ public interface ProcessGroupDAO {
      * @return The process group
      */
     ProcessGroup updateProcessGroup(ProcessGroupDTO processGroup);
+
+    /**
+     * Sets the version control info on an unversioned process group.
+     *
+     * @param processGroup the process group with the version control info specified
+     * @param flowSnapshot the flow snapshot for the given version control info
+     * @return the updated process group
+     */
+    ProcessGroup setVersionControlInformation(ProcessGroupDTO processGroup, RegisteredFlowSnapshot flowSnapshot);
 
     /**
      * Updates the process group so that it matches the proposed flow

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessGroupDAO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/dao/impl/StandardProcessGroupDAO.java
@@ -136,8 +136,25 @@ public class StandardProcessGroupDAO extends ComponentDAO implements ProcessGrou
 
         final VersionControlInformationDTO versionControlInfoDTO = processGroup.getVersionControlInformation();
         final VersionControlInformation versionControlInformation = group.getVersionControlInformation();
-        if (versionControlInfoDTO != null && versionControlInformation != null) {
-            throw new IllegalStateException("Cannot set Version Control Info because process group is already under version control");
+        if (versionControlInfoDTO != null) {
+            if (versionControlInformation != null) {
+                throw new IllegalStateException("Cannot set Version Control Info because process group is already under version control");
+            }
+            verifyChildProcessGroupsNotUnderVersionControl(group.getProcessGroups());
+        }
+    }
+
+    private void verifyChildProcessGroupsNotUnderVersionControl(final Set<ProcessGroup> childGroups) {
+        if (childGroups == null || childGroups.isEmpty()) {
+            return;
+        }
+
+        for (final ProcessGroup childGroup : childGroups) {
+            final VersionControlInformation versionControlInformation = childGroup.getVersionControlInformation();
+            if (versionControlInformation != null) {
+                throw new IllegalStateException("Cannot set Version Control Info because a child process group is already under version control");
+            }
+            verifyChildProcessGroupsNotUnderVersionControl(childGroup.getProcessGroups());
         }
     }
 

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/flow/registry/FileSystemFlowRegistryClient.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/flow/registry/FileSystemFlowRegistryClient.java
@@ -238,6 +238,9 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
             populateBucket(snapshot, bucketId);
             populateFlow(snapshot, bucketId, flowId, versionFiles == null ? 0 : versionFiles.length);
 
+            final String latestVersion = getLatestVersion(context, flowVersionLocation).orElse(null);
+            snapshot.setLatest(version.equals(latestVersion));
+
             return snapshot;
         }
     }

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/RegistryClientIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/RegistryClientIT.java
@@ -414,10 +414,5 @@ public class RegistryClientIT extends NiFiSystemIT {
         assertEquals(vci.getVersionControlInformation().getFlowId(), groupAfterSetVersionInfo.getComponent().getVersionControlInformation().getFlowId());
         assertEquals(vci.getVersionControlInformation().getVersion(), groupAfterSetVersionInfo.getComponent().getVersionControlInformation().getVersion());
         assertEquals("UP_TO_DATE", groupAfterSetVersionInfo.getComponent().getVersionControlInformation().getState());
-
-        waitFor(() -> {
-            final ProcessGroupEntity syncedGroup = getNifiClient().getProcessGroupClient().getProcessGroup(group.getId());
-            return syncedGroup.getComponent().getVersionControlInformation().getState().equals("UP_TO_DATE");
-        });
     }
 }

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/RegistryClientIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/registry/RegistryClientIT.java
@@ -25,6 +25,7 @@ import org.apache.nifi.web.api.dto.FlowSnippetDTO;
 import org.apache.nifi.web.api.dto.ProcessorDTO;
 import org.apache.nifi.web.api.dto.RevisionDTO;
 import org.apache.nifi.web.api.dto.SnippetDTO;
+import org.apache.nifi.web.api.dto.VersionControlInformationDTO;
 import org.apache.nifi.web.api.dto.flow.FlowDTO;
 import org.apache.nifi.web.api.dto.flow.ProcessGroupFlowDTO;
 import org.apache.nifi.web.api.entity.ConnectionEntity;
@@ -369,4 +370,54 @@ public class RegistryClientIT extends NiFiSystemIT {
         assertEquals("UP_TO_DATE", versionedFlowState);
     }
 
+    @Test
+    public void testStopVersionControlThenSetVersionControlInfo() throws NiFiClientException, IOException, InterruptedException {
+        final FlowRegistryClientEntity clientEntity = registerClient();
+        final ProcessGroupEntity group = getClientUtil().createProcessGroup("Test Set Version Control Info", "root");
+
+        final VersionControlInformationEntity vci = getClientUtil().startVersionControl(group, clientEntity, TEST_FLOWS_BUCKET, FIRST_FLOW_ID);
+
+        // Retrieve PG under version control and verify the PG's VCI
+        final ProcessGroupEntity groupAfterStartVersionControl = getNifiClient().getProcessGroupClient().getProcessGroup(group.getId());
+        assertNotNull(groupAfterStartVersionControl);
+        assertNotNull(groupAfterStartVersionControl.getComponent());
+        assertNotNull(groupAfterStartVersionControl.getComponent().getVersionControlInformation());
+        assertEquals(clientEntity.getId(), groupAfterStartVersionControl.getComponent().getVersionControlInformation().getRegistryId());
+        assertEquals(TEST_FLOWS_BUCKET, groupAfterStartVersionControl.getComponent().getVersionControlInformation().getBucketId());
+        assertEquals(vci.getVersionControlInformation().getFlowId(), groupAfterStartVersionControl.getComponent().getVersionControlInformation().getFlowId());
+        assertEquals(vci.getVersionControlInformation().getVersion(), groupAfterStartVersionControl.getComponent().getVersionControlInformation().getVersion());
+        assertEquals("UP_TO_DATE", groupAfterStartVersionControl.getComponent().getVersionControlInformation().getState());
+
+        // Stop version control
+        getNifiClient().getVersionsClient().stopVersionControl(groupAfterStartVersionControl);
+
+        // Retrieve PG again and verify no VCI present
+        final ProcessGroupEntity groupAfterStopVersionControl = getNifiClient().getProcessGroupClient().getProcessGroup(group.getId());
+        assertNotNull(groupAfterStopVersionControl);
+        assertNotNull(groupAfterStopVersionControl.getComponent());
+        assertNull(groupAfterStopVersionControl.getComponent().getVersionControlInformation());
+
+        // Submit PG update specifying VCI
+        final VersionControlInformationDTO setVersionInfo = new VersionControlInformationDTO();
+        setVersionInfo.setRegistryId(clientEntity.getId());
+        setVersionInfo.setBucketId(vci.getVersionControlInformation().getBucketId());
+        setVersionInfo.setFlowId(vci.getVersionControlInformation().getFlowId());
+        setVersionInfo.setVersion(vci.getVersionControlInformation().getVersion());
+        groupAfterStopVersionControl.getComponent().setVersionControlInformation(setVersionInfo);
+
+        final ProcessGroupEntity groupAfterSetVersionInfo = getNifiClient().getProcessGroupClient().updateProcessGroup(groupAfterStopVersionControl);
+        assertNotNull(groupAfterSetVersionInfo);
+        assertNotNull(groupAfterSetVersionInfo.getComponent());
+        assertNotNull(groupAfterSetVersionInfo.getComponent().getVersionControlInformation());
+        assertEquals(clientEntity.getId(), groupAfterSetVersionInfo.getComponent().getVersionControlInformation().getRegistryId());
+        assertEquals(TEST_FLOWS_BUCKET, groupAfterSetVersionInfo.getComponent().getVersionControlInformation().getBucketId());
+        assertEquals(vci.getVersionControlInformation().getFlowId(), groupAfterSetVersionInfo.getComponent().getVersionControlInformation().getFlowId());
+        assertEquals(vci.getVersionControlInformation().getVersion(), groupAfterSetVersionInfo.getComponent().getVersionControlInformation().getVersion());
+        assertEquals("UP_TO_DATE", groupAfterSetVersionInfo.getComponent().getVersionControlInformation().getState());
+
+        waitFor(() -> {
+            final ProcessGroupEntity syncedGroup = getNifiClient().getProcessGroupClient().getProcessGroup(group.getId());
+            return syncedGroup.getComponent().getVersionControlInformation().getState().equals("UP_TO_DATE");
+        });
+    }
 }


### PR DESCRIPTION
…ess group

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14550](https://issues.apache.org/jira/browse/NIFI-14550)

Updates the existing PUT to `/process-groups/{id}` to allow optionally specifying Version Control Information which allows putting the PG under version control and tracking to a specific version in a registry client.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
