### PR TITLE
Nifi 14424 support for confluent encoded protobuf headers pr1of2

### DIFF
--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-platform-api/pom.xml
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-platform-api/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+    license agreements. See the NOTICE file distributed with this work for additional
+    information regarding copyright ownership. The ASF licenses this file to
+    You under the Apache License, Version 2.0 (the "License"); you may not use
+    this file except in compliance with the License. You may obtain a copy of
+    the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+    by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied. See the License for the specific
+    language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-confluent-platform-bundle</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-confluent-platform-api</artifactId>
+
+</project>

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-platform-api/src/main/java/org/apache/nifi/confluent/schema/ProtobufMessageSchema.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-platform-api/src/main/java/org/apache/nifi/confluent/schema/ProtobufMessageSchema.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schema;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Basic abstraction over Protobuf schema message entity.
+ * It contains only the fields that are needed for crude schema insights. It's useful when the
+ * message name resolver needs to pinpoint specific messages by message indexes encoded on the wire
+ * <p>
+ * https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+ * <p>
+ * It contains bare minimum of information for name resolver to be able to resolve message names
+ */
+public final class ProtobufMessageSchema {
+
+    private final String name;
+    private final String packageName;
+    private final List<ProtobufMessageSchema> childMessageSchemas = new ArrayList<>();
+
+    public ProtobufMessageSchema(final String name, final String packageName) {
+        this.name = name;
+        this.packageName = (packageName == null ? null : packageName.trim());
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public Optional<String> packageName() {
+        return Optional.ofNullable(packageName);
+    }
+
+    public boolean isDefaultPackage() {
+        return packageName == null || packageName.isEmpty();
+    }
+
+    public List<ProtobufMessageSchema> getChildMessageSchemas() {
+        return childMessageSchemas;
+    }
+
+    void addChildMessage(final ProtobufMessageSchema protobufMessageSchema) {
+        childMessageSchemas.add(protobufMessageSchema);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        final var that = (ProtobufMessageSchema) obj;
+        return Objects.equals(this.name, that.name) && Objects.equals(this.packageName, that.packageName) && Objects.equals(this.childMessageSchemas, that.childMessageSchemas);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, packageName, childMessageSchemas);
+    }
+
+    @Override
+    public String toString() {
+        return "ProtobufMessageSchema[" + "name=" + name + ", " + "packageName=" + packageName + ", " + "childMessageSchemas=" + childMessageSchemas + ']';
+    }
+
+
+}

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-platform-api/src/main/java/org/apache/nifi/confluent/schema/ProtobufMessageSchemaParser.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-platform-api/src/main/java/org/apache/nifi/confluent/schema/ProtobufMessageSchemaParser.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schema;
+
+import java.util.List;
+
+public interface ProtobufMessageSchemaParser {
+
+    List<ProtobufMessageSchema> parse(final String schemaText);
+}

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/pom.xml
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+    license agreements. See the NOTICE file distributed with this work for additional 
+    information regarding copyright ownership. The ASF licenses this file to 
+    You under the Apache License, Version 2.0 (the "License"); you may not use 
+    this file except in compliance with the License. You may obtain a copy of 
+    the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+    by applicable law or agreed to in writing, software distributed under the 
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+    OF ANY KIND, either express or implied. See the License for the specific 
+    language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-confluent-platform-bundle</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-confluent-protobuf-antlr-parser</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <antlr4.version>4.13.1</antlr4.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>${antlr4.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-confluent-platform-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-maven-plugin</artifactId>
+                <version>${antlr4.version}</version>
+                <configuration>
+                    <arguments>
+                        <argument>-package</argument>
+                        <argument>org.apache.nifi.confluent.schema.antlr</argument>
+                    </arguments>
+                    <sourceDirectory>src/main/resources</sourceDirectory>
+                    <outputDirectory>target/generated-sources/antlr4/org/apache/nifi/confluent/schema/antlr</outputDirectory>
+                    <visitor>true</visitor>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>antlr4</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>target/generated-sources/antlr4</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project> 

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/src/main/java/org/apache/nifi/confluent/schema/AntlrProtobufMessageSchemaParser.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/src/main/java/org/apache/nifi/confluent/schema/AntlrProtobufMessageSchemaParser.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schema;
+
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.apache.nifi.confluent.schema.antlr.Protobuf3BaseVisitor;
+import org.apache.nifi.confluent.schema.antlr.Protobuf3Lexer;
+import org.apache.nifi.confluent.schema.antlr.Protobuf3Parser;
+import org.apache.nifi.confluent.schema.antlr.Protobuf3Parser.MessageDefContext;
+import org.apache.nifi.confluent.schema.antlr.Protobuf3Parser.PackageStatementContext;
+import org.apache.nifi.confluent.schema.antlr.Protobuf3Parser.ProtoContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+
+/**
+ * Implementation of ProtobufMessageSchemaParser that uses ANTLR to parse protobuf schemas
+ * and extract message definitions including nested messages.
+ */
+public class AntlrProtobufMessageSchemaParser implements ProtobufMessageSchemaParser {
+
+    @Override
+    public List<ProtobufMessageSchema> parse(final String schemaText) {
+
+        final CharStream input = CharStreams.fromString(schemaText);
+        final Protobuf3Lexer lexer = new Protobuf3Lexer(input);
+        final Protobuf3Parser parser = getProtobuf3Parser(lexer);
+
+        final ProtoContext tree = parser.proto();
+
+        // Create visitor and analyze
+        final SchemaVisitor visitor = new SchemaVisitor();
+        visitor.visit(tree);
+
+        return visitor.getProtoMessages();
+
+    }
+
+    private Protobuf3Parser getProtobuf3Parser(final Protobuf3Lexer lexer) {
+        final CommonTokenStream tokens = new CommonTokenStream(lexer);
+        final Protobuf3Parser parser = new Protobuf3Parser(tokens);
+
+        // Add error listener to capture parsing errors
+        parser.removeErrorListeners();
+        parser.addErrorListener(new BaseErrorListener() {
+            @Override
+            public void syntaxError(final Recognizer<?, ?> recognizer, final Object offendingSymbol, final int line, final int charPositionInLine, final String msg, final RecognitionException e) {
+                throw new RuntimeException(String.format("Syntax error at line %d, position %d: %s", line, charPositionInLine, msg), e);
+            }
+        });
+        return parser;
+    }
+
+    private static class SchemaVisitor extends Protobuf3BaseVisitor<Void> {
+
+        private final List<ProtobufMessageSchema> rootMessages = new ArrayList<>();
+        private final Stack<ProtobufMessageSchema> messageStack = new Stack<>();
+        private String currentPackage;
+
+        @Override
+        public Void visitPackageStatement(final PackageStatementContext ctx) {
+            if (ctx.fullIdent() != null) {
+                currentPackage = ctx.fullIdent().getText();
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitMessageDef(final MessageDefContext ctx) {
+            final String messageName = ctx.messageName().getText();
+
+            final ProtobufMessageSchema protobufMessageSchema = new ProtobufMessageSchema(messageName, currentPackage);
+
+            // Add to parent's nested messages or root messages
+            if (messageStack.isEmpty()) {
+                rootMessages.add(protobufMessageSchema);
+            } else {
+                final ProtobufMessageSchema parent = messageStack.peek();
+                parent.addChildMessage(protobufMessageSchema);
+            }
+
+            messageStack.push(protobufMessageSchema);
+            // Visit nested messages
+            super.visitMessageDef(ctx);
+            messageStack.pop();
+
+            return null;
+        }
+
+        public List<ProtobufMessageSchema> getProtoMessages() {
+            return rootMessages.stream().toList();
+        }
+    }
+}

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/src/main/resources/Protobuf3.g4
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/src/main/resources/Protobuf3.g4
@@ -1,0 +1,662 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * A Protocol Buffers 3 grammar
+ *
+ * Original source: https://developers.google.com/protocol-buffers/docs/reference/proto3-spec
+ * Original source is published under Apache License 2.0.
+ *
+ * Changes from the source above:
+ * - rewrite to antlr
+ * - extract some group to rule.
+ *
+ * @author anatawa12
+ */
+
+// $antlr-format alignTrailingComments true, columnLimit 150, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine false, allowShortBlocksOnASingleLine true, alignSemicolons hanging, alignColons hanging
+
+grammar Protobuf3;
+
+proto
+    : syntax (importStatement | packageStatement | optionStatement | topLevelDef | emptyStatement_)* EOF
+    ;
+
+// Syntax
+
+syntax
+    : SYNTAX EQ (PROTO3_LIT_SINGLE | PROTO3_LIT_DOBULE) SEMI
+    ;
+
+// Import Statement
+
+importStatement
+    : IMPORT (WEAK | PUBLIC)? strLit SEMI
+    ;
+
+// Package
+
+packageStatement
+    : PACKAGE fullIdent SEMI
+    ;
+
+// Option
+
+optionStatement
+    : OPTION optionName EQ constant SEMI
+    ;
+
+optionName
+    : fullIdent
+    | LP fullIdent RP ( DOT fullIdent)?
+    ;
+
+// Normal Field
+fieldLabel
+    : OPTIONAL
+    | REPEATED
+    ;
+
+field
+    : fieldLabel? type_ fieldName EQ fieldNumber (LB fieldOptions RB)? SEMI
+    ;
+
+fieldOptions
+    : fieldOption (COMMA fieldOption)*
+    ;
+
+fieldOption
+    : optionName EQ constant
+    ;
+
+fieldNumber
+    : intLit
+    ;
+
+// Oneof and oneof field
+
+oneof
+    : ONEOF oneofName LC (optionStatement | oneofField | emptyStatement_)* RC
+    ;
+
+oneofField
+    : type_ fieldName EQ fieldNumber (LB fieldOptions RB)? SEMI
+    ;
+
+// Map field
+
+mapField
+    : MAP LT keyType COMMA type_ GT mapName EQ fieldNumber (LB fieldOptions RB)? SEMI
+    ;
+
+keyType
+    : INT32
+    | INT64
+    | UINT32
+    | UINT64
+    | SINT32
+    | SINT64
+    | FIXED32
+    | FIXED64
+    | SFIXED32
+    | SFIXED64
+    | BOOL
+    | STRING
+    ;
+
+// field types
+
+type_
+    : DOUBLE
+    | FLOAT
+    | INT32
+    | INT64
+    | UINT32
+    | UINT64
+    | SINT32
+    | SINT64
+    | FIXED32
+    | FIXED64
+    | SFIXED32
+    | SFIXED64
+    | BOOL
+    | STRING
+    | BYTES
+    | messageType
+    | enumType
+    ;
+
+// Reserved
+
+reserved
+    : RESERVED (ranges | reservedFieldNames) SEMI
+    ;
+
+ranges
+    : range_ (COMMA range_)*
+    ;
+
+range_
+    : intLit (TO ( intLit | MAX))?
+    ;
+
+reservedFieldNames
+    : strLit (COMMA strLit)*
+    ;
+
+// Top Level definitions
+
+topLevelDef
+    : messageDef
+    | enumDef
+    | extendDef
+    | serviceDef
+    ;
+
+// enum
+
+enumDef
+    : ENUM enumName enumBody
+    ;
+
+enumBody
+    : LC enumElement* RC
+    ;
+
+enumElement
+    : optionStatement
+    | enumField
+    | emptyStatement_
+    ;
+
+enumField
+    : ident EQ (MINUS)? intLit enumValueOptions? SEMI
+    ;
+
+enumValueOptions
+    : LB enumValueOption (COMMA enumValueOption)* RB
+    ;
+
+enumValueOption
+    : optionName EQ constant
+    ;
+
+// message
+
+messageDef
+    : MESSAGE messageName messageBody
+    ;
+
+messageBody
+    : LC messageElement* RC
+    ;
+
+messageElement
+    : field
+    | enumDef
+    | messageDef
+    | extendDef
+    | optionStatement
+    | oneof
+    | mapField
+    | reserved
+    | emptyStatement_
+    ;
+
+// Extend definition
+//
+// NB: not defined in the spec but supported by protoc and covered by protobuf3 tests
+//     see e.g. php/tests/proto/test_import_descriptor_proto.proto
+//     of https://github.com/protocolbuffers/protobuf
+// it also was discussed here: https://github.com/protocolbuffers/protobuf/issues/4610
+
+extendDef
+    : EXTEND messageType LC (field | emptyStatement_)* RC
+    ;
+
+// service
+
+serviceDef
+    : SERVICE serviceName LC serviceElement* RC
+    ;
+
+serviceElement
+    : optionStatement
+    | rpc
+    | emptyStatement_
+    ;
+
+rpc
+    : RPC rpcName LP (STREAM)? messageType RP RETURNS LP (STREAM)? messageType RP (
+        LC ( optionStatement | emptyStatement_)* RC
+        | SEMI
+    )
+    ;
+
+// lexical
+
+constant
+    : fullIdent
+    | (MINUS | PLUS)? intLit
+    | ( MINUS | PLUS)? floatLit
+    | strLit
+    | boolLit
+    | blockLit
+    ;
+
+// not specified in specification but used in tests
+blockLit
+    : LC (ident COLON constant)* RC
+    ;
+
+emptyStatement_
+    : SEMI
+    ;
+
+// Lexical elements
+
+ident
+    : IDENTIFIER
+    | keywords
+    ;
+
+fullIdent
+    : ident (DOT ident)*
+    ;
+
+messageName
+    : ident
+    ;
+
+enumName
+    : ident
+    ;
+
+fieldName
+    : ident
+    ;
+
+oneofName
+    : ident
+    ;
+
+mapName
+    : ident
+    ;
+
+serviceName
+    : ident
+    ;
+
+rpcName
+    : ident
+    ;
+
+messageType
+    : (DOT)? (ident DOT)* messageName
+    ;
+
+enumType
+    : (DOT)? (ident DOT)* enumName
+    ;
+
+intLit
+    : INT_LIT
+    ;
+
+strLit
+    : STR_LIT
+    | PROTO3_LIT_SINGLE
+    | PROTO3_LIT_DOBULE
+    ;
+
+boolLit
+    : BOOL_LIT
+    ;
+
+floatLit
+    : FLOAT_LIT
+    ;
+
+// keywords
+SYNTAX
+    : 'syntax'
+    ;
+
+IMPORT
+    : 'import'
+    ;
+
+WEAK
+    : 'weak'
+    ;
+
+PUBLIC
+    : 'public'
+    ;
+
+PACKAGE
+    : 'package'
+    ;
+
+OPTION
+    : 'option'
+    ;
+
+OPTIONAL
+    : 'optional'
+    ;
+
+REPEATED
+    : 'repeated'
+    ;
+
+ONEOF
+    : 'oneof'
+    ;
+
+MAP
+    : 'map'
+    ;
+
+INT32
+    : 'int32'
+    ;
+
+INT64
+    : 'int64'
+    ;
+
+UINT32
+    : 'uint32'
+    ;
+
+UINT64
+    : 'uint64'
+    ;
+
+SINT32
+    : 'sint32'
+    ;
+
+SINT64
+    : 'sint64'
+    ;
+
+FIXED32
+    : 'fixed32'
+    ;
+
+FIXED64
+    : 'fixed64'
+    ;
+
+SFIXED32
+    : 'sfixed32'
+    ;
+
+SFIXED64
+    : 'sfixed64'
+    ;
+
+BOOL
+    : 'bool'
+    ;
+
+STRING
+    : 'string'
+    ;
+
+DOUBLE
+    : 'double'
+    ;
+
+FLOAT
+    : 'float'
+    ;
+
+BYTES
+    : 'bytes'
+    ;
+
+RESERVED
+    : 'reserved'
+    ;
+
+TO
+    : 'to'
+    ;
+
+MAX
+    : 'max'
+    ;
+
+ENUM
+    : 'enum'
+    ;
+
+MESSAGE
+    : 'message'
+    ;
+
+SERVICE
+    : 'service'
+    ;
+
+EXTEND
+    : 'extend'
+    ;
+
+RPC
+    : 'rpc'
+    ;
+
+STREAM
+    : 'stream'
+    ;
+
+RETURNS
+    : 'returns'
+    ;
+
+PROTO3_LIT_SINGLE
+    : '"proto3"'
+    ;
+
+PROTO3_LIT_DOBULE
+    : '\'proto3\''
+    ;
+
+// symbols
+
+SEMI
+    : ';'
+    ;
+
+EQ
+    : '='
+    ;
+
+LP
+    : '('
+    ;
+
+RP
+    : ')'
+    ;
+
+LB
+    : '['
+    ;
+
+RB
+    : ']'
+    ;
+
+LC
+    : '{'
+    ;
+
+RC
+    : '}'
+    ;
+
+LT
+    : '<'
+    ;
+
+GT
+    : '>'
+    ;
+
+DOT
+    : '.'
+    ;
+
+COMMA
+    : ','
+    ;
+
+COLON
+    : ':'
+    ;
+
+PLUS
+    : '+'
+    ;
+
+MINUS
+    : '-'
+    ;
+
+STR_LIT
+    : ('\'' ( CHAR_VALUE)*? '\'')
+    | ( '"' ( CHAR_VALUE)*? '"')
+    ;
+
+fragment CHAR_VALUE
+    : HEX_ESCAPE
+    | OCT_ESCAPE
+    | CHAR_ESCAPE
+    | ~[\u0000\n\\]
+    ;
+
+fragment HEX_ESCAPE
+    : '\\' ('x' | 'X') HEX_DIGIT HEX_DIGIT
+    ;
+
+fragment OCT_ESCAPE
+    : '\\' OCTAL_DIGIT OCTAL_DIGIT OCTAL_DIGIT
+    ;
+
+fragment CHAR_ESCAPE
+    : '\\' ('a' | 'b' | 'f' | 'n' | 'r' | 't' | 'v' | '\\' | '\'' | '"')
+    ;
+
+BOOL_LIT
+    : 'true'
+    | 'false'
+    ;
+
+FLOAT_LIT
+    : (DECIMALS DOT DECIMALS? EXPONENT? | DECIMALS EXPONENT | DOT DECIMALS EXPONENT?)
+    | 'inf'
+    | 'nan'
+    ;
+
+fragment EXPONENT
+    : ('e' | 'E') (PLUS | MINUS)? DECIMALS
+    ;
+
+fragment DECIMALS
+    : DECIMAL_DIGIT+
+    ;
+
+INT_LIT
+    : DECIMAL_LIT
+    | OCTAL_LIT
+    | HEX_LIT
+    ;
+
+fragment DECIMAL_LIT
+    : ([1-9]) DECIMAL_DIGIT*
+    ;
+
+fragment OCTAL_LIT
+    : '0' OCTAL_DIGIT*
+    ;
+
+fragment HEX_LIT
+    : '0' ('x' | 'X') HEX_DIGIT+
+    ;
+
+IDENTIFIER
+    : LETTER (LETTER | DECIMAL_DIGIT)*
+    ;
+
+fragment LETTER
+    : [A-Za-z_]
+    ;
+
+fragment DECIMAL_DIGIT
+    : [0-9]
+    ;
+
+fragment OCTAL_DIGIT
+    : [0-7]
+    ;
+
+fragment HEX_DIGIT
+    : [0-9A-Fa-f]
+    ;
+
+// comments
+WS
+    : [ \t\r\n\u000C]+ -> skip
+    ;
+
+LINE_COMMENT
+    : '//' ~[\r\n]* -> channel(HIDDEN)
+    ;
+
+COMMENT
+    : '/*' .*? '*/' -> channel(HIDDEN)
+    ;
+
+keywords
+    : SYNTAX
+    | IMPORT
+    | WEAK
+    | PUBLIC
+    | PACKAGE
+    | OPTION
+    | OPTIONAL
+    | REPEATED
+    | ONEOF
+    | MAP
+    | INT32
+    | INT64
+    | UINT32
+    | UINT64
+    | SINT32
+    | SINT64
+    | FIXED32
+    | FIXED64
+    | SFIXED32
+    | SFIXED64
+    | BOOL
+    | STRING
+    | DOUBLE
+    | FLOAT
+    | BYTES
+    | RESERVED
+    | TO
+    | MAX
+    | ENUM
+    | MESSAGE
+    | SERVICE
+    | EXTEND
+    | RPC
+    | STREAM
+    | RETURNS
+    | BOOL_LIT
+    ;

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/src/main/resources/README.txt
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/src/main/resources/README.txt
@@ -1,0 +1,3 @@
+Protobuf 3 grammar from https://github.com/antlr/grammars-v4/blob/e1491245d045474fa5393fb7be03b3b8ed22080f/protobuf3/Protobuf3.g4
+
+We need this to be able to parse protobuf schema text and not rely on heavy Wire library built in parser.

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/src/test/java/org/apache/nifi/confluent/schema/AntlrProtobufMessageSchemaReaderTest.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/src/test/java/org/apache/nifi/confluent/schema/AntlrProtobufMessageSchemaReaderTest.java
@@ -1,0 +1,368 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schema;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for AntlrProtobufMessageSchemaParser implementation
+ */
+class AntlrProtobufMessageSchemaReaderTest {
+
+    private AntlrProtobufMessageSchemaParser reader;
+
+    @BeforeEach
+    void setUp() {
+        reader = new AntlrProtobufMessageSchemaParser();
+    }
+
+    @Test
+    void testSimpleMessageWithNoPackage() {
+        final String schema = """
+            syntax = "proto3";
+            message User {
+                string name = 1;
+            }
+            """;
+
+        final List<ProtobufMessageSchema> messages = reader.parse(schema);
+
+        assertNotNull(messages);
+        assertEquals(1, messages.size());
+
+        final ProtobufMessageSchema user = messages.getFirst();
+        assertEquals("User", user.name());
+        assertEquals("", user.packageName().orElse(""));
+        assertTrue(user.getChildMessageSchemas().isEmpty());
+    }
+
+    @Test
+    void testSimpleMessageWithPackage() {
+        final String schema = """
+            syntax = "proto3";
+            package com.example.test;
+            message User {
+                string name = 1;
+            }
+            """;
+
+        final List<ProtobufMessageSchema> messages = reader.parse(schema);
+
+        assertNotNull(messages);
+        assertEquals(1, messages.size());
+
+        final ProtobufMessageSchema user = messages.getFirst();
+        assertEquals("User", user.name());
+        assertEquals("com.example.test", user.packageName().orElse(""));
+        assertTrue(user.getChildMessageSchemas().isEmpty());
+    }
+
+    @Test
+    void testMultipleTopLevelGetChildMessages() {
+        final String schema = """
+            syntax = "proto3";
+            package com.example.test;
+            message User {
+                string name = 1;
+            }
+            message Company {
+                string name = 1;
+            }
+            message Project {
+                string title = 1;
+            }
+            """;
+
+        final List<ProtobufMessageSchema> messages = reader.parse(schema);
+
+        assertNotNull(messages);
+        assertEquals(3, messages.size());
+
+        final ProtobufMessageSchema user = messages.getFirst();
+        assertEquals("User", user.name());
+        assertEquals("com.example.test", user.packageName().orElse(""));
+        assertTrue(user.getChildMessageSchemas().isEmpty());
+
+        final ProtobufMessageSchema company = messages.get(1);
+        assertEquals("Company", company.name());
+        assertEquals("com.example.test", company.packageName().orElse(""));
+        assertTrue(company.getChildMessageSchemas().isEmpty());
+
+        final ProtobufMessageSchema project = messages.get(2);
+        assertEquals("Project", project.name());
+        assertEquals("com.example.test", project.packageName().orElse(""));
+        assertTrue(project.getChildMessageSchemas().isEmpty());
+    }
+
+    @Test
+    void testNestedGetChildMessages() {
+        final String schema = """
+            syntax = "proto3";
+            package com.example.test;
+            message User {
+                string name = 1;
+                message Profile {
+                    string bio = 1;
+                    message Settings {
+                        bool notifications_enabled = 1;
+                    }
+                }
+            }
+            """;
+
+        final List<ProtobufMessageSchema> messages = reader.parse(schema);
+
+        assertNotNull(messages);
+        assertEquals(1, messages.size());
+
+        final ProtobufMessageSchema user = messages.getFirst();
+        assertEquals("User", user.name());
+        assertEquals("com.example.test", user.packageName().orElse(""));
+        assertEquals(1, user.getChildMessageSchemas().size());
+
+        final ProtobufMessageSchema profile = user.getChildMessageSchemas().getFirst();
+        assertEquals("Profile", profile.name());
+        assertEquals("com.example.test", profile.packageName().orElse(""));
+        assertEquals(1, profile.getChildMessageSchemas().size());
+
+        final ProtobufMessageSchema settings = profile.getChildMessageSchemas().getFirst();
+        assertEquals("Settings", settings.name());
+        assertEquals("com.example.test", settings.packageName().orElse(""));
+        assertTrue(settings.getChildMessageSchemas().isEmpty());
+    }
+
+    @Test
+    void testComplexNestedStructure() {
+        final String schema = """
+            syntax = "proto3";
+            package com.example.company;
+            message Company {
+                string name = 1;
+                repeated Department departments = 2;
+                message Department {
+                    string name = 1;
+                    Employee manager = 2;
+                    repeated Employee employees = 3;
+                    message Employee {
+                        string name = 1;
+                        string email = 2;
+                        Position position = 3;
+                        message Position {
+                            string title = 1;
+                            int32 level = 2;
+                            double salary = 3;
+                        }
+                    }
+                }
+            }
+            message Address {
+                string street = 1;
+                string city = 2;
+                string country = 3;
+            }
+            """;
+
+        final List<ProtobufMessageSchema> messages = reader.parse(schema);
+
+        assertNotNull(messages);
+        assertEquals(2, messages.size());
+
+        // Test Company message and its nested structure
+        final ProtobufMessageSchema company = messages.getFirst();
+        assertEquals("Company", company.name());
+        assertEquals("com.example.company", company.packageName().orElse(""));
+        assertEquals(1, company.getChildMessageSchemas().size());
+
+        final ProtobufMessageSchema department = company.getChildMessageSchemas().getFirst();
+        assertEquals("Department", department.name());
+        assertEquals("com.example.company", department.packageName().orElse(""));
+        assertEquals(1, department.getChildMessageSchemas().size());
+
+        final ProtobufMessageSchema employee = department.getChildMessageSchemas().getFirst();
+        assertEquals("Employee", employee.name());
+        assertEquals("com.example.company", employee.packageName().orElse(""));
+        assertEquals(1, employee.getChildMessageSchemas().size());
+
+        final ProtobufMessageSchema position = employee.getChildMessageSchemas().getFirst();
+        assertEquals("Position", position.name());
+        assertEquals("com.example.company", position.packageName().orElse(""));
+        assertTrue(position.getChildMessageSchemas().isEmpty());
+
+        // Test Address message (top-level)
+        final ProtobufMessageSchema address = messages.get(1);
+        assertEquals("Address", address.name());
+        assertEquals("com.example.company", address.packageName().orElse(""));
+        assertTrue(address.getChildMessageSchemas().isEmpty());
+    }
+
+    @Test
+    void testMultipleNestedGetChildMessagesInSameParent() {
+        final String schema = """
+            syntax = "proto3";
+            package com.example.test;
+            message User {
+                string name = 1;
+                message Profile {
+                    string bio = 1;
+                }
+                message Settings {
+                    bool notifications = 1;
+                }
+                message Preferences {
+                    string theme = 1;
+                }
+            }
+            """;
+
+        final List<ProtobufMessageSchema> messages = reader.parse(schema);
+
+        assertNotNull(messages);
+        assertEquals(1, messages.size());
+
+        final ProtobufMessageSchema user = messages.getFirst();
+        assertEquals("User", user.name());
+        assertEquals("com.example.test", user.packageName().orElse(""));
+        assertEquals(3, user.getChildMessageSchemas().size());
+
+        final ProtobufMessageSchema profile = user.getChildMessageSchemas().getFirst();
+        assertEquals("Profile", profile.name());
+        assertEquals("com.example.test", profile.packageName().orElse(""));
+        assertTrue(profile.getChildMessageSchemas().isEmpty());
+
+        final ProtobufMessageSchema settings = user.getChildMessageSchemas().get(1);
+        assertEquals("Settings", settings.name());
+        assertEquals("com.example.test", settings.packageName().orElse(""));
+        assertTrue(settings.getChildMessageSchemas().isEmpty());
+
+        final ProtobufMessageSchema preferences = user.getChildMessageSchemas().get(2);
+        assertEquals("Preferences", preferences.name());
+        assertEquals("com.example.test", preferences.packageName().orElse(""));
+        assertTrue(preferences.getChildMessageSchemas().isEmpty());
+    }
+
+    @Test
+    void testSchemaWithCommentsAndOptions() {
+        final String schema = """
+            syntax = "proto3";
+            // This is a test package
+            package com.example.test;
+            option java_package = "com.example.test";
+            option java_outer_classname = "TestProto";
+            // User message definition
+            message User {
+                // User's name
+                string name = 1;
+                // User's age
+                int32 age = 2;
+            }
+            """;
+
+        final List<ProtobufMessageSchema> messages = reader.parse(schema);
+
+        assertNotNull(messages);
+        assertEquals(1, messages.size());
+
+        final ProtobufMessageSchema user = messages.getFirst();
+        assertEquals("User", user.name());
+        assertEquals("com.example.test", user.packageName().orElse(""));
+        assertTrue(user.getChildMessageSchemas().isEmpty());
+    }
+
+    @Test
+    void testEmptySchema() {
+        final String schema = """
+            syntax = "proto3";
+            """;
+
+        final List<ProtobufMessageSchema> messages = reader.parse(schema);
+
+        assertNotNull(messages);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void testSchemaWithOnlyEnums() {
+        final String schema = """
+            syntax = "proto3";
+            package com.example.test;
+            enum Status {
+                UNKNOWN = 0;
+                ACTIVE = 1;
+                INACTIVE = 2;
+            }
+            enum Priority {
+                LOW = 0;
+                MEDIUM = 1;
+                HIGH = 2;
+            }
+            """;
+
+        final List<ProtobufMessageSchema> messages = reader.parse(schema);
+
+        assertNotNull(messages);
+        assertTrue(messages.isEmpty());
+    }
+
+    @Test
+    void testInvalidSyntax() {
+        final String schema = """
+            syntax = "proto3";
+            message User {
+                string name = 1
+                // Missing semicolon
+            }
+            """;
+
+        assertThrows(RuntimeException.class, () -> reader.parse(schema));
+    }
+
+    @Test
+    void testDefaultPackage() {
+        final String schema = """
+            syntax = "proto3";
+            message User {
+                string name = 1;
+            }
+            message Product {
+                string name = 1;
+            }
+            """;
+
+        final List<ProtobufMessageSchema> messages = reader.parse(schema);
+
+        assertNotNull(messages);
+        assertEquals(2, messages.size());
+
+        final ProtobufMessageSchema user = messages.getFirst();
+        assertEquals("User", user.name());
+        assertEquals("", user.packageName().orElse(""));
+        assertTrue(user.isDefaultPackage());
+
+        final ProtobufMessageSchema product = messages.get(1);
+        assertEquals("Product", product.name());
+        assertEquals("", product.packageName().orElse(""));
+        assertTrue(product.isDefaultPackage());
+    }
+}

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/src/test/java/org/apache/nifi/confluent/schema/AntlrProtobufMessageSchemaReaderTest.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-antlr-parser/src/test/java/org/apache/nifi/confluent/schema/AntlrProtobufMessageSchemaReaderTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -54,7 +55,7 @@ class AntlrProtobufMessageSchemaReaderTest {
 
         final ProtobufMessageSchema user = messages.getFirst();
         assertEquals("User", user.name());
-        assertEquals("", user.packageName().orElse(""));
+        assertTrue(user.packageName().isEmpty());
         assertTrue(user.getChildMessageSchemas().isEmpty());
     }
 
@@ -75,7 +76,7 @@ class AntlrProtobufMessageSchemaReaderTest {
 
         final ProtobufMessageSchema user = messages.getFirst();
         assertEquals("User", user.name());
-        assertEquals("com.example.test", user.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), user.packageName());
         assertTrue(user.getChildMessageSchemas().isEmpty());
     }
 
@@ -102,17 +103,17 @@ class AntlrProtobufMessageSchemaReaderTest {
 
         final ProtobufMessageSchema user = messages.getFirst();
         assertEquals("User", user.name());
-        assertEquals("com.example.test", user.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), user.packageName());
         assertTrue(user.getChildMessageSchemas().isEmpty());
 
         final ProtobufMessageSchema company = messages.get(1);
         assertEquals("Company", company.name());
-        assertEquals("com.example.test", company.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), company.packageName());
         assertTrue(company.getChildMessageSchemas().isEmpty());
 
         final ProtobufMessageSchema project = messages.get(2);
         assertEquals("Project", project.name());
-        assertEquals("com.example.test", project.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), company.packageName());
         assertTrue(project.getChildMessageSchemas().isEmpty());
     }
 
