### PR TITLE
NIFI-14710 - Stateless should trigger failure callback when queues are not empty after process group is stopped

### DIFF
--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessFlow.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessFlow.java
@@ -405,7 +405,7 @@ public class StandardStatelessFlow implements StatelessDataflow {
             } else {
                 final boolean gracefullyStopped = waitForProcessorThreadsToComplete(runningProcessors, gracefulShutdownDuration);
                 if (gracefullyStopped) {
-                    if (isFlowFileQueued()) {
+                    if (rootGroup.isDataQueuedForProcessing()) {
                         final int queuedCount = allConnections.stream()
                                 .mapToInt(conn -> conn.getFlowFileQueue().size().getObjectCount())
                                 .sum();
@@ -424,7 +424,7 @@ public class StandardStatelessFlow implements StatelessDataflow {
             }
         } else {
             waitForProcessorThreadsToComplete(runningProcessors, gracefulShutdownDuration);
-            if (isFlowFileQueued()) {
+            if (rootGroup.isDataQueuedForProcessing()) {
                 final int queuedCount = allConnections.stream()
                         .mapToInt(conn -> conn.getFlowFileQueue().size().getObjectCount())
                         .sum();

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessFlow.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/flow/StandardStatelessFlow.java
@@ -144,6 +144,16 @@ public class StandardStatelessFlow implements StatelessDataflow {
                                  final ProcessContextFactory processContextFactory, final RepositoryContextFactory repositoryContextFactory, final DataflowDefinition dataflowDefinition,
                                  final StatelessStateManagerProvider stateManagerProvider, final ProcessScheduler processScheduler, final BulletinRepository bulletinRepository,
                                  final LifecycleStateManager lifecycleStateManager, final Duration componentEnableTimeout, final StatsTracker statsTracker) {
+        this(rootGroup, reportingTasks, controllerServiceProvider, processContextFactory, repositoryContextFactory, dataflowDefinition,
+                stateManagerProvider, processScheduler, bulletinRepository, lifecycleStateManager, componentEnableTimeout, statsTracker,
+                new AsynchronousCommitTracker(rootGroup));
+    }
+
+    public StandardStatelessFlow(final ProcessGroup rootGroup, final List<ReportingTaskNode> reportingTasks, final ControllerServiceProvider controllerServiceProvider,
+                                 final ProcessContextFactory processContextFactory, final RepositoryContextFactory repositoryContextFactory, final DataflowDefinition dataflowDefinition,
+                                 final StatelessStateManagerProvider stateManagerProvider, final ProcessScheduler processScheduler, final BulletinRepository bulletinRepository,
+                                 final LifecycleStateManager lifecycleStateManager, final Duration componentEnableTimeout, final StatsTracker statsTracker,
+                                 final AsynchronousCommitTracker commitTracker) {
         this.rootGroup = rootGroup;
         this.allConnections = rootGroup.findAllConnections();
         this.reportingTasks = reportingTasks;
@@ -156,7 +166,7 @@ public class StandardStatelessFlow implements StatelessDataflow {
         this.transactionThresholdMeter = new TransactionThresholdMeter(dataflowDefinition.getTransactionThresholds());
         this.bulletinRepository = bulletinRepository;
         this.componentEnableTimeoutMillis = componentEnableTimeout.toMillis();
-        this.tracker = new AsynchronousCommitTracker(rootGroup);
+        this.tracker = commitTracker;
         this.lifecycleStateManager = lifecycleStateManager;
         this.inputPorts = new ArrayList<>(rootGroup.getInputPorts());
         this.statsTracker = statsTracker;
@@ -395,8 +405,16 @@ public class StandardStatelessFlow implements StatelessDataflow {
             } else {
                 final boolean gracefullyStopped = waitForProcessorThreadsToComplete(runningProcessors, gracefulShutdownDuration);
                 if (gracefullyStopped) {
-                    logger.info("All Processors have finished running; triggering session callbacks");
-                    tracker.triggerCallbacks();
+                    if (isFlowFileQueued()) {
+                        final int queuedCount = allConnections.stream()
+                                .mapToInt(conn -> conn.getFlowFileQueue().size().getObjectCount())
+                                .sum();
+                        logger.warn("All Processors finished running but {} FlowFiles remain queued; treating session as failure", queuedCount);
+                        tracker.triggerFailureCallbacks(new TerminatedTaskException());
+                    } else {
+                        logger.info("All Processors have finished running; triggering session callbacks");
+                        tracker.triggerCallbacks();
+                    }
                 } else {
                     logger.warn("{} Processors did not finish running within the graceful shutdown period of {} millis. Interrupting all running components. Processors still running: {}",
                         runningProcessors.size(), gracefulShutdownDuration.toMillis(), runningProcessors);
@@ -406,7 +424,15 @@ public class StandardStatelessFlow implements StatelessDataflow {
             }
         } else {
             waitForProcessorThreadsToComplete(runningProcessors, gracefulShutdownDuration);
-            tracker.triggerCallbacks();
+            if (isFlowFileQueued()) {
+                final int queuedCount = allConnections.stream()
+                        .mapToInt(conn -> conn.getFlowFileQueue().size().getObjectCount())
+                        .sum();
+                logger.warn("{} FlowFiles remain queued after shutdown; treating session as failure", queuedCount);
+                tracker.triggerFailureCallbacks(new TerminatedTaskException());
+            } else {
+                tracker.triggerCallbacks();
+            }
         }
 
         if (runDataflowExecutor != null) {

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/test/java/org/apache/nifi/stateless/flow/TestStandardStatelessFlow.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/test/java/org/apache/nifi/stateless/flow/TestStandardStatelessFlow.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.stateless.flow;
+
+import org.apache.nifi.components.state.StatelessStateManagerProvider;
+import org.apache.nifi.connectable.Connectable;
+import org.apache.nifi.connectable.Connection;
+import org.apache.nifi.controller.ProcessScheduler;
+import org.apache.nifi.controller.queue.FlowFileQueue;
+import org.apache.nifi.controller.queue.QueueSize;
+import org.apache.nifi.controller.repository.metrics.tracking.StatsTracker;
+import org.apache.nifi.controller.scheduling.LifecycleStateManager;
+import org.apache.nifi.controller.service.ControllerServiceProvider;
+import org.apache.nifi.groups.ProcessGroup;
+import org.apache.nifi.processor.exception.TerminatedTaskException;
+import org.apache.nifi.reporting.BulletinRepository;
+import org.apache.nifi.stateless.engine.ProcessContextFactory;
+import org.apache.nifi.stateless.repository.RepositoryContextFactory;
+import org.apache.nifi.stateless.session.AsynchronousCommitTracker;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestStandardStatelessFlow {
+
+    @Test
+    public void testShutdownWithQueuedFlowFilesTriggersFailure() throws Exception {
+        ProcessGroup rootGroup = mock(ProcessGroup.class);
+        when(rootGroup.getName()).thenReturn("root");
+        when(rootGroup.getInputPorts()).thenReturn(Collections.emptySet());
+        when(rootGroup.getOutputPorts()).thenReturn(Collections.emptySet());
+        when(rootGroup.findAllProcessors()).thenReturn(Collections.emptyList());
+        when(rootGroup.stopComponents(any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(rootGroup.findAllRemoteProcessGroups()).thenReturn(Collections.emptyList());
+
+        FlowFileQueue queue = mock(FlowFileQueue.class);
+        when(queue.isActiveQueueEmpty()).thenReturn(false);
+        when(queue.size()).thenReturn(new QueueSize(1, 0L));
+
+        Connection connection = mock(Connection.class);
+        when(connection.getFlowFileQueue()).thenReturn(queue);
+        when(connection.getSource()).thenReturn(mock(Connectable.class));
+        when(connection.getDestination()).thenReturn(mock(Connectable.class));
+        when(rootGroup.findAllConnections()).thenReturn(Collections.singletonList(connection));
+
+        ControllerServiceProvider controllerServiceProvider = mock(ControllerServiceProvider.class);
+        ProcessContextFactory processContextFactory = mock(ProcessContextFactory.class);
+        RepositoryContextFactory repositoryContextFactory = mock(RepositoryContextFactory.class);
+        DataflowDefinition dataflowDefinition = mock(DataflowDefinition.class);
+        when(dataflowDefinition.getTransactionThresholds()).thenReturn(TransactionThresholds.SINGLE_FLOWFILE);
+        when(dataflowDefinition.getFailurePortNames()).thenReturn(Collections.emptySet());
+        StatelessStateManagerProvider stateManagerProvider = mock(StatelessStateManagerProvider.class);
+        ProcessScheduler processScheduler = mock(ProcessScheduler.class);
+        BulletinRepository bulletinRepository = mock(BulletinRepository.class);
+        LifecycleStateManager lifecycleStateManager = mock(LifecycleStateManager.class);
+        StatsTracker statsTracker = mock(StatsTracker.class);
+
+        AsynchronousCommitTracker tracker = spy(new AsynchronousCommitTracker(rootGroup));
+        StandardStatelessFlow flow = new StandardStatelessFlow(rootGroup, List.of(), controllerServiceProvider, processContextFactory,
+                repositoryContextFactory, dataflowDefinition, stateManagerProvider, processScheduler, bulletinRepository,
+                lifecycleStateManager, Duration.ZERO, statsTracker, tracker);
+
+        flow.shutdown(false, false, Duration.ZERO);
+
+        verify(tracker, times(1)).triggerFailureCallbacks(any(TerminatedTaskException.class));
+    }
+
+}


### PR DESCRIPTION
# Summary

[NIFI-14710](https://issues.apache.org/jira/browse/NIFI-14710) - Stateless should trigger failure callback when queues are not empty after process group is stopped

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
