### PR TITLE
NIFI-14590 fix nifi prometheus metrics that should be reporting durat…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/prometheusutil/PrometheusMetricsUtil.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/prometheusutil/PrometheusMetricsUtil.java
@@ -45,6 +45,7 @@ public class PrometheusMetricsUtil {
     protected static final String DEFAULT_LABEL_STRING = "";
     private static final double MAXIMUM_BACKPRESSURE = 1.0;
     private static final double UNDEFINED_BACKPRESSURE = -1.0;
+    private static final double NANOS_PER_MILLI = 1000000.0;
 
     public static CollectorRegistry createNifiMetrics(NiFiMetricsRegistry nifiMetricsRegistry, ProcessGroupStatus status,
                                                       String instId, String parentProcessGroupId, String compType, String metricsStrategy) {
@@ -84,7 +85,8 @@ public class PrometheusMetricsUtil {
         addProcessingPerformanceMetrics(nifiMetricsRegistry, status.getProcessingPerformanceStatus(),
                 instanceId, componentType, componentName, componentId, parentPGId);
 
-        nifiMetricsRegistry.setDataPoint(status.getProcessingNanos(), "TOTAL_TASK_DURATION",
+        // prometheus metric expects milliseconds
+        nifiMetricsRegistry.setDataPoint(status.getProcessingNanos() / NANOS_PER_MILLI, "TOTAL_TASK_DURATION",
                 instanceId, componentType, componentName, componentId, parentPGId);
 
         // Report metrics for child process groups if specified
@@ -522,20 +524,20 @@ public class PrometheusMetricsUtil {
     private static void addProcessingPerformanceMetrics(final NiFiMetricsRegistry niFiMetricsRegistry, final ProcessingPerformanceStatus perfStatus, final String instanceId,
                                                         final String componentType, final String componentName, final String componentId, final String parentId) {
         if (perfStatus != null) {
-            niFiMetricsRegistry.setDataPoint(perfStatus.getCpuDuration() / 1000.0, "PROCESSING_PERFORMANCE_CPU_DURATION",
+            // convert base metrics from nanoseconds to milliseconds except for PROCESSING_PERFORMANCE_GC_DURATION which is already in milliseconds
+            niFiMetricsRegistry.setDataPoint(perfStatus.getCpuDuration() / NANOS_PER_MILLI, "PROCESSING_PERFORMANCE_CPU_DURATION",
                     instanceId, componentType, componentName, componentId, parentId, perfStatus.getIdentifier());
 
-            // Base metric already in milliseconds
             niFiMetricsRegistry.setDataPoint(perfStatus.getGarbageCollectionDuration(), "PROCESSING_PERFORMANCE_GC_DURATION",
                     instanceId, componentType, componentName, componentId, parentId, perfStatus.getIdentifier());
 
-            niFiMetricsRegistry.setDataPoint(perfStatus.getContentReadDuration() / 1000.0, "PROCESSING_PERFORMANCE_CONTENT_READ_DURATION",
+            niFiMetricsRegistry.setDataPoint(perfStatus.getContentReadDuration() / NANOS_PER_MILLI, "PROCESSING_PERFORMANCE_CONTENT_READ_DURATION",
                     instanceId, componentType, componentName, componentId, parentId, perfStatus.getIdentifier());
 
-            niFiMetricsRegistry.setDataPoint(perfStatus.getContentWriteDuration() / 1000.0, "PROCESSING_PERFORMANCE_CONTENT_WRITE_DURATION",
+            niFiMetricsRegistry.setDataPoint(perfStatus.getContentWriteDuration() / NANOS_PER_MILLI, "PROCESSING_PERFORMANCE_CONTENT_WRITE_DURATION",
                     instanceId, componentType, componentName, componentId, parentId, perfStatus.getIdentifier());
 
-            niFiMetricsRegistry.setDataPoint(perfStatus.getSessionCommitDuration() / 1000.0, "PROCESSING_PERFORMANCE_SESSION_COMMIT_DURATION",
+            niFiMetricsRegistry.setDataPoint(perfStatus.getSessionCommitDuration() / NANOS_PER_MILLI, "PROCESSING_PERFORMANCE_SESSION_COMMIT_DURATION",
                     instanceId, componentType, componentName, componentId, parentId, perfStatus.getIdentifier());
         }
     }


### PR DESCRIPTION
Several metrics in nifi prometheus claim to be reported in milliseconds but were either actually in nanoseconds or microseconds. 

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14590](https://issues.apache.org/jira/browse/NIFI-14590)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- n/a (no new deps) New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- n/a (no new deps) New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- n/a (no new docs) Documentation formatting appears as expected in rendered files
