### PR TITLE
NIFI-14704 - Map ordered by key for git flow normalization

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/serialize/JacksonFlowSnapshotSerializer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/serialize/JacksonFlowSnapshotSerializer.java
@@ -42,6 +42,7 @@ public class JacksonFlowSnapshotSerializer implements FlowSnapshotSerializer {
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
             .enable(SerializationFeature.INDENT_OUTPUT)
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
             .addModule(new VersionedComponentModule())
             .addModule(new SortedStringCollectionsModule())
             .build();


### PR DESCRIPTION
# Summary

[NIFI-14704](https://issues.apache.org/jira/browse/NIFI-14704) - Map ordered by key for git flow normalization

This is a follow-up improvement of [NIFI-14660](https://issues.apache.org/jira/browse/NIFI-14660). The goal is to also have alphabetical ordering of the maps based on the keys. This will order, for example, properties and propertyDescriptors for the configurable component.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
