### PR TITLE
NIFI-14765 Correct Authorizable Lookup for Nested Controller Objects

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/StandardAuthorizableLookup.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/authorization/StandardAuthorizableLookup.java
@@ -591,6 +591,23 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
                         return new OperationAuthorizable(getAccessPolicy(baseResourceType, resource));
                 }
 
+            case Controller:
+                // Handle Nested Resource Types such as Flow Analysis Rules and Flow Registry Clients
+                final ResourceType nestedResourceType;
+                if (resource.startsWith(ResourceType.RegistryClient.getValue())) {
+                    nestedResourceType = ResourceType.RegistryClient;
+                } else if (resource.startsWith(ResourceType.FlowAnalysisRule.getValue())) {
+                    nestedResourceType = ResourceType.FlowAnalysisRule;
+                } else {
+                    nestedResourceType = null;
+                }
+
+                if (nestedResourceType == null) {
+                    return getAccessPolicy(resourceType, resource);
+                } else {
+                    final String componentId = StringUtils.substringAfter(resource, nestedResourceType.getValue()).substring(1);
+                    return getAccessPolicyByResource(nestedResourceType, componentId);
+                }
             case RestrictedComponents:
                 final String slashRequiredPermission = StringUtils.substringAfter(resource, resourceType.getValue());
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/authorization/StandardAuthorizableLookupTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/authorization/StandardAuthorizableLookupTest.java
@@ -22,13 +22,18 @@ import org.apache.nifi.authorization.resource.DataAuthorizable;
 import org.apache.nifi.authorization.resource.DataTransferAuthorizable;
 import org.apache.nifi.authorization.resource.OperationAuthorizable;
 import org.apache.nifi.authorization.resource.ProvenanceDataAuthorizable;
+import org.apache.nifi.controller.FlowAnalysisRuleNode;
 import org.apache.nifi.controller.ProcessorNode;
 import org.apache.nifi.nar.ExtensionDiscoveringManager;
 import org.apache.nifi.nar.ExtensionManager;
+import org.apache.nifi.registry.flow.FlowRegistryClientNode;
 import org.apache.nifi.web.controller.ControllerFacade;
+import org.apache.nifi.web.dao.FlowAnalysisRuleDAO;
+import org.apache.nifi.web.dao.FlowRegistryDAO;
 import org.apache.nifi.web.dao.ProcessorDAO;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -36,20 +41,11 @@ import static org.mockito.Mockito.when;
 
 public class StandardAuthorizableLookupTest {
 
+    private static final String COMPONENT_ID = "id";
+
     @Test
-    public void testGetAuthorizableFromResource() {
-        final ExtensionManager extensionManager = mock(ExtensionDiscoveringManager.class);
-        final ControllerFacade controllerFacade = mock(ControllerFacade.class);
-        when(controllerFacade.getExtensionManager()).thenReturn(extensionManager);
-
-        final ProcessorDAO processorDAO = mock(ProcessorDAO.class);
-        final ProcessorNode processorNode = mock(ProcessorNode.class);
-
-        when(processorDAO.getProcessor(eq("id"))).thenReturn(processorNode);
-
-        final StandardAuthorizableLookup lookup = new StandardAuthorizableLookup();
-        lookup.setProcessorDAO(processorDAO);
-        lookup.setControllerFacade(controllerFacade);
+    void testGetAuthorizableFromResource() {
+        final StandardAuthorizableLookup lookup = getLookup();
 
         Authorizable authorizable = lookup.getAuthorizableFromResource("/processors/id");
         assertInstanceOf(ProcessorNode.class, authorizable);
@@ -73,5 +69,52 @@ public class StandardAuthorizableLookupTest {
         authorizable = lookup.getAuthorizableFromResource("/operation/processors/id");
         assertInstanceOf(OperationAuthorizable.class, authorizable);
         assertInstanceOf(ProcessorNode.class, ((OperationAuthorizable) authorizable).getBaseAuthorizable());
+    }
+
+    @Test
+    void testGetAuthorizableFromResourceController() {
+        final StandardAuthorizableLookup lookup = getLookup();
+
+        final Authorizable authorizable = lookup.getAuthorizableFromResource("/controller");
+        assertInstanceOf(ControllerFacade.class, authorizable);
+    }
+
+    @Test
+    void testGetAuthorizableFromResourceRegistryClient() {
+        final StandardAuthorizableLookup lookup = getLookup();
+        final FlowRegistryDAO flowRegistryDAO = mock(FlowRegistryDAO.class);
+        final FlowRegistryClientNode flowRegistryClientNode = mock(FlowRegistryClientNode.class);
+        when(flowRegistryDAO.getFlowRegistryClient(eq(COMPONENT_ID))).thenReturn(flowRegistryClientNode);
+        lookup.setFlowRegistryDAO(flowRegistryDAO);
+
+        final Authorizable authorizable = lookup.getAuthorizableFromResource("/controller/registry-clients/id");
+        assertEquals(flowRegistryClientNode, authorizable);
+    }
+
+    @Test
+    void testGetAuthorizableFromResourceFlowAnalysisRule() {
+        final StandardAuthorizableLookup lookup = getLookup();
+        final FlowAnalysisRuleDAO flowAnalysisRuleDAO = mock(FlowAnalysisRuleDAO.class);
+        final FlowAnalysisRuleNode flowAnalysisRuleNode = mock(FlowAnalysisRuleNode.class);
+        when(flowAnalysisRuleDAO.getFlowAnalysisRule(eq(COMPONENT_ID))).thenReturn(flowAnalysisRuleNode);
+        lookup.setFlowAnalysisRuleDAO(flowAnalysisRuleDAO);
+
+        final Authorizable authorizable = lookup.getAuthorizableFromResource("/controller/flow-analysis-rules/id");
+        assertEquals(flowAnalysisRuleNode, authorizable);
+    }
+
+    private StandardAuthorizableLookup getLookup() {
+        final ExtensionManager extensionManager = mock(ExtensionDiscoveringManager.class);
+        final ControllerFacade controllerFacade = mock(ControllerFacade.class);
+        when(controllerFacade.getExtensionManager()).thenReturn(extensionManager);
+
+        final ProcessorDAO processorDAO = mock(ProcessorDAO.class);
+        final ProcessorNode processorNode = mock(ProcessorNode.class);
+        when(processorDAO.getProcessor(eq(COMPONENT_ID))).thenReturn(processorNode);
+
+        final StandardAuthorizableLookup lookup = new StandardAuthorizableLookup();
+        lookup.setProcessorDAO(processorDAO);
+        lookup.setControllerFacade(controllerFacade);
+        return lookup;
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-14765](https://issues.apache.org/jira/browse/NIFI-14765) Corrects the Authorizable Lookup handling for Registry Clients and Flow Analysis Rules, which are nested under the Controller Resource Type.

Loading and editing Access Policies includes resolving entries defined in persisted authorization configuration. The introduction of nested Registry Clients and Flow Analysis Rules as Authorizable objects under the parent Controller Resource supports optional fine-grained authorization for individual instances of these components, but also supports inheriting existing policies defined at the Controller level. Although the initial implementation supported enforcement, defining nested policies for either of these objects resulted in policy resolution errors that prevented the Access Policies screen from loading when using the Managed Authorizer.

Updates to the `StandardAuthorizableLookup` class check for the presence of either Registry Clients or Flow Analysis Rules in the resource path, and then delegate resolution based on the presence or absence of the nested Resource Type.

Updates to the associated unit test exercise these changes and verify the expected type of Authorizable object returned.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
