### PR TITLE
NIFI-14243 add Load Balance Status to the Connections tab of the Summ…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ConnectionStatusSnapshotDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/ConnectionStatusSnapshotDTO.java
@@ -19,6 +19,7 @@ package org.apache.nifi.web.api.dto.status;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.xml.bind.annotation.XmlType;
+import org.apache.nifi.controller.status.LoadBalanceStatus;
 
 /**
  * DTO for serializing the status of a connection.
@@ -49,6 +50,7 @@ public class ConnectionStatusSnapshotDTO implements Cloneable {
     private Integer percentUseCount;
     private Integer percentUseBytes;
     private String flowFileAvailability;
+    private LoadBalanceStatus loadBalanceStatus;
 
     /* getters / setters */
     /**
@@ -206,7 +208,7 @@ public class ConnectionStatusSnapshotDTO implements Cloneable {
     /**
      * @return output for this connection
      */
-    @Schema(description = "The output count/sie for the connection in the last 5 minutes, pretty printed.")
+    @Schema(description = "The output count/size for the connection in the last 5 minutes, pretty printed.")
     public String getOutput() {
         return output;
     }
@@ -293,6 +295,18 @@ public class ConnectionStatusSnapshotDTO implements Cloneable {
         this.flowFileAvailability = availability;
     }
 
