### PR TITLE
NIFI-14723 - Bump Azure SDK to 1.2.36, GCP SDK to 26.63.0 and others

### DIFF
--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -28,8 +28,8 @@
 
     <properties>
         <!-- when changing the Azure SDK version, also update msal4j to the version that is required by azure-identity -->
-        <azure.sdk.bom.version>1.2.35</azure.sdk.bom.version>
-        <msal4j.version>1.20.1</msal4j.version>
+        <azure.sdk.bom.version>1.2.36</azure.sdk.bom.version>
+        <msal4j.version>1.21.0</msal4j.version>
         <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.62.0</google.libraries.version>
+        <google.libraries.version>26.63.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <org.apache.commons.codec.version>1.18.0</org.apache.commons.codec.version>
         <org.apache.commons.collections4.version>4.5.0</org.apache.commons.collections4.version>
         <org.apache.commons.compress.version>1.27.1</org.apache.commons.compress.version>
-        <com.github.luben.zstd-jni.version>1.5.7-3</com.github.luben.zstd-jni.version>
+        <com.github.luben.zstd-jni.version>1.5.7-4</com.github.luben.zstd-jni.version>
         <org.apache.commons.configuration.version>2.12.0</org.apache.commons.configuration.version>
         <org.apache.commons.lang3.version>3.17.0</org.apache.commons.lang3.version>
         <org.apache.commons.net.version>3.11.1</org.apache.commons.net.version>


### PR DESCRIPTION
# Summary

[NIFI-14723](https://issues.apache.org/jira/browse/NIFI-14723) - Bump Azure SDK to 1.2.36, GCP SDK to 26.63.0 and others

- Azure SDK from 1.2.35 to 1.2.36 - https://github.com/Azure/azure-sdk-for-java/pull/45877
- MSAL4J from 1.20.1 to 1.21.0 - https://github.com/AzureAD/microsoft-authentication-library-for-java/releases/tag/v1.21.0
- Google SDK from 26.62.0 to 26.63.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.63.0
- zstd jni from 1.5.7-3 to 1.5.7-4 - https://github.com/luben/zstd-jni/releases/tag/v1.5.7-4

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
