### PR TITLE
NIFI-14682 - Help user with JDBC Driver configuration in DBCP controller service

### DIFF
--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/main/java/org/apache/nifi/dbcp/DBCPConnectionPool.java
@@ -16,13 +16,6 @@
  */
 package org.apache.nifi.dbcp;
 
-import java.sql.Driver;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.AbstractMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.annotation.behavior.DynamicProperties;
@@ -36,6 +29,9 @@ import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.components.RequiredPermission;
+import org.apache.nifi.components.resource.ResourceReference;
+import org.apache.nifi.components.resource.ResourceReferences;
+import org.apache.nifi.components.resource.ResourceType;
 import org.apache.nifi.controller.ConfigurationContext;
 import org.apache.nifi.controller.VerifiableControllerService;
 import org.apache.nifi.dbcp.utils.DataSourceConfiguration;
@@ -44,6 +40,21 @@ import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.processor.util.StandardValidators;
+
+import java.io.File;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
 
 import static org.apache.nifi.dbcp.utils.DBCPProperties.DATABASE_URL;
 import static org.apache.nifi.dbcp.utils.DBCPProperties.DB_DRIVERNAME;
@@ -202,7 +213,33 @@ public class DBCPConnectionPool extends AbstractDBCPConnectionPool implements DB
         try {
             clazz = Class.forName(driverName);
         } catch (final ClassNotFoundException e) {
-            throw new ProcessException("Driver class " + driverName + " is not found", e);
+            // Enhanced error message with discovery
+            ResourceReferences driverResources = null;
+            try {
+                // Try to get driver resources from current context if available
+                if (getConfigurationContext() != null) {
+                    driverResources = getConfigurationContext().getProperty(DB_DRIVER_LOCATION).evaluateAttributeExpressions().asResources();
+                }
+            } catch (Exception ignored) {
+                // Context might not be available, continue without it
+            }
+
+            final List<String> availableDrivers = (driverResources != null && driverResources.getCount() != 0) ? List.of() : discoverDriverClasses(driverResources);
+
+            String errorMessage = String.format("JDBC driver class '%s' not found.", driverName);
+
+            if (!availableDrivers.isEmpty()) {
+                errorMessage += String.format(" Available driver classes found in resources: %s.", String.join(", ", availableDrivers));
+            } else if (driverResources != null && driverResources.getCount() != 0) {
+                final List<ResourceReference> resourcesList = driverResources.asList();
+                if (resourcesList.stream().filter(r -> r.getResourceType() != ResourceType.URL).count() != 0) {
+                    errorMessage += " No JDBC driver classes found in the provided resources.";
+                }
+            } else if (driverResources == null) {
+                errorMessage += " The property 'Database Driver Location(s)' should be set.";
+            }
+
+            throw new ProcessException(errorMessage.toString(), e);
         }
 
         try {
@@ -218,6 +255,100 @@ public class DBCPConnectionPool extends AbstractDBCPConnectionPool implements DB
             } catch (final Exception e2) {
                 throw new ProcessException("Creating driver instance is failed", e2);
             }
+        }
+    }
+
+    /**
+     * Discovers all potential JDBC driver classes in the provided resources Since
+     * dynamicallyModifiesClasspath=true, we scan the resources directly rather than
+     * trying to load classes, as NiFi handles classpath modification
+     */
+    private List<String> discoverDriverClasses(final ResourceReferences driverResources) {
+        final Set<String> driverClasses = new TreeSet<>(); // Use TreeSet for sorted results
+
+        if (driverResources == null || driverResources.getCount() == 0) {
+            return new ArrayList<>();
+        }
+
+        for (final ResourceReference resource : driverResources.flattenRecursively().asList()) {
+            try {
+                final List<File> jarFiles = getJarFilesFromResource(resource);
+                for (final File jarFile : jarFiles) {
+                    driverClasses.addAll(scanJarForDriverClasses(jarFile));
+                }
+            } catch (final Exception e) {
+                getLogger().warn("Error processing resource {} for driver discovery", resource.getLocation(), e);
+            }
+        }
+
+        return new ArrayList<>(driverClasses);
+    }
+
+    /**
+     * Scans a JAR file for potential JDBC driver class names (without loading them)
+     */
+    private Set<String> scanJarForDriverClasses(final File jarFile) {
+        final Set<String> actualDriverClasses = new TreeSet<>();
+
+        try (JarFile jar = new JarFile(jarFile)) {
+            final Enumeration<JarEntry> entries = jar.entries();
+            while (entries.hasMoreElements()) {
+                final JarEntry entry = entries.nextElement();
+                final String entryName = entry.getName();
+
+                // Look for .class files (exclude inner classes)
+                if (entryName.endsWith(".class") && !entryName.contains("$")) {
+                    String className = entryName.substring(0, entryName.length() - 6).replace('/', '.');
+
+                    // First filter with heuristics to avoid loading every class
+                    if (isPotentialDriverClass(className)) {
+                        // Now actually verify it's a JDBC driver
+                        if (isActualDriverClass(className)) {
+                            actualDriverClasses.add(className);
+                        }
+                    }
+                }
+            }
+        } catch (final Exception e) {
+            getLogger().warn("Error scanning JAR file {} for driver classes", jarFile.getAbsolutePath(), e);
+        }
+
+        return actualDriverClasses;
+    }
+
+    /**
+     * Uses heuristics to identify potential JDBC driver classes without loading
+     * them This is a first-pass filter to avoid loading every single class
+     */
+    private boolean isPotentialDriverClass(final String className) {
+        final String lowerClassName = className.toLowerCase();
+
+        // Common patterns for JDBC driver class names
+        boolean isCandidate = lowerClassName.contains("driver")
+                || lowerClassName.contains("jdbc")
+                || className.matches(".*\\.(mysql|postgres|postgresql|oracle|h2|hsql|derby|sqlite|mariadb|sqlserver|mssql|jtds)\\..*")
+                || className.matches(".*Driver$")
+                || className.matches(".*JdbcDriver$")
+                || className.matches(".*SQLServerDriver$");
+
+        return isCandidate;
+    }
+
+    /**
+     * Actually loads and checks if a class implements java.sql.Driver Since
+     * dynamicallyModifiesClasspath=true, the class should be available
+     */
+    private boolean isActualDriverClass(final String className) {
+        try {
+            final Class<?> clazz = Class.forName(className);
+
+            // Check if it implements Driver interface and is not abstract/interface
+            return Driver.class.isAssignableFrom(clazz)
+                    && !clazz.isInterface()
+                    && !java.lang.reflect.Modifier.isAbstract(clazz.getModifiers());
+        } catch (final Throwable e) {
+            // Class couldn't be loaded or has issues - not a valid driver
+            return false;
         }
     }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/java/org/apache/nifi/dbcp/DBCPServiceTest.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-dbcp-service/src/test/java/org/apache/nifi/dbcp/DBCPServiceTest.java
