### PR TITLE
Nifi 14457 New processor to run xQuery on BaseX

### DIFF
--- a/nifi-assembly/LICENSE
+++ b/nifi-assembly/LICENSE
@@ -2684,6 +2684,40 @@ The binary distribution of this product bundles 'Py4J' under a BSD license.
      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
      FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
      OTHER DEALINGS IN THE SOFTWARE.
+The binary distribution of this product bundles 'Basex' which is available under a BSD license.
+More details found here: https://basex.org/.
+
+Copyright (c) BaseX Team
+All rights reserved.
+
+The BSD 3-Clause License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 For the binary distribution of nifi-ui see its 3rdpartylicenses.txt
 for additional license and notice information.

--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -2539,6 +2539,15 @@ SIL OFL 1.1
 The following binary components are provided under the SIL Open Font License 1.1
   (SIL OFL 1.1) FontAwesome (4.7.0 - https://fontawesome.com/license/free)
 
+******************
+BSD-3-Clause License
+******************
+The following binary components are provided under the BSD-3-Clause License:
+  (BSD-3-Clause) BaseX
+      The following NOTICE information applies:
+        Copyright BaseX Team (https://basex.org/)
+
+
 For the binary distribution of nifi-ui see its 3rdpartylicenses.txt
 for additional license and notice information.
 

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-nar/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-basex-bundle</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+
+    <artifactId>nifi-basex-nar</artifactId>
+    <packaging>nar</packaging>
+    <repositories>
+        <repository>
+            <id>basex</id>
+            <name>BaseX Maven Repository</name>
+            <url>https://files.basex.org/maven</url>
+        </repository>
+    </repositories>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-shared-nar</artifactId>
+            <version>2.3.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-basex-processors</artifactId>
+            <version>2.4.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-nar/pom.xml:Zone.Identifier
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-nar/pom.xml:Zone.Identifier
@@ -1,2 +1,0 @@
-[ZoneTransfer]
-ZoneId=3

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-nar/pom.xml:Zone.Identifier
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-nar/pom.xml:Zone.Identifier
@@ -1,0 +1,2 @@
+[ZoneTransfer]
+ZoneId=3

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-nar/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,241 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes the following third-party component under the BSD-3-Clause License:
+
+Copyright (c) BaseX Team
+All rights reserved.
+
+The BSD 3-Clause License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-nar/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,13 @@
+nifi-basex-nar
+Copyright 2014-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/)
+and incorporates BaseX code under the BSD-3-Clause License.
+******************
+BSD-3-Clause License
+******************
+The following binary components are provided under the BSD-3-Clause License:
+  (BSD-3-Clause) BaseX
+      The following NOTICE information applies:
+        Copyright BaseX Team (https://basex.org/)

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-basex-bundle</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-basex-processors</artifactId>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <repositories>
+        <repository>
+            <id>basex</id>
+            <name>BaseX Maven Repository</name>
+            <url>https://files.basex.org/maven</url>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.basex</groupId>
+            <artifactId>basex</artifactId>
+            <version>7.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-xml-processing</artifactId>
+            <version>2.4.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/main/java/org/apache/nifi/processors/basex/EvaluateBaseXQuery.java
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/main/java/org/apache/nifi/processors/basex/EvaluateBaseXQuery.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nifi.processors.basex;
+
+
+import org.apache.nifi.annotation.behavior.*;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.*;
+import org.apache.nifi.expression.AttributeExpression;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.basex.core.Context;
+import org.basex.core.Prop;
+import org.basex.io.IOContent;
+import org.basex.query.QueryException;
+import org.basex.query.QueryProcessor;
+import org.basex.query.value.Value;
+import org.basex.query.value.item.Item;
+import org.basex.query.value.node.DBNode;
+
+import java.io.BufferedInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+
+@SideEffectFree
+@SupportsBatching
+@Tags({"XML", "evaluate", "XPath", "XQuery", "basex"})
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+@CapabilityDescription(
+        "Executes an XQuery expression using the BaseX engine, passing the FlowFile content as a string context to the script. "
+                + "An XQuery script must be provided for the processor to run. Users can choose how FlowFile attributes are mapped "
+                + "to external variables: map all attributes, map only a specific list, or ignore attributes altogether. "
+                + "The output of the query can be written to a specified FlowFile attribute (similarly to the InvokeHTTP processor) "
+                + "or used to replace the content of the original FlowFile. The processor defines the following relationships: "
+                + "'success' (on successful execution), 'failure' (if the script fails), and 'original' (preserves the unmodified FlowFile)."
+)
+@SystemResourceConsiderations({
+        @SystemResourceConsideration(resource = SystemResource.MEMORY, description = "Processing requires reading the entire FlowFile into memory")
+})
+public class EvaluateBaseXQuery extends AbstractProcessor {
+
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder().name("success").build();
+    public static final Relationship REL_FAILURE = new Relationship.Builder().name("failure")
+            .description("Content extraction failed").build();
+    public static final Relationship REL_ORIGINAL = new Relationship.Builder().name("original")
+            .description("Success for original input FlowFiles").build();
+
+    public static final PropertyDescriptor XQUERY_SCRIPT = new PropertyDescriptor.Builder()
+            .name("XQuery Script")
+            .description("XQuery to execute on the incoming FlowFile content")
+            .required(true)
+            .addValidator(new BaseXqueryValidator())
+            .build();
+
+
+
+    public static final String MAP_ALL = "Map all";
+    public static final String MAP_LIST = "Map list";
+    public static final String DO_NOT_MAP = "Do not map";
+
+    public static final PropertyDescriptor ATTR_MAPPING_STRATEGY = new PropertyDescriptor.Builder()
+            .name("Attribute Mapping Strategy")
+            .description("How to map FlowFile attributes as external XQuery variables")
+            .allowableValues(MAP_ALL, MAP_LIST, DO_NOT_MAP)
+            .required(true)
+            .build();
+
+    public static final PropertyDescriptor MAPPING_LIST = new PropertyDescriptor.Builder()
+            .name("Mapping list")
+            .description("List of attributes to map to external variables, separated by comma")
+            .required(false)
+            .dependsOn(ATTR_MAPPING_STRATEGY, MAP_LIST)
+            .addValidator(Validator.VALID)
+            .build();
+
+    public static final PropertyDescriptor OUTPUT_BODY_ATTRIBUTE_NAME = new PropertyDescriptor.Builder()
+            .name("Response Body Attribute Name")
+            .description("FlowFile attribute name used to write an xquery output body for FlowFiles transferred to the Original relationship.")
+            .addValidator(StandardValidators.createAttributeExpressionLanguageValidator(AttributeExpression.ResultType.STRING))
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .build();
+
+    private static final Set<Relationship> RELATIONSHIPS = Set.of(
+            REL_SUCCESS,
+            REL_FAILURE,
+            REL_ORIGINAL
+    );
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        final List<PropertyDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(XQUERY_SCRIPT);
+        descriptors.add(ATTR_MAPPING_STRATEGY);
+        descriptors.add(MAPPING_LIST);
+        descriptors.add(OUTPUT_BODY_ATTRIBUTE_NAME);
+        return descriptors;
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return RELATIONSHIPS;
+    }
+
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+        Context basexContext = new Context();
+        final List<FlowFile> flowFileBatch = session.get(50);
+        final ComponentLog logger = getLogger();
+        if (flowFileBatch.isEmpty()) {
+            return;
+        }
+        for (FlowFile transformed : flowFileBatch) {
+
+            if (!isScheduled()) {
+                session.rollback();
+                return;
+            }
+            final AtomicReference<String> input = new AtomicReference<>(null);
+            try {
+                session.read(transformed, rawIn -> {
+                    final InputStream in = new BufferedInputStream(rawIn);
+                    input.set(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+                });
+            } catch (final Exception e) {
+                logger.error("Input reading failed {}", transformed, e);
+                session.transfer(transformed, REL_FAILURE);
+                continue;
+            }
+            Prop prop = new Prop();
+            String query = context.getProperty(XQUERY_SCRIPT).getValue();
+            final String attrMappingStrategy = String.valueOf(context.getProperty(ATTR_MAPPING_STRATEGY));
+
+            QueryProcessor queryProcessor = new QueryProcessor(query, basexContext);
+            if (attrMappingStrategy.equals(MAP_LIST)) {
+                String mappingList = context.getProperty(MAPPING_LIST).getValue();
+                List<String> mappedAttributes = List.of(mappingList.split(","));
+                processAttributes(queryProcessor, transformed, mappedAttributes, logger, session);
+            }else if (attrMappingStrategy.equals(MAP_ALL)) {
+                processAttributes(queryProcessor, transformed, logger, session);
+            }
+
+            Value result = null;
+            try {
+                Item node = new DBNode(new IOContent(input.get()), prop);
+                queryProcessor.context(node);
+                result = queryProcessor.value();
+            } catch (Exception e) {
+                logger.error("Query failed: ", transformed, e);
+                session.transfer(transformed, REL_FAILURE);
+                continue;
+            }
+
+            Value finalResult = result;
+            String finalResultSerialized = null;
+            try {
+                 finalResultSerialized = finalResult.serialize().toString();
+            } catch (QueryException e) {
+                logger.error("Failed during serializing output: ", transformed, e);
+                session.transfer(transformed, REL_FAILURE);
+                continue;
+            }
+            FlowFile original = session.clone(transformed);
+            if (context.getProperty(OUTPUT_BODY_ATTRIBUTE_NAME).isSet()) {
+                String attributeKey = context.getProperty(OUTPUT_BODY_ATTRIBUTE_NAME).getValue();
+                original = session.putAttribute(original, attributeKey, finalResultSerialized);
+            }
+
+            String finalResultSerializedClone = finalResultSerialized;
+
+            transformed = session.write(transformed, out -> {
+                    out.write(finalResultSerializedClone.getBytes(StandardCharsets.UTF_8));
+
+            });
+
+            route(original, transformed, session);
+
+        }
+
+
+
+    }
+
+
+    private void processAttributes(QueryProcessor queryProcessor,
+                                                  FlowFile flowFile,
+                                                  List<String> mappedAttributes,
+                                                  ComponentLog logger, ProcessSession session)
+    {
+        flowFile.getAttributes().forEach((key, value) -> {
+            try {
+                if (mappedAttributes.contains(key)) {
+                    queryProcessor.bind(key, value);
+                }
+            } catch (Exception e) {
+                logger.error("Query failed while processing attribute: {}", flowFile, e);
+                session.transfer(flowFile, REL_FAILURE);
+            }
+        });
+    }
+    private void processAttributes(QueryProcessor queryProcessor,
+                                                     FlowFile flowFile,
+                                                     ComponentLog logger, ProcessSession session)
+    {
+        flowFile.getAttributes().forEach((key, value) -> {
+            try {
+                queryProcessor.bind(key, value);
+
+            } catch (Exception e) {
+                logger.error("Query failed while processing attribute: {}", flowFile, e);
+                session.transfer(flowFile, REL_FAILURE);
+            }
+        });
+    }
+    private void route(FlowFile original, FlowFile transformed, ProcessSession session){
+        if (original != null) {
+            session.transfer(original, REL_ORIGINAL);
+        }
+        if (transformed != null) {
+            session.transfer(transformed, REL_SUCCESS);
+        }
+    }
+
+    private static class BaseXqueryValidator implements Validator {
+
+        @Override
+        public ValidationResult validate(final String subject, final String input, final ValidationContext validationContext) {
+            try {
+                Context context = new Context();
+                final QueryProcessor proc = new QueryProcessor(input, context);
+                String error = null;
+                try {
+                    proc.compile();
+                } catch (final Exception e) {
+                    error = e.toString().contains("variable") ? null : e.toString();
+                }
+                return new ValidationResult.Builder().input(input).subject(subject).valid(error == null).explanation(error).build();
+            } catch (final Exception e) {
+                return new ValidationResult.Builder().input(input).subject(subject).valid(false)
+                        .explanation("Unable to initialize XQuery engine due to " + e).build();
+            }
+        }
+    }
+
+}
+
+
+

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.processors.basex.EvaluateBaseXQuery
+

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/main/resources/docs/org.apache.nifi.processors.basex.EvaluateBaseXQuery/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/main/resources/docs/org.apache.nifi.processors.basex.EvaluateBaseXQuery/additionalDetails.md
@@ -1,0 +1,37 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# EvaluateBaseXQuery
+
+## Description:
+
+This Processor evaluates an XQuery expression against the content of a Flow File using the BaseX XML database engine.
+The Flow File content must be valid XML. The result of the query can be written back to the content or stored in a
+Flow File attribute, depending on the processor configuration.
+
+This processor is useful for filtering, transforming, or extracting values from XML documents using standard XQuery syntax.
+
+**Processor's static properties:**
+
+* **XQuery Expression** – the XQuery to evaluate against the Flow File content. You can reference FlowFile attributes using NiFi Expression Language (e.g., `${attribute}`).
+* **Return Type** – determines where the result will be written. Possible values: `content`, `attribute`.
+* **Output Attribute Name** (used only if Return Type = attribute) – name of the attribute to store the result in.
+
+**Processor's dynamic properties:**
+
+This processor does not use dynamic properties.
+
+For more about XQuery syntax and BaseX, see:
+[BaseX Documentation](https://docs.basex.org/wiki/XQuery)

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/java/org/apache/nifi/processors/TestEvaluateBaseXQuery.java
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/java/org/apache/nifi/processors/TestEvaluateBaseXQuery.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nifi.processors.basex;
+
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestEvaluateBaseXQuery {
+    private TestRunner testRunner;
+
+    @BeforeEach
+    public void init() {
+        testRunner = TestRunners.newTestRunner(EvaluateBaseXQuery.class);
+    }
+
+    @Test
+    public void testsimple() throws IOException {
+        final TestRunner runner = TestRunners.newTestRunner(new EvaluateBaseXQuery());
+        runner.setProperty(EvaluateBaseXQuery.ATTR_MAPPING_STRATEGY, EvaluateBaseXQuery.MAP_ALL);
+        runner.setProperty(EvaluateBaseXQuery.XQUERY_SCRIPT, "//books/book");
+
+        runner.enqueue(Paths.get("src/test/resources/xml/test1.xml"));
+        runner.run();
+        final MockFlowFile outOriginal = runner.getFlowFilesForRelationship(EvaluateBaseXQuery.REL_SUCCESS).get(0);
+        assertEquals("<book>Java</book>" + "\n" + "<book>Python</book>", outOriginal.getContent());
+    }
+
+    @Test
+    public void testBaseXQueryEvaluationReturnsFlowFileContent() throws IOException {
+        testRunner.setProperty(EvaluateBaseXQuery.XQUERY_SCRIPT, "for $x in //book return data($x/title)");
+        testRunner.setProperty(EvaluateBaseXQuery.ATTR_MAPPING_STRATEGY, EvaluateBaseXQuery.MAP_ALL);
+
+        final Map<String, String> attrs = new HashMap<>();
+        attrs.put("id", "1");
+
+        testRunner.enqueue(Paths.get("src/test/resources/xml/test2.xml"), attrs);
+
+        testRunner.run();
+
+        testRunner.assertTransferCount(EvaluateBaseXQuery.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(EvaluateBaseXQuery.REL_ORIGINAL, 1);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(EvaluateBaseXQuery.REL_SUCCESS).get(0);
+        out.assertContentEquals("Everyday Italian Harry Potter Java Soup");
+    }
+
+
+    @Test
+    public void testBaseXQueryEvaluationIgnoresAttributes() throws IOException {
+        testRunner.setProperty(EvaluateBaseXQuery.XQUERY_SCRIPT, "for $x in //book let $title := data($x/title) where $title != $id return $title");
+        testRunner.setProperty(EvaluateBaseXQuery.ATTR_MAPPING_STRATEGY, EvaluateBaseXQuery.MAP_LIST);
+        testRunner.setProperty(EvaluateBaseXQuery.MAPPING_LIST, "id");
+
+        final Map<String, String> attrs = new HashMap<>();
+        attrs.put("id", "Everyday Italian");
+
+        testRunner.enqueue(Paths.get("src/test/resources/xml/test3.xml"), attrs);
+        testRunner.run();
+
+        testRunner.assertTransferCount(EvaluateBaseXQuery.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(EvaluateBaseXQuery.REL_ORIGINAL, 1);
+    }
+
+    @Test
+    public void testFailureDueToInvalidXQueryScript() throws IOException {
+        testRunner.setProperty(EvaluateBaseXQuery.XQUERY_SCRIPT, "for $x in //book let $title := data($x/title) where $title = $id return");
+        testRunner.setProperty(EvaluateBaseXQuery.ATTR_MAPPING_STRATEGY, EvaluateBaseXQuery.MAP_ALL);
+
+        final Map<String, String> attrs = new HashMap<>();
+        attrs.put("id", "1");
+
+        testRunner.enqueue(Paths.get("src/test/resources/xml/test3.xml"), attrs);
+        testRunner.run();
+
+        testRunner.assertTransferCount(EvaluateBaseXQuery.REL_FAILURE, 1);
+
+    }
+
+    @Test
+    public void testBaseXQueryEvaluationWithPartialAttributeMapping() throws IOException {
+        testRunner.setProperty(EvaluateBaseXQuery.XQUERY_SCRIPT, "for $x in //book return $x/title || ' by ' || $x/author/text()");
+        testRunner.setProperty(EvaluateBaseXQuery.ATTR_MAPPING_STRATEGY, EvaluateBaseXQuery.MAP_LIST);
+        testRunner.setProperty(EvaluateBaseXQuery.MAPPING_LIST, "title,author");
+
+        final Map<String, String> attrs = new HashMap<>();
+        attrs.put("title", "Effective Java");
+        attrs.put("author", "Joshua Bloch");
+
+        testRunner.enqueue(Paths.get("src/test/resources/xml/test4.xml"), attrs);
+
+        testRunner.run();
+
+        testRunner.assertTransferCount(EvaluateBaseXQuery.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(EvaluateBaseXQuery.REL_ORIGINAL, 1);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(EvaluateBaseXQuery.REL_SUCCESS).get(0);
+        out.assertContentEquals("Effective Java by Joshua Bloch");
+    }
+
+    @Test
+    public void testOutputBodyAttributeName() throws IOException {
+        testRunner.setProperty(EvaluateBaseXQuery.XQUERY_SCRIPT, "for $x in //book return $x/title/text() || ' by ' || $x/author");
+        testRunner.setProperty(EvaluateBaseXQuery.ATTR_MAPPING_STRATEGY, EvaluateBaseXQuery.MAP_LIST);
+        testRunner.setProperty(EvaluateBaseXQuery.MAPPING_LIST, "title,author");
+        testRunner.setProperty(EvaluateBaseXQuery.OUTPUT_BODY_ATTRIBUTE_NAME, "OutputResult");
+
+        final Map<String, String> attrs = new HashMap<>();
+        attrs.put("title", "Effective Java");
+        attrs.put("author", "Joshua Bloch");
+
+        testRunner.enqueue(Paths.get("src/test/resources/xml/test4.xml"), attrs);
+        testRunner.setValidateExpressionUsage(false);
+        testRunner.run();
+
+        testRunner.assertTransferCount(EvaluateBaseXQuery.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(EvaluateBaseXQuery.REL_ORIGINAL, 1);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(EvaluateBaseXQuery.REL_SUCCESS).get(0);
+        out.assertContentEquals("Effective Java by Joshua Bloch");
+        final MockFlowFile original = testRunner.getFlowFilesForRelationship(EvaluateBaseXQuery.REL_ORIGINAL).get(0);
+        assertEquals("Effective Java by Joshua Bloch", original.getAttribute("OutputResult"));
+    }
+
+    @Test
+    public void testBaseXQueryEvaluationWithNoAttributeMapping() throws IOException {
+        testRunner.setProperty(EvaluateBaseXQuery.XQUERY_SCRIPT, "for $x in //book return $x/author/text()");
+        testRunner.setProperty(EvaluateBaseXQuery.ATTR_MAPPING_STRATEGY, EvaluateBaseXQuery.DO_NOT_MAP);
+
+        testRunner.enqueue(Paths.get("src/test/resources/xml/test5.xml"));
+
+        testRunner.run();
+
+        testRunner.assertTransferCount(EvaluateBaseXQuery.REL_SUCCESS, 1);
+        testRunner.assertTransferCount(EvaluateBaseXQuery.REL_ORIGINAL, 1);
+        final MockFlowFile out = testRunner.getFlowFilesForRelationship(EvaluateBaseXQuery.REL_SUCCESS).get(0);
+        out.assertContentEquals("Giada De LaurentiisJ.K. RowlingJoshua Bloch");
+    }
+
+
+}

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/resources/xml/test1.xml
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/resources/xml/test1.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<books>
+    <book>Java</book>
+    <book>Python</book>
+</books>

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/resources/xml/test2.xml
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/resources/xml/test2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<library>
+    <book>
+        <title>Everyday Italian</title>
+        <author>Giada De Laurentiis</author>
+    </book>
+    <book>
+        <title>Harry Potter</title>
+        <author>J.K. Rowling</author>
+    </book>
+    <book>
+        <title>Java Soup</title>
+        <author>Unknown Author</author>
+    </book>
+</library>

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/resources/xml/test3.xml
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/resources/xml/test3.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<books>
+    <book>Java</book>
+    <book>Python</book>
+</books>

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/resources/xml/test4.xml
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/resources/xml/test4.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<library>
+    <book>
+        <title>Effective Java</title>
+        <author>Joshua Bloch</author>
+    </book>
+</library>

--- a/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/resources/xml/test5.xml
+++ b/nifi-extension-bundles/nifi-basex-bundle/nifi-basex-processors/src/test/resources/xml/test5.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<library>
+    <book>
+        <title>Everyday Italian</title>
+        <author>Giada De Laurentiis</author>
+    </book>
+    <book>
+        <title>Harry Potter</title>
+        <author>J.K. Rowling</author>
+    </book>
+    <book>
+        <title>Effective Java</title>
+        <author>Joshua Bloch</author>
+    </book>
+</library>

--- a/nifi-extension-bundles/nifi-basex-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-basex-bundle/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-standard-shared-bom</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+        <relativePath>../nifi-standard-shared-bundle/nifi-standard-shared-bom</relativePath>
+    </parent>
+    <artifactId>nifi-basex-bundle</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>nifi-basex-processors</module>
+        <module>nifi-basex-nar</module>
+    </modules>
+
+
+</project>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Nifi 14457- New processor to run xQuery on BaseX.

Introduced a new `EvaluateBaseXQuery` for executing XQuery queries against a remote or embedded BaseX XML database instance. This processor allows integration with BaseX for high-performance XML data querying and transformation.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI-14457) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-XXXXX`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-XXXXX`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] BaseX dependency (BSD 3-Clause) verified to be compatible with [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0)
- [x] BaseX dependency added to module-level `LICENSE` and `NOTICE` files (`nifi-basex-processor-nar`)
- [x] BaseX added to root `nifi-assembly` `LICENSE` and `NOTICE` files

### Documentation

- [x] Processor documentation renders correctly
- [x] Usage examples and configuration parameters documented
