### PR TITLE
NIFI-14628 Added AmazonGlueEncodedSchemaReferenceReader

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/pom.xml
@@ -76,6 +76,10 @@
             <artifactId>regions</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.glue</groupId>
+            <artifactId>schema-registry-serde</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
         </dependency>

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/AmazonGlueEncodedSchemaReferenceReader.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/AmazonGlueEncodedSchemaReferenceReader.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.aws.schemaregistry;
+
+import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializerDataParser;
+import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.schema.access.SchemaField;
+import org.apache.nifi.schema.access.SchemaNotFoundException;
+import org.apache.nifi.schemaregistry.services.SchemaReferenceReader;
+import org.apache.nifi.serialization.record.SchemaIdentifier;
+import org.apache.nifi.stream.io.StreamUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Tags({"schema", "registry", "aws", "avro", "glue"})
+@CapabilityDescription("Reads Schema Identifier according to AWS Glue Schema encoding as a header consisting of a two byte markers and a 16 byte UUID")
+public class AmazonGlueEncodedSchemaReferenceReader extends AbstractControllerService implements SchemaReferenceReader {
+
+    private final GlueSchemaRegistryDeserializerDataParser deserializerDataParser = GlueSchemaRegistryDeserializerDataParser.getInstance();
+
+    private static final int HEADER_CAPACITY = AWSSchemaRegistryConstants.HEADER_VERSION_BYTE_SIZE
+                    + AWSSchemaRegistryConstants.COMPRESSION_BYTE_SIZE
+                    + AWSSchemaRegistryConstants.SCHEMA_VERSION_ID_SIZE;
+
+    private static final Set<SchemaField> SUPPLIED_SCHEMA_FIELDS = Set.of(SchemaField.SCHEMA_BRANCH_NAME);
+
+    @Override
+    public SchemaIdentifier getSchemaIdentifier(final Map<String, String> variables, final InputStream contentStream) throws SchemaNotFoundException {
+        final byte[] header = new byte[HEADER_CAPACITY];
+        try {
+            StreamUtils.fillBuffer(contentStream, header);
+        } catch (final IOException e) {
+            throw new SchemaNotFoundException("Failed to read header in first %d bytes from stream".formatted(HEADER_CAPACITY), e);
+        }
+
+        final ByteBuffer headerBuffer = ByteBuffer.wrap(header);
+        final StringBuilder errorStringBuilder = new StringBuilder();
+        if (!deserializerDataParser.isDataCompatible(headerBuffer, errorStringBuilder)) {
+            throw new SchemaNotFoundException("Failed to parse Glue Schema Registry header: %s".formatted(errorStringBuilder));
+        }
+        final UUID schemaVersionId = deserializerDataParser.getSchemaVersionId(headerBuffer);
+        return SchemaIdentifier.builder().name(WireFormatSchemaVersionIdUtil.toWireFormatName(schemaVersionId)).build();
+    }
+
+    @Override
+    public Set<SchemaField> getSuppliedSchemaFields() {
+        return SUPPLIED_SCHEMA_FIELDS;
+    }
+}

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/AmazonGlueSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/AmazonGlueSchemaRegistry.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Tags({"schema", "registry", "aws", "avro", "glue"})
@@ -185,6 +186,13 @@ public class AmazonGlueSchemaRegistry extends AbstractControllerService implemen
         final String schemaName = schemaIdentifier.getName().orElseThrow(
                 () -> new SchemaNotFoundException("Cannot retrieve schema because Schema Name is not present")
         );