@@ -139,17 +140,17 @@ class AntlrProtobufMessageSchemaReaderTest {
 
         final ProtobufMessageSchema user = messages.getFirst();
         assertEquals("User", user.name());
-        assertEquals("com.example.test", user.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), user.packageName());
         assertEquals(1, user.getChildMessageSchemas().size());
 
         final ProtobufMessageSchema profile = user.getChildMessageSchemas().getFirst();
         assertEquals("Profile", profile.name());
-        assertEquals("com.example.test", profile.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), profile.packageName());
         assertEquals(1, profile.getChildMessageSchemas().size());
 
         final ProtobufMessageSchema settings = profile.getChildMessageSchemas().getFirst();
         assertEquals("Settings", settings.name());
-        assertEquals("com.example.test", settings.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), settings.packageName());
         assertTrue(settings.getChildMessageSchemas().isEmpty());
     }
 
@@ -192,22 +193,22 @@ class AntlrProtobufMessageSchemaReaderTest {
         // Test Company message and its nested structure
         final ProtobufMessageSchema company = messages.getFirst();
         assertEquals("Company", company.name());
-        assertEquals("com.example.company", company.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.company"), company.packageName());
         assertEquals(1, company.getChildMessageSchemas().size());
 
         final ProtobufMessageSchema department = company.getChildMessageSchemas().getFirst();
         assertEquals("Department", department.name());
-        assertEquals("com.example.company", department.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.company"), department.packageName());
         assertEquals(1, department.getChildMessageSchemas().size());
 
         final ProtobufMessageSchema employee = department.getChildMessageSchemas().getFirst();
         assertEquals("Employee", employee.name());
-        assertEquals("com.example.company", employee.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.company"), employee.packageName());
         assertEquals(1, employee.getChildMessageSchemas().size());
 
         final ProtobufMessageSchema position = employee.getChildMessageSchemas().getFirst();
         assertEquals("Position", position.name());
-        assertEquals("com.example.company", position.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.company"), position.packageName());
         assertTrue(position.getChildMessageSchemas().isEmpty());
 
         // Test Address message (top-level)
@@ -243,22 +244,22 @@ class AntlrProtobufMessageSchemaReaderTest {
 
         final ProtobufMessageSchema user = messages.getFirst();
         assertEquals("User", user.name());
-        assertEquals("com.example.test", user.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), user.packageName());
         assertEquals(3, user.getChildMessageSchemas().size());
 
         final ProtobufMessageSchema profile = user.getChildMessageSchemas().getFirst();
         assertEquals("Profile", profile.name());
-        assertEquals("com.example.test", profile.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), profile.packageName());
         assertTrue(profile.getChildMessageSchemas().isEmpty());
 
         final ProtobufMessageSchema settings = user.getChildMessageSchemas().get(1);
         assertEquals("Settings", settings.name());
-        assertEquals("com.example.test", settings.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), settings.packageName());
         assertTrue(settings.getChildMessageSchemas().isEmpty());
 
         final ProtobufMessageSchema preferences = user.getChildMessageSchemas().get(2);
         assertEquals("Preferences", preferences.name());
-        assertEquals("com.example.test", preferences.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), preferences.packageName());
         assertTrue(preferences.getChildMessageSchemas().isEmpty());
     }
 
@@ -286,7 +287,7 @@ class AntlrProtobufMessageSchemaReaderTest {
 
         final ProtobufMessageSchema user = messages.getFirst();
         assertEquals("User", user.name());
-        assertEquals("com.example.test", user.packageName().orElse(""));
+        assertEquals(Optional.of("com.example.test"), user.packageName());
         assertTrue(user.getChildMessageSchemas().isEmpty());
     }
 
@@ -357,12 +358,12 @@ class AntlrProtobufMessageSchemaReaderTest {
 
         final ProtobufMessageSchema user = messages.getFirst();
         assertEquals("User", user.name());
-        assertEquals("", user.packageName().orElse(""));
+        assertTrue(user.packageName().isEmpty());
         assertTrue(user.isDefaultPackage());
 
         final ProtobufMessageSchema product = messages.get(1);
         assertEquals("Product", product.name());
-        assertEquals("", product.packageName().orElse(""));
+        assertTrue(product.packageName().isEmpty());
         assertTrue(product.isDefaultPackage());
     }
 }

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/pom.xml
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/pom.xml
@@ -11,29 +11,48 @@
     language governing permissions and limitations under the License. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-confluent-platform-bundle</artifactId>
         <version>2.5.0-SNAPSHOT</version>
     </parent>
