### PR TITLE
NIFI-14661 - Fix UnpackContent for TAR file handling

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestUnpackContent.java
@@ -65,7 +65,7 @@ public class TestUnpackContent {
         Map<String, String> attributes = new HashMap<>(1);
         Map<String, String> attributes2 = new HashMap<>(1);
         attributes.put("mime.type", UnpackContent.PackageFormat.TAR_FORMAT.getMimeType());
-        attributes2.put("mime.type", UnpackContent.PackageFormat.X_TAR_FORMAT.getMimeType());
+        attributes2.put("mime.type", "application/tar");
         autoUnpackRunner.enqueue(dataPath.resolve("data.tar"), attributes);
         autoUnpackRunner.enqueue(dataPath.resolve("data.tar"), attributes2);
         runner.run(2);


### PR DESCRIPTION
# Summary

[NIFI-14661](https://issues.apache.org/jira/browse/NIFI-14661) - Fix UnpackContent for TAR file handling

The bug is caused by the change in https://github.com/apache/nifi/commit/a3249e91df5678cf3e88d47aa09f7f8504e9d667#diff-cf5484ea7827b2fe534ea3663c05f1a138adbab01b7a765ac6accae7c4339e25

TLDR ; previously we were passing a specific list of allowable values and we changed to the enum representation of the possible values. However, for TAR, we have two potential values with the same "key" in the enum.

Given that `application/x-tar` is the most commonly used MIME type, I changed the enum to only keep this one but also added the possibility to properly handle `application/tar` in case we use the auto detection based on the MIME type.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
