### PR TITLE
NIFI-14560 Remove Supported Proxies from Property Description Field

### DIFF
--- a/nifi-extension-bundles/nifi-standard-services/nifi-proxy-configuration-api/src/main/java/org/apache/nifi/proxy/ProxyConfiguration.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-proxy-configuration-api/src/main/java/org/apache/nifi/proxy/ProxyConfiguration.java
@@ -38,13 +38,10 @@ public class ProxyConfiguration {
 
     public static final ProxyConfiguration DIRECT_CONFIGURATION = new ProxyConfiguration();
 
-    public static PropertyDescriptor createProxyConfigPropertyDescriptor(final ProxySpec... _specs) {
-
-        final Set<ProxySpec> specs = getUniqueProxySpecs(_specs);
+    public static PropertyDescriptor createProxyConfigPropertyDescriptor(final ProxySpec... supportedProxySpecs) {
+        final Set<ProxySpec> specs = getUniqueProxySpecs(supportedProxySpecs);
 
         final StringBuilder description = new StringBuilder("Specifies the Proxy Configuration Controller Service to proxy network requests.");
-        description.append(" Supported proxies: ");
-        description.append(specs.stream().map(ProxySpec::getDisplayName).collect(Collectors.joining(", ")));
 
         if (specs.contains(SOCKS)) {
             description.append(" In case of SOCKS, it is not guaranteed that the selected SOCKS Version will be used by the processor.");


### PR DESCRIPTION
# Summary

[NIFI-14560](https://issues.apache.org/jira/browse/NIFI-14560) Removes the supported proxy information from the description field of the Proxy Configuration Service.

The supported proxy information is enforced through other methods, and writing the supported proxy information in the description field results in non-deterministic manifest information.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
