### PR TITLE
[NIFI-14667] - Fix: Duplicate new canvas item icons in header when browser font size scaled up or down

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/new-canvas-item/new-canvas-item.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/header/new-canvas-item/new-canvas-item.component.html
@@ -22,9 +22,11 @@
     [tooltipDisabled]="dragging"
     [position]="tooltipPosition"
     [delayClose]="false">
-    <div class="h-16 w-16 pl-1.5 flex items-center justify-center relative icon text-3xl" [class]="iconClass"></div>
+    <div
+        class="h-[64px] w-[64px] pl-1.5 flex items-center justify-center relative icon text-3xl"
+        [class]="iconClass"></div>
     <button
-        class="h-16 w-16 pl-1.5 -mt-16 flex items-center justify-center relative icon text-3xl"
+        class="h-[64px] w-[64px] pl-1.5 -mt-[64px] flex items-center justify-center relative icon text-3xl"
         [class]="isHovering() ? iconHoverClass + ' hovering' : iconClass"
         [class.dragging]="dragging"
         [disabled]="disabled"
@@ -34,6 +36,6 @@
         cdkDragBoundary="body"
         (cdkDragStarted)="onDragStarted()"
         (cdkDragEnded)="onDragEnded($event)">
-        <span class="h-1 absolute left-[3px] right-[3px] bottom-0.5 component-button-grip"></span>
+        <span class="h-[4px] absolute left-[3px] right-[3px] bottom-0.5 component-button-grip"></span>
     </button>
 </div>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/navigation/navigation.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/navigation/navigation.component.html
@@ -17,9 +17,9 @@
 
 <div class="flex flex-col">
     <nav class="nifi-navigation select-none">
-        <div class="flex justify-between items-center h-16 pl-4">
+        <div class="flex justify-between items-center h-[64px] pl-4">
             <div class="flex">
-                <div class="h-16 w-28 mr-6 relative">
+                <div class="h-[64px] w-[112px] mr-6 relative">
                     <img
                         ngSrc="assets/icons/nifi-logo.svg"
                         fill


### PR DESCRIPTION
# Summary

[NIFI-14667](https://issues.apache.org/jira/browse/NIFI-14667)

Before:
<img width="838" alt="Screenshot 2025-06-17 at 08 19 12" src="https://github.com/user-attachments/assets/9051ab56-21fe-470a-95c6-de85fe887e06" />


After:
<img width="737" alt="Screenshot 2025-06-17 at 08 19 51" src="https://github.com/user-attachments/assets/1f577f79-90de-4e76-b3a6-5b2d1b063db6" />