+
+        if (WireFormatSchemaVersionIdUtil.isWireFormatName(schemaName)) {
+            final UUID schemaVersionId = WireFormatSchemaVersionIdUtil.fromWireFormatName(schemaName).orElseThrow(
+                    () -> new SchemaNotFoundException("Cannot retrieve schema because Schema Name does not contain a valid Schema Version ID: " + schemaName)
+            );
+            return client.getSchema(schemaVersionId);
+        }
 
         final OptionalInt version = schemaIdentifier.getVersion();
 

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/WireFormatSchemaVersionIdUtil.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/WireFormatSchemaVersionIdUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.aws.schemaregistry;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class WireFormatSchemaVersionIdUtil {
+    private static final String GLUE_SCHEMA_REGISTRY_WIRE_FORMAT_UUID_PREFIX = "aws-glue-schema-registry-wire-format-uuid$$";
+
+    private WireFormatSchemaVersionIdUtil() {
+        // Prevent instantiation
+    }
+
+    public static String toWireFormatName(final UUID schemaVersionId) {
+        if (schemaVersionId == null) {
+            throw new IllegalArgumentException("Schema version ID must not be null");
+        }
+        return GLUE_SCHEMA_REGISTRY_WIRE_FORMAT_UUID_PREFIX + schemaVersionId;
+    }
+
+    public static Optional<UUID> fromWireFormatName(final String schemaName) {
+        try {
+            if (!isWireFormatName(schemaName)) {
+                return Optional.empty();
+            }
+            final UUID uuid = UUID.fromString(schemaName.substring(GLUE_SCHEMA_REGISTRY_WIRE_FORMAT_UUID_PREFIX.length()));
+            return Optional.of(uuid);
+        } catch (final IllegalArgumentException e) {
+            // If the string is not a valid UUID, return empty
+            return Optional.empty();
+        }
+    }
+
+    public static boolean isWireFormatName(final String schemaName) {
+        return schemaName != null && schemaName.startsWith(GLUE_SCHEMA_REGISTRY_WIRE_FORMAT_UUID_PREFIX);
+    }
+}

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/client/CachingSchemaRegistryClient.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/client/CachingSchemaRegistryClient.java
@@ -23,11 +23,13 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.nifi.serialization.record.RecordSchema;
 
 import java.time.Duration;
