### PR TITLE
NIFI-14749 - Bump Log4J to 2.25.1, datafaker to 2.4.4 and others

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -27,7 +27,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <aws-kinesis-client-library-version>2.7.0</aws-kinesis-client-library-version>
+        <aws-kinesis-client-library-version>2.7.1</aws-kinesis-client-library-version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -127,12 +127,12 @@
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-data</artifactId>
-            <version>6.0.3</version>
+            <version>7.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-ingest</artifactId>
-            <version>6.0.3</version>
+            <version>7.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoIngestService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoIngestService.java
@@ -36,7 +36,6 @@ import com.microsoft.azure.kusto.ingest.result.IngestionStatus;
 import com.microsoft.azure.kusto.ingest.result.OperationStatus;
 import com.microsoft.azure.kusto.ingest.source.StreamSourceInfo;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
@@ -118,7 +117,7 @@ public class StandardKustoIngestService extends AbstractControllerService implem
 
     private static final String COUNT_TABLE_COMMAND = "%s | count";
 
-    private static final Pair<String, String> NIFI_SINK = Pair.of("processor", StandardKustoIngestService.class.getSimpleName());
+    private static final Map<String, String> NIFI_SINK = Map.of("processor", StandardKustoIngestService.class.getSimpleName());
 
     private volatile QueuedIngestClient queuedIngestClient;
 

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoQueryService.java
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/src/main/java/org/apache/nifi/services/azure/data/explorer/StandardKustoQueryService.java
@@ -19,7 +19,6 @@ package org.apache.nifi.services.azure.data.explorer;
 import com.microsoft.azure.kusto.data.ClientFactory;
 import com.microsoft.azure.kusto.data.StreamingClient;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
@@ -33,6 +32,7 @@ import org.apache.nifi.processor.util.StandardValidators;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @Tags({"Azure", "Data", "Explorer", "ADX", "Kusto"})
@@ -98,7 +98,7 @@ public class StandardKustoQueryService extends AbstractControllerService impleme
         return PROPERTY_DESCRIPTORS;
     }
 
-    public static final Pair<String, String> NIFI_SOURCE = Pair.of("processor", "nifi-source");
+    public static final Map<String, String> NIFI_SOURCE = Map.of("processor", "nifi-source");
 
     @OnEnabled
     public void onEnabled(final ConfigurationContext context) throws ProcessException, URISyntaxException {
@@ -138,7 +138,6 @@ public class StandardKustoQueryService extends AbstractControllerService impleme
         return ClientFactory.createStreamingClient(connectionStringBuilder);
     }
 
-    @SuppressWarnings("unchecked")
     private ConnectionStringBuilder getConnectionStringBuilder(final ConfigurationContext context) {
         final String clusterUrl = context.getProperty(CLUSTER_URI).getValue();
         final String clientId = context.getProperty(APPLICATION_CLIENT_ID).getValue();

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
-            <version>2.1.3</version>
+            <version>2.1.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -412,7 +412,7 @@
         <dependency>
             <groupId>net.datafaker</groupId>
             <artifactId>datafaker</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.4</version>
             <exclusions>
                 <!-- Exclude snakeyaml with android qualifier -->
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <gcs.version>2.1.5</gcs.version>
         <aspectj.version>1.9.24</aspectj.version>
         <jersey.bom.version>3.1.10</jersey.bom.version>
-        <log4j2.version>2.25.0</log4j2.version>
+        <log4j2.version>2.25.1</log4j2.version>
         <logback.version>1.5.18</logback.version>
         <mockito.version>5.18.0</mockito.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
@@ -161,7 +161,7 @@
         <swagger.annotations.version>2.2.34</swagger.annotations.version>
         <h2.version>2.3.232</h2.version>
         <zookeeper.version>3.9.3</zookeeper.version>
-        <caffeine.version>3.2.1</caffeine.version>
+        <caffeine.version>3.2.2</caffeine.version>
         <hapi.version>2.6.0</hapi.version>
         <commons.dbcp2.version>2.13.0</commons.dbcp2.version>
         <prometheus.version>0.16.0</prometheus.version>


### PR DESCRIPTION
# Summary

[NIFI-14749](https://issues.apache.org/jira/browse/NIFI-14749) - Bump Log4J to 2.25.1, datafaker to 2.4.4 and others

- AWS Kinesis Client from 2.7.0 to 2.7.1 - https://github.com/awslabs/amazon-kinesis-client/blob/v2.x/CHANGELOG.md
- Microsoft Azure Kusto from 6.0.3 to 7.0.0 - https://github.com/Azure/azure-kusto-java/releases/tag/v7.0.0
- Greenmail from 2.1.3 to 2.1.4 - https://github.com/greenmail-mail-test/greenmail/releases/tag/release-2.1.4
- Datafaker from 2.4.3 to 2.4.4 - https://github.com/datafaker-net/datafaker/releases/tag/2.4.4
- Log4j2 from 2.25.0 to 2.25.1 - https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.25.1
- Caffeine from 3.2.1 to 3.2.2 - https://github.com/ben-manes/caffeine/releases/tag/v3.2.2

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
