### PR TITLE
NIFI-14698 Replace AntPathRequestMatcher with PathPatternRequestMatcher

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
@@ -73,7 +73,7 @@ import org.springframework.security.saml2.provider.service.web.authentication.lo
 import org.springframework.security.saml2.provider.service.web.authentication.logout.Saml2LogoutResponseResolver;
 import org.springframework.security.saml2.provider.service.web.authentication.logout.Saml2RelyingPartyInitiatedLogoutSuccessHandler;
 import org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509ExtendedTrustManager;
@@ -122,7 +122,7 @@ public class SamlAuthenticationSecurityConfiguration {
     @Bean
     public Saml2MetadataFilter saml2MetadataFilter() {
         final Saml2MetadataFilter filter = new Saml2MetadataFilter(relyingPartyRegistrationResolver(), saml2MetadataResolver());
-        filter.setRequestMatcher(new AntPathRequestMatcher(SamlUrlPath.METADATA.getPath()));
+        filter.setRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher(SamlUrlPath.METADATA.getPath()));
         return filter;
     }
 
@@ -182,7 +182,7 @@ public class SamlAuthenticationSecurityConfiguration {
                 saml2LogoutResponseResolver(),
                 saml2SingleLogoutHandler()
         );
-        filter.setLogoutRequestMatcher(new AntPathRequestMatcher(SamlUrlPath.SINGLE_LOGOUT_RESPONSE.getPath()));
+        filter.setLogoutRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher(SamlUrlPath.SINGLE_LOGOUT_RESPONSE.getPath()));
         return filter;
     }
 
@@ -199,7 +199,7 @@ public class SamlAuthenticationSecurityConfiguration {
                 saml2LogoutSuccessHandler()
         );
         saml2LogoutResponseFilter.setLogoutRequestRepository(saml2LogoutRequestRepository());
