### PR TITLE
NIFI-14588 Fixed Endpoint Override URL handling in AWS S3 processors

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/s3/AbstractS3Processor.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/s3/AbstractS3Processor.java
@@ -324,6 +324,12 @@ public abstract class AbstractS3Processor extends AbstractAWSCredentialsProvider
         }
     }
 
+    @Override
+    protected boolean isCustomSignerConfigured(final ProcessContext context) {
+        final AwsSignerType signerType = context.getProperty(SIGNER_OVERRIDE).asAllowableValue(AwsSignerType.class);
+        return signerType == CUSTOM_SIGNER;
+    }
+
 
     protected Grantee createGrantee(final String value) {
         if (StringUtils.isEmpty(value)) {


### PR DESCRIPTION
The PR restores the [endpoint handling logic](https://github.com/apache/nifi/blob/7aaaba2c8331dc310d9ec192926ff72f24a138ab/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/AbstractAWSProcessor.java#L342-L355) from NiFi 1.x (except the regex-based parsing of VPCE endpoints which does not seem to work in NiFi 1.x either).

# Summary

[NIFI-14588](https://issues.apache.org/jira/browse/NIFI-14588)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
