### PR TITLE
NIFI-14596 Added logic to the ExcelHeaderSchemaStrategy to rename duplicate column names thereby ensuring no data loss or skewing of data.

### DIFF
--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelHeaderSchemaStrategy.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/main/java/org/apache/nifi/excel/ExcelHeaderSchemaStrategy.java
@@ -51,8 +51,7 @@ public class ExcelHeaderSchemaStrategy implements SchemaAccessStrategy {
                     + "column names in the header of the first sheet and the following " + NUM_ROWS_TO_DETERMINE_TYPES + " rows to determine the type(s) of each column "
                     + "while the configured header rows of subsequent sheets are skipped. "
                     + "NOTE: If there are duplicate column names then each subsequent duplicate column name is given a one up number. "
-                    + "For example, column names \"Frequency\", \"Intervals\", \"Frequency\" \"Name\", \"Frequency\", \"Intervals\" will be "
-                    + "changed to \"Frequency\", \"Intervals\", \"Frequency_2\" \"Name\", \"Frequency_3\", \"Intervals_2\".");
+                    + "For example, column names \"Name\", \"Name\" will be changed to \"Name\", \"Name_1\"");
 
     private final PropertyContext context;
     private final ComponentLog logger;
@@ -135,15 +134,15 @@ public class ExcelHeaderSchemaStrategy implements SchemaAccessStrategy {
         return renamedDuplicateFieldNames;
     }
 
-    private List<String> renameDuplicateFieldNames(List<String> fieldNames) {
+    private List<String> renameDuplicateFieldNames(final List<String> fieldNames) {
         final Map<String, Integer> fieldNameCounts = new HashMap<>();
         final List<String> renamedDuplicateFieldNames = new ArrayList<>();
 
         for (String fieldName : fieldNames) {
             if (fieldNameCounts.containsKey(fieldName)) {
-                int count = fieldNameCounts.get(fieldName) + 1;
-                fieldNameCounts.put(fieldName, count);
-                renamedDuplicateFieldNames.add(fieldName + "_" + count);
+                final int count = fieldNameCounts.get(fieldName);
+                renamedDuplicateFieldNames.add("%s_%d".formatted(fieldName, count));
+                fieldNameCounts.put(fieldName, count + 1);
             } else {
                 fieldNameCounts.put(fieldName, 1);
                 renamedDuplicateFieldNames.add(fieldName);

--- a/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelHeaderSchemaStrategy.java
+++ b/nifi-extension-bundles/nifi-poi-bundle/nifi-poi-services/src/test/java/org/apache/nifi/excel/TestExcelHeaderSchemaStrategy.java
@@ -215,7 +215,7 @@ public class TestExcelHeaderSchemaStrategy {
         try (final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray())) {
             RecordSchema recordSchema = schemaStrategy.getSchema(null, inputStream, null);
             assertEquals(6, recordSchema.getFieldNames().size());
-            assertEquals(List.of("Frequency", "Intervals", "Frequency_2", "Name", "Frequency_3", "Intervals_2"), recordSchema.getFieldNames());
+            assertEquals(List.of("Frequency", "Intervals", "Frequency_1", "Name", "Frequency_2", "Intervals_1"), recordSchema.getFieldNames());
         }
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14596](https://issues.apache.org/jira/browse/NIFI-14596)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