-        saml2LogoutResponseFilter.setLogoutRequestMatcher(new AntPathRequestMatcher(SamlUrlPath.SINGLE_LOGOUT_RESPONSE.getPath()));
+        saml2LogoutResponseFilter.setLogoutRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher(SamlUrlPath.SINGLE_LOGOUT_RESPONSE.getPath()));
         return saml2LogoutResponseFilter;
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/WebSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/WebSecurityConfiguration.java
@@ -54,8 +54,8 @@ import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.AndRequestMatcher;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatchers;
@@ -80,7 +80,7 @@ public class WebSecurityConfiguration {
     );
 
     private static final RequestMatcher UNFILTERED_PATHS_REQUEST_MATCHER = new OrRequestMatcher(
-            UNFILTERED_PATHS.stream().map(AntPathRequestMatcher::new).collect(Collectors.toList())
+            UNFILTERED_PATHS.stream().map(PathPatternRequestMatcher.withDefaults()::matcher).collect(Collectors.toList())
     );
 
     /**

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/logout/StandardLogoutFilter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/logout/StandardLogoutFilter.java
@@ -20,7 +20,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import jakarta.servlet.FilterChain;
@@ -33,12 +33,12 @@ import java.io.IOException;
  * Standard Logout Filter completes application Logout Requests
  */
 public class StandardLogoutFilter extends OncePerRequestFilter {
-    private final AntPathRequestMatcher requestMatcher;
+    private final PathPatternRequestMatcher requestMatcher;
 
     private final LogoutSuccessHandler logoutSuccessHandler;
 
     public StandardLogoutFilter(
-            final AntPathRequestMatcher requestMatcher,
+            final PathPatternRequestMatcher requestMatcher,
             final LogoutSuccessHandler logoutSuccessHandler
     ) {
         this.requestMatcher = requestMatcher;

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/client/web/OidcBearerTokenRefreshFilter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/client/web/OidcBearerTokenRefreshFilter.java
@@ -46,7 +46,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import jakarta.servlet.FilterChain;
@@ -72,7 +72,7 @@ public class OidcBearerTokenRefreshFilter extends OncePerRequestFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(OidcBearerTokenRefreshFilter.class);
 
-    private final AntPathRequestMatcher currentUserRequestMatcher = new AntPathRequestMatcher("/flow/current-user");
+    private final PathPatternRequestMatcher currentUserRequestMatcher = PathPatternRequestMatcher.withDefaults().matcher("/flow/current-user");
 
     private final ApplicationCookieService applicationCookieService = new StandardApplicationCookieService();
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/logout/OidcLogoutFilter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/logout/OidcLogoutFilter.java
@@ -19,7 +19,7 @@ package org.apache.nifi.web.security.oidc.logout;
 import org.apache.nifi.web.security.logout.StandardLogoutFilter;
 import org.apache.nifi.web.security.oidc.OidcUrlPath;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
 /**
  * OpenID Connect Logout Filter completes application Logout Requests
@@ -28,6 +28,6 @@ public class OidcLogoutFilter extends StandardLogoutFilter {
     public OidcLogoutFilter(
             final LogoutSuccessHandler logoutSuccessHandler
     ) {
-        super(new AntPathRequestMatcher(OidcUrlPath.LOGOUT.getPath()), logoutSuccessHandler);
+        super(PathPatternRequestMatcher.withDefaults().matcher(OidcUrlPath.LOGOUT.getPath()), logoutSuccessHandler);
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/web/authentication/logout/Saml2LocalLogoutFilter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/web/authentication/logout/Saml2LocalLogoutFilter.java
@@ -19,7 +19,7 @@ package org.apache.nifi.web.security.saml2.web.authentication.logout;
 import org.apache.nifi.web.security.logout.StandardLogoutFilter;
 import org.apache.nifi.web.security.saml2.SamlUrlPath;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 /**
  * SAML 2 Logout Filter completes application Logout Requests
  */
@@ -27,6 +27,6 @@ public class Saml2LocalLogoutFilter extends StandardLogoutFilter {
     public Saml2LocalLogoutFilter(
             final LogoutSuccessHandler logoutSuccessHandler
     ) {
-        super(new AntPathRequestMatcher(SamlUrlPath.LOCAL_LOGOUT_REQUEST.getPath()), logoutSuccessHandler);
+        super(PathPatternRequestMatcher.withDefaults().matcher(SamlUrlPath.LOCAL_LOGOUT_REQUEST.getPath()), logoutSuccessHandler);
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/web/authentication/logout/Saml2SingleLogoutFilter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/saml2/web/authentication/logout/Saml2SingleLogoutFilter.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import jakarta.servlet.FilterChain;
@@ -46,7 +46,7 @@ public class Saml2SingleLogoutFilter extends OncePerRequestFilter {
 
     private static final ApplicationCookieService applicationCookieService = new StandardApplicationCookieService();
 
-    private final AntPathRequestMatcher requestMatcher = new AntPathRequestMatcher(SamlUrlPath.SINGLE_LOGOUT_REQUEST.getPath());
+    private final PathPatternRequestMatcher requestMatcher = PathPatternRequestMatcher.withDefaults().matcher(SamlUrlPath.SINGLE_LOGOUT_REQUEST.getPath());
 
     private final LogoutRequestManager logoutRequestManager;
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/oidc/client/web/OidcBearerTokenRefreshFilterTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/oidc/client/web/OidcBearerTokenRefreshFilterTest.java
@@ -166,7 +166,7 @@ class OidcBearerTokenRefreshFilterTest {
 
     @Test
     void testDoFilterBearerTokenNotFound() throws ServletException, IOException {
-        request.setServletPath(CURRENT_USER_URI);
+        request.setRequestURI(CURRENT_USER_URI);
 
         filter.doFilter(request, response, filterChain);
 
@@ -175,7 +175,7 @@ class OidcBearerTokenRefreshFilterTest {
 
     @Test
     void testDoFilterBearerTokenFoundRefreshNotRequired() throws ServletException, IOException {
-        request.setServletPath(CURRENT_USER_URI);
+        request.setRequestURI(CURRENT_USER_URI);
 
         when(bearerTokenResolver.resolve(eq(request))).thenReturn(BEARER_TOKEN);
         final Jwt jwt = getJwt(Instant.MAX);
@@ -188,7 +188,7 @@ class OidcBearerTokenRefreshFilterTest {
 
     @Test
     void testDoFilterRefreshRequiredClientNotFound() throws ServletException, IOException {
-        request.setServletPath(CURRENT_USER_URI);
+        request.setRequestURI(CURRENT_USER_URI);
 
         when(bearerTokenResolver.resolve(eq(request))).thenReturn(BEARER_TOKEN);
         final Jwt jwt = getJwt(Instant.now().minusSeconds(INSTANT_OFFSET));
@@ -204,7 +204,7 @@ class OidcBearerTokenRefreshFilterTest {
 
     @Test
     void testDoFilterRefreshRequiredRefreshTokenNotFound() throws ServletException, IOException {
-        request.setServletPath(CURRENT_USER_URI);
+        request.setRequestURI(CURRENT_USER_URI);
 
         when(bearerTokenResolver.resolve(eq(request))).thenReturn(BEARER_TOKEN);
         final Jwt jwt = getJwt(Instant.now().minusSeconds(INSTANT_OFFSET));
@@ -226,7 +226,7 @@ class OidcBearerTokenRefreshFilterTest {
         final SecurityContext securityContext = new SecurityContextImpl(authenticationToken);
         SecurityContextHolder.setContext(securityContext);
 
-        request.setServletPath(CURRENT_USER_URI);
+        request.setRequestURI(CURRENT_USER_URI);
 
         when(bearerTokenResolver.resolve(eq(request))).thenReturn(BEARER_TOKEN);
         final Instant expiration = Instant.now().minusSeconds(INSTANT_OFFSET);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/saml2/web/authentication/logout/Saml2LocalLogoutFilterTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/saml2/web/authentication/logout/Saml2LocalLogoutFilterTest.java
@@ -65,7 +65,7 @@ class Saml2LocalLogoutFilterTest {
 
     @Test
     void testDoFilterInternal() throws ServletException, IOException {
-        httpServletRequest.setPathInfo(SamlUrlPath.LOCAL_LOGOUT_REQUEST.getPath());
+        httpServletRequest.setRequestURI(SamlUrlPath.LOCAL_LOGOUT_REQUEST.getPath());
         filter.doFilter(httpServletRequest, httpServletResponse, filterChain);
 
         verify(logoutSuccessHandler).onLogoutSuccess(eq(httpServletRequest), eq(httpServletResponse), isNull());

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/saml2/web/authentication/logout/Saml2SingleLogoutFilterTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/saml2/web/authentication/logout/Saml2SingleLogoutFilterTest.java
@@ -78,7 +78,7 @@ class Saml2SingleLogoutFilterTest {
 
     @Test
     void testDoFilterInternal() throws ServletException, IOException {
-        httpServletRequest.setPathInfo(SamlUrlPath.SINGLE_LOGOUT_REQUEST.getPath());
+        httpServletRequest.setRequestURI(SamlUrlPath.SINGLE_LOGOUT_REQUEST.getPath());
 
         final Cookie cookie = new Cookie(ApplicationCookieName.LOGOUT_REQUEST_IDENTIFIER.getCookieName(), REQUEST_IDENTIFIER);
         httpServletRequest.setCookies(cookie);

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
@@ -55,10 +55,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.csrf.CsrfException;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
 import java.io.IOException;
-
-import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
 /**
  * Spring Security Filter Configuration
@@ -112,12 +111,12 @@ public class NiFiRegistrySecurityConfig {
                 )
                 .authorizeRequests((authorize) -> authorize
                         .requestMatchers(
-                                antMatcher("/access/token"),
-                                antMatcher("/access/token/identity-provider"),
-                                antMatcher("/access/token/kerberos"),
-                                antMatcher("/access/oidc/callback"),
-                                antMatcher("/access/oidc/exchange"),
-                                antMatcher("/access/oidc/request")
+                                PathPatternRequestMatcher.withDefaults().matcher("/access/token"),
+                                PathPatternRequestMatcher.withDefaults().matcher("/access/token/identity-provider"),
+                                PathPatternRequestMatcher.withDefaults().matcher("/access/token/kerberos"),
+                                PathPatternRequestMatcher.withDefaults().matcher("/access/oidc/callback"),
+                                PathPatternRequestMatcher.withDefaults().matcher("/access/oidc/exchange"),
+                                PathPatternRequestMatcher.withDefaults().matcher("/access/oidc/request")
                         )
                         .permitAll()
                         .anyRequest().fullyAuthenticated()


### PR DESCRIPTION
# Summary

[NIFI-14698](https://issues.apache.org/jira/browse/NIFI-14698) Replaces the deprecated Spring Security `AndPathRequestMatcher` with the recommended [PathPatternRequestMatcher](https://docs.spring.io/spring-security/reference/api/java/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcher.html).

Changes surfaced unit test behavior with mock HttpServletRequest objects that did not align with running behavior, requiring changes to set Request URI.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
