### PR TITLE
NIFI-14668 - Bump Log4J to 2.25.0, Jackson to 2.19.1, Spring Security to 6.5.1, and others

### DIFF
--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
@@ -20,7 +20,7 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <snmp4j.version>3.9.3</snmp4j.version>
+        <snmp4j.version>3.9.4</snmp4j.version>
         <snmp4j-agent.version>3.8.2</snmp4j-agent.version>
     </properties>
 

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-ldap-iaa-providers-bundle/nifi-ldap-iaa-providers/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>com.unboundid</groupId>
             <artifactId>unboundid-ldapsdk</artifactId>
-            <version>7.0.2</version>
+            <version>7.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/pom.xml
@@ -398,7 +398,7 @@
         <dependency>
             <groupId>com.unboundid</groupId>
             <artifactId>unboundid-ldapsdk</artifactId>
-            <version>7.0.2</version>
+            <version>7.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
@@ -325,7 +325,7 @@
         <dependency>
             <groupId>com.unboundid</groupId>
             <artifactId>unboundid-ldapsdk</artifactId>
-            <version>7.0.2</version>
+            <version>7.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.787</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.31.63</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.31.64</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.1.21</kotlin.version>
@@ -135,7 +135,7 @@
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <derby.version>10.17.1.0</derby.version>
         <jetty.version>12.0.22</jetty.version>
-        <jackson.bom.version>2.18.4</jackson.bom.version>
+        <jackson.bom.version>2.19.1</jackson.bom.version>
         <avro.version>1.11.4</avro.version>
         <jaxb.runtime.version>4.0.5</jaxb.runtime.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
@@ -149,7 +149,7 @@
         <gcs.version>2.1.5</gcs.version>
         <aspectj.version>1.9.24</aspectj.version>
         <jersey.bom.version>3.1.10</jersey.bom.version>
-        <log4j2.version>2.24.3</log4j2.version>
+        <log4j2.version>2.25.0</log4j2.version>
         <logback.version>1.5.18</logback.version>
         <mockito.version>5.18.0</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
@@ -157,7 +157,7 @@
         <netty.4.version>4.2.2.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.version>6.2.8</spring.version>
-        <spring.security.version>6.5.0</spring.security.version>
+        <spring.security.version>6.5.1</spring.security.version>
         <swagger.annotations.version>2.2.33</swagger.annotations.version>
         <h2.version>2.3.232</h2.version>
         <zookeeper.version>3.9.3</zookeeper.version>


### PR DESCRIPTION
# Summary

[NIFI-14668](https://issues.apache.org/jira/browse/NIFI-14668) - Bump Log4J to 2.25.0, Jackson to 2.19.1, Spring Security to 6.5.1, and others

- SNMP4J from 3.9.3 to 3.9.4 - https://www.snmp4j.org/CHANGES.txt
- unboundid-ldapsdk from 7.0.2 to 7.0.3 - https://docs.ldap.com/ldap-sdk/docs/release-notes.html
- AWS SDK v2 from 2.31.63 to 2.31.64 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md#23164-2025-06-16
- Jackson from 2.18.4 to 2.19.1 - https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.19.1
- Log4J from 2.24.3 to 2.25.0 - https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.25.0
- Spring Security from 6.5.0 to 6.5.1 - https://github.com/spring-projects/spring-security/releases/tag/6.5.1

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
