### PR TITLE
NIFI-14644 Fixed Kafka3ProducerService to close producer when its ini…

### DIFF
--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/producer/Kafka3ProducerService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-shared/src/main/java/org/apache/nifi/kafka/service/producer/Kafka3ProducerService.java
@@ -31,6 +31,7 @@ import org.apache.nifi.kafka.service.api.record.KafkaRecord;
 import org.apache.nifi.kafka.service.producer.transaction.KafkaNonTransactionalProducerWrapper;
 import org.apache.nifi.kafka.service.producer.transaction.KafkaProducerWrapper;
 import org.apache.nifi.kafka.service.producer.transaction.KafkaTransactionalProducerWrapper;
+import org.apache.nifi.processor.exception.ProcessException;
 
 import java.io.UncheckedIOException;
 import java.time.Duration;
@@ -53,14 +54,32 @@ public class Kafka3ProducerService implements KafkaProducerService {
                                  final ServiceConfiguration serviceConfiguration,
                                  final ProducerConfiguration producerConfiguration) {
         final ByteArraySerializer serializer = new ByteArraySerializer();
-        this.producer = new KafkaProducer<>(properties, serializer, serializer);
+
+        try {
+            this.producer = new KafkaProducer<>(properties, serializer, serializer);
+        } catch (Exception e) {
+            throw new ProcessException("Failed to create Kafka Producer", e);
+        }
+
         this.callbacks = new ArrayList<>();
 
         this.serviceConfiguration = serviceConfiguration;
 
-        this.wrapper = producerConfiguration.getTransactionsEnabled()
-                ? new KafkaTransactionalProducerWrapper(producer)
-                : new KafkaNonTransactionalProducerWrapper(producer);
+        try {
+            this.wrapper = producerConfiguration.getTransactionsEnabled()
+                    ? new KafkaTransactionalProducerWrapper(producer)
+                    : new KafkaNonTransactionalProducerWrapper(producer);
+        } catch (Exception e) {
+            boolean success;
+            try {
+                close();
+                success = true;
+            } catch (Exception e2) {
+                success = false;
+            }
+            throw new ProcessException(String.format("Failed to initialize Kafka Producer (%s)",
+                    success ? "closed producer cleanly after failure" : "also failed to close producer after failure"), e);
+        }
     }
 
     @Override


### PR DESCRIPTION
…tialization fails

Closing the partially created producer is needed to clean up resources (stop kafka-producer-network-thread)
Also improved exception handling around producer creation

# Summary

[NIFI-14644](https://issues.apache.org/jira/browse/NIFI-14644)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
