### PR TITLE
[NIFI-14707] Use a single logger for TimedLock

### DIFF
--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/concurrency/DebugEnabledTimedLock.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/concurrency/DebugEnabledTimedLock.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 public class DebugEnabledTimedLock implements DebuggableTimedLock {
 
     private final Lock lock;
-    private final Logger logger;
+    private static final Logger logger = LoggerFactory.getLogger(TimedLock.class.getName());
     private long lockTime = 0L;
 
     private final Map<String, Long> lockIterations = new HashMap<>();
@@ -40,7 +40,6 @@ public class DebugEnabledTimedLock implements DebuggableTimedLock {
         this.lock = lock;
         this.name = name;
         this.iterationFrequency = iterationFrequency;
-        logger = LoggerFactory.getLogger(TimedLock.class.getName() + "." + name);
     }
 
     /**
@@ -54,7 +53,7 @@ public class DebugEnabledTimedLock implements DebuggableTimedLock {
             logger.trace("TryLock failed for Lock: {}", name);
             return false;
         }
-        logger.trace("TryLock successful");
+        logger.trace("TryLock successful for Lock: {}", name);
 
         return true;
     }
@@ -78,7 +77,7 @@ public class DebugEnabledTimedLock implements DebuggableTimedLock {
             logger.trace("TryLock failed for Lock {} with a timeout of {} {}", name, timeout, timeUnit);
             return false;
         }
-        logger.trace("TryLock successful");
+        logger.trace("TryLock successful for Lock: {}", name);
         return true;
     }
 

--- a/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/concurrency/TimedLock.java
+++ b/nifi-commons/nifi-utils/src/main/java/org/apache/nifi/util/concurrency/TimedLock.java
@@ -27,13 +27,11 @@ public class TimedLock {
     private final DebugEnabledTimedLock enabled;
     private final DebugDisabledTimedLock disabled;
 
-    private final Logger logger;
+    private static final Logger logger = LoggerFactory.getLogger(TimedLock.class.getName());
 
     public TimedLock(final Lock lock, final String name, final int iterationFrequency) {
         this.enabled = new DebugEnabledTimedLock(lock, name, iterationFrequency);
         this.disabled = new DebugDisabledTimedLock(lock);
-
-        logger = LoggerFactory.getLogger(TimedLock.class.getName() + "." + name);
     }
 
     private DebuggableTimedLock getLock() {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14707](https://issues.apache.org/jira/browse/NIFI-14707)
Go with the simple approach to use a single logger for all instances of TimedLock and its debuggable counterpart. If you all still want the ability to configure logging on a specific TimedLock instance please drop a comment. I just wanted to get a PR up with the simplest solution.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- N/A New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- N/A New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- N/A Documentation formatting appears as expected in rendered files
