### PR TITLE
NIFI-14752 Add Max Uncommitted Size to ConsumeKafka

### DIFF
--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/ConsumeKafkaIT.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-3-integration/src/test/java/org/apache/nifi/kafka/processors/ConsumeKafkaIT.java
@@ -19,7 +19,9 @@ package org.apache.nifi.kafka.processors;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.kafka.processors.consumer.ProcessingStrategy;
+import org.apache.nifi.kafka.service.Kafka3ConnectionService;
 import org.apache.nifi.kafka.service.api.consumer.AutoOffsetReset;
 import org.apache.nifi.kafka.shared.attribute.KafkaFlowFileAttribute;
 import org.apache.nifi.reporting.InitializationException;
@@ -28,14 +30,18 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ConsumeKafkaIT extends AbstractConsumeKafkaIT {
@@ -198,5 +204,52 @@ class ConsumeKafkaIT extends AbstractConsumeKafkaIT {
         }
 
         runner.assertAllFlowFilesTransferred(ConsumeKafka.SUCCESS, 1);
+    }
+
+    @Timeout(5)
+    @Test
+    void testMaxUncommittedSize() throws InterruptedException, ExecutionException {
+        final String topic = UUID.randomUUID().toString();
+        final String groupId = topic.substring(0, topic.indexOf("-"));
+
+        final int recordCount = 100;
+        final int maxPollRecords = 10;
+        final int flowFilesExpected = recordCount / maxPollRecords;
+
+        final int recordSize = RECORD_VALUE.length();
+        final int maxUncommittedSize = recordSize * recordCount;
+
+        // Adjust Poll Records for this method
+        final ControllerService connectionService = runner.getControllerService(CONNECTION_SERVICE_ID);
+        runner.disableControllerService(connectionService);
+        runner.setProperty(connectionService, Kafka3ConnectionService.MAX_POLL_RECORDS, Integer.toString(maxPollRecords));
+        runner.enableControllerService(connectionService);
+
+        runner.setProperty(ConsumeKafka.GROUP_ID, groupId);
+        runner.setProperty(ConsumeKafka.TOPICS, topic);
+        runner.setProperty(ConsumeKafka.PROCESSING_STRATEGY, ProcessingStrategy.DEMARCATOR.getValue());
+        runner.setProperty(ConsumeKafka.MESSAGE_DEMARCATOR, System.lineSeparator());
+
+        // Set Uncommitted Size so that processing completes before 5 second test timeout expires
+        runner.setProperty(ConsumeKafka.MAX_UNCOMMITTED_SIZE, "%d B".formatted(maxUncommittedSize));
+        runner.setProperty(ConsumeKafka.MAX_UNCOMMITTED_TIME, "5 s");
+
+        final Collection<ProducerRecord<String, String>> records = new ArrayList<>();
+        for (int i = 0; i < recordCount; i++) {
+            records.add(new ProducerRecord<>(topic, RECORD_VALUE));
+        }
+        produce(topic, records);
+
+        runner.run();
+
+        final List<MockFlowFile> flowFiles = runner.getFlowFilesForRelationship(ConsumeKafka.SUCCESS);
+        assertEquals(flowFilesExpected, flowFiles.size());
+
+        long totalFlowFileSize = 0;
+        for (final MockFlowFile flowFile : flowFiles) {
+            totalFlowFileSize += flowFile.getSize();
+        }
+
+        assertTrue(totalFlowFileSize > maxUncommittedSize, "Total FlowFile Size [%d] less than Max Uncommitted Size [%d]".formatted(totalFlowFileSize, maxUncommittedSize));
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-14752](https://issues.apache.org/jira/browse/NIFI-14752) Adds a `Max Uncommitted Size` optional property to the `ConsumeKafka` Processor.

The `Max Uncommitted Size` property provides an optional soft limit on the total size of records consumed during an invocation of `ConsumeKafka`. When configured with a value, `Max Uncommitted Size` breaks the polling loop inside `ConsumeKafka.onTrigger()` before reaching the `Max Uncommitted Time`.

The `Max Uncommitted Time` property behavior remains unchanged, but in flows with high volume, configuring the `Max Uncommitted Size` enables `ConsumeKafka` to transfer FlowFiles before waiting for the total time configured.

Changes include a new unit test with a smaller Kafka `max.poll.records` and a larger `Max Uncommitted Time` with corresponding JUnit test timeout. The new test method with `Max Uncommitted Size` configured verifies that `ConsumeKafka` completes before waiting for the maximum amount of time to elapse.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
