### PR TITLE
NIFI-14691 - Bump Lucene to 10.2.2, Elastic to 9.0.3, and others

### DIFF
--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -127,12 +127,12 @@
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-data</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-ingest</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>9.0.2</elasticsearch.client.version>
+        <elasticsearch.client.version>9.0.3</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-neo4j-cypher-service/pom.xml
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <neo4j.driver.version>5.28.5</neo4j.driver.version>
+        <neo4j.driver.version>5.28.6</neo4j.driver.version>
         <neo4j.docker.version>5.19</neo4j.docker.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/pom.xml
@@ -19,7 +19,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <activemq.version>6.1.6</activemq.version>
+        <activemq.version>6.1.7</activemq.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/pom.xml
@@ -20,7 +20,7 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <snmp4j.version>3.9.4</snmp4j.version>
+        <snmp4j.version>3.9.5</snmp4j.version>
         <snmp4j-agent.version>3.8.2</snmp4j-agent.version>
     </properties>
 

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/pom.xml
@@ -27,7 +27,7 @@
         <module>nifi-provenance-repository-nar</module>
     </modules>
     <properties>
-        <lucene.version>10.2.1</lucene.version>
+        <lucene.version>10.2.2</lucene.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.11.1</version>
+            <version>5.11.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,10 +110,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.787</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.31.67</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.31.70</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
-        <kotlin.version>2.1.21</kotlin.version>
+        <kotlin.version>2.2.0</kotlin.version>
         <okhttp.version>4.12.0</okhttp.version>
         <okio.version>3.13.0</okio.version>
         <org.apache.commons.cli.version>1.9.0</org.apache.commons.cli.version>
@@ -541,7 +541,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.20.1</version>
+                <version>1.21.1</version>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
# Summary

[NIFI-14691](https://issues.apache.org/jira/browse/NIFI-14691) - Bump Lucene to 10.2.2, Elastic to 9.0.3, and others

- kusto from 6.0.2 to 6.0.3 - https://github.com/Azure/azure-kusto-java/releases/tag/v6.0.3
- elastic client from 9.0.2 to 9.0.3 - https://github.com/elastic/elasticsearch-java/releases/tag/v9.0.3
- neo4j driver from 5.28.5 to 5.28.6 - https://github.com/neo4j/neo4j-java-driver/releases/tag/5.28.6
- activeMQ from 6.1.6 to 6.1.7 - https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12355749
- snmp4j from 3.9.4 to 3.9.5 - https://www.snmp4j.org/CHANGES.txt
- lucene from 10.2.1 to 10.2.2 - https://github.com/apache/lucene/releases/tag/releases%2Flucene%2F10.2.2
- opencsv from 5.11.1 to 5.11.2 - https://sourceforge.net/p/opencsv/wiki/What%27s%20new/
- AWS SDK v2 from 2.31.67 to 2.31.70 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- kotlin from 2.1.21 to 2.2.0 - https://github.com/JetBrains/kotlin/releases/tag/v2.2.0
- jsoup from 1.20.1 to 1.21.1 - https://github.com/jhy/jsoup/blob/master/CHANGES.md

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