-    <artifactId>nifi-confluent-platform-nar</artifactId>
-    <packaging>nar</packaging>
+
+    <artifactId>nifi-confluent-protobuf-message-name-resolver</artifactId>
+    <packaging>jar</packaging>
+    <description>Confluent Protobuf Message Name Resolver for NiFi</description>
+    
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-standard-shared-nar</artifactId>
-            <version>${project.version}</version>
-            <type>nar</type>
+            <artifactId>nifi-schema-registry-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-confluent-schema-registry-service</artifactId>
+            <artifactId>nifi-confluent-platform-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-confluent-protobuf-message-name-resolver</artifactId>
+            <artifactId>nifi-confluent-protobuf-antlr-parser</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentProtobufMessageNameResolver.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentProtobufMessageNameResolver.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schemaregistry;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.confluent.schema.AntlrProtobufMessageSchemaParser;
+import org.apache.nifi.confluent.schema.ProtobufMessageSchema;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.schemaregistry.services.MessageName;
+import org.apache.nifi.schemaregistry.services.MessageNameResolver;
+import org.apache.nifi.schemaregistry.services.SchemaDefinition;
+import org.apache.nifi.schemaregistry.services.StandardMessageName;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static org.apache.nifi.confluent.schemaregistry.VarintUtils.decodeZigZag;
+import static org.apache.nifi.confluent.schemaregistry.VarintUtils.readVarintFromStream;
+
+@Tags({"confluent", "schema", "registry", "protobuf", "message", "name", "resolver"})
+@CapabilityDescription("""
+    Resolves Protobuf message names from Confluent Schema Registry wire format by decoding message indexes and looking up the fully qualified name in the schema definition
+    For Confluent wire format reference see: <a href="https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format">Confluent Wire Format</a>
+    """)
+public class ConfluentProtobufMessageNameResolver extends AbstractControllerService implements MessageNameResolver {
+
+    public static final int MAXIMUM_SUPPORTED_ARRAY_LENGTH = 100;
+    private Cache<FindMessageNameArguments, MessageName> messageNameCache;
+
+    @OnEnabled
+    public void onEnabled(final ConfigurationContext context) {
+        messageNameCache = Caffeine.newBuilder().maximumSize(1000).expireAfterWrite(Duration.ofHours(1)).build();
+    }
+
+    @OnDisabled
+    public void onDisabled(final ConfigurationContext context) {
+        if (messageNameCache != null) {
+            messageNameCache.invalidateAll();
+        }
+    }
+
+
+    @Override
+    public MessageName getMessageName(@NotNull final SchemaDefinition schemaDefinition, final InputStream inputStream) throws IOException {
+        final ComponentLog logger = getLogger();
+
+        // Read message indexes directly from stream (Confluent wire format)
+        final List<Integer> messageIndexes = readMessageIndexesFromStream(inputStream);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Decoded message indexes: {}", messageIndexes);
+        }
+
+        final FindMessageNameArguments findMessageNameArgs = new FindMessageNameArguments(schemaDefinition, messageIndexes);
+
+        return messageNameCache.get(findMessageNameArgs, this::findMessageName);
+
+    }
+
+    /**
+     * Reads message indexes directly from the input stream using Confluent wire format.
+     * Format: [array_length:varint][index1:varint][index2:varint]...[indexN:varint]
+     * Special case: single 0 byte means first message (index 0)
+     * <p>
+     * <a href="https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format">Wire format</a>
+     *
+     * @param inputStream the input stream positioned after the Confluent header (magic byte + schema ID)
+     * @return list of message indexes
+     * @throws IOException if unable to read from stream or invalid format
+     */
+    private @NotNull List<Integer> readMessageIndexesFromStream(final InputStream inputStream) throws IOException {
+        // Special case: check if first byte is 0 (most common case)
+        final int firstByte = inputStream.read();
+        if (firstByte == -1) {
+            throw new IOException("Unexpected end of stream while reading message indexes");
+        }
+
+        if (firstByte == 0) {
+            // Single 0 byte means first message type (index 0)
+            return List.of(0);
+        }
+
+        // General case: read array length as varint
+        int arrayLength = readVarintFromStream(inputStream, firstByte);
+        arrayLength = decodeZigZag(arrayLength);
+
+        if (arrayLength < 0 || arrayLength > MAXIMUM_SUPPORTED_ARRAY_LENGTH) { // Reasonable limit
+            throw new IllegalStateException("Invalid message index array length: " + arrayLength);
+        }
+
+        // Read each index as varint
+        final List<Integer> indexes = new ArrayList<>();
+        for (int i = 0; i < arrayLength; i++) {
+            final int rawIndex = readVarintFromStream(inputStream, -1);
+            final int index = decodeZigZag(rawIndex);
+            indexes.add(index);
+        }
+
+        return indexes;
+    }
+
+    /**
+     * Finds the fully qualified message name in the protobuf schema using the message indexes.
+     */
+    private @NotNull MessageName findMessageName(final FindMessageNameArguments findMessageNameArguments) {
+        try {
+            final List<Integer> messageIndexes = findMessageNameArguments.messageIndexes();
+            final String schemaText = findMessageNameArguments.schemaDefinition().text();
+            // Parse the protobuf schema using AntlrProtobufMessageSchemaParser
+            final AntlrProtobufMessageSchemaParser reader = new AntlrProtobufMessageSchemaParser();
+            final List<ProtobufMessageSchema> rootMessages = reader.parse(schemaText);
+
+            if (messageIndexes.isEmpty()) {
+                // Return the topmost root message name
+                if (!rootMessages.isEmpty()) {
+                    return getFullyQualifiedName(singletonList(rootMessages.getFirst()));
+                } else {
+                    throw new IllegalStateException("No root messages found in schema");
+                }
+            }
+
+            // Navigate through the message hierarchy using indexes
+            ProtobufMessageSchema currentMessage;
+            List<ProtobufMessageSchema> currentLevel = rootMessages;
+            final List<ProtobufMessageSchema> messagePath = new ArrayList<>();
+
+            for (final int index : messageIndexes) {
+                if (index >= currentLevel.size()) {
+                    final String msg = format("Message index %d out of bounds for level with %d messages. Message indexes: [%s]", index, currentLevel.size(), messageIndexes);
+                    getLogger().error(msg);
+                    throw new IllegalStateException(msg);
+                }
+
+                currentMessage = currentLevel.get(index);
+                messagePath.add(currentMessage);
+
+                // Move to nested messages of the current message
+                currentLevel = currentMessage.getChildMessageSchemas();
+            }
+
+            // Return the fully qualified name including parent message hierarchy
+            return getFullyQualifiedName(messagePath);
+
+        } catch (final Exception e) {
+            throw new IllegalStateException("Failed to parse protobuf schema", e);
+        }
+    }
+
+    /**
+     * Gets the fully qualified name for a message path, including parent message names.
+     */
+    private @NotNull MessageName getFullyQualifiedName(@NotNull final List<ProtobufMessageSchema> messagePath) {
+
+        final StringBuilder fullName = new StringBuilder();
+        final ProtobufMessageSchema firstMessage = messagePath.getFirst();
+
+        // Add all message names in the path
+        for (int i = 0; i < messagePath.size(); i++) {
+            if (i > 0) {
+                fullName.append(".");
+            }
+            fullName.append(messagePath.get(i).name());
+        }
+
+        return new StandardMessageName(firstMessage.packageName().get(), fullName.toString());
+    }
+
+    record FindMessageNameArguments(SchemaDefinition schemaDefinition, List<Integer> messageIndexes) {
+    }
+}
+
+

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/src/main/java/org/apache/nifi/confluent/schemaregistry/VarintUtils.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/src/main/java/org/apache/nifi/confluent/schemaregistry/VarintUtils.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schemaregistry;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Utility class for reading, writing and decoding varint values from input streams.
+ * This class provides methods for reading variable-length integers (varints),
+ * writing zigzag-encoded varints, and decoding zigzag-encoded integers as per the Protocol Buffers specification.
+ */
+public final class VarintUtils {
+
+    private VarintUtils() {}
+
+    /**
+     * Reads a single varint from the input stream.
+     * 
+     * <p>Variable-length integers (varints) are a method of serializing integers using one or more bytes.
+     * Smaller numbers take fewer bytes. Each byte in a varint, except the last byte, has the most
+     * significant bit set – this indicates that there are further bytes to come. The lower 7 bits
+     * of each byte are used to store the two's complement representation of the number in groups of 7 bits,
+     * least significant group first.</p>
+     * 
+     * <p>For more information about varint encoding, see:
+     * <a href="https://en.wikipedia.org/wiki/Variable-length_quantity">Variable-length quantity - Wikipedia</a></p>
+     * 
+     * <p>This implementation follows the Protocol Buffers varint encoding format as described in:
+     * <a href="https://developers.google.com/protocol-buffers/docs/encoding#varints">Protocol Buffers Encoding</a></p>
+     * 
+     *
+     * @param inputStream the input stream to read from
+     * @param firstByte   the first byte already read, or -1 if not yet read
+     * @return the decoded varint value
+     * @throws IOException if unable to read from stream or invalid varint format
+     */
+    public static int readVarintFromStream(InputStream inputStream, int firstByte) throws IOException {
+        // accumulated result
+        int value = 0;
+        
+        // stores bit shift position (0, 7, 14, 21, 28 for consecutive bytes)
+        int shift = 0;
+        
+        // Store the current byte being processed
+        int currentByte = firstByte;
+
+        // Handle the case where no first byte was provided (-1 indicates not yet read)
+        if (currentByte == -1) {
+            currentByte = inputStream.read();
+            
+            if (currentByte == -1) {
+                throw new IOException("Unexpected end of stream while reading varint");
+            }
+        }
+
+        // continues until we find a byte without the continuation bit
+        while (true) {
+            // Prevent overflow by limiting varint to 32 bits (5 bytes maximum: 5 * 7 = 35 bits, but we bail at 32)
+            if (shift >= 32) {
+                throw new IOException("Varint too long (more than 32 bits)");
+            }
+
+            // Extract the lower 7 bits of the current byte using & 0x7F (0111 1111)
+            // Shift these 7 bits to their correct position in the final value
+            // Combine with the accumulated value |=
+            value |= (currentByte & 0x7F) << shift;
+
+            // Check if this is the last byte by testing the MSB
+            // If bit 7 is 0 (no continuation bit), we're done
+            if ((currentByte & 0x80) == 0) {
+                break;
+            }
+
+            // Increment the bit shift position by 7 for the next byte
+            shift += 7;
+            
+            currentByte = inputStream.read();
+            
+            if (currentByte == -1) {
+                throw new IOException("Unexpected end of stream while reading varint");
+            }
+        }
+
+        return value;
+    }
+
+    /**
+     * Decodes a zigzag encoded integer.
+     * ZigZag encoding maps signed integers to unsigned integers so that 
+     * numbers with a small absolute value have a small varint encoding.
+     * 
+     * @param encodedValue the zigzag encoded value
+     * @return the decoded integer value
+     */
+    public static int decodeZigZag(int encodedValue) {
+        return (encodedValue >>> 1) ^ -(encodedValue & 1);
+    }
+
+    /**
+     * Writes a zigzag encoded varint to the output stream.
+     * ZigZag encoding maps signed integers to unsigned integers so that 
+     * numbers with a small absolute value have a small varint encoding.
+     * 
+     * @param output the output stream to write to
+     * @param value the integer value to encode and write
+     * @throws IOException if unable to write to the stream
+     */
+    public static void writeZigZagVarint(ByteArrayOutputStream output, int value) throws IOException {
+        // Zigzag encode
+        int encoded = (value << 1) ^ (value >> 31);
+
+        // Write as varint
+        while ((encoded & 0xFFFFFF80) != 0) {
+            output.write((encoded & 0x7F) | 0x80);
+            encoded >>>= 7;
+        }
+        output.write(encoded & 0x7F);
+    }
+} 

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.nifi.confluent.schemaregistry.ConfluentProtobufMessageNameResolver

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/src/test/java/org/apache/nifi/confluent/schemaregistry/ConfluentProtobufMessageNameResolverTest.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/src/test/java/org/apache/nifi/confluent/schemaregistry/ConfluentProtobufMessageNameResolverTest.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schemaregistry;
+
+import org.apache.nifi.schemaregistry.services.MessageName;
+import org.apache.nifi.schemaregistry.services.SchemaDefinition;
+import org.apache.nifi.schemaregistry.services.StandardSchemaDefinition;
+import org.apache.nifi.serialization.record.SchemaIdentifier;
+import org.apache.nifi.util.NoOpProcessor;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.apache.nifi.confluent.schemaregistry.VarintUtils.writeZigZagVarint;
+
+import static org.apache.nifi.schemaregistry.services.SchemaDefinition.SchemaType.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class ConfluentProtobufMessageNameResolverTest {
+
+
+    private static final int MAGIC_BYTE_LENGTH = 1;
+    private static final int SCHEMA_ID_LENGTH = 4;
+    // Schema without package (default package)
+    private static final String DEFAULT_PACKAGE_SCHEMA = """
+        syntax = "proto3";
+        message User {
+          int32 id = 1;
+          string name = 2;
+          Address address = 3;
+          message Profile {
+            string bio = 1;
+            Settings settings = 2;
+            message Settings {
+              bool notifications = 1;
+              string theme = 2;
+            }
+          }
+        }
+        message Company {
+          string name = 1;
+          Address address = 2;
+        }
+        message Address {
+          string street = 1;
+          string city = 2;
+        }""";
+
+    // Schema with explicit package
+    private static final String EXPLICIT_PACKAGE_SCHEMA = """
+        syntax = "proto3";
+        package com.example.proto;
+        message User {
+          int32 id = 1;
+          string name = 2;
+          Address address = 3;
+          message Profile {
+            string bio = 1;
+            Settings settings = 2;
+            message Settings {
+              bool notifications = 1;
+              string theme = 2;
+            }
+          }
+        }
+        message Company {
+          string name = 1;
+          Address address = 2;
+        }
+        message Address {
+          string street = 1;
+          string city = 2;
+        }""";
+
+    private static final SchemaIdentifier ID = SchemaIdentifier.builder()
+        .id(1L)
+        .build();
+
+    private static final SchemaDefinition SCHEMA_WITH_DEFAULT_PACKAGE = new StandardSchemaDefinition(
+        ID,
+        DEFAULT_PACKAGE_SCHEMA,
+        PROTOBUF,
+        Map.of());
+    private static final SchemaDefinition SCHEMA_WITH_EXPLICIT_PACKAGE = new StandardSchemaDefinition(
+        ID,
+        EXPLICIT_PACKAGE_SCHEMA,
+        PROTOBUF,
+        Map.of()
+    );
+
+    private ConfluentProtobufMessageNameResolver resolver;
+
+    private static Stream<Arguments> provideMessageNameTestCases() {
+        return Stream.of(
+            // Default package schema tests
+            // the format is [input schema], [message indexes as decoded from protobuf header], [expected FQN message name]
+            Arguments.of(SCHEMA_WITH_DEFAULT_PACKAGE, new int[] {0}, "User"),
+            Arguments.of(SCHEMA_WITH_DEFAULT_PACKAGE, new int[] {1}, "Company"),
+            Arguments.of(SCHEMA_WITH_DEFAULT_PACKAGE, new int[] {2}, "Address"),
+            Arguments.of(SCHEMA_WITH_DEFAULT_PACKAGE, new int[] {0, 0}, "User.Profile"),
+            Arguments.of(SCHEMA_WITH_DEFAULT_PACKAGE, new int[] {0, 0, 0}, "User.Profile.Settings"),
+
+            // Packaged schema tests
+            Arguments.of(SCHEMA_WITH_EXPLICIT_PACKAGE, new int[] {0}, "com.example.proto.User"),
+            Arguments.of(SCHEMA_WITH_EXPLICIT_PACKAGE, new int[] {1}, "com.example.proto.Company"),
+            Arguments.of(SCHEMA_WITH_EXPLICIT_PACKAGE, new int[] {2}, "com.example.proto.Address"),
+            Arguments.of(SCHEMA_WITH_EXPLICIT_PACKAGE, new int[] {0, 0}, "com.example.proto.User.Profile"),
+            Arguments.of(SCHEMA_WITH_EXPLICIT_PACKAGE, new int[] {0, 0, 0}, "com.example.proto.User.Profile.Settings")
+        );
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        resolver = new ConfluentProtobufMessageNameResolver();
+        TestRunner testRunner = TestRunners.newTestRunner(NoOpProcessor.class);
+        testRunner.addControllerService("messageNameResolver", resolver);
+        testRunner.enableControllerService(resolver);
+
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMessageNameTestCases")
+    void testGetMessageName(final SchemaDefinition schemaDefinition, final int[] messageIndexes, final String expectedMessageName) throws IOException {
+        final InputStream inputStream = createWireFormatData(schemaDefinition, messageIndexes);
+
+        final MessageName messageName = resolver.getMessageName(schemaDefinition, inputStream);
+
+        assertNotNull(messageName);
+        assertEquals(expectedMessageName, messageName.getFQNName());
+    }
+
+    @Test
+    void testGetMessageNameWithSpecialCaseZero() throws IOException {
+        // Test special case: single 0 byte means first message type for default package
+        InputStream inputStream = createWireFormatDataSpecialCase(SCHEMA_WITH_DEFAULT_PACKAGE);
+        MessageName messageName = resolver.getMessageName(SCHEMA_WITH_DEFAULT_PACKAGE, inputStream);
+        assertNotNull(messageName);
+        assertEquals("User", messageName.getFQNName());
+        assertTrue(messageName.getNamespace().isEmpty());
+
+        inputStream = createWireFormatDataSpecialCase(SCHEMA_WITH_EXPLICIT_PACKAGE);
+        messageName = resolver.getMessageName(SCHEMA_WITH_EXPLICIT_PACKAGE, inputStream);
+        assertNotNull(messageName);
+        assertEquals("com.example.proto.User", messageName.getFQNName());
+        assertEquals("com.example.proto", messageName.getNamespace().get());
+        assertEquals("User", messageName.getName());
+    }
+
+    @Test
+    void testGetMessageNameEmptyInputStream() throws IOException {
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
+        assertThrows(IOException.class, () -> resolver.getMessageName(SCHEMA_WITH_EXPLICIT_PACKAGE, inputStream));
+    }
+
+    @Test
+    void testGetMessageNameTooShortInputStream() throws IOException {
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {1}); // Only 4 bytes
+        assertThrows(IllegalStateException.class, () -> resolver.getMessageName(SCHEMA_WITH_EXPLICIT_PACKAGE, inputStream));
+    }
+
+    @Test
+    void testGetMessageNameIndexOutOfBounds() throws IOException {
+        // Test with index [99] which should be out of bounds for both schemas
+        
+        // Test with default package schema
+        final InputStream inputStream1 = createWireFormatData(SCHEMA_WITH_DEFAULT_PACKAGE, new int[] {99});
+        assertThrows(IllegalStateException.class, () -> resolver.getMessageName(SCHEMA_WITH_DEFAULT_PACKAGE, inputStream1));
+        
+        // Test with explicit package schema  
+        final InputStream inputStream2 = createWireFormatData(SCHEMA_WITH_EXPLICIT_PACKAGE, new int[] {99});
+        assertThrows(IllegalStateException.class, () -> {
+            resolver.getMessageName(SCHEMA_WITH_EXPLICIT_PACKAGE, inputStream2);
+        });
+    }
+
+
+    /**
+     * Creates wire format data according to Confluent specification:
+     * [magic_byte:1][schema_id:4][message_indexes:variable][protobuf_payload:rest]
+     *
+     * https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
+     */
+    private InputStream createWireFormatData(final SchemaDefinition schemaDefinition, final int[] messageIndexes) throws IOException {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        // Magic byte (0x0)
+        output.write(0x00);
+
+        // Schema ID (4 bytes, big-endian)
+        final ByteBuffer schemaIdBuffer = ByteBuffer.allocate(4);
+        schemaIdBuffer.putInt((int) schemaDefinition.identifier().getIdentifier().getAsLong());
+        output.write(schemaIdBuffer.array());
+
+        // Message indexes (varint zigzag encoded)
+        final byte[] encodedIndexes = encodeMessageIndexes(messageIndexes);
+        output.write(encodedIndexes);
+
+        // Optional: Add some dummy protobuf payload (not needed for message name resolution)
+        output.write(new byte[] {0x5F, 0x5F, 0x5F, 0x5F, 0x48, 0x45, 0x4C, 0x50, 0x20, 0x4D, 0x45, 0x5F, 0x5F, 0x5F});
+        final ByteArrayInputStream payloadStream = new ByteArrayInputStream(output.toByteArray());
+        // Skip magic byte, schema ID,
+        // Message name resolver is designed to work on a stream positioned exacltly
+        // at the start of the message index wireformat section (6 th byte)
+        payloadStream.skip(MAGIC_BYTE_LENGTH + SCHEMA_ID_LENGTH);
+        return payloadStream;
+    }
+
+    /**
+     * Creates wire format data for the special case (single 0 byte for first message type)
+     */
+    private InputStream createWireFormatDataSpecialCase(final SchemaDefinition schemaDefinition) throws IOException {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        output.write(0x00);
+
+        final ByteBuffer schemaIdBuffer = ByteBuffer.allocate(4);
+        schemaIdBuffer.putInt((int) schemaDefinition.identifier().getIdentifier().getAsLong());
+        output.write(schemaIdBuffer.array());
+
+        // Special case: single 0 byte
+        output.write(0x00);
+        final ByteArrayInputStream payloadStream = new ByteArrayInputStream(output.toByteArray());
+        payloadStream.skip(MAGIC_BYTE_LENGTH + SCHEMA_ID_LENGTH); // Skip magic byte, schema ID, and indexes
+        return payloadStream;
+    }
+
+    /**
+     * Encodes message indexes using zigzag varint encoding as per Confluent specification
+     */
+    private byte[] encodeMessageIndexes(final int[] indexes) throws IOException {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        // Encode array length as zigzag varint
+        writeZigZagVarint(output, indexes.length);
+
+        // Encode each index as zigzag varint
+        for (final int index : indexes) {
+            writeZigZagVarint(output, index);
+        }
+
+        return output.toByteArray();
+    }
+
+
+}

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/src/test/java/org/apache/nifi/confluent/schemaregistry/VarintUtilsTest.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-protobuf-message-name-resolver/src/test/java/org/apache/nifi/confluent/schemaregistry/VarintUtilsTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schemaregistry;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.apache.nifi.confluent.schemaregistry.VarintUtils.decodeZigZag;
+import static org.apache.nifi.confluent.schemaregistry.VarintUtils.readVarintFromStream;
+import static org.apache.nifi.confluent.schemaregistry.VarintUtils.writeZigZagVarint;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VarintUtilsTest {
+
+    @Test
+    public void testReadVarintFromStream_SingleByte() throws IOException {
+        byte[] data = {0x08}; // 8 in varint format (0x08 = 00001000)
+        InputStream inputStream = new ByteArrayInputStream(data);
+        
+        int result = readVarintFromStream(inputStream, -1);
+        assertEquals(8, result);
+    }
+
+    @Test
+    public void testReadVarintFromStream_MultiByte() throws IOException {
+        byte[] data = {(byte) 0x96, 0x01}; // 150 in varint format (10010110 00000001)
+        InputStream inputStream = new ByteArrayInputStream(data);
+        
+        int result = readVarintFromStream(inputStream, -1);
+        assertEquals(150, result);
+    }
+
+    @Test
+    public void testReadVarintFromStream_MaxValue() throws IOException {
+        // Maximum 32-bit value in varint format (11111111 11111111 11111111 11111111 00001111)
+        byte[] data = {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x0F};
+        InputStream inputStream = new ByteArrayInputStream(data);
+        
+        int result = readVarintFromStream(inputStream, -1);
+        assertEquals(0xFFFFFFFF, result);
+    }
+
+    @Test
+    public void testReadVarintFromStream_WithFirstByte() throws IOException {
+        byte[] data = {0x08}; // 8 in varint format (0x08 = 00001000)
+        InputStream inputStream = new ByteArrayInputStream(data);
+        
+        int result = readVarintFromStream(inputStream, 0x08);
+        assertEquals(8, result);
+    }
+
+    @Test
+    public void testReadVarintFromStream_Zero() throws IOException {
+        byte[] data = {0x00}; // 0 in varint format (0x00 = 00000000)
+        InputStream inputStream = new ByteArrayInputStream(data);
+        
+        int result = readVarintFromStream(inputStream, -1);
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void testReadVarintFromStream_LargeValue() throws IOException {
+        // 16384 in varint format (10000000 10000000 00000001)
+        byte[] data = {(byte) 0x80, (byte) 0x80, 0x01};
+        InputStream inputStream = new ByteArrayInputStream(data);
+        
+        int result = readVarintFromStream(inputStream, -1);
+        assertEquals(16384, result);
+    }
+
+    @Test
+    public void testReadVarintFromStream_EmptyStream() {
+        InputStream inputStream = new ByteArrayInputStream(new byte[0]);
+        
+        IOException exception = assertThrows(IOException.class, () -> readVarintFromStream(inputStream, -1));
+        assertTrue(exception.getMessage().contains("Unexpected end of stream while reading varint"));
+    }
+
+    @Test
+    public void testReadVarintFromStream_TruncatedStream() {
+        // Start of a multi-byte varint but missing continuation bytes (0x80 = 10000000)
+        byte[] data = {(byte) 0x80}; // Indicates more bytes to follow but none provided
+        InputStream inputStream = new ByteArrayInputStream(data);
+        
+        IOException exception = assertThrows(IOException.class, () -> readVarintFromStream(inputStream, -1));
+        assertTrue(exception.getMessage().contains("Unexpected end of stream while reading varint"));
+    }
+
+    @Test
+    public void testReadVarintFromStream_TooLong() {
+        // Varint with more than 32 bits (5 bytes with continuation bit set)
+        // (10000000 10000000 10000000 10000000 10000000 00000001)
+        byte[] data = {(byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, 0x01};
+        InputStream inputStream = new ByteArrayInputStream(data);
+        
+        IOException exception = assertThrows(IOException.class, () -> readVarintFromStream(inputStream, -1));
+        assertTrue(exception.getMessage().contains("Varint too long (more than 32 bits)"));
+    }
+
+    @Test
+    public void testDecodeZigZag_PositiveValues() {
+        // Test positive values
+        assertEquals(0, decodeZigZag(0));   // 0 -> 0
+        assertEquals(1, decodeZigZag(2));   // 1 -> 2
+        assertEquals(2, decodeZigZag(4));   // 2 -> 4
+        assertEquals(3, decodeZigZag(6));   // 3 -> 6
+        assertEquals(150, decodeZigZag(300)); // 150 -> 300
+    }
+
+    @Test
+    public void testDecodeZigZag_NegativeValues() {
+        // Test negative values
+        assertEquals(-1, decodeZigZag(1));   // -1 -> 1
+        assertEquals(-2, decodeZigZag(3));   // -2 -> 3
+        assertEquals(-3, decodeZigZag(5));   // -3 -> 5
+        assertEquals(-150, decodeZigZag(299)); // -150 -> 299
+    }
+
+    @Test
+    public void testDecodeZigZag_ExtremeValues() {
+        // Test extreme values
+        assertEquals(Integer.MAX_VALUE, decodeZigZag(0xFFFFFFFE));
+        assertEquals(Integer.MIN_VALUE, decodeZigZag(0xFFFFFFFF));
+    }
+
+    @Test
+    public void testDecodeZigZag_LargeValues() {
+        // Test some larger values to verify the algorithm
+        assertEquals(1000, decodeZigZag(2000));  // 1000 -> 2000
+        assertEquals(-1000, decodeZigZag(1999)); // -1000 -> 1999
+    }
+
+    @Test
+    public void testWriteZigZagVarint_Zero() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeZigZagVarint(output, 0);
+        byte[] result = output.toByteArray();
+        
+        assertEquals(1, result.length);
+        assertEquals(0x00, result[0]);
+    }
+
+    @Test
+    public void testWriteZigZagVarint_PositiveSmallNumbers() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeZigZagVarint(output, 1);
+        byte[] result = output.toByteArray();
+        
+        assertEquals(1, result.length);
+        assertEquals(0x02, result[0]); // 1 -> 2 (zigzag encoded)
+        
+        output = new ByteArrayOutputStream();
+        writeZigZagVarint(output, 2);
+        result = output.toByteArray();
+        
+        assertEquals(1, result.length);
+        assertEquals(0x04, result[0]); // 2 -> 4 (zigzag encoded)
+    }
+
+    @Test
+    public void testWriteZigZagVarint_NegativeSmallNumbers() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeZigZagVarint(output, -1);
+        byte[] result = output.toByteArray();
+        
+        assertEquals(1, result.length);
+        assertEquals(0x01, result[0]); // -1 -> 1 (zigzag encoded)
+        
+        output = new ByteArrayOutputStream();
+        writeZigZagVarint(output, -2);
+        result = output.toByteArray();
+        
+        assertEquals(1, result.length);
+        assertEquals(0x03, result[0]); // -2 -> 3 (zigzag encoded)
+    }
+
+    @Test
+    public void testWriteZigZagVarint_LargePositiveNumber() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeZigZagVarint(output, 150);
+        byte[] result = output.toByteArray();
+        
+        assertEquals(2, result.length);
+        assertEquals((byte) 0xAC, result[0]); // Lower 7 bits of 300 with continuation bit
+        assertEquals(0x02, result[1]); // Upper bits of 300 (150 -> 300 zigzag)
+    }
+
+    @Test
+    public void testWriteZigZagVarint_LargeNegativeNumber() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeZigZagVarint(output, -150);
+        byte[] result = output.toByteArray();
+        
+        assertEquals(2, result.length);
+        assertEquals((byte) 0xAB, result[0]); // Lower 7 bits of 299 with continuation bit
+        assertEquals(0x02, result[1]); // Upper bits of 299 (-150 -> 299 zigzag)
+    }
+
+    @Test
+    public void testWriteZigZagVarint_ExtremeValues() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeZigZagVarint(output, Integer.MAX_VALUE);
+        byte[] result = output.toByteArray();
+        
+        assertEquals(5, result.length);
+        
+        output = new ByteArrayOutputStream();
+        writeZigZagVarint(output, Integer.MIN_VALUE);
+        result = output.toByteArray();
+        
+        assertEquals(5, result.length);
+    }
+
+    @Test
+    public void testWriteZigZagVarint_MultipleValues() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        
+        // Write multiple values
+        writeZigZagVarint(output, 0);
+        writeZigZagVarint(output, 1);
+        writeZigZagVarint(output, -1);
+        writeZigZagVarint(output, 150);
+        
+        byte[] result = output.toByteArray();
+        
+        // Verify we have the expected number of bytes
+        assertTrue(result.length > 4); // At least one byte per value
+        
+        // Read back and verify
+        ByteArrayInputStream input = new ByteArrayInputStream(result);
+        
+        assertEquals(0, decodeZigZag(readVarintFromStream(input, -1)));
+        assertEquals(1, decodeZigZag(readVarintFromStream(input, -1)));
+        assertEquals(-1, decodeZigZag(readVarintFromStream(input, -1)));
+        assertEquals(150, decodeZigZag(readVarintFromStream(input, -1)));
+    }
+}

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/pom.xml
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-avro-record-utils</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -77,5 +77,30 @@
             <artifactId>nifi-web-utils</artifactId>
             <version>2.5.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-confluent-protobuf-message-name-resolver</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+            <version>2.35.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
