### PR TITLE
NIFI-14620 Correct toDate EL Function handling of time zone

### DIFF
--- a/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
+++ b/nifi-commons/nifi-expression-language/src/test/java/org/apache/nifi/attribute/expression/language/TestQuery.java
@@ -1012,6 +1012,29 @@ public class TestQuery {
     }
 
     @Test
+    public void testToDateAdjustedWithTimeZone() {
+        final String dateFormat = "yyyy-MM-dd";
+        final String created = "2025-06-01";
+        final String timeZoneId = "UTC";
+        final TimeZone timeZone = TimeZone.getTimeZone(timeZoneId);
+
+        // Build Calendar for java.util.Date to match expected result of toDate() function
+        final Calendar calendar = Calendar.getInstance();
+        calendar.clear();
+        calendar.set(Calendar.YEAR, 2025);
+        calendar.set(Calendar.MONTH, Calendar.JUNE);
+        calendar.set(Calendar.DAY_OF_MONTH, 1);
+        calendar.setTimeZone(timeZone);
+
+        // Expected Date with System Default Time Zone and hours adjusted based on Time Zone specified
+        final Date expected = calendar.getTime();
+
+        final String expression = "${created:toDate('%s', '%s')}".formatted(dateFormat, timeZoneId);
+        final Map<String, String> attributes = Map.of("created", created);
+        verifyEquals(expression, attributes, expected);
+    }
+
+    @Test
     public void testInstantConversion() {
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("instant", "1403620278642");
@@ -2591,6 +2614,8 @@ public class TestQuery {
             }
         } else if (expectedResult instanceof Boolean) {
             assertEquals(ResultType.BOOLEAN, result.getResultType());
+        } else if (expectedResult instanceof Date) {
+            assertEquals(ResultType.DATE, result.getResultType());
         } else {
             assertEquals(ResultType.STRING, result.getResultType());
         }


### PR DESCRIPTION
# Summary

[NIFI-14620](https://issues.apache.org/jira/browse/NIFI-14620) Corrects the behavior of the `toDate()` Expression Language function when parsing values using the optional second argument containing a time zone identifier.

Prior to changes in [NIFI-8161](https://issues.apache.org/jira/browse/NIFI-8161), the `toDate` function used the [SimpleDateFormat.setTimeZone()](https://docs.oracle.com/javase/8/docs/api/java/text/DateFormat.html#setTimeZone-java.util.TimeZone-) method to set the Time Zone for string parsing.

With the migration to [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html) in NiFi 2.0.0-M1, the [parseBest()](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#parseBest-java.lang.CharSequence-java.time.temporal.TemporalQuery...-) method covered various types of results, but effectively ignored the Time Zone applied to the `DateTimeFormatter` using the `withTimeZone()` method.

Changes in this pull request update the `FormatUtils.parseInstant()` method, used only for Expression Language functions, to use the [DateTimeFormatter.parse()](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#parse-java.lang.CharSequence-) method. The utility method then queries the parsed `TemporalAccessor` for available fields, first constructing a `LocalDateTime` and then accounting for both the `ZoneId` passed as an argument and the `ZoneOffset` when present in the input string.

The updated approach passes existing tests for `toDate()` with and without time zone, and also passes a new unit test the compares a `java.util.Date` result with an expected instance constructed to match.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
