### PR TITLE
[NIFI-14233] Fix PropertyDependency resolution for imported PropertyDescriptors

### DIFF
--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/nifi-python-framework-core/src/test/resources/python_extensions/TestProcessorWithImport.py
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/nifi-python-framework-core/src/test/resources/python_extensions/TestProcessorWithImport.py
@@ -1,0 +1,20 @@
+from nifiapi.properties import PropertyDescriptor, PropertyDependency
+from shared_props import SHARED_PROP
+
+MY_PROP = PropertyDescriptor(
+    name="my.property",
+    description="This is my property",
+    display_name="My Property",
+    required=True,
+    dependencies=[PropertyDependency(SHARED_PROP, ["value1", "value2"])]
+)
+
+class TestProcessorWithImport:
+    def __init__(self):
+        self._logger = None
+
+    def set_logger(self, logger):
+        self._logger = logger
+
+    def get_property_descriptors(self):
+        return [MY_PROP]

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/nifi-python-framework-core/src/test/resources/python_extensions/shared_props.py
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/nifi-python-framework-core/src/test/resources/python_extensions/shared_props.py
@@ -1,0 +1,8 @@
+from nifiapi.properties import PropertyDescriptor
+
+SHARED_PROP = PropertyDescriptor(
+    name="shared.property",
+    description="Shared property defined in shared module",
+    display_name="Shared Property",
+    required=False
+)

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/src/main/python/framework/ProcessorInspection.py
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-py4j-framework-bundle/nifi-python-framework/src/main/python/framework/ProcessorInspection.py
@@ -59,10 +59,14 @@ class CollectPropertyDescriptorVisitors(ast.NodeVisitor):
         resolved_dependencies = []
         for dependency in node.elts:
             variable_name = dependency.args[0].id
-            if not self.discovered_property_descriptors[variable_name]:
-                self.logger.error(f"Not able to find actual property descriptor for {variable_name}, so not able to resolve property dependencies in {self.processor_name}.")
-            else:
-                actual_property = self.discovered_property_descriptors[variable_name]
+            actual_property = self.discovered_property_descriptors.get(variable_name)
+                if actual_property is None:
+                           imported_value = self.module_string_constants.get(variable_name)
+                           if isinstance(imported_value, PropertyDescription):
+                               actual_property = imported_value
+                           if actual_property is None:
+                               self.logger.error(f"Cannot resolve property descriptor '{variable_name}' in {self.processor_name}. Skipping.")
+                                       continue
                 dependent_values = []
                 for dependent_value in dependency.args[1:]:
                     dependent_values.append(get_constant_values(dependent_value, self.module_string_constants))


### PR DESCRIPTION
**Summary**
Fixes a bug where Python processor `Property Dependency` resolution failed if a `Property Descriptor` was imported from another module (e.g., `shared_props.py`), leading to `Key Error`.

**Fix**
1.Updated `resolve_dependencies()` in `ProcessorInspection.py` to:
2.Check `module_string_constants` if not found in `discovered_property_descriptors`
3.Gracefully skip unresolved properties with logging

**Related Tickets**
1.Closes: [NIFI-14233](https://issues.apache.org/jira/browse/NIFI-14233)
2.Closes: [NIFI-14368](https://issues.apache.org/jira/browse/NIFI-14368)

 **Testing**
1.Added test processors with shared imports
2.Verified dependencies resolve correctly with no errors
