### PR TITLE
NIFI-14681 Upgrade Download Maven Plugin from 1.13.0 to 2.0.0

### DIFF
--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/pom.xml
@@ -31,9 +31,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <groupId>io.github.download-maven-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.13.0</version>
+                <version>2.0.0</version>
                 <executions>
                     <execution>
                         <id>download-py4j</id>

--- a/nifi-system-tests/nifi-python-test-extensions-nar/pom.xml
+++ b/nifi-system-tests/nifi-python-test-extensions-nar/pom.xml
@@ -51,9 +51,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <groupId>io.github.download-maven-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.13.0</version>
+                <version>2.0.0</version>
                 <executions>
                     <execution>
                         <id>download-bech32</id>


### PR DESCRIPTION
# Summary

[NIFI-14681](https://issues.apache.org/jira/browse/NIFI-14681) Upgrades the Download Maven Plugin from 1.13.0 to [2.0.0](https://github.com/download-maven-plugin/download-maven-plugin/releases/tag/2.0.0) which includes changing to a new Maven group of `io.github.download-maven-plugin`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
