### PR TITLE
NIFI-14570 Retain Git Registry Client Metadata Timestamp in JSON

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
@@ -355,7 +355,6 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
         flowSnapshot.getSnapshotMetadata().setBranch(null);
         flowSnapshot.getSnapshotMetadata().setVersion(null);
         flowSnapshot.getSnapshotMetadata().setComments(null);
-        flowSnapshot.getSnapshotMetadata().setTimestamp(0);
 
         // remove all parameter values if configured to do so
         final ParameterContextValuesStrategy parameterContextValuesStrategy = context.getProperty(PARAMETER_CONTEXT_VALUES).asAllowableValue(ParameterContextValuesStrategy.class);

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/test/java/org/apache/nifi/github/GitHubFlowRegistryClientTest.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/test/java/org/apache/nifi/github/GitHubFlowRegistryClientTest.java
@@ -116,11 +116,13 @@ public class GitHubFlowRegistryClientTest {
 
         final RegisteredFlow incomingFlow = createIncomingRegisteredFlow();
 
+        final long timestamp = System.currentTimeMillis();
         final RegisteredFlowSnapshotMetadata incomingMetadata = new RegisteredFlowSnapshotMetadata();
         incomingMetadata.setBranch(incomingFlow.getBranch());
         incomingMetadata.setBucketIdentifier(incomingFlow.getBucketIdentifier());
         incomingMetadata.setFlowIdentifier(incomingFlow.getIdentifier());
         incomingMetadata.setComments("Unit test");
+        incomingMetadata.setTimestamp(timestamp);
 
         final RegisteredFlowSnapshot incomingSnapshot = new RegisteredFlowSnapshot();
         incomingSnapshot.setFlow(incomingFlow);
@@ -154,6 +156,7 @@ public class GitHubFlowRegistryClientTest {
         assertEquals(incomingMetadata.getBucketIdentifier(), resultMetadata.getBucketIdentifier());
         assertEquals(incomingMetadata.getFlowIdentifier(), resultMetadata.getFlowIdentifier());
         assertEquals(incomingMetadata.getComments(), resultMetadata.getComments());
+        assertEquals(timestamp, resultMetadata.getTimestamp());
 
         final FlowRegistryBucket resultBucket = resultSnapshot.getBucket();
         assertNotNull(resultBucket);


### PR DESCRIPTION
# Summary

[NIFI-14570](https://issues.apache.org/jira/browse/NIFI-14570) Updates the abstract Git Flow Registry Client to retain the `timestamp` in the Flow Snapshot Metadata instead of setting it to `0`.

Although Git Flow Registry Client implementations overwrite the `timestamp` field with the value from the Git commit, persisting the timestamp in the serialized JSON enables visibility of flow definition updated time in the serialized snapshot itself.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