+import java.util.UUID;
 
 public class CachingSchemaRegistryClient implements SchemaRegistryClient {
     private final SchemaRegistryClient client;
     private final LoadingCache<String, RecordSchema> nameCache;
     private final LoadingCache<Pair<String, Long>, RecordSchema> nameVersionCache;
+    private final LoadingCache<UUID, RecordSchema> nameVersionIdCache;
 
     public CachingSchemaRegistryClient(final SchemaRegistryClient toWrap, final int cacheSize, final long expirationNanos) {
         this.client = toWrap;
@@ -40,6 +42,10 @@ public class CachingSchemaRegistryClient implements SchemaRegistryClient {
                 .maximumSize(cacheSize)
                 .expireAfterWrite(Duration.ofNanos(expirationNanos))
                 .build(key -> client.getSchema(key.getLeft(), key.getRight()));
+        nameVersionIdCache = Caffeine.newBuilder()
+                .maximumSize(cacheSize)
+                .expireAfterWrite(Duration.ofNanos(expirationNanos))
+                .build(client::getSchema);
     }
 
     @Override
@@ -48,7 +54,12 @@ public class CachingSchemaRegistryClient implements SchemaRegistryClient {
     }
 
     @Override
-    public RecordSchema getSchema(String schemaName, long version) {
+    public RecordSchema getSchema(final String schemaName, final long version) {
         return nameVersionCache.get(Pair.of(schemaName, version));
+    }
+
+    @Override
+    public RecordSchema getSchema(final UUID schemaVersionId) {
+        return nameVersionIdCache.get(schemaVersionId);
     }
 }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/client/SchemaRegistryClient.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/java/org/apache/nifi/aws/schemaregistry/client/SchemaRegistryClient.java
@@ -21,10 +21,13 @@ import org.apache.nifi.schema.access.SchemaNotFoundException;
 import org.apache.nifi.serialization.record.RecordSchema;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public interface SchemaRegistryClient {
 
     RecordSchema getSchema(final String schemaName) throws IOException, SchemaNotFoundException;
 
     RecordSchema getSchema(final String schemaName, final long version) throws IOException, SchemaNotFoundException;
+
+    RecordSchema getSchema(final UUID schemaVersionId) throws IOException, SchemaNotFoundException;
 }

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -13,4 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+org.apache.nifi.aws.schemaregistry.AmazonGlueEncodedSchemaReferenceReader
 org.apache.nifi.aws.schemaregistry.AmazonGlueSchemaRegistry

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/test/java/org/apache/nifi/aws/schemaregistry/client/GlueSchemaRegistryClientTest.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-schema-registry-service/src/test/java/org/apache/nifi/aws/schemaregistry/client/GlueSchemaRegistryClientTest.java
@@ -23,10 +23,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.DataFormat;
 import software.amazon.awssdk.services.glue.model.GetSchemaVersionRequest;
 import software.amazon.awssdk.services.glue.model.GetSchemaVersionResponse;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -40,6 +42,7 @@ class GlueSchemaRegistryClientTest {
     private static final String REGISTRY_NAME = "registry";
     private static final String SCHEMA_DEFINITION = "{\"namespace\":\"com.example\",\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}";
     private static final GetSchemaVersionResponse MOCK_RESPONSE = GetSchemaVersionResponse.builder()
+            .dataFormat(DataFormat.AVRO)
             .schemaDefinition(SCHEMA_DEFINITION)
             .versionNumber(1L)
             .build();
@@ -68,6 +71,7 @@ class GlueSchemaRegistryClientTest {
         int version = 1;
 
         final GetSchemaVersionResponse mockResponse = GetSchemaVersionResponse.builder()
+                .dataFormat(DataFormat.AVRO)
                 .schemaDefinition(SCHEMA_DEFINITION)
                 .versionNumber(1L)
                 .build();
@@ -77,6 +81,30 @@ class GlueSchemaRegistryClientTest {
         when(mockClient.getSchemaVersion(any(GetSchemaVersionRequest.class))).thenReturn(mockResponse);
 
         final RecordSchema actualSchema = schemaRegistryClient.getSchema(SCHEMA_NAME, version);
+
+        assertNotNull(actualSchema);
+        assertEquals(EXPECTED_SCHEMA_NAMESPACE, actualSchema.getSchemaNamespace().orElseThrow(() -> new RuntimeException("Schema namespace not found")));
+        assertEquals(EXPECTED_SCHEMA_NAME, actualSchema.getSchemaName().orElseThrow(() -> new RuntimeException("Schema name not found")));
+        verify(mockClient).getSchemaVersion(any(GetSchemaVersionRequest.class));
+    }
+
+    @Test
+    void getSchemaWithNameVersionIdInvokesClientAndReturnsRecordSchema() throws IOException, SchemaNotFoundException {
+        UUID schemaVersionId = UUID.randomUUID();
+        String schemaArn = "arn:aws:glue:us-east-1:123456789012:schema/registry/name";
+
+        final GetSchemaVersionResponse mockResponse = GetSchemaVersionResponse.builder()
+                .dataFormat(DataFormat.AVRO)
+                .schemaDefinition(SCHEMA_DEFINITION)
+                .versionNumber(1L)
+                .schemaArn(schemaArn)
+                .build();
+
+        schemaRegistryClient = new GlueSchemaRegistryClient(mockClient, REGISTRY_NAME);
+
+        when(mockClient.getSchemaVersion(any(GetSchemaVersionRequest.class))).thenReturn(mockResponse);
+
+        final RecordSchema actualSchema = schemaRegistryClient.getSchema(schemaVersionId);
 
         assertNotNull(actualSchema);
         assertEquals(EXPECTED_SCHEMA_NAMESPACE, actualSchema.getSchemaNamespace().orElseThrow(() -> new RuntimeException("Schema namespace not found")));

--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -66,6 +66,17 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>software.amazon.glue</groupId>
+                <artifactId>schema-registry-serde</artifactId>
+                <version>1.1.24</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
             <!-- Override kotlin-stdlib-common from amazon-kinesis-client -->
             <!-- can be removed when not relying on kotlin-stdlib-common:jar anymore -->
             <dependency>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14629](https://issues.apache.org/jira/browse/NIFI-14629)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] (there are no new dependencies) New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] (there are no new dependencies) New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] (there is no new documentation) Documentation formatting appears as expected in rendered files
