### PR TITLE
NIFI-14566 - Introduce Inject Metadata Output Strategy in ConsumeKafka

### DIFF
--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/ConsumeKafkaInjectMetadataRecordIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/ConsumeKafkaInjectMetadataRecordIT.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kafka.processors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.apache.commons.io.IOUtils;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.nifi.kafka.processors.consumer.ProcessingStrategy;
+import org.apache.nifi.kafka.processors.producer.wrapper.InjectMetadataRecord;
+import org.apache.nifi.kafka.service.api.consumer.AutoOffsetReset;
+import org.apache.nifi.kafka.shared.property.KeyFormat;
+import org.apache.nifi.kafka.shared.property.OutputStrategy;
+import org.apache.nifi.provenance.ProvenanceEventRecord;
+import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConsumeKafkaInjectMetadataRecordIT extends AbstractConsumeKafkaIT {
+    private static final String TEST_RESOURCE = "org/apache/nifi/kafka/processors/publish/ff.json";
+    private static final int TEST_RECORD_COUNT = 3;
+    private static final String MESSAGE_KEY = "{\"id\": 0,\"name\": \"K\"}";
+
+    private static final int FIRST_PARTITION = 0;
+    private static final long FIRST_OFFSET = 0;
+
+    private TestRunner runner;
+
+    @BeforeEach
+    void setRunner() throws InitializationException {
+        runner = TestRunners.newTestRunner(ConsumeKafka.class);
+        addKafkaConnectionService(runner);
+        runner.setProperty(ConsumeKafka.CONNECTION_SERVICE, CONNECTION_SERVICE_ID);
+        addRecordReaderService(runner);
+        addRecordWriterService(runner);
+        addRecordKeyReaderService(runner);
+    }
+
+    static abstract class Verifier {
+        abstract void verify(final JsonNode jsonNode);
+    }
+
+    static class RecordVerifier extends Verifier {
+        void verify(final JsonNode jsonNode) {
+            final ObjectNode key = assertInstanceOf(ObjectNode.class, jsonNode);
+            assertEquals(2, key.size());
+            assertEquals(0, key.get("id").asInt());
+            assertEquals("K", key.get("name").asText());
+        }
+    }
+
+    static class StringVerifier extends Verifier {
+        void verify(final JsonNode jsonNode) {
+            final TextNode key = assertInstanceOf(TextNode.class, jsonNode);
+            assertEquals(MESSAGE_KEY, key.asText());
+        }
+    }
+
+    static class ByteArrayVerifier extends Verifier {
+        void verify(final JsonNode jsonNode) {
+            final ArrayNode key = assertInstanceOf(ArrayNode.class, jsonNode);
+            assertEquals(MESSAGE_KEY.length(), key.size());
+            for (int i = 0; (i < MESSAGE_KEY.length()); ++i) {
+                assertEquals(MESSAGE_KEY.charAt(i), key.get(i).asInt());
+            }
+        }
+    }
+
+    public static Stream<Arguments> permutationsKeyFormat() {
+        return Stream.of(
+                Arguments.arguments(KeyFormat.RECORD, new RecordVerifier()),
+                Arguments.arguments(KeyFormat.STRING, new StringVerifier()),
+                Arguments.arguments(KeyFormat.BYTE_ARRAY, new ByteArrayVerifier())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("permutationsKeyFormat")
+    void testWrapperRecord(final KeyFormat keyFormat, final Verifier verifier)
+            throws InterruptedException, ExecutionException, IOException {
+        final String topic = UUID.randomUUID().toString();
+        final String groupId = topic.substring(0, topic.indexOf("-"));
+
+        runner.setProperty(ConsumeKafka.GROUP_ID, groupId);
+        runner.setProperty(ConsumeKafka.TOPICS, topic);
+        runner.setProperty(ConsumeKafka.PROCESSING_STRATEGY, ProcessingStrategy.RECORD);
+        runner.setProperty(ConsumeKafka.AUTO_OFFSET_RESET, AutoOffsetReset.EARLIEST);
+        runner.setProperty(ConsumeKafka.OUTPUT_STRATEGY, OutputStrategy.INJECT_METADATA);
+        runner.setProperty(ConsumeKafka.KEY_FORMAT, keyFormat);
+        runner.setProperty(ConsumeKafka.HEADER_NAME_PATTERN, "header*");
+
+        runner.run(1, false, true);
+        final String message = new String(IOUtils.toByteArray(Objects.requireNonNull(
+                getClass().getClassLoader().getResource(TEST_RESOURCE))), StandardCharsets.UTF_8);
+        final List<Header> headersPublish = Collections.singletonList(
+                new RecordHeader("header1", "value1".getBytes(StandardCharsets.UTF_8)));
+        produceOne(topic, 0, MESSAGE_KEY, message, headersPublish);
+        while (runner.getFlowFilesForRelationship("success").isEmpty()) {
+            runner.run(1, false, false);
+        }
+        runner.run(1, true, false);
+
+        runner.assertAllFlowFilesTransferred(ConsumeKafka.SUCCESS, 1);
+
+        final List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumeKafka.SUCCESS);
+        assertEquals(1, flowFiles.size());
+
+        final MockFlowFile flowFile = flowFiles.getFirst();
+        runner.getLogger().trace(flowFile.getContent());
+        flowFile.assertAttributeEquals("record.count", Long.toString(TEST_RECORD_COUNT));
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final JsonNode jsonNodeTree = objectMapper.readTree(flowFile.getContent());
+        final ArrayNode arrayNode = assertInstanceOf(ArrayNode.class, jsonNodeTree);
+
+        final Iterator<JsonNode> elements = arrayNode.elements();
+        assertEquals(TEST_RECORD_COUNT, arrayNode.size());
+
+        while (elements.hasNext()) {
+            final ObjectNode record = assertInstanceOf(ObjectNode.class, elements.next());
+
+            assertTrue(Arrays.asList(1, 2, 3).contains(record.get("id").asInt()));
+            assertTrue(Arrays.asList("A", "B", "C").contains(record.get("name").asText()));
+
+            final ObjectNode metadata = assertInstanceOf(ObjectNode.class, record.get(InjectMetadataRecord.METADATA));
+
+            verifier.verify(metadata.get(InjectMetadataRecord.KEY));
+
+            final ObjectNode headers = assertInstanceOf(ObjectNode.class, metadata.get(InjectMetadataRecord.HEADERS));
+            assertEquals(1, headers.size());
+            assertEquals("value1", headers.get("header1").asText());
+
+            assertEquals(topic, metadata.get(InjectMetadataRecord.TOPIC).asText());
+            assertEquals(FIRST_PARTITION, metadata.get(InjectMetadataRecord.PARTITION).asInt());
+            assertEquals(FIRST_OFFSET, metadata.get(InjectMetadataRecord.OFFSET).asInt());
+            assertTrue(metadata.get(InjectMetadataRecord.TIMESTAMP).isIntegralNumber());
+        }
+
+        final List<ProvenanceEventRecord> provenanceEvents = runner.getProvenanceEvents();
+        assertEquals(1, provenanceEvents.size());
+        final ProvenanceEventRecord provenanceEvent = provenanceEvents.getFirst();
+        assertEquals(ProvenanceEventType.RECEIVE, provenanceEvent.getEventType());
+    }
+}

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/convert/AbstractRecordStreamKafkaMessageConverter.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/convert/AbstractRecordStreamKafkaMessageConverter.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kafka.processors.consumer.convert;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.kafka.processors.ConsumeKafka;
+import org.apache.nifi.kafka.processors.common.KafkaUtils;
+import org.apache.nifi.kafka.processors.consumer.OffsetTracker;
+import org.apache.nifi.kafka.service.api.record.ByteRecord;
+import org.apache.nifi.kafka.shared.attribute.KafkaFlowFileAttribute;
+import org.apache.nifi.kafka.shared.property.KeyEncoding;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.schema.access.SchemaNotFoundException;
+import org.apache.nifi.serialization.MalformedRecordException;
+import org.apache.nifi.serialization.RecordReader;
+import org.apache.nifi.serialization.RecordReaderFactory;
+import org.apache.nifi.serialization.RecordSetWriter;
+import org.apache.nifi.serialization.RecordSetWriterFactory;
+import org.apache.nifi.serialization.SimpleRecordSchema;
+import org.apache.nifi.serialization.WriteResult;
+import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.serialization.record.RecordSchema;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public abstract class AbstractRecordStreamKafkaMessageConverter implements KafkaMessageConverter {
+    private static final RecordSchema EMPTY_SCHEMA = new SimpleRecordSchema(List.of());
+
+    protected final RecordReaderFactory readerFactory;
+    protected final RecordSetWriterFactory writerFactory;
+    protected final Charset headerEncoding;
+    protected final Pattern headerNamePattern;
+    protected final KeyEncoding keyEncoding;
+    protected final boolean commitOffsets;
+    protected final OffsetTracker offsetTracker;
+    protected final ComponentLog logger;
+    protected final String brokerUri;
+
+    public AbstractRecordStreamKafkaMessageConverter(
+            final RecordReaderFactory readerFactory,
+            final RecordSetWriterFactory writerFactory,
+            final Charset headerEncoding,
+            final Pattern headerNamePattern,
+            final KeyEncoding keyEncoding,
+            final boolean commitOffsets,
+            final OffsetTracker offsetTracker,
+            final ComponentLog logger,
+            final String brokerUri) {
+        this.readerFactory = readerFactory;
+        this.writerFactory = writerFactory;
+        this.headerEncoding = headerEncoding;
+        this.headerNamePattern = headerNamePattern;
+        this.keyEncoding = keyEncoding;
+        this.commitOffsets = commitOffsets;
+        this.offsetTracker = offsetTracker;
+        this.logger = logger;
+        this.brokerUri = brokerUri;
+    }
+
+    @Override
+    public void toFlowFiles(final ProcessSession session, final Iterator<ByteRecord> consumerRecords) {
+        final Map<RecordGroupCriteria, RecordGroup> recordGroups = new HashMap<>();
+
+        while (consumerRecords.hasNext()) {
+            final ByteRecord consumerRecord = consumerRecords.next();
+            final String topic = consumerRecord.getTopic();
+            final int partition = consumerRecord.getPartition();
+            final byte[] value = consumerRecord.getValue();
+
+            // shared attribute extraction
+            final Map<String, String> attributes = KafkaUtils.toAttributes(
+                    consumerRecord, keyEncoding, headerNamePattern, headerEncoding, commitOffsets);
+
+            // hook for subclasses to expose headers (if desired)
+            final Map<String, String> extraAttrs = extractHeaders(consumerRecord);
+
+            try (final InputStream in = new ByteArrayInputStream(value);
+                    final RecordReader reader = readerFactory.createRecordReader(attributes, in, value.length, logger)) {
+
+                int recordCount = 0;
+                while (true) {
+                    final Record record = reader.nextRecord();
+                    if (recordCount++ > 0 && record == null) {
+                        break;
+                    }
+                    // delegate the actual grouping & writing
+                    processSingleRecord(session, recordGroups, consumerRecord, record, attributes, extraAttrs, topic, partition);
+                }
+            } catch (final MalformedRecordException | IOException | SchemaNotFoundException e) {
+                handleParseFailure(session, consumerRecord, attributes, value);
+                offsetTracker.update(consumerRecord);
+                continue;
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to process Kafka message", e);
+            }
+
+            offsetTracker.update(consumerRecord);
+        }
+
+        finishAllGroups(session, recordGroups);
+    }
+
+    private void processSingleRecord(final ProcessSession session,
+            final Map<RecordGroupCriteria, RecordGroup> recordGroups,
+            final ByteRecord consumerRecord,
+            final Record record,
+            final Map<String, String> attributes,
+            final Map<String, String> extraAttrs,
+            final String topic,
+            final int partition) throws Exception {
+        // pick the “bare” schema if the record is null
+        final RecordSchema inputSchema = record == null ? EMPTY_SCHEMA : record.getSchema();
+        // let subclass decide how to wrap/transform that into the final schema
+        final RecordSchema writeSchema = getWriteSchema(inputSchema, consumerRecord, attributes);
+
+        final RecordGroupCriteria criteria = new RecordGroupCriteria(writeSchema, extraAttrs, topic, partition);
+        RecordGroup group = recordGroups.get(criteria);
+        if (group == null) {
+            FlowFile ff = session.create();
+            ff = session.putAllAttributes(ff, Map.of(
+                    KafkaFlowFileAttribute.KAFKA_TOPIC, topic,
+                    KafkaFlowFileAttribute.KAFKA_PARTITION, String.valueOf(partition)));
+
+            final OutputStream out = session.write(ff);
+            final RecordSetWriter writer;
+            try {
+                writer = writerFactory.createWriter(logger, writeSchema, out, attributes);
+                writer.beginRecordSet();
+            } catch (final Exception ex) {
+                out.close();
+                throw ex;
+            }
+
+            group = new RecordGroup(ff, writer);
+            recordGroups.put(criteria, group);
+        }
+
+        // let subclass convert into the thing to write
+        final Record toWrite = convertRecord(consumerRecord, record, attributes);
+        if (toWrite != null) {
+            group.writer().write(toWrite);
+        }
+    }
+
+    private void finishAllGroups(final ProcessSession session, final Map<RecordGroupCriteria, RecordGroup> recordGroups) {
+        for (final Map.Entry<RecordGroupCriteria, RecordGroup> e : recordGroups.entrySet()) {
+            final RecordGroupCriteria criteria = e.getKey();
+            final RecordGroup group = e.getValue();
+
+            final Map<String, String> resultAttrs = new HashMap<>();
+            final int recordCount;
+            try (final RecordSetWriter writer = group.writer()) {
+                final WriteResult wr = writer.finishRecordSet();
+                resultAttrs.putAll(wr.getAttributes());
+                resultAttrs.put("record.count", String.valueOf(wr.getRecordCount()));
+                resultAttrs.put(CoreAttributes.MIME_TYPE.key(), writer.getMimeType());
+                // add any extra header‐derived attributes
+                resultAttrs.putAll(criteria.extraAttributes());
+                resultAttrs.put(KafkaFlowFileAttribute.KAFKA_CONSUMER_OFFSETS_COMMITTED, String.valueOf(commitOffsets));
+                recordCount = wr.getRecordCount();
+            } catch (final Exception ex) {
+                throw new ProcessException("Failed to write Kafka records to FlowFile", ex);
+            }
+
+            FlowFile ff = group.flowFile();
+            ff = session.putAllAttributes(ff, resultAttrs);
+
+            session.getProvenanceReporter().receive(ff, brokerUri + "/" + criteria.topic());
+            session.adjustCounter("Records Received from " + criteria.topic(), recordCount, false);
+            session.transfer(ff, ConsumeKafka.SUCCESS);
+        }
+    }
+
+    protected void handleParseFailure(final ProcessSession session, final ByteRecord consumerRecord, final Map<String, String> attributes, final byte[] value) {
+        FlowFile ff = session.create();
+        ff = session.putAllAttributes(ff, attributes);
+        ff = session.write(ff, out -> out.write(value));
+        session.transfer(ff, ConsumeKafka.PARSE_FAILURE);
+        session.adjustCounter("Records Received from " + consumerRecord.getTopic(), 1, false);
+    }
+
+    /**
+     * By default we do *not* promote any headers to FlowFile attributes.
+     **/
+    protected Map<String, String> extractHeaders(final ByteRecord consumerRecord) {
+        return Map.of();
+    }
+
+    protected abstract RecordSchema getWriteSchema(RecordSchema inputSchema, ByteRecord consumerRecord, Map<String, String> attributes) throws IOException;
+
+    protected abstract Record convertRecord(ByteRecord consumerRecord, Record record, Map<String, String> attributes) throws IOException;
+
+    private static record RecordGroupCriteria(RecordSchema schema, Map<String, String> extraAttributes, String topic, int partition) {
+    }
+
+    private static record RecordGroup(FlowFile flowFile, RecordSetWriter writer) {
+    }
+}

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/convert/AbstractRecordStreamKafkaMessageConverter.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/convert/AbstractRecordStreamKafkaMessageConverter.java
@@ -103,12 +103,8 @@ public abstract class AbstractRecordStreamKafkaMessageConverter implements Kafka
             try (final InputStream in = new ByteArrayInputStream(value);
                     final RecordReader reader = readerFactory.createRecordReader(attributes, in, value.length, logger)) {
 
-                int recordCount = 0;
-                while (true) {
-                    final Record record = reader.nextRecord();
-                    if (recordCount++ > 0 && record == null) {
-                        break;
-                    }
+                Record record;
+                while ((record = reader.nextRecord()) != null) {
                     // delegate the actual grouping & writing
                     processSingleRecord(session, recordGroups, consumerRecord, record, attributes, extraAttrs, topic, partition);
                 }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/convert/WrapperRecordStreamKafkaMessageConverter.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/convert/WrapperRecordStreamKafkaMessageConverter.java
@@ -16,194 +16,79 @@
  */
 package org.apache.nifi.kafka.processors.consumer.convert;
 
-import org.apache.nifi.flowfile.FlowFile;
-import org.apache.nifi.flowfile.attributes.CoreAttributes;
-import org.apache.nifi.kafka.processors.ConsumeKafka;
-import org.apache.nifi.kafka.processors.common.KafkaUtils;
 import org.apache.nifi.kafka.processors.consumer.OffsetTracker;
 import org.apache.nifi.kafka.processors.consumer.wrapper.ConsumeWrapperRecord;
 import org.apache.nifi.kafka.processors.consumer.wrapper.WrapperRecordKeyReader;
+import org.apache.nifi.kafka.processors.producer.wrapper.InjectMetadataRecord;
 import org.apache.nifi.kafka.processors.producer.wrapper.WrapperRecord;
 import org.apache.nifi.kafka.service.api.record.ByteRecord;
-import org.apache.nifi.kafka.shared.attribute.KafkaFlowFileAttribute;
 import org.apache.nifi.kafka.shared.property.KeyEncoding;
 import org.apache.nifi.kafka.shared.property.KeyFormat;
+import org.apache.nifi.kafka.shared.property.OutputStrategy;
 import org.apache.nifi.logging.ComponentLog;
-import org.apache.nifi.processor.ProcessSession;
-import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
 import org.apache.nifi.serialization.MalformedRecordException;
-import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
-import org.apache.nifi.serialization.RecordSetWriter;
 import org.apache.nifi.serialization.RecordSetWriterFactory;
-import org.apache.nifi.serialization.SimpleRecordSchema;
-import org.apache.nifi.serialization.WriteResult;
-import org.apache.nifi.serialization.record.MapRecord;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.util.Tuple;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
-public class WrapperRecordStreamKafkaMessageConverter implements KafkaMessageConverter {
-    private static final RecordSchema EMPTY_SCHEMA = new SimpleRecordSchema(List.of());
+public class WrapperRecordStreamKafkaMessageConverter extends AbstractRecordStreamKafkaMessageConverter {
 
-    private final RecordReaderFactory readerFactory;
-    private final RecordSetWriterFactory writerFactory;
     private final RecordReaderFactory keyReaderFactory;
-    private final Charset headerEncoding;
-    private final Pattern headerNamePattern;
     private final KeyFormat keyFormat;
-    private final KeyEncoding keyEncoding;
-    private final boolean commitOffsets;
-    private final OffsetTracker offsetTracker;
-    private final ComponentLog logger;
-    private final String brokerUri;
+    private final OutputStrategy outputStrategy;
 
     public WrapperRecordStreamKafkaMessageConverter(
             final RecordReaderFactory readerFactory,
             final RecordSetWriterFactory writerFactory,
             final RecordReaderFactory keyReaderFactory,
             final Charset headerEncoding,
-            final Pattern headerNamePattern,
+            final java.util.regex.Pattern headerNamePattern,
             final KeyFormat keyFormat,
             final KeyEncoding keyEncoding,
             final boolean commitOffsets,
             final OffsetTracker offsetTracker,
             final ComponentLog logger,
-            final String brokerUri) {
-        this.readerFactory = readerFactory;
-        this.writerFactory = writerFactory;
+            final String brokerUri,
+            final OutputStrategy outputStrategy) {
+        super(readerFactory, writerFactory, headerEncoding, headerNamePattern, keyEncoding, commitOffsets, offsetTracker, logger, brokerUri);
         this.keyReaderFactory = keyReaderFactory;
-        this.headerEncoding = headerEncoding;
-        this.headerNamePattern = headerNamePattern;
         this.keyFormat = keyFormat;
-        this.keyEncoding = keyEncoding;
-        this.commitOffsets = commitOffsets;
-        this.offsetTracker = offsetTracker;
-        this.logger = logger;
-        this.brokerUri = brokerUri;
+        this.outputStrategy = outputStrategy;
     }
 
     @Override
-    public void toFlowFiles(final ProcessSession session, final Iterator<ByteRecord> consumerRecords) {
+    protected RecordSchema getWriteSchema(final RecordSchema inputSchema, final ByteRecord consumerRecord, final Map<String, String> attributes) throws IOException {
         try {
-            final Map<RecordGroupCriteria, RecordGroup> recordGroups = new HashMap<>();
-
-            while (consumerRecords.hasNext()) {
-                final ByteRecord consumerRecord = consumerRecords.next();
-                final String topic = consumerRecord.getTopic();
-                final int partition = consumerRecord.getPartition();
-
-                final byte[] value = consumerRecord.getValue();
-                final Map<String, String> attributes = KafkaUtils.toAttributes(
-                        consumerRecord, keyEncoding, headerNamePattern, headerEncoding, commitOffsets);
-
-                try (final InputStream in = new ByteArrayInputStream(value);
-                     final RecordReader valueRecordReader = readerFactory.createRecordReader(attributes, in, value.length, logger)) {
-
-                    int recordCount = 0;
-                    while (true) {
-                        final Record record = valueRecordReader.nextRecord();
-                        // If we get a KafkaRecord that has no value, we still need to process it.
-                        if (recordCount++ > 0 && record == null) {
-                            break;
-                        }
-
-                        final WrapperRecordKeyReader keyReader = new WrapperRecordKeyReader(keyFormat, keyReaderFactory, keyEncoding, logger);
-                        final Tuple<RecordField, Object> recordKey = keyReader.toWrapperRecordKey(consumerRecord.getKey().orElse(null), attributes);
-                        final RecordSchema recordSchema = record == null ? EMPTY_SCHEMA : record.getSchema();
-                        final RecordSchema fullSchema = WrapperRecord.toWrapperSchema(recordKey.getKey(), recordSchema);
-                        final RecordSchema writeSchema = writerFactory.getSchema(attributes, fullSchema);
-                        final RecordGroupCriteria recordGroupCriteria = new RecordGroupCriteria(writeSchema, topic, partition);
-
-                        // Get/Register the Record Group that is associated with the schema for this Kafka Record
-                        RecordGroup recordGroup = recordGroups.get(recordGroupCriteria);
-                        if (recordGroup == null) {
-                            FlowFile flowFile = session.create();
-                            final Map<String, String> groupAttributes = Map.of(
-                                KafkaFlowFileAttribute.KAFKA_TOPIC, consumerRecord.getTopic(),
-                                KafkaFlowFileAttribute.KAFKA_PARTITION, Long.toString(consumerRecord.getPartition())
-                            );
-
-                            flowFile = session.putAllAttributes(flowFile, groupAttributes);
-
-                            final OutputStream out = session.write(flowFile);
-                            final RecordSetWriter writer;
-                            try {
-                                writer = writerFactory.createWriter(logger, writeSchema, out, attributes);
-                                writer.beginRecordSet();
-                            } catch (final Exception e) {
-                                out.close();
-                                throw e;
-                            }
-
-                            recordGroup = new RecordGroup(flowFile, writer, topic, partition);
-                            recordGroups.put(recordGroupCriteria, recordGroup);
-                        }
-
-                        // Create the Record object and write it to the Record Writer.
-                        final ConsumeWrapperRecord consumeWrapperRecord = new ConsumeWrapperRecord(headerEncoding);
-                        final MapRecord wrapperRecord = consumeWrapperRecord.toWrapperRecord(consumerRecord, record, recordKey);
-                        recordGroup.writer().write(wrapperRecord);
-                    }
-                } catch (final MalformedRecordException e) {
-                    // Failed to parse the record. Transfer to a 'parse.failure' relationship
-                    FlowFile flowFile = session.create();
-                    flowFile = session.putAllAttributes(flowFile, attributes);
-                    flowFile = session.write(flowFile, out -> out.write(value));
-                    session.transfer(flowFile, ConsumeKafka.PARSE_FAILURE);
-                    session.adjustCounter("Records Received from " + consumerRecord.getTopic(), 1, false);
-
-                    // Track the offsets for the Kafka Record
-                    offsetTracker.update(consumerRecord);
-                    continue;
-                }
-
-                // Track the offsets for the Kafka Record
-                offsetTracker.update(consumerRecord);
-            }
-
-            // Finish writing the records
-            for (final RecordGroup recordGroup : recordGroups.values()) {
-                final Map<String, String> attributes;
-                final int recordCount;
-                try (final RecordSetWriter writer = recordGroup.writer()) {
-                    final WriteResult writeResult = writer.finishRecordSet();
-                    attributes = new HashMap<>(writeResult.getAttributes());
-                    attributes.put("record.count", String.valueOf(writeResult.getRecordCount()));
-                    attributes.put(CoreAttributes.MIME_TYPE.key(), writer.getMimeType());
-                    attributes.put(KafkaFlowFileAttribute.KAFKA_CONSUMER_OFFSETS_COMMITTED, String.valueOf(commitOffsets));
-
-                    recordCount = writeResult.getRecordCount();
-                }
-
-                FlowFile flowFile = recordGroup.flowFile();
-                flowFile = session.putAllAttributes(flowFile, attributes);
-
-                session.getProvenanceReporter().receive(flowFile, brokerUri + "/" + recordGroup.topic);
-                session.adjustCounter("Records Received from " + recordGroup.topic, recordCount, false);
-                session.transfer(flowFile, ConsumeKafka.SUCCESS);
-            }
-        } catch (final SchemaNotFoundException | IOException e) {
-            throw new ProcessException("FlowFile Record conversion failed", e);
+            final WrapperRecordKeyReader keyReader = new WrapperRecordKeyReader(keyFormat, keyReaderFactory, keyEncoding, logger);
+            final Tuple<RecordField, Object> recordKey = keyReader.toWrapperRecordKey(consumerRecord.getKey().orElse(null), attributes);
+            final RecordSchema fullSchema = outputStrategy == OutputStrategy.USE_WRAPPER
+                    ? WrapperRecord.toWrapperSchema(recordKey.getKey(), inputSchema)
+                    : InjectMetadataRecord.toWrapperSchema(recordKey.getKey(), inputSchema);
+            return writerFactory.getSchema(attributes, fullSchema);
+        } catch (IOException | SchemaNotFoundException | MalformedRecordException e) {
+            throw new IOException("Unable to get schema for wrapper record", e);
         }
     }
 
-    private record RecordGroupCriteria(RecordSchema schema, String topic, int partition) {
+    @Override
+    protected Record convertRecord(final ByteRecord consumerRecord, final Record record, final Map<String, String> attributes) throws IOException {
+        try {
+            final WrapperRecordKeyReader keyReader = new WrapperRecordKeyReader(keyFormat, keyReaderFactory, keyEncoding, logger);
+            final Tuple<RecordField, Object> recordKey = keyReader.toWrapperRecordKey(consumerRecord.getKey().orElse(null), attributes);
+            return outputStrategy == OutputStrategy.USE_WRAPPER
+                    ? new ConsumeWrapperRecord(headerEncoding).toWrapperRecord(consumerRecord, record, recordKey)
+                    : InjectMetadataRecord.toWrapperRecord(headerEncoding, consumerRecord, record, recordKey);
+        } catch (IOException | SchemaNotFoundException | MalformedRecordException e) {
+            throw new IOException("Unable to convert record", e);
+        }
     }
 
-    private record RecordGroup(FlowFile flowFile, RecordSetWriter writer, String topic, int partition) {
-    }
 }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/wrapper/ConsumeWrapperRecord.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/wrapper/ConsumeWrapperRecord.java
@@ -28,7 +28,6 @@ import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.util.Tuple;
 
 import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,11 +48,14 @@ public class ConsumeWrapperRecord {
         final Tuple<RecordField, Object> tupleValue = toWrapperRecordValue(record);
         final Tuple<RecordField, Object> tupleHeaders = toWrapperRecordHeaders(consumerRecord);
         final Tuple<RecordField, Object> tupleMetadata = toWrapperRecordMetadata(consumerRecord);
-        final RecordSchema rootRecordSchema = new SimpleRecordSchema(Arrays.asList(
-                tupleKey.getKey(), tupleValue.getKey(), tupleHeaders.getKey(), tupleMetadata.getKey()));
+        final RecordSchema rootRecordSchema = tupleKey.getKey() == null
+                ? new SimpleRecordSchema(List.of(tupleValue.getKey(), tupleHeaders.getKey(), tupleMetadata.getKey()))
+                : new SimpleRecordSchema(List.of(tupleKey.getKey(), tupleValue.getKey(), tupleHeaders.getKey(), tupleMetadata.getKey()));
 
         final Map<String, Object> recordValues = new HashMap<>();
-        recordValues.put(tupleKey.getKey().getFieldName(), tupleKey.getValue());
+        if (tupleKey.getKey() != null) {
+            recordValues.put(tupleKey.getKey().getFieldName(), tupleKey.getValue());
+        }
         recordValues.put(tupleValue.getKey().getFieldName(), tupleValue.getValue());
         recordValues.put(tupleHeaders.getKey().getFieldName(), tupleHeaders.getValue());
         recordValues.put(tupleMetadata.getKey().getFieldName(), tupleMetadata.getValue());
@@ -79,7 +81,7 @@ public class ConsumeWrapperRecord {
     private static final RecordField FIELD_PARTITION = new RecordField(WrapperRecord.PARTITION, RecordFieldType.INT.getDataType());
     private static final RecordField FIELD_OFFSET = new RecordField(WrapperRecord.OFFSET, RecordFieldType.LONG.getDataType());
     private static final RecordField FIELD_TIMESTAMP = new RecordField(WrapperRecord.TIMESTAMP, RecordFieldType.TIMESTAMP.getDataType());
-    private static final RecordSchema SCHEMA_WRAPPER = new SimpleRecordSchema(Arrays.asList(
+    private static final RecordSchema SCHEMA_WRAPPER = new SimpleRecordSchema(List.of(
             FIELD_TOPIC, FIELD_PARTITION, FIELD_OFFSET, FIELD_TIMESTAMP));
 
     private Tuple<RecordField, Object> toWrapperRecordMetadata(final ByteRecord consumerRecord) {

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/wrapper/WrapperRecordKeyReader.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/consumer/wrapper/WrapperRecordKeyReader.java
@@ -75,7 +75,9 @@ public class WrapperRecordKeyReader {
     private Tuple<RecordField, Object> toKeyRecord(final byte[] key, final Map<String, String> attributes)
             throws IOException, SchemaNotFoundException, MalformedRecordException {
         final Tuple<RecordField, Object> keyRecord;
-        if (key.length == 0) {
+        if (key == null) {
+            keyRecord = new Tuple<>(null, null);
+        } else if (key.length == 0) {
             keyRecord = new Tuple<>(EMPTY_SCHEMA_KEY_RECORD_FIELD, null);
         } else {
             try (final InputStream is = new ByteArrayInputStream(key);

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/producer/wrapper/InjectMetadataRecord.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/producer/wrapper/InjectMetadataRecord.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kafka.processors.producer.wrapper;
+
+import org.apache.nifi.kafka.service.api.header.RecordHeader;
+import org.apache.nifi.kafka.service.api.record.ByteRecord;
+import org.apache.nifi.serialization.SimpleRecordSchema;
+import org.apache.nifi.serialization.record.MapRecord;
+import org.apache.nifi.serialization.record.Record;
+import org.apache.nifi.serialization.record.RecordField;
+import org.apache.nifi.serialization.record.RecordFieldType;
+import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.util.Tuple;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Record implementation for use with {@link org.apache.nifi.kafka.processors.PublishKafka} publish strategy
+ * {@link org.apache.nifi.kafka.shared.property.PublishStrategy#USE_WRAPPER}.
+ */
+public class InjectMetadataRecord extends MapRecord {
+
+    public static final String TOPIC = "topic";
+    public static final String PARTITION = "partition";
+    public static final String OFFSET = "offset";
+    public static final String TIMESTAMP = "timestamp";
+
+    public static final String METADATA = "kafka_metadata";
+    public static final String HEADERS = "headers";
+    public static final String KEY = "key";
+
+    private static final RecordField FIELD_TOPIC = new RecordField(TOPIC, RecordFieldType.STRING.getDataType());
+    private static final RecordField FIELD_PARTITION = new RecordField(PARTITION, RecordFieldType.INT.getDataType());
+    private static final RecordField FIELD_OFFSET = new RecordField(OFFSET, RecordFieldType.LONG.getDataType());
+    private static final RecordField FIELD_TIMESTAMP = new RecordField(TIMESTAMP, RecordFieldType.TIMESTAMP.getDataType());
+    private static final RecordField FIELD_HEADERS = new RecordField(HEADERS, RecordFieldType.MAP.getMapDataType(RecordFieldType.STRING.getDataType()));
+
+    private static RecordSchema toRecordSchema(final Record record, final String messageKeyField) {
+        final Record recordKey = (Record) record.getValue(messageKeyField);
+        final RecordSchema recordSchemaKey = ((recordKey == null) ? null : recordKey.getSchema());
+        final RecordField fieldKey = new RecordField(KEY, RecordFieldType.RECORD.getRecordDataType(recordSchemaKey));
+
+        final RecordSchema metadataRecordSchema = new SimpleRecordSchema(Arrays.asList(FIELD_TOPIC, FIELD_PARTITION, FIELD_OFFSET, FIELD_TIMESTAMP, fieldKey, FIELD_HEADERS));
+        final RecordField metadataField = new RecordField(METADATA, RecordFieldType.RECORD.getRecordDataType(metadataRecordSchema));
+
+        final RecordSchema valueSchema = record.getSchema();
+        final List<RecordField> valueFields = valueSchema.getFields();
+        valueFields.add(metadataField);
+
+        return new SimpleRecordSchema(valueFields);
+    }
+
+    private static Map<String, Object> toValues(
+            final Record record, final List<RecordHeader> headers, final Charset headerCharset,
+            final String messageKeyField, final String topic, final int partition, final long offset, final long timestamp) {
+        final Map<String, Object> valuesMetadata = new HashMap<>();
+        valuesMetadata.put(TOPIC, topic);
+        valuesMetadata.put(PARTITION, partition);
+        valuesMetadata.put(OFFSET, offset);
+        valuesMetadata.put(TIMESTAMP, timestamp);
+        valuesMetadata.put(KEY, record.getValue(messageKeyField));
+
+        final Map<String, Object> valuesHeaders = new HashMap<>();
+        for (RecordHeader header : headers) {
+            valuesHeaders.put(header.key(), new String(header.value(), headerCharset));
+        }
+        valuesMetadata.put(HEADERS, valuesHeaders);
+
+        Map<String, Object> valueMap = record.toMap();
+        valueMap.put(METADATA, valuesMetadata);
+
+        return valueMap;
+    }
+
+    public InjectMetadataRecord(final Record record, final String messageKeyField,
+                         final List<RecordHeader> headers, final Charset headerCharset,
+                         final String topic, final int partition, final long offset, final long timestamp) {
+        super(toRecordSchema(record, messageKeyField),
+                toValues(record, headers, headerCharset, messageKeyField, topic, partition, offset, timestamp));
+    }
+
+    public static RecordSchema toWrapperSchema(final RecordField fieldKey, final RecordSchema recordSchema) {
+        final RecordSchema metadataRecordSchema = new SimpleRecordSchema(Arrays.asList(FIELD_TOPIC, FIELD_PARTITION, FIELD_OFFSET, FIELD_TIMESTAMP, fieldKey, FIELD_HEADERS));
+        final RecordField metadataField = new RecordField(METADATA, RecordFieldType.RECORD.getRecordDataType(metadataRecordSchema));
+        final List<RecordField> valueFields = recordSchema.getFields();
+        final List<RecordField> valueFieldsWithInjectedMetadata = new ArrayList<>(valueFields);
+        valueFieldsWithInjectedMetadata.add(metadataField);
+        return new SimpleRecordSchema(valueFieldsWithInjectedMetadata);
+    }
+
+    public static MapRecord toWrapperRecord(final Charset headerCharacterSet, final ByteRecord consumerRecord, final Record record, final Tuple<RecordField, Object> tupleKey) {
+        final RecordSchema schema = record.getSchema();
+        RecordSchema finalSchema = InjectMetadataRecord.toWrapperSchema(tupleKey.getKey(), schema);
+
+        final Map<String, Object> valuesMetadata = new HashMap<>();
+        valuesMetadata.put(InjectMetadataRecord.TOPIC, consumerRecord.getTopic());
+        valuesMetadata.put(InjectMetadataRecord.PARTITION, consumerRecord.getPartition());
+        valuesMetadata.put(InjectMetadataRecord.OFFSET, consumerRecord.getOffset());
+        valuesMetadata.put(InjectMetadataRecord.TIMESTAMP, consumerRecord.getTimestamp());
+        valuesMetadata.put(InjectMetadataRecord.KEY, tupleKey.getValue());
+
+        final Map<String, Object> valuesHeaders = new HashMap<>();
+        for (RecordHeader header : consumerRecord.getHeaders()) {
+            valuesHeaders.put(header.key(), new String(header.value(), headerCharacterSet));
+        }
+        valuesMetadata.put(InjectMetadataRecord.HEADERS, valuesHeaders);
+
+        final Map<String, Object> valueMap = record.toMap();
+        final Map<String, Object> valueMapWithInjectedMetadata = new HashMap<>(valueMap);
+        valueMapWithInjectedMetadata.put(InjectMetadataRecord.METADATA, valuesMetadata);
+
+        return new MapRecord(finalSchema, valueMapWithInjectedMetadata);
+    }
+}

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/producer/wrapper/WrapperRecord.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/java/org/apache/nifi/kafka/processors/producer/wrapper/WrapperRecord.java
@@ -95,6 +95,8 @@ public class WrapperRecord extends MapRecord {
 
     public static RecordSchema toWrapperSchema(final RecordField fieldKey, final RecordSchema recordSchema) {
         final RecordField fieldValue = new RecordField(VALUE, RecordFieldType.RECORD.getRecordDataType(recordSchema));
-        return new SimpleRecordSchema(Arrays.asList(FIELD_METADATA, FIELD_HEADERS, fieldKey, fieldValue));
+        return fieldKey == null
+                ? new SimpleRecordSchema(Arrays.asList(FIELD_METADATA, FIELD_HEADERS, fieldValue))
+                : new SimpleRecordSchema(Arrays.asList(FIELD_METADATA, FIELD_HEADERS, fieldKey, fieldValue));
     }
 }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/resources/docs/org.apache.nifi.kafka.processors.ConsumeKafka/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/resources/docs/org.apache.nifi.kafka.processors.ConsumeKafka/additionalDetails.md
@@ -1,0 +1,177 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# ConsumeKafka
+
+### Output Strategies
+
+This processor offers multiple output strategies (configured via processor property 'Output Strategy') for converting Kafka records into FlowFiles.
+
+- 'Use Content as Value' (the default) emits FlowFile records containing only the Kafka record value.
+- 'Use Wrapper' emits FlowFile records containing the Kafka record key, value, and headers, as well as additional metadata from the Kafka record.
+- 'Inject Metadata' emits FlowFile records containing the Kafka record value into which a sub record field has been added to hold metadata, headers and key information.
+
+The record schema that is used when "Use Wrapper" is selected is as follows (in Avro format):
+
+```json
+{
+  "type": "record",
+  "name": "nifiRecord",
+  "namespace": "org.apache.nifi",
+  "fields": [{
+      "name": "key",
+      "type": [{
+          < Schema is determined by the Key Record Reader, or will be "string" or "bytes", depending on the "Key Format" property (see below for more details) >
+        }, "null"]
+    },
+    {
+      "name": "value",
+      "type": [
+        {
+          < Schema is determined by the Record Reader >
+        },
+        "null"
+      ]
+    },
+    {
+      "name": "headers",
+      "type": [
+        { "type": "map", "values": "string", "default": {}},
+        "null"]
+    },
+    {
+      "name": "metadata",
+      "type": [
+        {
+          "type": "record",
+          "name": "metadataType",
+          "fields": [
+            { "name": "topic", "type": ["string", "null"] },
+            { "name": "partition", "type": ["int", "null"] },
+            { "name": "offset", "type": ["int", "null"] },
+            { "name": "timestamp", "type": ["long", "null"] }
+          ]
+        },
+        "null"
+      ]
+    }
+  ]
+}
+```
+
+The record schema that is used when "Inject Metadata" is selected is as follows (in Avro format):
+
+```json
+{
+  "type": "record",
+  "name": "nifiRecord",
+  "namespace": "org.apache.nifi",
+  "fields": [
+      < Fields as determined by the Record Reader for the Kafka message >,
+    {
+      "name": "kafka_metadata",
+      "type": [
+        {
+          "type": "record",
+          "name": "metadataType",
+          "fields": [
+            { "name": "topic", "type": ["string", "null"] },
+            { "name": "partition", "type": ["int", "null"] },
+            { "name": "offset", "type": ["int", "null"] },
+            { "name": "timestamp", "type": ["long", "null"] },
+            {
+              "name": "headers",
+              "type": [ { "type": "map", "values": "string", "default": {}}, "null"]
+            },
+            {
+              "name": "key",
+              "type": [{
+                < Schema is determined by the Key Record Reader, or will be "string" or "bytes", depending on the "Key Format" property (see below for more details) >
+              }, "null"]
+            }
+          ]
+        },
+        "null"
+      ]
+    }
+  ]
+}
+```
+
+If the Output Strategy property is set to 'Use Wrapper' or 'Inject Metadata', an additional processor configuration property ('Key Format') is activated. This property is used to specify how the Kafka Record's key should be written out to the FlowFile. The possible values for 'Key Format' are as follows:
+
+- 'Byte Array' supplies the Kafka Record Key as a byte array, exactly as they are received in the Kafka record.
+- 'String' converts the Kafka Record Key bytes into a string using the UTF-8 character encoding. (Failure to parse the key bytes as UTF-8 will result in the record being routed to the 'parse.failure' relationship.)
+- 'Record' converts the Kafka Record Key bytes into a deserialized NiFi record, using the associated 'Key Record Reader' controller service. If the Key Format property is set to 'Record', an additional processor configuration property name 'Key Record Reader' is made available. This property is used to specify the Record Reader to use in order to parse the Kafka Record's key as a Record.
+
+Here is an example of FlowFile content that is emitted by JsonRecordSetWriter when strategy "Use Wrapper" is selected:
+
+```json
+[
+  {
+    "key": {
+      "name": "Acme",
+      "number": "AC1234"
+    },
+    "value": {
+      "address": "1234 First Street",
+      "zip": "12345",
+      "account": {
+        "name": "Acme",
+        "number": "AC1234"
+      }
+    },
+    "headers": {
+      "attributeA": "valueA",
+      "attributeB": "valueB"
+    },
+    "metadata": {
+      "topic": "accounts",
+      "partition": 0,
+      "offset": 0,
+      "timestamp": 0
+    }
+  }
+]
+```
+
+Here is an example of FlowFile content that is emitted by JsonRecordSetWriter when strategy "Inject Metadata" is selected:
+
+```json
+[
+  {
+    "address": "1234 First Street",
+    "zip": "12345",
+    "account": {
+      "name": "Acme",
+      "number": "AC1234"
+    },
+    "kafka_metadata": {
+      "topic": "accounts",
+      "partition": 0,
+      "offset": 0,
+      "timestamp": 0,
+      "headers": {
+        "attributeA": "valueA",
+        "attributeB": "valueB"
+      },
+      "key": {
+        "name": "Acme",
+        "number": "AC1234"
+      }
+    }
+  }
+]
+```

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/resources/docs/org.apache.nifi.kafka.processors.ConsumeKafka/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/main/resources/docs/org.apache.nifi.kafka.processors.ConsumeKafka/additionalDetails.md
@@ -81,7 +81,7 @@ The record schema that is used when "Inject Metadata" is selected is as follows 
   "fields": [
       < Fields as determined by the Record Reader for the Kafka message >,
     {
-      "name": "kafka_metadata",
+      "name": "kafkaMetadata",
       "type": [
         {
           "type": "record",
@@ -158,7 +158,7 @@ Here is an example of FlowFile content that is emitted by JsonRecordSetWriter wh
       "name": "Acme",
       "number": "AC1234"
     },
-    "kafka_metadata": {
+    "kafkaMetadata": {
       "topic": "accounts",
       "partition": 0,
       "offset": 0,

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/convert/WrapperRecordStreamKafkaMessageConverterTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-processors/src/test/java/org/apache/nifi/kafka/processors/consumer/convert/WrapperRecordStreamKafkaMessageConverterTest.java
@@ -22,6 +22,7 @@ import org.apache.nifi.kafka.service.api.record.ByteRecord;
 import org.apache.nifi.kafka.shared.attribute.KafkaFlowFileAttribute;
 import org.apache.nifi.kafka.shared.property.KeyEncoding;
 import org.apache.nifi.kafka.shared.property.KeyFormat;
+import org.apache.nifi.kafka.shared.property.OutputStrategy;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.serialization.RecordReaderFactory;
@@ -82,7 +83,8 @@ class WrapperRecordStreamKafkaMessageConverterTest {
                 true,
                 offsetTracker,
                 logger,
-                "brokerUri"
+                "brokerUri",
+                OutputStrategy.USE_WRAPPER
         );
 
         // Create ByteRecords

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/OutputStrategy.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/OutputStrategy.java
@@ -23,7 +23,9 @@ import org.apache.nifi.components.DescribedValue;
  */
 public enum OutputStrategy implements DescribedValue {
     USE_VALUE("USE_VALUE", "Use Content as Value", "Write only the Kafka Record value to the FlowFile record."),
-    USE_WRAPPER("USE_WRAPPER", "Use Wrapper", "Write the Kafka Record key, value, headers, and metadata into the FlowFile record. (See processor usage for more information.)");
+    USE_WRAPPER("USE_WRAPPER", "Use Wrapper", "Write the Kafka Record key, value, headers, and metadata into the FlowFile record. (See processor's additional details for more information.)"),
+    INJECT_METADATA("INJECT_METADATA", "Inject Metadata",
+            "Write the Kafka Record value to the FlowFile record and add a sub-record to it with key, headers, and metadata. (See processor's additional details for more information.)");
 
     private final String value;
     private final String displayName;


### PR DESCRIPTION
# Summary

[NIFI-14566](https://issues.apache.org/jira/browse/NIFI-14566) - Introduce Inject Metadata Output Strategy in ConsumeKafka

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
