### PR TITLE
NIFI-14739 Add Logback NopStatusListener to Bootstrap Command

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/bin/nifi.sh
@@ -214,8 +214,11 @@ run() {
     echo "NIFI_HOME=${NIFI_HOME}"
     echo
 
+    # NopStatusListener prevents Logback from writing configuration failures to the standard output stream
+    BOOTSTRAP_LOGBACK_STATUS_LISTENER="-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener"
+
     #setup directory parameters
-    BOOTSTRAP_LOG_PARAMS="-Dorg.apache.nifi.bootstrap.config.log.dir='${NIFI_LOG_DIR}'"
+    BOOTSTRAP_LOG_PARAMS="${BOOTSTRAP_LOGBACK_STATUS_LISTENER} -Dorg.apache.nifi.bootstrap.config.log.dir='${NIFI_LOG_DIR}'"
     BOOTSTRAP_CONF_PARAMS="-Dorg.apache.nifi.bootstrap.config.file='${BOOTSTRAP_CONF}'"
 
     # uncomment to allow debugging of the bootstrap process


### PR DESCRIPTION
# Summary

[NIFI-14739](https://issues.apache.org/jira/browse/NIFI-14739) Adds the Logback [NopStatusListener](https://javadoc.io/static/ch.qos.logback/logback-core/1.5.18/ch.qos.logback.core/ch/qos/logback/core/status/NopStatusListener.html) to the NiFi Bootstrap command to prevent Logback configuration failure messages from interfering with `run` command formatting.

The addition uses the Logback [system property](https://logback.qos.ch/manual/configuration.html#logback.statusLC) for the NiFi Bootstrap command, but avoids setting the property for the NiFi application command. This approach avoids issues with the Bootstrap process, but continues to write Logback messages in the event of configuration issues when starting the NiFi application Java process.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
