### PR TITLE
NIFI-14758 Ensure decommission waits for new coordinator when decommi…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/coordination/ClusterCoordinator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/coordination/ClusterCoordinator.java
@@ -128,6 +128,15 @@ public interface ClusterCoordinator {
     NodeConnectionStatus getConnectionStatus(NodeIdentifier nodeId);
 
     /**
+     * Retrieves the current status of the node by fetching it from the cluster coordinator.
+     *
+     * @param nodeId the identifier of the node
+     * @return the current status of the node with the given identifier,
+     *         or <code>null</code> if no node is known with the given identifier
+     */
+    NodeConnectionStatus fetchConnectionStatus(NodeIdentifier nodeId);
+
+    /**
      * Returns the identifiers of all nodes that have the given connection state
      *
      * @param states the states of interest
@@ -214,6 +223,13 @@ public interface ClusterCoordinator {
     NodeIdentifier getLocalNodeIdentifier();
 
     /**
+     * Waits for a cluster coordinator to be elected and returns the identifier of the node that is currently elected as the cluster coordinator.
+     *
+     * @return the identifier of the node that is currently elected as the cluster coordinator
+     */
+    NodeIdentifier waitForElectedClusterCoordinator();
+
+    /**
      * @return <code>true</code> if this node has been elected the active cluster coordinator, <code>false</code> otherwise.
      */
     boolean isActiveClusterCoordinator();
@@ -292,19 +308,4 @@ public interface ClusterCoordinator {
     default void validateHeartbeat(NodeHeartbeat nodeHeartbeat) {
     }
 
-    /**
-     * Stops notifying the given listener when cluster topology events occurs
-     * @param eventListener the event listener to stop notifying
-     */
-    void unregisterEventListener(ClusterTopologyEventListener eventListener);
-
-    default String summarizeClusterState() {
-        final StringBuilder sb = new StringBuilder();
-        for (final NodeIdentifier nodeId : getNodeIdentifiers()) {
-            sb.append(nodeId.getFullDescription()).append(" : ").append(getConnectionStatus(nodeId));
-            sb.append("\n");
-        }
-
-        return sb.toString();
-    }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/AbstractNodeProtocolSender.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/AbstractNodeProtocolSender.java
@@ -24,6 +24,8 @@ import org.apache.nifi.cluster.protocol.message.ConnectionRequestMessage;
 import org.apache.nifi.cluster.protocol.message.ConnectionResponseMessage;
 import org.apache.nifi.cluster.protocol.message.HeartbeatMessage;
 import org.apache.nifi.cluster.protocol.message.HeartbeatResponseMessage;
+import org.apache.nifi.cluster.protocol.message.NodeStatusesRequestMessage;
+import org.apache.nifi.cluster.protocol.message.NodeStatusesResponseMessage;
 import org.apache.nifi.cluster.protocol.message.ProtocolMessage;
 import org.apache.nifi.cluster.protocol.message.ProtocolMessage.MessageType;
 import org.apache.nifi.io.socket.SocketConfiguration;
@@ -154,6 +156,23 @@ public abstract class AbstractNodeProtocolSender implements NodeProtocolSender {
         }
 
         throw new ProtocolException("Expected message type '" + MessageType.CLUSTER_WORKLOAD_RESPONSE + "' but found '" + responseMessage.getType() + "'");
+    }
+
+    @Override
+    public NodeStatusesResponseMessage nodeStatuses(final NodeStatusesRequestMessage msg) throws ProtocolException {
+        final InetSocketAddress serviceAddress;
+        try {
+            serviceAddress = getServiceAddress();
+        } catch (IOException e) {
+            throw new ProtocolException("Failed to get Service Address", e);
+        }
+
+        final ProtocolMessage responseMessage = sendProtocolMessage(msg, serviceAddress.getHostName(), serviceAddress.getPort(), new CommsTimingDetails());
+        if (MessageType.NODE_STATUSES_RESPONSE == responseMessage.getType()) {
+            return (NodeStatusesResponseMessage) responseMessage;
+        }
+
+        throw new ProtocolException("Expected message type '" + MessageType.NODE_STATUSES_RESPONSE + "' but found '" + responseMessage.getType() + "'");
     }
 
     private Socket createSocket(final InetSocketAddress socketAddress) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/NodeProtocolSender.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/NodeProtocolSender.java
@@ -22,6 +22,8 @@ import org.apache.nifi.cluster.protocol.message.ConnectionRequestMessage;
 import org.apache.nifi.cluster.protocol.message.ConnectionResponseMessage;
 import org.apache.nifi.cluster.protocol.message.HeartbeatMessage;
 import org.apache.nifi.cluster.protocol.message.HeartbeatResponseMessage;
+import org.apache.nifi.cluster.protocol.message.NodeStatusesRequestMessage;
+import org.apache.nifi.cluster.protocol.message.NodeStatusesResponseMessage;
 
 /**
  * An interface for sending protocol messages from a node to the cluster
@@ -60,4 +62,13 @@ public interface NodeProtocolSender {
      * @throws ProtocolException if communication failed
      */
     ClusterWorkloadResponseMessage clusterWorkload(ClusterWorkloadRequestMessage msg) throws ProtocolException;
+
+    /**
+     * Sends a "node statuses" request message to the Cluster Coordinator.
+     *
+     * @param msg a request message
+     * @return the response from the Cluster Coordinator containing the statuses of all nodes in the cluster
+     * @throws ProtocolException if communication failed
+     */
+    NodeStatusesResponseMessage nodeStatuses(NodeStatusesRequestMessage msg) throws ProtocolException;
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/NodeProtocolSenderListener.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/impl/NodeProtocolSenderListener.java
@@ -27,6 +27,8 @@ import org.apache.nifi.cluster.protocol.message.ConnectionRequestMessage;
 import org.apache.nifi.cluster.protocol.message.ConnectionResponseMessage;
 import org.apache.nifi.cluster.protocol.message.HeartbeatMessage;
 import org.apache.nifi.cluster.protocol.message.HeartbeatResponseMessage;
+import org.apache.nifi.cluster.protocol.message.NodeStatusesRequestMessage;
+import org.apache.nifi.cluster.protocol.message.NodeStatusesResponseMessage;
 import org.apache.nifi.reporting.BulletinRepository;
 
 import java.io.IOException;
@@ -102,5 +104,10 @@ public class NodeProtocolSenderListener implements NodeProtocolSender, ProtocolL
     @Override
     public ClusterWorkloadResponseMessage clusterWorkload(ClusterWorkloadRequestMessage msg) throws ProtocolException {
         return sender.clusterWorkload(msg);
+    }
+
+    @Override
+    public NodeStatusesResponseMessage nodeStatuses(NodeStatusesRequestMessage msg) throws ProtocolException {
+        return sender.nodeStatuses(msg);
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/jaxb/message/ObjectFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/jaxb/message/ObjectFactory.java
@@ -20,6 +20,8 @@ import jakarta.xml.bind.annotation.XmlRegistry;
 
 import org.apache.nifi.cluster.protocol.message.ConnectionRequestMessage;
 import org.apache.nifi.cluster.protocol.message.ConnectionResponseMessage;
+import org.apache.nifi.cluster.protocol.message.NodeStatusesRequestMessage;
+import org.apache.nifi.cluster.protocol.message.NodeStatusesResponseMessage;
 import org.apache.nifi.cluster.protocol.message.OffloadMessage;
 import org.apache.nifi.cluster.protocol.message.DisconnectMessage;
 import org.apache.nifi.cluster.protocol.message.FlowRequestMessage;
@@ -101,8 +103,16 @@ public class ObjectFactory {
         return new NodeConnectionStatusRequestMessage();
     }
 
-    public NodeConnectionStatusResponseMessage createNodeConnectionStatusResponsetMessage() {
+    public NodeConnectionStatusResponseMessage createNodeConnectionStatusResponseMessage() {
         return new NodeConnectionStatusResponseMessage();
+    }
+
+    public NodeStatusesRequestMessage createNodeStatusesRequestMessage() {
+        return new NodeStatusesRequestMessage();
+    }
+
+    public NodeStatusesResponseMessage createNodeStatusesResponseMessage() {
+        return new NodeStatusesResponseMessage();
     }
 
     public HeartbeatResponseMessage createHeartbeatResponse() {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/message/NodeStatusesRequestMessage.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/message/NodeStatusesRequestMessage.java
@@ -16,31 +16,13 @@
  */
 package org.apache.nifi.cluster.protocol.message;
 
-public abstract class ProtocolMessage {
+import jakarta.xml.bind.annotation.XmlRootElement;
 
-    public static enum MessageType {
-        CONNECTION_REQUEST,
-        CONNECTION_RESPONSE,
-        OFFLOAD_REQUEST,
-        DISCONNECTION_REQUEST,
-        EXCEPTION,
-        FLOW_REQUEST,
-        FLOW_RESPONSE,
-        PING,
-        RECONNECTION_REQUEST,
-        RECONNECTION_RESPONSE,
-        SERVICE_BROADCAST,
-        HEARTBEAT,
-        HEARTBEAT_RESPONSE,
-        NODE_CONNECTION_STATUS_REQUEST,
-        NODE_CONNECTION_STATUS_RESPONSE,
-        NODE_STATUS_CHANGE,
-        NODE_STATUSES_REQUEST,
-        NODE_STATUSES_RESPONSE,
-        CLUSTER_WORKLOAD_REQUEST,
-        CLUSTER_WORKLOAD_RESPONSE
+@XmlRootElement(name = "nodeStatusesRequest")
+public class NodeStatusesRequestMessage extends ProtocolMessage {
+
+    @Override
+    public MessageType getType() {
+        return MessageType.NODE_STATUSES_REQUEST;
     }
-
-    public abstract MessageType getType();
-
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/message/NodeStatusesResponseMessage.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster-protocol/src/main/java/org/apache/nifi/cluster/protocol/message/NodeStatusesResponseMessage.java
@@ -16,31 +16,26 @@
  */
 package org.apache.nifi.cluster.protocol.message;
 
-public abstract class ProtocolMessage {
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.apache.nifi.cluster.coordination.node.NodeConnectionStatus;
 
-    public static enum MessageType {
-        CONNECTION_REQUEST,
-        CONNECTION_RESPONSE,
-        OFFLOAD_REQUEST,
-        DISCONNECTION_REQUEST,
-        EXCEPTION,
-        FLOW_REQUEST,
-        FLOW_RESPONSE,
-        PING,
-        RECONNECTION_REQUEST,
-        RECONNECTION_RESPONSE,
-        SERVICE_BROADCAST,
-        HEARTBEAT,
-        HEARTBEAT_RESPONSE,
-        NODE_CONNECTION_STATUS_REQUEST,
-        NODE_CONNECTION_STATUS_RESPONSE,
-        NODE_STATUS_CHANGE,
-        NODE_STATUSES_REQUEST,
-        NODE_STATUSES_RESPONSE,
-        CLUSTER_WORKLOAD_REQUEST,
-        CLUSTER_WORKLOAD_RESPONSE
+import java.util.List;
+
+@XmlRootElement(name = "nodeStatusesResponse")
+public class NodeStatusesResponseMessage extends ProtocolMessage {
+
+    private List<NodeConnectionStatus> nodeStatuses;
+
+    @Override
+    public MessageType getType() {
+        return MessageType.NODE_STATUSES_RESPONSE;
     }
 
-    public abstract MessageType getType();
+    public List<NodeConnectionStatus> getNodeStatuses() {
+        return nodeStatuses;
+    }
 
+    public void setNodeStatuses(final List<NodeConnectionStatus> nodeStatuses) {
+        this.nodeStatuses = nodeStatuses;
+    }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/StandardClusterDetailsFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/StandardClusterDetailsFactory.java
@@ -49,7 +49,15 @@ public class StandardClusterDetailsFactory implements ClusterDetailsFactory {
             return ConnectionState.UNKNOWN;
         }
 
-        final NodeConnectionStatus connectionStatus = clusterCoordinator.getConnectionStatus(nodeIdentifier);
+        final NodeConnectionStatus connectionStatus;
+        if (clusterCoordinator.isActiveClusterCoordinator()) {
+            logger.debug("Getting Connection Status for Node Identifier {} from local state", nodeIdentifier.getId());
+            connectionStatus = clusterCoordinator.getConnectionStatus(nodeIdentifier);
+        } else {
+            logger.debug("Fetching Connection Status for Node Identifier {} from Cluster Coordinator", nodeIdentifier.getId());
+            connectionStatus = clusterCoordinator.fetchConnectionStatus(nodeIdentifier);
+        }
+
         if (connectionStatus == null) {
             logger.info("Cluster connection status is not currently known for Node Identifier {}; returning Connection State of UNKNOWN", nodeIdentifier.getId());
             return ConnectionState.UNKNOWN;

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/ClusterProtocolHeartbeatMonitor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/heartbeat/ClusterProtocolHeartbeatMonitor.java
@@ -30,6 +30,8 @@ import org.apache.nifi.cluster.protocol.message.ClusterWorkloadRequestMessage;
 import org.apache.nifi.cluster.protocol.message.ClusterWorkloadResponseMessage;
 import org.apache.nifi.cluster.protocol.message.HeartbeatMessage;
 import org.apache.nifi.cluster.protocol.message.HeartbeatResponseMessage;
+import org.apache.nifi.cluster.protocol.message.NodeStatusesRequestMessage;
+import org.apache.nifi.cluster.protocol.message.NodeStatusesResponseMessage;
 import org.apache.nifi.cluster.protocol.message.ProtocolMessage;
 import org.apache.nifi.cluster.protocol.message.ProtocolMessage.MessageType;
 import org.apache.nifi.util.NiFiProperties;
@@ -136,14 +138,12 @@ public class ClusterProtocolHeartbeatMonitor extends AbstractHeartbeatMonitor im
 
     @Override
     public ProtocolMessage handle(final ProtocolMessage msg, Set<String> nodeIds) throws ProtocolException {
-        switch (msg.getType()) {
-            case HEARTBEAT:
-                return handleHeartbeat((HeartbeatMessage) msg);
-            case CLUSTER_WORKLOAD_REQUEST:
-                return handleClusterWorkload((ClusterWorkloadRequestMessage) msg);
-            default:
-                throw new ProtocolException("Cannot handle message of type " + msg.getType());
-        }
+        return switch (msg.getType()) {
+            case HEARTBEAT -> handleHeartbeat((HeartbeatMessage) msg);
+            case CLUSTER_WORKLOAD_REQUEST -> handleClusterWorkload((ClusterWorkloadRequestMessage) msg);
+            case NODE_STATUSES_REQUEST -> handleNodeStatuses((NodeStatusesRequestMessage) msg);
+            default -> throw new ProtocolException("Cannot handle message of type " + msg.getType());
+        };
     }
 
     private ProtocolMessage handleHeartbeat(final HeartbeatMessage msg) {
@@ -203,6 +203,15 @@ public class ClusterProtocolHeartbeatMonitor extends AbstractHeartbeatMonitor im
         return response;
     }
 
+    private ProtocolMessage handleNodeStatuses(final NodeStatusesRequestMessage msg) {
+        logger.debug("Received Node Statuses Request Message");
+        final NodeStatusesResponseMessage response = new NodeStatusesResponseMessage();
+        final List<NodeConnectionStatus> nodeStatuses = clusterCoordinator.getConnectionStatuses();
+        response.setNodeStatuses(nodeStatuses == null ? Collections.emptyList() : nodeStatuses);
+        logger.debug("Responding with Node Statuses: {}", response.getNodeStatuses());
+        return response;
+    }
+
     private List<NodeConnectionStatus> getUpdatedStatuses(final List<NodeConnectionStatus> nodeStatusList) {
         // Map node's statuses by NodeIdentifier for quick & easy lookup
         final Map<NodeIdentifier, NodeConnectionStatus> nodeStatusMap = nodeStatusList.stream()
@@ -235,6 +244,6 @@ public class ClusterProtocolHeartbeatMonitor extends AbstractHeartbeatMonitor im
 
     @Override
     public boolean canHandle(ProtocolMessage msg) {
-        return msg.getType() == MessageType.HEARTBEAT || msg.getType() == MessageType.CLUSTER_WORKLOAD_REQUEST;
+        return msg.getType() == MessageType.HEARTBEAT || msg.getType() == MessageType.CLUSTER_WORKLOAD_REQUEST || msg.getType() == MessageType.NODE_STATUSES_REQUEST;
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/heartbeat/TestAbstractHeartbeatMonitor.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/heartbeat/TestAbstractHeartbeatMonitor.java
@@ -275,6 +275,11 @@ public class TestAbstractHeartbeatMonitor {
         }
 
         @Override
+        public NodeConnectionStatus fetchConnectionStatus(NodeIdentifier nodeId) {
+            return getConnectionStatus(nodeId);
+        }
+
+        @Override
         public synchronized Set<NodeIdentifier> getNodeIdentifiers(NodeConnectionState... states) {
             final Set<NodeConnectionState> stateSet = new HashSet<>();
             for (final NodeConnectionState state : states) {
@@ -367,6 +372,11 @@ public class TestAbstractHeartbeatMonitor {
         }
 
         @Override
+        public NodeIdentifier waitForElectedClusterCoordinator() {
+            return null;
+        }
+
+        @Override
         public List<NodeConnectionStatus> getConnectionStatuses() {
             return Collections.emptyList();
         }
@@ -395,9 +405,6 @@ public class TestAbstractHeartbeatMonitor {
         public void registerEventListener(final ClusterTopologyEventListener eventListener) {
         }
 
-        @Override
-        public void unregisterEventListener(final ClusterTopologyEventListener eventListener) {
-        }
     }
 
 


### PR DESCRIPTION
…ssioning current coordinator

- Add new cluster protocol command for requesting node statuses from the coordinator

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14758](https://issues.apache.org/jira/browse/FLOW-14758)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
