### PR TITLE
NIFI-14662 - Bump Spring to 6.2.8, AWS SDK to 2.31.63, GCP SDK to 26.62.0 and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -89,7 +89,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.2.6</version>
+                <version>1.2.7</version>
             </dependency>
             <!-- SSHD from Registry and other modules -->
             <dependency>

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.7.6</version>
+            <version>3.7.7</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.7.6</version>
+            <version>3.7.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.61.0</google.libraries.version>
+        <google.libraries.version>26.62.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.hivemq</groupId>
             <artifactId>hivemq-mqtt-client</artifactId>
-            <version>1.3.6</version>
+            <version>1.3.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-extension-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring.data.redis.version>3.5.0</spring.data.redis.version>
+        <spring.data.redis.version>3.5.1</spring.data.redis.version>
         <jedis.version>6.0.0</jedis.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,13 +109,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
-        <com.amazonaws.version>1.12.785</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.31.59</software.amazon.awssdk.version>
+        <com.amazonaws.version>1.12.787</com.amazonaws.version>
+        <software.amazon.awssdk.version>2.31.63</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.1.21</kotlin.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <okio.version>3.12.0</okio.version>
+        <okio.version>3.13.0</okio.version>
         <org.apache.commons.cli.version>1.9.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.18.0</org.apache.commons.codec.version>
         <org.apache.commons.collections4.version>4.5.0</org.apache.commons.collections4.version>
@@ -156,9 +156,9 @@
         <snakeyaml.version>2.4</snakeyaml.version>
         <netty.4.version>4.2.2.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
-        <spring.version>6.2.7</spring.version>
+        <spring.version>6.2.8</spring.version>
         <spring.security.version>6.5.0</spring.security.version>
-        <swagger.annotations.version>2.2.32</swagger.annotations.version>
+        <swagger.annotations.version>2.2.33</swagger.annotations.version>
         <h2.version>2.3.232</h2.version>
         <zookeeper.version>3.9.3</zookeeper.version>
         <caffeine.version>3.2.1</caffeine.version>
@@ -785,7 +785,7 @@
                 <plugin>
                     <groupId>io.swagger.core.v3</groupId>
                     <artifactId>swagger-maven-plugin-jakarta</artifactId>
-                    <version>2.2.32</version>
+                    <version>2.2.33</version>
                 </plugin>
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>


### PR DESCRIPTION
# Summary

[NIFI-14662](https://issues.apache.org/jira/browse/NIFI-14662) - Bump Spring to 6.2.8, AWS SDK to 2.31.63, GCP SDK to 26.62.0 and others

- reactor-netty-http from 1.2.6 to 1.2.7 - https://github.com/reactor/reactor-netty/releases/tag/v1.2.7
- reactor from 3.7.6 to 3.7.7 - https://github.com/reactor/reactor-core/releases/tag/v3.7.7
- GCP SDK BOM from 26.61.0 to 26.62.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.62.0
- HiveMQ MQTT client from 1.3.6 to 1.3.7 - https://github.com/hivemq/hivemq-mqtt-client/releases/tag/v1.3.7
- Spring Data Redis from 3.5.0 to 3.5.1 - https://github.com/spring-projects/spring-data-redis/releases/tag/3.5.1
- Spring Framework from 6.2.7 to 6.2.8 - https://github.com/spring-projects/spring-framework/releases/tag/v6.2.8
- AWS SDK v1 from 1.12.785 to 1.12.787 - https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md
- AWS SDK v2 from 2.31.59 to 2.31.63 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- okio from 3.12.0 to 3.13.0 - https://github.com/square/okio/blob/master/CHANGELOG.md#version-3130
- Swagger from 2.2.32 to 2.2.33 - https://github.com/swagger-api/swagger-core/releases/tag/v2.2.33

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