+
 </project>

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/ConfluentSchemaRegistry.java
@@ -53,6 +53,7 @@ import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.schema.access.SchemaField;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
+import org.apache.nifi.schemaregistry.services.SchemaDefinition;
 import org.apache.nifi.schemaregistry.services.SchemaRegistry;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.SchemaIdentifier;
@@ -314,5 +315,10 @@ public class ConfluentSchemaRegistry extends AbstractControllerService implement
     @Override
     public Set<SchemaField> getSuppliedSchemaFields() {
         return schemaFields;
+    }
+
+    @Override
+    public SchemaDefinition retrieveSchemaRaw(final SchemaIdentifier schemaIdentifier) throws IOException, SchemaNotFoundException {
+        return client.getSchemaDefinition(schemaIdentifier);
     }
 }

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/client/RestSchemaRegistryClient.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/client/RestSchemaRegistryClient.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.avro.AvroTypeUtil;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.schema.access.SchemaNotFoundException;
+import org.apache.nifi.schemaregistry.services.SchemaDefinition;
+import org.apache.nifi.schemaregistry.services.StandardSchemaDefinition;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.SchemaIdentifier;
 import org.apache.nifi.web.util.WebClientUtils;
@@ -40,12 +42,15 @@ import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import java.io.IOException;
+
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.apache.nifi.schemaregistry.services.SchemaDefinition.SchemaType;
 
 
 /**
@@ -69,8 +74,13 @@ public class RestSchemaRegistryClient implements SchemaRegistryClient {
     private static final String VERSION_FIELD_NAME = "version";
     private static final String ID_FIELD_NAME = "id";
     private static final String SCHEMA_TEXT_FIELD_NAME = "schema";
+    private static final String SCHEMA_TYPE_FIELD_NAME = "schemaType";
     private static final String CONTENT_TYPE_HEADER = "Content-Type";
     private static final String SCHEMA_REGISTRY_CONTENT_TYPE = "application/vnd.schemaregistry.v1+json";
+    private static final String REFERENCES_FIELD_NAME = "references";
+    private static final String REFERENCE_NAME_FIELD_NAME = "name";
+    private static final String REFERENCE_SUBJECT_FIELD_NAME = "subject";
+    private static final String REFERENCE_VERSION_FIELD_NAME = "version";
 
 
     public RestSchemaRegistryClient(final List<String> baseUrls,
@@ -97,7 +107,7 @@ public class RestSchemaRegistryClient implements SchemaRegistryClient {
 
 
     @Override
-    public RecordSchema getSchema(final String schemaName) throws IOException, SchemaNotFoundException {
+    public RecordSchema getSchema(final String schemaName) throws SchemaNotFoundException {
         final String pathSuffix = getSubjectPath(schemaName, null);
         final JsonNode responseJson = fetchJsonResponse(pathSuffix, "name " + schemaName);
 
@@ -105,7 +115,7 @@ public class RestSchemaRegistryClient implements SchemaRegistryClient {
     }
 
     @Override
-    public RecordSchema getSchema(final String schemaName, final int schemaVersion) throws IOException, SchemaNotFoundException {
+    public RecordSchema getSchema(final String schemaName, final int schemaVersion) throws SchemaNotFoundException {
         final String pathSuffix = getSubjectPath(schemaName, schemaVersion);
         final JsonNode responseJson = fetchJsonResponse(pathSuffix, "name " + schemaName);
 
@@ -113,7 +123,7 @@ public class RestSchemaRegistryClient implements SchemaRegistryClient {
     }
 
     @Override
-    public RecordSchema getSchema(final int schemaId) throws IOException, SchemaNotFoundException {
+    public RecordSchema getSchema(final int schemaId) throws SchemaNotFoundException {
         // The Confluent Schema Registry's version below 5.3.1 REST API does not provide us with the 'subject' (name) of a Schema given the ID.
         // It will provide us only the text of the Schema itself. Therefore, in order to determine the name (which is required for
         // a SchemaIdentifier), we must obtain a list of all Schema names, and then request each and every one of the schemas to determine
@@ -211,6 +221,91 @@ public class RestSchemaRegistryClient implements SchemaRegistryClient {
         return createRecordSchema(completeSchema);
     }
 
+    @Override
+    public SchemaDefinition getSchemaDefinition(SchemaIdentifier identifier) throws SchemaNotFoundException {
+        JsonNode schemaJson;
+        String subject = null;
+        Integer version = null;
+
+        // If we have an ID, get the schema by ID first
+        // Using schemaVersionId, because that is what is set by ConfluentEncodedSchemaReferenceReader.
+        // probably identifier field should be used, but I'm not changing ConfluentEncodedSchemaReferenceReader for backward compatibility reasons.
+        if (identifier.getSchemaVersionId().isPresent()) {
+            long schemaId = identifier.getSchemaVersionId().getAsLong();
+            String schemaPath = getSchemaPath(schemaId);
+            schemaJson = fetchJsonResponse(schemaPath, "id " + schemaId);
+        } else if (identifier.getName().isPresent()) {
+            // If we have a name or (name and version), get the schema by those
+            subject = identifier.getName().get();
+            version = identifier.getVersion().isPresent() ? identifier.getVersion().getAsInt() : null;
+            // if no version was specified, the latest version will be used. See @getSubjectPath method.
+            String pathSuffix = getSubjectPath(subject, version);
+            schemaJson = fetchJsonResponse(pathSuffix, "name " + subject);
+        } else {
+            throw new SchemaNotFoundException("Schema identifier must contain either a version identifier or a subject name");
+        }
+
+        // Extract schema information
+        String schemaText = schemaJson.get(SCHEMA_TEXT_FIELD_NAME).asText();
+        String schemaTypeText = schemaJson.get(SCHEMA_TYPE_FIELD_NAME).asText();
+        SchemaType schemaType = toSchemaType(schemaTypeText);
+
+        long schemaId;
+        if (schemaJson.has(ID_FIELD_NAME)) {
+            schemaId = schemaJson.get(ID_FIELD_NAME).asLong();
+        } else {
+            schemaId = identifier.getSchemaVersionId().getAsLong();
+        }
+
+        if (subject == null && schemaJson.has(SUBJECT_FIELD_NAME)) {
+            subject = schemaJson.get(SUBJECT_FIELD_NAME).asText();
+        }
+
+        if (version == null && schemaJson.has(VERSION_FIELD_NAME)) {
+            version = schemaJson.get(VERSION_FIELD_NAME).asInt();
+        }
+
+        // Build schema identifier with all available information
+        SchemaIdentifier schemaIdentifier = SchemaIdentifier.builder()
+            .id(schemaId)
+            .name(subject)
+            .version(version)
+            .build();
+
+        // Process references if present
+        Map<String, SchemaDefinition> references = new HashMap<>();
+        if (schemaJson.has(REFERENCES_FIELD_NAME) && !schemaJson.get(REFERENCES_FIELD_NAME).isNull()) {
+            ArrayNode refsArray = (ArrayNode) schemaJson.get(REFERENCES_FIELD_NAME);
+            for (JsonNode ref : refsArray) {
+                String refName = ref.get(REFERENCE_NAME_FIELD_NAME).asText();
+                String refSubject = ref.get(REFERENCE_SUBJECT_FIELD_NAME).asText();
+                int refVersion = ref.get(REFERENCE_VERSION_FIELD_NAME).asInt();
+
+                // Recursively get referenced schema
+                SchemaIdentifier refId = SchemaIdentifier.builder()
+                    .name(refSubject)
+                    .version(refVersion)
+                    .build();
+                SchemaDefinition refSchema = getSchemaDefinition(refId);
+                references.put(refName, refSchema);
+            }
+        }
+
+        return new StandardSchemaDefinition(schemaIdentifier, schemaText, schemaType, references);
+    }
+
+    private SchemaType toSchemaType(final String schemaTypeText) {
+        try {
+            if (schemaTypeText == null || schemaTypeText.isEmpty()) {
+                return SchemaType.AVRO; // Default schema type for confluent schema registry is AVRO.
+            }
+            return SchemaType.valueOf(schemaTypeText.toUpperCase().trim());
+        } catch (final Exception e) {
+            final String error = String.format("Could not convert schema type '%s' to SchemaType enum.", schemaTypeText);
+            throw new IllegalArgumentException(error, e);
+        }
+    }
+
     private RecordSchema createRecordSchema(final String name, final Integer version, final int id, final String schema) throws SchemaNotFoundException {
         try {
             final Schema avroSchema = new Schema.Parser().parse(schema);
@@ -243,7 +338,7 @@ public class RestSchemaRegistryClient implements SchemaRegistryClient {
                 (schemaVersion == null ? "latest" : URLEncoder.encode(String.valueOf(schemaVersion), StandardCharsets.UTF_8));
     }
 
-    private String getSchemaPath(final int schemaId) {
+    private String getSchemaPath(final long schemaId) {
         return "/schemas/ids/" + URLEncoder.encode(String.valueOf(schemaId), StandardCharsets.UTF_8);
     }
 
@@ -322,10 +417,8 @@ public class RestSchemaRegistryClient implements SchemaRegistryClient {
 
                 default:
                     errorMessage = response.readEntity(String.class);
-                    continue;
             }
         }
-
         throw new SchemaNotFoundException("Failed to retrieve Schema with " + schemaDescription
                 + " from any of the Confluent Schema Registry URL's provided; failure response message: " + errorMessage);
     }

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/client/SchemaRegistryClient.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/main/java/org/apache/nifi/confluent/schemaregistry/client/SchemaRegistryClient.java
@@ -20,7 +20,9 @@ package org.apache.nifi.confluent.schemaregistry.client;
 import java.io.IOException;
 
 import org.apache.nifi.schema.access.SchemaNotFoundException;
+import org.apache.nifi.schemaregistry.services.SchemaDefinition;
 import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.serialization.record.SchemaIdentifier;
 
 public interface SchemaRegistryClient {
 
@@ -29,4 +31,13 @@ public interface SchemaRegistryClient {
     RecordSchema getSchema(String schemaName, int version) throws IOException, SchemaNotFoundException;
 
     RecordSchema getSchema(int schemaId) throws IOException, SchemaNotFoundException;
+
+    /**
+     * Gets a schema definition with all its references from the schema registry.
+     * @param identifier The schema identifier containing id, name and version
+     * @return The schema definition with all references resolved
+     * @throws IOException if there is an error communicating with the schema registry
+     * @throws SchemaNotFoundException if the schema cannot be found
+     */
+    SchemaDefinition getSchemaDefinition(SchemaIdentifier identifier) throws IOException, SchemaNotFoundException;
 }

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/test/java/org/apache/nifi/confluent/schemaregistry/client/CompleteSchemaResponse.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/test/java/org/apache/nifi/confluent/schemaregistry/client/CompleteSchemaResponse.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schemaregistry.client;
+
+import java.util.List;
+record CompleteSchemaResponse(String subject, int version, int id, String schema, String schemaType, List<SchemaReference> references) {
+}

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/test/java/org/apache/nifi/confluent/schemaregistry/client/RestSchemaRegistryClientTest.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/test/java/org/apache/nifi/confluent/schemaregistry/client/RestSchemaRegistryClientTest.java
@@ -1,0 +1,481 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schemaregistry.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.schema.access.SchemaNotFoundException;
+import org.apache.nifi.schemaregistry.services.SchemaDefinition;
+import org.apache.nifi.schemaregistry.services.SchemaDefinition.SchemaType;
+import org.apache.nifi.serialization.record.RecordSchema;
+import org.apache.nifi.serialization.record.SchemaIdentifier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+@ExtendWith(MockitoExtension.class)
+class RestSchemaRegistryClientTest {
+
+    public static final String CONTENT_TYPE = "application/vnd.schemaregistry.v1+json";
+    private static final int SCHEMA_ID = 123;
+    private static final int SCHEMA_VERSION = 1;
+    private static final String SUBJECT_NAME = "test-subject";
+    private static final int REFERENCED_SCHEMA_VERSION = 2;
+    private static final int REFERENCED_SCHEMA_ID = 123;
+    private static final String REFERENCED_SUBJECT_NAME = "referenced-subject";
+    private static final String REFERENCED_SCHEMA_NAME = "common.proto";
+    private static final String PROTOBUF = "PROTOBUF";
+    private static final String AVRO_SCHEMA_TEXT = """
+        {
+            "type": "record",
+            "name": "User",
+            "fields": [
+                {
+                    "name": "id",
+                    "type": "int"
+                },
+                {
+                    "name": "name",
+                    "type": "string"
+                },
+                {
+                    "name": "address",
+                    "type": {
+                        "type": "record",
+                        "name": "Address",
+                        "fields": [
+                            { "name": "street", "type": "string" },
+                            { "name": "city", "type": "string" },
+                            { "name": "zip", "type": "int" }
+                        ]
+                    }
+                }
+            ]
+        }""";
+    private static final String PROTOBUF_SCHEMA_TEXT = """
+        syntax = "proto3";
+                    
+        package example;
+                    
+        import "common.proto";
+                    
+        message User {
+          int32 id = 1;
+          string name = 2;
+          string email = 3;
+          Address address = 4;
+          google.protobuf.Timestamp created_at = 5;
+          common.Status status = 6;
+        }
+                    
+        message Address {
+          string street = 1;
+          string city = 2;
+          string state = 3;
+          string zip_code = 4;
+          string country = 5;
+        }""";
+    private static final String REFERENCED_SCHEMA_TEXT = """
+        syntax = "proto3";
+                    
+        package common;
+                    
+        enum Status {
+          UNKNOWN = 0;
+          ACTIVE = 1;
+          INACTIVE = 2;
+          PENDING = 3;
+        }""";
+    private WireMockServer wireMockServer;
+    private RestSchemaRegistryClient client;
+    private String baseUrl;
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private ComponentLog logger;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().port(0));
+        wireMockServer.start();
+
+        WireMock.configureFor("localhost", wireMockServer.port());
+        baseUrl = "http://localhost:" + wireMockServer.port();
+
+        client = new RestSchemaRegistryClient(List.of(baseUrl), 30000, null, null, null, logger, Map.of());
+        objectMapper = new ObjectMapper();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void testGetSchemaByIdWithoutSubjectAndVersionInfo() throws IOException, SchemaNotFoundException {
+        // Mock the primary schema endpoint
+        stubSchemaByIdEndpoint(SCHEMA_ID, AVRO_SCHEMA_TEXT);
+
+        // Mock all other endpoints to return 404 (not supported or no data)
+        stubEndpointNotFound("/schemas/ids/" + SCHEMA_ID + "/subjects");
+        stubEndpointNotFound("/schemas/ids/" + SCHEMA_ID + "/versions");
+        stubEndpointNotFound("/subjects");
+
+        RecordSchema schema = client.getSchema(SCHEMA_ID);
+
+        // Verify the result (should still work but without subject/version info)
+        assertNotNull(schema);
+        assertFalse(schema.getIdentifier().getName().isPresent());
+        assertEquals(SCHEMA_ID, schema.getIdentifier().getIdentifier().getAsLong());
+        assertFalse(schema.getIdentifier().getVersion().isPresent());
+        assertTrue(schema.getSchemaText().isPresent());
+
+        // Verify that the expected endpoints were called
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID)));
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID + "/subjects")));
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID + "/versions")));
+        verify(getRequestedFor(urlEqualTo("/subjects")));
+    }
+
+
+    @Test
+    void testGetSchemaByIdWithSubjectsEndpointSupport() throws IOException, SchemaNotFoundException {
+        stubSchemaByIdEndpoint(SCHEMA_ID, AVRO_SCHEMA_TEXT);
+
+        // Mock the subjects endpoint (v5.3.1+ feature)
+        stubSubjectsEndpoint(SCHEMA_ID, SUBJECT_NAME);
+
+        stubCompleteSchemaEndpoint(SUBJECT_NAME, SCHEMA_ID, SCHEMA_VERSION, AVRO_SCHEMA_TEXT);
+
+        RecordSchema schema = client.getSchema(SCHEMA_ID);
+
+        assertNotNull(schema);
+        assertEquals(SUBJECT_NAME, schema.getIdentifier().getName().get());
+        assertEquals(SCHEMA_ID, schema.getIdentifier().getIdentifier().getAsLong());
+        assertEquals(SCHEMA_VERSION, schema.getIdentifier().getVersion().getAsInt());
+        assertTrue(schema.getSchemaText().isPresent());
+
+        // Verify that the expected endpoints were called
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID)));
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID + "/subjects")));
+        verify(postRequestedFor(urlEqualTo("/subjects/" + SUBJECT_NAME)));
+    }
+
+    @Test
+    void testGetSchemaByIdWithVersionsEndpointFallback() throws IOException, SchemaNotFoundException {
+        stubSchemaByIdEndpoint(SCHEMA_ID, AVRO_SCHEMA_TEXT);
+
+        stubEndpointNotFound("/schemas/ids/" + SCHEMA_ID + "/subjects");
+        stubVersionsEndpoint(SCHEMA_ID, SUBJECT_NAME, SCHEMA_VERSION);
+
+        RecordSchema schema = client.getSchema(SCHEMA_ID);
+
+        assertNotNull(schema);
+        assertEquals(SUBJECT_NAME, schema.getIdentifier().getName().get());
+        assertEquals(SCHEMA_ID, schema.getIdentifier().getIdentifier().getAsLong());
+        assertEquals(SCHEMA_VERSION, schema.getIdentifier().getVersion().getAsInt());
+        assertTrue(schema.getSchemaText().isPresent());
+
+        // Verify that the expected endpoints were called
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID)));
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID + "/subjects")));
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID + "/versions")));
+    }
+
+    @Test
+    void testGetSchemaByIdWithAllSubjectsFallback() throws IOException, SchemaNotFoundException {
+        stubSchemaByIdEndpoint(SCHEMA_ID, AVRO_SCHEMA_TEXT);
+        stubEndpointNotFound("/schemas/ids/" + SCHEMA_ID + "/subjects");
+        stubEndpointNotFound("/schemas/ids/" + SCHEMA_ID + "/versions");
+        stubAllSubjectsEndpoint(SUBJECT_NAME, "other-subject");
+        stubCompleteSchemaEndpoint(SUBJECT_NAME, SCHEMA_ID, SCHEMA_VERSION, AVRO_SCHEMA_TEXT);
+        stubPostEndpointNotFound("/subjects/other-subject");
+
+        RecordSchema schema = client.getSchema(SCHEMA_ID);
+
+        assertNotNull(schema);
+        assertEquals(SUBJECT_NAME, schema.getIdentifier().getName().get());
+        assertEquals(SCHEMA_ID, schema.getIdentifier().getIdentifier().getAsLong());
+        assertEquals(SCHEMA_VERSION, schema.getIdentifier().getVersion().getAsInt());
+        assertTrue(schema.getSchemaText().isPresent());
+
+        // Verify that the expected endpoints were called
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID)));
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID + "/subjects")));
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID + "/versions")));
+        verify(getRequestedFor(urlEqualTo("/subjects")));
+        verify(postRequestedFor(urlEqualTo("/subjects/" + SUBJECT_NAME)));
+    }
+
+
+    @Test
+    void testGetSchemaByIdNotFound() {
+
+        stubEndpointNotFound("/schemas/ids/" + SCHEMA_ID);
+        assertThrows(SchemaNotFoundException.class, () -> client.getSchema(SCHEMA_ID));
+
+        // Verify that the expected endpoint was called        
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID)));
+    }
+
+    @Test
+    void testGetSchemaByIdServerError() {
+
+        stubEndpointServerError("/schemas/ids/" + SCHEMA_ID, "Internal Server Error");
+        assertThrows(SchemaNotFoundException.class, () -> client.getSchema(SCHEMA_ID));
+
+        // Verify that the expected endpoint was called
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID)));
+    }
+
+    @Test
+    void testGetSchemaByIdInvalidAvroSchema() throws JsonProcessingException {
+        stubSchemaByIdEndpoint(SCHEMA_ID, "invalid-avro-schema");
+        stubEndpointNotFound("/schemas/ids/" + SCHEMA_ID + "/subjects");
+
+        assertThrows(SchemaNotFoundException.class, () -> client.getSchema(SCHEMA_ID));
+
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID)));
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID + "/subjects")));
+    }
+
+    @Test
+    void testGetSchemaDefinitionWithProtobufAndReferences() throws IOException, SchemaNotFoundException {
+        SchemaReference reference = new SchemaReference(REFERENCED_SCHEMA_NAME, REFERENCED_SUBJECT_NAME, REFERENCED_SCHEMA_VERSION);
+        stubSchemaByIdEndpointWithReferences(SCHEMA_ID, PROTOBUF_SCHEMA_TEXT, List.of(reference));
+        stubSchemaBySubjectVersionEndpoint(REFERENCED_SCHEMA_ID, REFERENCED_SUBJECT_NAME, REFERENCED_SCHEMA_TEXT, REFERENCED_SCHEMA_VERSION);
+
+        SchemaIdentifier schemaIdentifier = SchemaIdentifier.builder().schemaVersionId((long) SCHEMA_ID).build();
+
+        SchemaDefinition schemaDefinition = client.getSchemaDefinition(schemaIdentifier);
+
+        assertNotNull(schemaDefinition);
+
+        final SchemaIdentifier identifier = schemaDefinition.identifier();
+        assertTrue(identifier.getName().isEmpty());
+        assertTrue(identifier.getVersion().isEmpty());
+
+        assertEquals(SCHEMA_ID, identifier.getIdentifier().getAsLong());
+        assertEquals(SchemaType.PROTOBUF, schemaDefinition.getSchemaType());
+        assertEquals(PROTOBUF_SCHEMA_TEXT, schemaDefinition.text());
+
+        // Verify that references were fetched
+        final Map<String, SchemaDefinition> references = schemaDefinition.getReferences();
+        assertNotNull(references);
+        assertEquals(1, references.size());
+        SchemaDefinition referencedSchema = references.get(REFERENCED_SCHEMA_NAME);
+        assertNotNull(referencedSchema);
+        final SchemaIdentifier referencedId = referencedSchema.identifier();
+        assertEquals(REFERENCED_SUBJECT_NAME, referencedId.getName().get());
+        assertEquals(REFERENCED_SCHEMA_ID, referencedId.getIdentifier().getAsLong());
+        assertEquals(REFERENCED_SCHEMA_VERSION, referencedId.getVersion().getAsInt());
+
+        // Verify that the expected endpoints were called
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID)));
+    }
+
+    @Test
+    void testGetSchemaDefinitionNotFound() {
+        stubEndpointNotFound("/schemas/ids/" + SCHEMA_ID);
+
+        SchemaIdentifier schemaIdentifier = SchemaIdentifier.builder().schemaVersionId((long) SCHEMA_ID).build();
+
+        assertThrows(SchemaNotFoundException.class, () -> client.getSchemaDefinition(schemaIdentifier));
+
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID)));
+    }
+
+    @Test
+    void testGetSchemaDefinitionServerError() {
+        stubEndpointServerError("/schemas/ids/" + SCHEMA_ID, "Internal Server Error");
+
+        SchemaIdentifier schemaIdentifier = SchemaIdentifier.builder().schemaVersionId((long) SCHEMA_ID).build();
+
+        assertThrows(SchemaNotFoundException.class, () -> client.getSchemaDefinition(schemaIdentifier));
+
+        verify(getRequestedFor(urlEqualTo("/schemas/ids/" + SCHEMA_ID)));
+    }
+
+    private void stubSchemaByIdEndpoint(int schemaId, String schemaText) throws JsonProcessingException {
+        Map<String, String> response = Map.of("schema", schemaText);
+        String jsonResponse = objectMapper.writeValueAsString(response);
+
+        stubFor(
+            get(urlEqualTo("/schemas/ids/" + schemaId))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", CONTENT_TYPE)
+                        .withBody(jsonResponse)
+                )
+        );
+    }
+
+    private void stubSchemaByIdEndpointWithReferences(int schemaId, String schemaText, List<SchemaReference> references) throws JsonProcessingException {
+        SchemaResponse response = new SchemaResponse(schemaText, PROTOBUF, references);
+        String jsonResponse = objectMapper.writeValueAsString(response);
+
+        stubFor(
+            get(urlEqualTo("/schemas/ids/" + schemaId))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", CONTENT_TYPE)
+                        .withBody(jsonResponse)
+                )
+        );
+    }
+
+    private void stubSchemaBySubjectVersionEndpoint(int schemaId, String subject, String schemaText, int version) throws JsonProcessingException {
+        CompleteSchemaResponse completeResponse = new CompleteSchemaResponse(subject, version, schemaId, schemaText, PROTOBUF, List.of());
+
+        String jsonResponse = objectMapper.writeValueAsString(completeResponse);
+
+        stubFor(
+            get(urlEqualTo(format("/subjects/%s/versions/%d", subject, version)))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", CONTENT_TYPE)
+                        .withBody(jsonResponse)
+                )
+        );
+    }
+
+    private void stubCompleteSchemaEndpoint(String subjectName, int schemaId, int schemaVersion, String schemaText) throws JsonProcessingException {
+        Map<String, Object> response = Map.of("subject", subjectName, "version", schemaVersion, "id", schemaId, "schema", schemaText);
+        String jsonResponse = objectMapper.writeValueAsString(response);
+
+        stubFor(
+            post(urlEqualTo("/subjects/" + subjectName))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", CONTENT_TYPE)
+                        .withBody(jsonResponse)
+                )
+        );
+    }
+
+    private void stubSubjectsEndpoint(int schemaId, String... subjects) throws JsonProcessingException {
+        List<String> subjectList = List.of(subjects);
+        String jsonResponse = objectMapper.writeValueAsString(subjectList);
+
+        stubFor(
+            get(urlEqualTo("/schemas/ids/" + schemaId + "/subjects"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", CONTENT_TYPE)
+                        .withBody(jsonResponse)
+                )
+        );
+    }
+
+    private void stubVersionsEndpoint(int schemaId, String subjectName, int schemaVersion) throws JsonProcessingException {
+        Map<String, Object> versionInfo1 = Map.of("subject", subjectName, "version", schemaVersion);
+        Map<String, Object> versionInfo2 = Map.of("subject", subjectName, "version", schemaVersion);
+        List<Map<String, Object>> response = List.of(versionInfo1, versionInfo2);
+        String jsonResponse = objectMapper.writeValueAsString(response);
+
+        stubFor(
+            get(urlEqualTo("/schemas/ids/" + schemaId + "/versions"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", CONTENT_TYPE)
+                        .withBody(jsonResponse)
+                )
+        );
+    }
+
+    private void stubAllSubjectsEndpoint(String... subjects) throws JsonProcessingException {
+        List<String> subjectList = List.of(subjects);
+        String jsonResponse = objectMapper.writeValueAsString(subjectList);
+
+        stubFor(
+            get(urlEqualTo("/subjects"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", CONTENT_TYPE)
+                        .withBody(jsonResponse)
+                )
+        );
+    }
+
+    private void stubEndpointNotFound(String url) {
+        stubFor(
+            get(urlEqualTo(url))
+                .willReturn(
+                    aResponse()
+                        .withStatus(404)
+                )
+        );
+    }
+
+    private void stubPostEndpointNotFound(String url) {
+        stubFor(
+            post(urlEqualTo(url))
+                .withHeader("Content-Type", equalTo(CONTENT_TYPE))
+                .willReturn(
+                    aResponse()
+                        .withStatus(404)
+                )
+        );
+    }
+
+    private void stubEndpointServerError(String url, String errorMessage) {
+        stubFor(
+            get(urlEqualTo(url))
+                .willReturn(
+                    aResponse()
+                        .withStatus(500)
+                        .withBody(errorMessage)
+                )
+        );
+    }
+
+} 

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/test/java/org/apache/nifi/confluent/schemaregistry/client/SchemaReference.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/test/java/org/apache/nifi/confluent/schemaregistry/client/SchemaReference.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schemaregistry.client;
+
+record SchemaReference(String name, String subject, int version) {
+}

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/test/java/org/apache/nifi/confluent/schemaregistry/client/SchemaResponse.java
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/nifi-confluent-schema-registry-service/src/test/java/org/apache/nifi/confluent/schemaregistry/client/SchemaResponse.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.confluent.schemaregistry.client;
+
+import java.util.List;
+
+
+record SchemaResponse(String schema, String schemaType, List<SchemaReference> references) {
+}

--- a/nifi-extension-bundles/nifi-confluent-platform-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-confluent-platform-bundle/pom.xml
@@ -23,6 +23,9 @@
 
 	<modules>
 		<module>nifi-confluent-schema-registry-service</module>
+		<module>nifi-confluent-protobuf-message-name-resolver</module>
 		<module>nifi-confluent-platform-nar</module>
+		<module>nifi-confluent-protobuf-antlr-parser</module>
+		<module>nifi-confluent-platform-api</module>
 	</modules>
 </project>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/MessageName.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/MessageName.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.schemaregistry.services;
+
+import java.util.Optional;
+
+/**
+ * Represents a message name in a schema registry service, providing access to both the simple name
+ * and the namespace for message types. This interface is typically used for schema formats
+ * that support namespaced message types, such as Protocol Buffers, where messages can be organized
+ * within packages.
+ * 
+ */
+public interface MessageName {
+
+    /**
+     * Returns the simple name of the message without any package qualification.
+     * 
+     * @return the message name
+     */
+    String getName();
+    
+    /**
+     * Returns the namespace that contains this message, if present.
+     * 
+     * @return an Optional containing the namespace name, or empty if the message
+     *         is not contained within a namespace
+     */
+    Optional<String> getNamespace();
+    
+    /**
+     * Returns the fully qualified name of the message by combining the namespace
+     * and simple name. If no namespace is present, returns just the simple name.
+     * 
+     * @return the fully qualified message name in the format "namespace.name" or
+     *         just "name" if no namespace is present
+     */
+    default String getFQNName() {
+        final StringBuilder sb = new StringBuilder();
+        if(getNamespace().isPresent()) {
+            sb.append(getNamespace().get().trim()).append(".");
+        }
+        return sb.append(getName()).toString();
+    }
+}

--- a/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/MessageName.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/MessageName.java
@@ -23,37 +23,34 @@ import java.util.Optional;
  * and the namespace for message types. This interface is typically used for schema formats
  * that support namespaced message types, such as Protocol Buffers, where messages can be organized
  * within packages.
- * 
  */
 public interface MessageName {
 
     /**
      * Returns the simple name of the message without any package qualification.
-     * 
+     *
      * @return the message name
      */
     String getName();
-    
+
     /**
      * Returns the namespace that contains this message, if present.
-     * 
+     *
      * @return an Optional containing the namespace name, or empty if the message
-     *         is not contained within a namespace
+     * is not contained within a namespace
      */
     Optional<String> getNamespace();
-    
+
     /**
      * Returns the fully qualified name of the message by combining the namespace
      * and simple name. If no namespace is present, returns just the simple name.
-     * 
+     *
      * @return the fully qualified message name in the format "namespace.name" or
-     *         just "name" if no namespace is present
+     * just "name" if no namespace is present
      */
     default String getFQNName() {
-        final StringBuilder sb = new StringBuilder();
-        if(getNamespace().isPresent()) {
-            sb.append(getNamespace().get().trim()).append(".");
-        }
-        return sb.append(getName()).toString();
+        return getNamespace()
+            .map(namespace -> namespace.trim() + ".")
+            .orElse("") + getName();
     }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/MessageNameResolver.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/MessageNameResolver.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.schemaregistry.services;
+
+import org.apache.nifi.controller.ControllerService;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A service interface for resolving message names from schema definitions and input streams.
+ * This interface is typically used in scenarios where message types need to be determined
+ * dynamically from the content of the message and the associated schema definition.
+ * <p>
+ * Implementations of this interface can be used to extract or derive message names from
+ * various sources such as message headers, content, or schema metadata, enabling proper
+ * message processing and routing based on the resolved message type.
+ * </p>
+ */
+public interface MessageNameResolver extends ControllerService {
+
+    /**
+     * Resolves and returns the message name based on the provided schema definition and input stream.
+     * <p>
+     * This method analyzes the given schema definition and input stream to determine the appropriate
+     * message name. The resolution strategy depends on the specific implementation and may involve
+     * parsing message headers, analyzing message content, or consulting schema metadata.
+     * </p>
+     *
+     * @param schemaDefinition the schema definition containing schema information and metadata
+     * @param inputStream the input stream containing the message data to analyze
+     * @return the resolved message name encapsulating the determined message type
+     * @throws IOException if an I/O error occurs while reading from the input stream or processing the schema
+     */
+    MessageName getMessageName(final SchemaDefinition schemaDefinition, final InputStream inputStream) throws IOException;
+}

--- a/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/SchemaDefinition.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/SchemaDefinition.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.schemaregistry.services;
+
+import org.apache.nifi.serialization.record.SchemaIdentifier;
+
+import java.util.Map;
+
+/**
+ * This acts as a data container for schema information retrieved from various schema registries.
+ */
+public interface SchemaDefinition {
+
+    enum SchemaType {
+        AVRO,
+        PROTOBUF,
+        JSON
+    }
+
+    /**
+     * @return the type of schema (e.g., AVRO, PROTOBUF, JSON, XML, OTHER)
+     */
+    SchemaType getSchemaType();
+
+    /**
+     * @return the unique identifier for this schema
+     */
+    SchemaIdentifier identifier();
+
+    /**
+     * @return the textual representation of the schema (e.g., Avro schema JSON, Protobuf definition)
+     */
+    String text();
+
+    /**
+     * @return a map of schema references where the key is the name by which the schema is referenced
+     *         from its parent, and the value is the referenced schema definition
+     */
+    default Map<String, SchemaDefinition> getReferences() {
+        return Map.of();
+    }
+}

--- a/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/SchemaRegistry.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/SchemaRegistry.java
@@ -45,4 +45,32 @@ public interface SchemaRegistry extends ControllerService {
      * @return the set of all Schema Fields that are supplied by the RecordSchema that is returned from {@link #retrieveSchema(SchemaIdentifier)}
      */
     Set<SchemaField> getSuppliedSchemaFields();
+
+    /**
+     * Retrieves the raw schema definition including its textual representation and references.
+     * <p>
+     * This method is used to retrieve the complete schema definition structure, including the raw schema text
+     * and any schema references. Unlike {@link #retrieveSchema(SchemaIdentifier)}, which returns a parsed
+     * {@link RecordSchema} ready for immediate use, this method returns a {@link SchemaDefinition} containing
+     * the raw schema content that can be used for custom schema processing, compilation, or when schema
+     * references need to be resolved.
+     * </p>
+     * <p>
+     * This method is particularly useful for:
+     * <ul>
+     *   <li>Processing schemas that reference other schemas (e.g., Protocol Buffers with imports)</li>
+     *   <li>Custom schema compilation workflows where the raw schema text is needed</li>
+     *   <li>Accessing schema metadata and references for advanced schema processing</li>
+     * </ul>
+     * </p>
+     *
+     * @param schemaIdentifier the schema identifier containing id, name, version, and optionally branch information
+     * @return a {@link SchemaDefinition} containing the raw schema text, type, identifier, and references
+     * @throws IOException if unable to communicate with the backing store
+     * @throws SchemaNotFoundException if unable to find the schema based on the given identifier
+     * @throws UnsupportedOperationException if the schema registry implementation does not support raw schema retrieval
+     */
+    default SchemaDefinition retrieveSchemaRaw(SchemaIdentifier schemaIdentifier) throws IOException, SchemaNotFoundException {
+        throw new UnsupportedOperationException("retrieveSchemaRaw is not supported by this SchemaRegistry implementation");
+    }
 }

--- a/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/StandardMessageName.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/StandardMessageName.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.schemaregistry.services;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class StandardMessageName implements MessageName {
+
+    private final String name;
+    private final String namespace;
+
+    public StandardMessageName(final String namespace, final String name) {
+        this.name = Objects.requireNonNull(name, "name must not be null");
+        this.namespace = namespace == null ? null : namespace.trim();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Optional<String> getNamespace() {
+        return Optional.ofNullable(namespace);
+    }
+
+    @Override
+    public final boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof final StandardMessageName that)) {
+            return false;
+        }
+
+        return name.equals(that.name) && namespace.equals(that.namespace);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + namespace.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "StandardMessageName{" +
+            "name='" + name + '\'' +
+            ", namespace=" + namespace +
+            '}';
+    }
+}

--- a/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/StandardSchemaDefinition.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/StandardSchemaDefinition.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.schemaregistry.services;
+
+import org.apache.nifi.serialization.record.SchemaIdentifier;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Simple implementation of SchemaDefinition that holds a schema identifier, text, and references.
+ */
+public class StandardSchemaDefinition implements SchemaDefinition {
+    
+    private final SchemaIdentifier identifier;
+    private final String text;
+    private final Map<String, SchemaDefinition> references;
+    private final SchemaType schemaType;
+
+    /**
+     * Creates a new StandardSchemaDefinition.
+     *
+     * @param identifier the schema identifier
+     * @param text the schema text content
+     * @param references map of schema references (key = reference name, value = referenced schema)
+     */
+    public StandardSchemaDefinition(final SchemaIdentifier identifier,
+                                    final String text,
+                                    final SchemaType schemaType,
+                                    final Map<String, SchemaDefinition> references
+
+    ) {
+        this.identifier = Objects.requireNonNull(identifier, "Schema identifier cannot be null");
+        this.text = Objects.requireNonNull(text, "Schema text cannot be null");
+        this.references = references != null ? Map.copyOf(references) : Map.of();
+        this.schemaType = schemaType;
+    }
+
+    /**
+     * Creates a new StandardSchemaDefinition without references.
+     *
+     * @param identifier the schema identifier
+     * @param text the schema text content
+     */
+    public StandardSchemaDefinition(final SchemaIdentifier identifier, final String text, final SchemaType schemaType) {
+        this(identifier, text, schemaType, null);
+    }
+
+    @Override
+    public SchemaType getSchemaType() {
+        return schemaType;
+    }
+
+    @Override
+    public SchemaIdentifier identifier() {
+        return identifier;
+    }
+
+    @Override
+    public String text() {
+        return text;
+    }
+
+    @Override
+    public Map<String, SchemaDefinition> getReferences() {
+        return references;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final StandardSchemaDefinition that = (StandardSchemaDefinition) o;
+        return Objects.equals(identifier, that.identifier) &&
+               Objects.equals(text, that.text) &&
+               Objects.equals(references, that.references);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier, text, references);
+    }
+
+    @Override
+    public String toString() {
+        return "StandardSchemaDefinition{" +
+               "identifier=" + identifier +
+               ", text='" + text + '\'' +
+               ", references=" + references.keySet() +
+               '}';
+    }
+} 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/StandardSchemaDefinition.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-schema-registry-service-api/src/main/java/org/apache/nifi/schemaregistry/services/StandardSchemaDefinition.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  * Simple implementation of SchemaDefinition that holds a schema identifier, text, and references.
  */
 public class StandardSchemaDefinition implements SchemaDefinition {
-    
+
     private final SchemaIdentifier identifier;
     private final String text;
     private final Map<String, SchemaDefinition> references;
@@ -35,7 +35,7 @@ public class StandardSchemaDefinition implements SchemaDefinition {
      * Creates a new StandardSchemaDefinition.
      *
      * @param identifier the schema identifier
-     * @param text the schema text content
+     * @param text       the schema text content
      * @param references map of schema references (key = reference name, value = referenced schema)
      */
     public StandardSchemaDefinition(final SchemaIdentifier identifier,
@@ -54,7 +54,7 @@ public class StandardSchemaDefinition implements SchemaDefinition {
      * Creates a new StandardSchemaDefinition without references.
      *
      * @param identifier the schema identifier
-     * @param text the schema text content
+     * @param text       the schema text content
      */
     public StandardSchemaDefinition(final SchemaIdentifier identifier, final String text, final SchemaType schemaType) {
         this(identifier, text, schemaType, null);
@@ -85,9 +85,9 @@ public class StandardSchemaDefinition implements SchemaDefinition {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final StandardSchemaDefinition that = (StandardSchemaDefinition) o;
-        return Objects.equals(identifier, that.identifier) &&
-               Objects.equals(text, that.text) &&
-               Objects.equals(references, that.references);
+        return Objects.equals(identifier, that.identifier)
+                && Objects.equals(text, that.text)
+                && Objects.equals(references, that.references);
     }
 
     @Override
@@ -98,9 +98,9 @@ public class StandardSchemaDefinition implements SchemaDefinition {
     @Override
     public String toString() {
         return "StandardSchemaDefinition{" +
-               "identifier=" + identifier +
-               ", text='" + text + '\'' +
-               ", references=" + references.keySet() +
-               '}';
+                "identifier=" + identifier +
+                ", text='" + text + '\'' +
+                ", references=" + references.keySet() +
+                '}';
     }
-} 
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