@@ -16,15 +16,8 @@
  */
 package org.apache.nifi.dbcp;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.UUID;
+import org.apache.nifi.components.ConfigVerificationResult;
+import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.dbcp.utils.DBCPProperties;
 import org.apache.nifi.processor.exception.ProcessException;
 import org.apache.nifi.reporting.InitializationException;
@@ -38,6 +31,20 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -203,6 +210,60 @@ public class DBCPServiceTest {
         assertEquals(1000, service.getDataSource().getSoftMinEvictableIdleDuration().toMillis());
 
         service.getDataSource().close();
+    }
+
+    @Test
+    public void testInvalidDriverDerby() throws URISyntaxException {
+        final URL driverURL = org.apache.derby.jdbc.EmbeddedDriver.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation();
+
+        final File jarFile = new File(driverURL.toURI());
+
+        runner.setProperty(service, DBCPProperties.DB_DRIVER_LOCATION, jarFile.getAbsolutePath());
+        runner.setProperty(service, DBCPProperties.DB_DRIVERNAME, "a.very.bad.jdbc.Driver");
+
+        final Collection<ConfigVerificationResult> verificationResults = runner.verify(service, Map.of());
+        assertEquals(1, verificationResults.size());
+
+        final ConfigVerificationResult result = verificationResults.stream().filter(r -> r.getVerificationStepName().equals("Configure Data Source")).findFirst().get();
+        assertTrue(result.getExplanation().contains("org.apache.derby.jdbc.EmbeddedDriver"));
+    }
+
+    @Test
+    public void testInvalidDirverH2() throws URISyntaxException {
+        final URL driverURL = org.h2.Driver.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation();
+
+        final File jarFile = new File(driverURL.toURI());
+
+        runner.setProperty(service, DBCPProperties.DB_DRIVER_LOCATION, jarFile.getAbsolutePath());
+        runner.setProperty(service, DBCPProperties.DB_DRIVERNAME, "a.very.bad.jdbc.Driver");
+
+        final Collection<ConfigVerificationResult> verificationResults = runner.verify(service, Map.of());
+        assertEquals(1, verificationResults.size());
+
+        final ConfigVerificationResult result = verificationResults.stream().filter(r -> r.getVerificationStepName().equals("Configure Data Source")).findFirst().get();
+        assertTrue(result.getExplanation().contains("org.h2.Driver"));
+    }
+
+    @Test
+    public void testInvalidDriverNoResource() {
+        runner.setProperty(service, DBCPProperties.DB_DRIVERNAME, "a.very.bad.jdbc.Driver");
+
+        final Collection<ValidationResult> validationResults = runner.validate(service);
+        assertEquals(0, validationResults.size());
+
+        AssertionFailedError thrown = assertThrows(AssertionFailedError.class, () -> {
+            runner.enableControllerService(service);
+        });
+
+        // Verify the underlying cause is what we expect
+        assertTrue(thrown.getMessage().contains("ProcessException"));
+        assertTrue(thrown.getMessage().contains("JDBC driver class 'a.very.bad.jdbc.Driver' not found. The property 'Database Driver Location(s)' should be set."));
     }
 
     private void assertConnectionNotNullDynamicProperty(final String propertyName, final String propertyValue) throws SQLException {


### PR DESCRIPTION
# Summary

[NIFI-14682](https://issues.apache.org/jira/browse/NIFI-14682) - Help user with JDBC Driver configuration in DBCP controller service

The goal is to improve the `verify` method in the `Abstract` class as well as the error handling in the `getDriver` method of the controller service implementation.

We cannot use a `customValidate` approach as we may be in situation where one of those situations happen:

- specified resources are not loaded in the classpath
- some specified resources are using the URL approach and we may not have the resource locally available at the time
- we may have some weirdly packaged JARs with very custom Drivers

Given the above, we don't want to take the risk of making the component invalid and unusable.

Instead we improve things in two places:

- the `verify()` method but we cannot expect all of the specified resources to be loaded in the classpath at the time the method is called so the best approach is to have a static analysis of whatever is available to us and provide a non exhaustive list of what drivers can be used.
- the `getDriver()` method - in this case, resources are loaded in the classpath so we can also verify that the classes that we suspect are potential drivers could indeed be loaded as drivers.

The changes have been tested with many drivers, specified in different ways (asset, directory, file, URL) with many different vendors (H2, Derby, MS SQL, Postgres, ClickHouse, Snowflake).

While this does not cover all possible scenarios of how the component has been configured, it does provide a more helpful error message in most cases when the specified driver class is not correct.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
