### PR TITLE
NIFI-14703 - Bump Test Containers to 1.21.3, Okio to 3.14.0, and others

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-test-utils/pom.xml
@@ -24,7 +24,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-api</artifactId>
-            <version>3.5.1</version>
+            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
@@ -57,7 +57,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>1.5.7</version>
+            <version>1.5.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -232,7 +232,7 @@
             <dependency>
                 <groupId>com.networknt</groupId>
                 <artifactId>json-schema-validator</artifactId>
-                <version>1.5.7</version>
+                <version>1.5.8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>3.5.3</spring.boot.version>
-        <flyway.version>11.9.2</flyway.version>
+        <flyway.version>11.10.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.3.0.202506031305-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,12 +110,12 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.787</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.31.70</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.31.73</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.0</kotlin.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <okio.version>3.13.0</okio.version>
+        <okio.version>3.14.0</okio.version>
         <org.apache.commons.cli.version>1.9.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.18.0</org.apache.commons.codec.version>
         <org.apache.commons.collections4.version>4.5.0</org.apache.commons.collections4.version>
@@ -130,7 +130,7 @@
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
         <org.bouncycastle.version>1.81</org.bouncycastle.version>
         <pmd.version>7.10.0</pmd.version>
-        <testcontainers.version>1.21.2</testcontainers.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
         <org.slf4j.version>2.0.17</org.slf4j.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <derby.version>10.17.1.0</derby.version>


### PR DESCRIPTION
# Summary

[NIFI-14703](https://issues.apache.org/jira/browse/NIFI-14703) - Bump Test Containers to 1.21.3, Okio to 3.14.0, and others

- Docker Java API from 3.5.1 to 3.5.2 - https://github.com/docker-java/docker-java/releases/tag/3.5.2
- JSON Schema Validator from 1.5.7 to 1.5.8 - https://github.com/networknt/json-schema-validator/releases/tag/1.5.8
- FlywayDB from 11.9.2 to 11.10.0 - https://github.com/flyway/flyway/releases/tag/flyway-11.10.0
- AWS SDK v2 fron 2.31.70 to 2.31.73 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Okio from 3.13.0 to 3.14.0 - https://github.com/square/okio/blob/master/CHANGELOG.md
- Test containers from 1.21.2 to 1.21.3 - https://github.com/testcontainers/testcontainers-java/releases/tag/1.21.3

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
