### PR TITLE
NIFI-14768 Upgrade Reactor Netty HTTP to 1.2.8

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -85,11 +85,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <!-- Reactor Netty client 1.0.34 from Azure Identity -->
+            <!-- Override Reactor Netty client 1.0.48 from azure-core-netty-http -->
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.2.7</version>
+                <version>1.2.8</version>
             </dependency>
             <!-- SSHD from Registry and other modules -->
             <dependency>

--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -75,6 +75,12 @@
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>${nimbus-jose-jwt.version}</version>
             </dependency>
+            <!-- Override Reactor Core Netty from azure-core-netty-http -->
+            <dependency>
+                <groupId>io.projectreactor.netty</groupId>
+                <artifactId>reactor-netty-http</artifactId>
+                <version>1.2.8</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
# Summary

[NIFI-14768](https://issues.apache.org/jira/browse/NIFI-14768) Upgrades Reactor Netty HTTP to [1.2.8](https://github.com/reactor/reactor-netty/releases/tag/v1.2.8) for the Azure Core HTTP Netty library to resolve associated issues including CVE-2025-22227.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
