### PR TITLE
NIFI-14442 Show bundle version changes in versioned flow differences

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
@@ -73,6 +73,10 @@ public class FlowDifferenceFilters {
             || isLogFileSuffixChange(difference);
     }
 
+    public static boolean isBundleChange(final FlowDifference difference) {
+        return difference.getDifferenceType() == DifferenceType.BUNDLE_CHANGED;
+    }
+
     private static boolean isSensitivePropertyDueToGhosting(final FlowDifference difference, final FlowManager flowManager) {
         final DifferenceType differenceType = difference.getDifferenceType();
         if (differenceType != DifferenceType.PROPERTY_SENSITIVITY_CHANGED && differenceType != DifferenceType.PROPERTY_ADDED) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -5531,12 +5531,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
                 + " but cannot find a Flow Registry with that identifier");
         }
 
-        VersionedProcessGroup registryGroup = null;
-        final VersionControlInformation vci = processGroup.getVersionControlInformation();
-        if (vci != null) {
-            registryGroup = vci.getFlowSnapshot();
-        }
-
+        VersionedProcessGroup registryGroup = versionControlInfo.getFlowSnapshot();
         if (registryGroup == null) {
             try {
                 final FlowVersionLocation flowVersionLocation = new FlowVersionLocation(versionControlInfo.getBranch(), versionControlInfo.getBucketIdentifier(),

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -286,6 +286,8 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public final class DtoFactory {
@@ -2770,10 +2772,18 @@ public final class DtoFactory {
 
    public Set<ComponentDifferenceDTO> createComponentDifferenceDtosForLocalModifications(final FlowComparison comparison, final VersionedProcessGroup localGroup, final FlowManager flowManager) {
        final Map<ComponentDifferenceDTO, List<DifferenceDTO>> differencesByComponent = new HashMap<>();
+       final Map<ComponentDifferenceDTO, Set<DifferenceDTO>> bundleDifferencesByComponent = new HashMap<>();
 
        final Map<String, VersionedProcessGroup> versionedGroups = flattenProcessGroups(comparison.getFlowA().getContents());
 
        for (final FlowDifference difference : comparison.getDifferences()) {
+           // capture bundle differences and dedupe those differences
+           if (FlowDifferenceFilters.isBundleChange(difference)) {
+               final ComponentDifferenceDTO componentDiff = createBundleDifference(difference);
+               final Set<DifferenceDTO> differences = bundleDifferencesByComponent.computeIfAbsent(componentDiff, key -> new HashSet<>());
+               differences.add(createDifferenceDto(difference));
+           }
+
            // Ignore any environment-specific change
            if (FlowDifferenceFilters.isEnvironmentalChange(difference, localGroup, flowManager)) {
                continue;
@@ -2787,12 +2797,19 @@ public final class DtoFactory {
 
            final ComponentDifferenceDTO componentDiff = createComponentDifference(difference);
            final List<DifferenceDTO> differences = differencesByComponent.computeIfAbsent(componentDiff, key -> new ArrayList<>());
+           differences.add(createDifferenceDto(difference));
+       }
 
-           final DifferenceDTO dto = new DifferenceDTO();
-           dto.setDifferenceType(difference.getDifferenceType().getDescription());
-           dto.setDifference(difference.getDescription());
-
-           differences.add(dto);
+       if (!differencesByComponent.isEmpty()) {
+           // differences were found, so now let's add back in any BUNDLE_CHANGED differences
+           // since they were initially filtered out as an environment-specific change
+           bundleDifferencesByComponent.forEach((key, value) -> {
+               List<DifferenceDTO> values = value.stream().toList();
+               differencesByComponent.merge(key, values, (v1, v2) -> {
+                   v1.addAll(v2);
+                   return v1;
+               });
+           });
        }
 
        for (final Map.Entry<ComponentDifferenceDTO, List<DifferenceDTO>> entry : differencesByComponent.entrySet()) {
@@ -2800,6 +2817,24 @@ public final class DtoFactory {
        }
 
        return differencesByComponent.keySet();
+   }
+
+   private static final Pattern DIFFERENCE_DESCRIPTION_PATTERN = Pattern.compile(".*artifact='(.*)'.*version='(.*)'].*version='(.*)']'$");
+
+   /*
+    * Create a custom difference with a simpler difference description, only for matching descriptions.
+    */
+   DifferenceDTO createDifferenceDto(final FlowDifference difference) {
+       final DifferenceDTO dto = new DifferenceDTO();
+       dto.setDifferenceType(difference.getDifferenceType().getDescription());
+
+       String description = difference.getDescription();
+       final Matcher matcher = DIFFERENCE_DESCRIPTION_PATTERN.matcher(description);
+       if (matcher.matches()) {
+           description = matcher.group(1) + " version " + matcher.group(2) + " to " + matcher.group(3);
+       }
+       dto.setDifference(description);
+       return dto;
    }
 
    private Map<String, VersionedProcessGroup> flattenProcessGroups(final VersionedProcessGroup group) {
@@ -2814,6 +2849,18 @@ public final class DtoFactory {
        for (final VersionedProcessGroup child : group.getProcessGroups()) {
            flattenProcessGroups(child, flattened);
        }
+   }
+
+   private ComponentDifferenceDTO createBundleDifference(final FlowDifference difference) {
+       VersionedComponent component = difference.getComponentB();
+
+       final ComponentDifferenceDTO dto = new ComponentDifferenceDTO();
+       dto.setComponentType(component.getComponentType().toString());
+       // bundle difference could apply to many components, but use the Process Group identifier as
+       // the Component Identifier here so that many similar component differences can be easily deduped
+       dto.setComponentId(component.getGroupIdentifier());
+
+       return dto;
    }
 
    private ComponentDifferenceDTO createComponentDifference(final FlowDifference difference) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/dto/DtoFactoryTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/dto/DtoFactoryTest.java
@@ -21,6 +21,7 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.controller.service.ControllerServiceNode;
 import org.apache.nifi.controller.service.ControllerServiceProvider;
+import org.apache.nifi.flow.Bundle;
 import org.apache.nifi.nar.ExtensionManager;
 import org.apache.nifi.nar.NarManifest;
 import org.apache.nifi.nar.NarNode;
@@ -28,6 +29,9 @@ import org.apache.nifi.nar.NarSource;
 import org.apache.nifi.nar.NarState;
 import org.apache.nifi.nar.StandardExtensionDiscoveringManager;
 import org.apache.nifi.nar.SystemBundle;
+import org.apache.nifi.registry.flow.diff.DifferenceType;
+import org.apache.nifi.registry.flow.diff.FlowDifference;
+import org.apache.nifi.registry.flow.diff.StandardFlowDifference;
 import org.apache.nifi.web.api.entity.AllowableValueEntity;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -209,6 +213,22 @@ public class DtoFactoryTest {
 
         final NarCoordinateDTO dependencyCoordinateDTO = summaryDTO.getDependencyCoordinate();
         verifyDependencyCoordinateDTO(narManifest, dependencyCoordinateDTO);
+    }
+
+    @Test
+    void testBundleDifferenceDescription() {
+        final Bundle oldBundle = new Bundle("org.apache.nifi", "nifi-standard-nar", "1.28.1");
+        final Bundle newBundle = new Bundle("org.apache.nifi", "nifi-standard-nar", "2.4.0");
+        final String description = String.format("From '%s' to '%s'", oldBundle, newBundle);
+        final FlowDifference difference = new StandardFlowDifference(
+                DifferenceType.BUNDLE_CHANGED,
+                null, null, null, null, null,
+                description
+        );
+        final DtoFactory dtoFactory = new DtoFactory();
+        DifferenceDTO differenceDTO = dtoFactory.createDifferenceDto(difference);
+        assertEquals(DifferenceType.BUNDLE_CHANGED.getDescription(), differenceDTO.getDifferenceType());
+        assertEquals("nifi-standard-nar version 1.28.1 to 2.4.0", differenceDTO.getDifference());
     }
 
     private void verifyCoordinateDTO(final NarManifest narManifest, final NarCoordinateDTO coordinateDTO) {


### PR DESCRIPTION
# Summary

[NIFI-14442](https://issues.apache.org/jira/browse/NIFI-14442)

This PR collects bundle version differences between a local Versioned Process Group and its FlowRegistry version.
These differences will only appear after another local change has been made.  Bundle version differences still do not
count when determining a Versioned Process Group's state.

This does not handle the case when a Versioned Process Group is imported from a FlowRegistry and then local changes
are immediately made.  In this scenario, there will be no bundle version differences.  This is because that Process Group's
versioned snapshot is modified from what is in the FlowRegistry, to update bundle versions and references to controller services
and parameter providers.  However, if you restart NiFi, the PG's versioned snapshot is pulled from the FlowRegisry on
startup, and then bundle version differences will be shown.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
