### PR TITLE
NIFI-14733: Fix Controller Service documentation rendering when @Tags…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -3074,7 +3074,6 @@ public final class DtoFactory {
                return false;
            }
        }
-
        return true;
    }
 
@@ -3084,7 +3083,7 @@ public final class DtoFactory {
     */
    private String getCapabilityDescription(final Class<?> cls) {
        final CapabilityDescription capabilityDesc = cls.getAnnotation(CapabilityDescription.class);
-       return capabilityDesc == null ? null : capabilityDesc.value();
+       return capabilityDesc == null ? "" : capabilityDesc.value();
    }
 
    /**

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/configurable-extension-definition/configurable-extension-definition.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/documentation/ui/common/configurable-extension-definition/configurable-extension-definition.component.html
@@ -53,7 +53,13 @@
         }
         <div>
             <div>Tags</div>
-            <div class="tertiary-color font-medium">{{ configurableExtensionDefinition.tags.join(', ') }}</div>
+            <div class="tertiary-color font-medium">
+                @if (configurableExtensionDefinition.tags && configurableExtensionDefinition.tags.length > 0) {
+                    {{ configurableExtensionDefinition.tags.join(', ') }}
+                } @else {
+                    No tags available
+                }
+            </div>
         </div>
         @if (configurableExtensionDefinition.propertyDescriptors) {
             <div>


### PR DESCRIPTION
### Description

This PR resolves issue [NIFI-14733](https://issues.apache.org/jira/browse/NIFI-14733)

When a Controller Service does not have the `@Tags` annotation, the NiFi UI previously rendered a blank section or reused old cached content.

### Fix Implemented:
- Added fallback logic in `DtoFactory.java`:
  - If `@Tags` is missing → display: **Tags: No tags available**
- Ensured clean behavior when switching between components.

### Testing
- Added a dummy ControllerService `DummyNoTagNoDescService` without annotations
- Performed local testing to confirm:
  - Proper message is shown in the UI
  - No caching bugs occur when switching components
  - Verified both positive and negative scenarios
  
### Testing Steps:
1. Created a ControllerService without `@Tags` 
2. Verified UI displays:
   - Tags: No tags available
   - Description: No description available
3. Verified normal services still render their tags/descriptions correctly
4. Ensured switching between services updates content correctly
