### PR TITLE
NIFI-14700 - Option to ignore parameter value changes in git registry clients

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/AbstractGitFlowRegistryClient.java
@@ -26,6 +26,8 @@ import org.apache.nifi.flow.Position;
 import org.apache.nifi.flow.VersionedComponent;
 import org.apache.nifi.flow.VersionedConnection;
 import org.apache.nifi.flow.VersionedFlowCoordinates;
+import org.apache.nifi.flow.VersionedParameter;
+import org.apache.nifi.flow.VersionedParameterContext;
 import org.apache.nifi.flow.VersionedProcessGroup;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.registry.flow.AbstractFlowRegistryClient;
@@ -58,9 +60,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -362,6 +366,22 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
             flowSnapshot.getParameterContexts().forEach((name, parameterContext) ->
                 parameterContext.getParameters().forEach(parameter -> parameter.setValue(null))
             );
+        } else if (ParameterContextValuesStrategy.IGNORE_CHANGES.equals(parameterContextValuesStrategy)) {
+            existingSnapshot.getParameterContexts().forEach((name, parameterContext) -> {
+                final VersionedParameterContext targetContext = flowSnapshot.getParameterContexts().get(name);
+                if (targetContext != null) {
+                    final Map<String, VersionedParameter> targetParamMap = targetContext.getParameters()
+                            .stream()
+                            .collect(Collectors.toMap(VersionedParameter::getName, Function.identity()));
+
+                    parameterContext.getParameters().forEach(parameter -> {
+                        final VersionedParameter targetParam = targetParamMap.get(parameter.getName());
+                        if (targetParam != null) {
+                            targetParam.setValue(parameter.getValue());
+                        }
+                    });
+                }
+            });
         }
 
         // replace the id of the top level group and all of its references with a constant value prior to serializing to avoid
@@ -676,7 +696,8 @@ public abstract class AbstractGitFlowRegistryClient extends AbstractFlowRegistry
 
     enum ParameterContextValuesStrategy implements DescribedValue {
         RETAIN("Retain", "Retain Values in Parameter Contexts without modifications"),
-        REMOVE("Remove", "Remove Values from Parameter Context");
+        REMOVE("Remove", "Remove Values from Parameter Context"),
+        IGNORE_CHANGES("Ignore Changes", "Ignore any change on existing parameters");
 
         private final String displayName;
         private final String description;


### PR DESCRIPTION
# Summary

[NIFI-14700](https://issues.apache.org/jira/browse/NIFI-14700) - Option to ignore parameter value changes in git registry clients

In [NIFI-14555](https://issues.apache.org/jira/browse/NIFI-14555) we added the option to commit a new versioned flow with empty values for all parameters. This is a good strategy in case you want to make sure that you're not inadvertently committing a new version that would contain some parameter values that are specific to a lower environment.

However this strategy is not great when you have parameters where you want to specify a default value. In such a case, and when using the strategy implemented in [NIFI-14555](https://issues.apache.org/jira/browse/NIFI-14555), you'd lose the default values for your parameters when you commit a new version.

This JIRA is to add a new strategy allowing to commit a version where any already existing parameter is ignored. It means that we change the version we are committing by copying the existing values of the existing parameters into the new version. This is particularly useful as changing the value of a parameter is not considered as a local change so it can be confusing for a user to commit a new version where it is also including parameter value changes.

This is not a perfect solution because this strategy does not allow the user to change a default value that would have been set previously. But in that case the user can switch between the strategies at the registry client level to execute the right sequence of steps to get the expected end result.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