+    /**
+     * @return load balance status of the connection
+     */
+    @Schema(description = "The load balance status of the connection")
+    public LoadBalanceStatus getLoadBalanceStatus() {
+        return loadBalanceStatus;
+    }
+
+    public void setLoadBalanceStatus(LoadBalanceStatus loadBalanceStatus) {
+        this.loadBalanceStatus = loadBalanceStatus;
+    }
+
     @Override
     public ConnectionStatusSnapshotDTO clone() {
         final ConnectionStatusSnapshotDTO other = new ConnectionStatusSnapshotDTO();
@@ -322,6 +336,7 @@ public class ConnectionStatusSnapshotDTO implements Cloneable {
         other.setPercentUseBytes(getPercentUseBytes());
         other.setPercentUseCount(getPercentUseCount());
         other.setFlowFileAvailability(getFlowFileAvailability());
+        other.setLoadBalanceStatus(getLoadBalanceStatus());
 
         return other;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/manager/StatusMerger.java
@@ -498,6 +498,7 @@ public class StatusMerger {
             target.setSourceName(toMerge.getSourceName());
             target.setDestinationId(toMerge.getDestinationId());
             target.setDestinationName(toMerge.getDestinationName());
+            target.setLoadBalanceStatus(toMerge.getLoadBalanceStatus());
         }
 
         target.setFlowFilesIn(target.getFlowFilesIn() + toMerge.getFlowFilesIn());

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -1182,6 +1182,8 @@ public final class DtoFactory {
        snapshot.setFlowFilesOut(connectionStatus.getOutputCount());
        snapshot.setBytesOut(connectionStatus.getOutputBytes());
 
+       snapshot.setLoadBalanceStatus(connectionStatus.getLoadBalanceStatus());
+
        ConnectionStatusPredictions predictions = connectionStatus.getPredictions();
        ConnectionStatusPredictionsSnapshotDTO predictionsDTO = null;
        if (predictions != null) {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/state/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/state/index.ts
@@ -65,6 +65,7 @@ export interface ConnectionStatusSnapshot extends BaseSnapshot {
     queuedCount: string;
     queuedSize: string;
     sourceName: string;
+    loadBalanceStatus: string;
 }
 
 export interface RemoteProcessGroupStatusSnapshot {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.html
@@ -196,7 +196,7 @@
                             <!-- Load Balance Status Column -->
                             <ng-container matColumnDef="loadBalanceStatus">
                                 <th mat-header-cell *matHeaderCellDef mat-sort-header>
-                                    <div class="overflow-ellipsis overflow-hidden whitespace-nowrap">Load Balance</div>
+                                    <div class="overflow-ellipsis overflow-hidden whitespace-nowrap">Load Balancing</div>
                                 </th>
                                 <td mat-cell *matCellDef="let item" [title]="formatLoadBalanceStatus(item)">
                                     {{ formatLoadBalanceStatus(item) }}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.html
@@ -196,7 +196,7 @@
                             <!-- Load Balance Status Column -->
                             <ng-container matColumnDef="loadBalanceStatus">
                                 <th mat-header-cell *matHeaderCellDef mat-sort-header>
-                                    <div class="overflow-ellipsis overflow-hidden whitespace-nowrap">Load Balance Status</div>
+                                    <div class="overflow-ellipsis overflow-hidden whitespace-nowrap">Load Balance</div>
                                 </th>
                                 <td mat-cell *matCellDef="let item" [title]="formatLoadBalanceStatus(item)">
                                     {{ formatLoadBalanceStatus(item) }}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.html
@@ -193,6 +193,16 @@
                                 </td>
                             </ng-container>
 
+                            <!-- Load Balance Status Column -->
+                            <ng-container matColumnDef="loadBalanceStatus">
+                                <th mat-header-cell *matHeaderCellDef mat-sort-header>
+                                    <div class="overflow-ellipsis overflow-hidden whitespace-nowrap">Load Balance Status</div>
+                                </th>
+                                <td mat-cell *matCellDef="let item" [title]="formatLoadBalanceStatus(item)">
+                                    {{ formatLoadBalanceStatus(item) }}
+                                </td>
+                            </ng-container>
+
                             <ng-container matColumnDef="actions">
                                 <th mat-header-cell *matHeaderCellDef></th>
                                 <td mat-cell *matCellDef="let item">

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.ts
@@ -81,8 +81,13 @@ export class ConnectionStatusTable extends ComponentStatusTable<ConnectionStatus
             return true;
         }
 
+        // Apply underscore substitution only for loadBalanceStatus column; trim whitespace so extraneous underscores are not introduced
+        const trimmedTerm: string = (filterTerm as string).trim();
+        const normalizedTerm: string =
+            filterColumn === 'loadBalanceStatus' ? trimmedTerm.replace(/\s+/g, '_') : trimmedTerm;
+
         const field: string = data.connectionStatusSnapshot[filterColumn as keyof ConnectionStatusSnapshot] as string;
-        return this.nifiCommon.stringContains(field, filterTerm, true);
+        return this.nifiCommon.stringContains(field, normalizedTerm, true);
     }
 
     getConnectionLink(connection: ConnectionStatusSnapshotEntity): string[] {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.ts
@@ -31,7 +31,7 @@ import { ComponentStatusTable } from '../../common/component-status-table/compon
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 
-export type SupportedColumns = 'name' | 'queue' | 'in' | 'out' | 'threshold' | 'sourceName' | 'destinationName';
+export type SupportedColumns = 'name' | 'queue' | 'in' | 'out' | 'threshold' | 'sourceName' | 'destinationName' | 'loadBalanceStatus';
 
 @Component({
     selector: 'connection-status-table',
@@ -54,7 +54,8 @@ export class ConnectionStatusTable extends ComponentStatusTable<ConnectionStatus
     filterableColumns: SummaryTableFilterColumn[] = [
         { key: 'sourceName', label: 'source' },
         { key: 'name', label: 'name' },
-        { key: 'destinationName', label: 'destination' }
+        { key: 'destinationName', label: 'destination' },
+        { key: 'loadBalanceStatus', label: 'loadBalanceStatus' }
     ];
 
     displayedColumns: string[] = [
@@ -65,6 +66,7 @@ export class ConnectionStatusTable extends ComponentStatusTable<ConnectionStatus
         'sourceName',
         'out',
         'destinationName',
+        'loadBalanceStatus',
         'actions'
     ];
 
@@ -124,12 +126,27 @@ export class ConnectionStatusTable extends ComponentStatusTable<ConnectionStatus
         return `${connection.connectionStatusSnapshot.percentUseCount}% | ${connection.connectionStatusSnapshot.percentUseBytes}%`;
     }
 
+    formatLoadBalanceStatus(connection: ConnectionStatusSnapshotEntity): string {
+        switch (connection.connectionStatusSnapshot.loadBalanceStatus) {
+            case 'LOAD_BALANCE_NOT_CONFIGURED':
+                return 'Not Configured';
+            case 'LOAD_BALANCE_ACTIVE':
+                return 'Active';
+            case 'LOAD_BALANCE_INACTIVE':
+                return 'Inactive';
+            default:
+                return 'unknown';
+
+            }
+    }
+
     override supportsMultiValuedSort(sort: Sort): boolean {
         switch (sort.active) {
             case 'in':
             case 'out':
             case 'threshold':
             case 'queue':
+            case 'loadBalanceStatus':
                 return true;
             default:
                 return false;
@@ -213,6 +230,12 @@ export class ConnectionStatusTable extends ComponentStatusTable<ConnectionStatus
                             b.connectionStatusSnapshot.percentUseBytes
                         );
                     }
+                    break;
+                case 'loadBalanceStatus':
+                    retVal = this.nifiCommon.compareString(
+                        a.connectionStatusSnapshot.loadBalanceStatus,
+                        b.connectionStatusSnapshot.loadBalanceStatus
+                    );
                     break;
                 default:
                     retVal = 0;

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/summary/ui/connection-status-listing/connection-status-table/connection-status-table.component.ts
@@ -135,7 +135,7 @@ export class ConnectionStatusTable extends ComponentStatusTable<ConnectionStatus
             case 'LOAD_BALANCE_INACTIVE':
                 return 'Inactive';
             default:
-                return 'unknown';
+                return connection.connectionStatusSnapshot.loadBalanceStatus;
 
             }
     }


### PR DESCRIPTION
…ary page

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Add a column to the table on the Connections tab of the Summary page. The load balancing status is now indicated. Possible values are Not Configured, Active and Inactive. These states are defined in the nifi-api. The column is sortable and can be used as a filter.

This feature makes it possible to find all connections throughout a flow which have load balancing configured.

[NIFI-14243](https://issues.apache.org/jira/browse/NIFI-14243)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
