### PR TITLE
NIFI-14564 Upgrade SSHJ from 0.39.0 to 0.40.0

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>com.hierynomus</groupId>
                 <artifactId>sshj</artifactId>
-                <version>0.39.0</version>
+                <version>0.40.0</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.activation</groupId>


### PR DESCRIPTION
# Summary

[NIFI-14564](https://issues.apache.org/jira/browse/NIFI-14564) Upgrades the SSHJ library from 0.39.0 to [0.40.0](https://github.com/hierynomus/sshj/compare/v0.39.0...v0.40.0) incorporating several bug fixes and improvements related to EdDSA library usage. This upgrade applies to SFTP Processors in the standard bundle.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
