### PR TITLE
NIFI-14771 Removed redundant public static final modifiers from interface fields

### DIFF
--- a/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/VariableImpact.java
+++ b/nifi-commons/nifi-expression-language/src/main/java/org/apache/nifi/attribute/expression/language/VariableImpact.java
@@ -20,7 +20,7 @@ package org.apache.nifi.attribute.expression.language;
 public interface VariableImpact {
     boolean isImpacted(String variableName);
 
-    public static final VariableImpact NEVER_IMPACTED = var -> false;
+    VariableImpact NEVER_IMPACTED = var -> false;
 
-    public static final VariableImpact ALWAYS_IMPACTED = var -> true;
+    VariableImpact ALWAYS_IMPACTED = var -> true;
 }

--- a/nifi-commons/nifi-hl7-query-language/src/main/java/org/apache/nifi/hl7/query/evaluator/Evaluator.java
+++ b/nifi-commons/nifi-hl7-query-language/src/main/java/org/apache/nifi/hl7/query/evaluator/Evaluator.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 public interface Evaluator<T> {
 
-    public static final String MESSAGE_KEY = "message";
+    String MESSAGE_KEY = "message";
 
     T evaluate(Map<String, Object> objectMap);
 

--- a/nifi-commons/nifi-write-ahead-log/src/main/java/org/wali/SyncListener.java
+++ b/nifi-commons/nifi-write-ahead-log/src/main/java/org/wali/SyncListener.java
@@ -60,7 +60,7 @@ public interface SyncListener {
      */
     void onGlobalSync();
 
-    public static final SyncListener NOP_SYNC_LISTENER = new SyncListener() {
+    SyncListener NOP_SYNC_LISTENER = new SyncListener() {
         @Override
         public void onSync(int partitionIndex) {
         }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/FileTransfer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-file-transfer/src/main/java/org/apache/nifi/processor/util/file/transfer/FileTransfer.java
@@ -71,21 +71,21 @@ public interface FileTransfer extends Closeable {
         return absoluteRemotePath.replace("\\", "/");
     }
 
-    public static final PropertyDescriptor HOSTNAME = new PropertyDescriptor.Builder()
+    PropertyDescriptor HOSTNAME = new PropertyDescriptor.Builder()
         .name("Hostname")
         .description("The fully qualified hostname or IP address of the remote system")
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .required(true)
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
-    public static final PropertyDescriptor USERNAME = new PropertyDescriptor.Builder()
+    PropertyDescriptor USERNAME = new PropertyDescriptor.Builder()
         .name("Username")
         .description("Username")
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .required(true)
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
-    public static final PropertyDescriptor PASSWORD = new PropertyDescriptor.Builder()
+    PropertyDescriptor PASSWORD = new PropertyDescriptor.Builder()
         .name("Password")
         .description("Password for the user account")
         .addValidator(Validator.VALID)
@@ -93,28 +93,28 @@ public interface FileTransfer extends Closeable {
         .sensitive(true)
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
-    public static final PropertyDescriptor DATA_TIMEOUT = new PropertyDescriptor.Builder()
+    PropertyDescriptor DATA_TIMEOUT = new PropertyDescriptor.Builder()
         .name("Data Timeout")
         .description("When transferring a file between the local and remote system, this value specifies how long is allowed to elapse without any data being transferred between systems")
         .required(true)
         .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
         .defaultValue("30 sec")
         .build();
-    public static final PropertyDescriptor CONNECTION_TIMEOUT = new PropertyDescriptor.Builder()
+    PropertyDescriptor CONNECTION_TIMEOUT = new PropertyDescriptor.Builder()
         .name("Connection Timeout")
         .description("Amount of time to wait before timing out while creating a connection")
         .required(true)
         .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
         .defaultValue("30 sec")
         .build();
-    public static final PropertyDescriptor REMOTE_PATH = new PropertyDescriptor.Builder()
+    PropertyDescriptor REMOTE_PATH = new PropertyDescriptor.Builder()
         .name("Remote Path")
         .description("The path on the remote system from which to pull or push files")
         .required(false)
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
-    public static final PropertyDescriptor CREATE_DIRECTORY = new PropertyDescriptor.Builder()
+    PropertyDescriptor CREATE_DIRECTORY = new PropertyDescriptor.Builder()
         .name("Create Directory")
         .description("Specifies whether or not the remote directory should be created if it does not exist.")
         .required(true)
@@ -122,7 +122,7 @@ public interface FileTransfer extends Closeable {
         .defaultValue("false")
         .build();
 
-    public static final PropertyDescriptor USE_COMPRESSION = new PropertyDescriptor.Builder()
+    PropertyDescriptor USE_COMPRESSION = new PropertyDescriptor.Builder()
         .name("Use Compression")
         .description("Indicates whether or not ZLIB compression should be used when transferring files")
         .allowableValues("true", "false")
@@ -131,14 +131,14 @@ public interface FileTransfer extends Closeable {
         .build();
 
     // GET-specific properties
-    public static final PropertyDescriptor RECURSIVE_SEARCH = new PropertyDescriptor.Builder()
+    PropertyDescriptor RECURSIVE_SEARCH = new PropertyDescriptor.Builder()
         .name("Search Recursively")
         .description("If true, will pull files from arbitrarily nested subdirectories; otherwise, will not traverse subdirectories")
         .required(true)
         .defaultValue("false")
         .allowableValues("true", "false")
         .build();
-    public static final PropertyDescriptor FOLLOW_SYMLINK = new PropertyDescriptor.Builder()
+    PropertyDescriptor FOLLOW_SYMLINK = new PropertyDescriptor.Builder()
         .name("follow-symlink")
         .displayName("Follow symlink")
         .description("If true, will pull even symbolic files and also nested symbolic subdirectories; otherwise, will not read symbolic files and will not traverse symbolic link subdirectories")
@@ -146,26 +146,26 @@ public interface FileTransfer extends Closeable {
         .defaultValue("false")
         .allowableValues("true", "false")
         .build();
-    public static final PropertyDescriptor FILE_FILTER_REGEX = new PropertyDescriptor.Builder()
+    PropertyDescriptor FILE_FILTER_REGEX = new PropertyDescriptor.Builder()
         .name("File Filter Regex")
         .description("Provides a Java Regular Expression for filtering Filenames; if a filter is supplied, only files whose names match that Regular Expression will be fetched")
         .required(false)
         .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
         .build();
-    public static final PropertyDescriptor PATH_FILTER_REGEX = new PropertyDescriptor.Builder()
+    PropertyDescriptor PATH_FILTER_REGEX = new PropertyDescriptor.Builder()
         .name("Path Filter Regex")
         .description("When " + RECURSIVE_SEARCH.getName() + " is true, then only subdirectories whose path matches the given Regular Expression will be scanned")
         .required(false)
         .addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
         .build();
-    public static final PropertyDescriptor MAX_SELECTS = new PropertyDescriptor.Builder()
+    PropertyDescriptor MAX_SELECTS = new PropertyDescriptor.Builder()
         .name("Max Selects")
         .description("The maximum number of files to pull in a single connection")
         .defaultValue("100")
         .required(true)
         .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
         .build();
-    public static final PropertyDescriptor REMOTE_POLL_BATCH_SIZE = new PropertyDescriptor.Builder()
+    PropertyDescriptor REMOTE_POLL_BATCH_SIZE = new PropertyDescriptor.Builder()
         .name("Remote Poll Batch Size")
         .description("The value specifies how many file paths to find in a given directory on the remote system when doing a file listing. This value "
             + "in general should not need to be modified but when polling against a remote system with a tremendous number of files this value can "
@@ -175,28 +175,28 @@ public interface FileTransfer extends Closeable {
         .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
         .required(true)
         .build();
-    public static final PropertyDescriptor DELETE_ORIGINAL = new PropertyDescriptor.Builder()
+    PropertyDescriptor DELETE_ORIGINAL = new PropertyDescriptor.Builder()
         .name("Delete Original")
         .description("Determines whether or not the file is deleted from the remote system after it has been successfully transferred")
         .defaultValue("true")
         .allowableValues("true", "false")
         .required(true)
         .build();
-    public static final PropertyDescriptor POLLING_INTERVAL = new PropertyDescriptor.Builder()
+    PropertyDescriptor POLLING_INTERVAL = new PropertyDescriptor.Builder()
         .name("Polling Interval")
         .description("Determines how long to wait between fetching the listing for new files")
         .addValidator(StandardValidators.TIME_PERIOD_VALIDATOR)
         .required(true)
         .defaultValue("60 sec")
         .build();
-    public static final PropertyDescriptor IGNORE_DOTTED_FILES = new PropertyDescriptor.Builder()
+    PropertyDescriptor IGNORE_DOTTED_FILES = new PropertyDescriptor.Builder()
         .name("Ignore Dotted Files")
         .description("If true, files whose names begin with a dot (\".\") will be ignored")
         .allowableValues("true", "false")
         .defaultValue("true")
         .required(true)
         .build();
-    public static final PropertyDescriptor USE_NATURAL_ORDERING = new PropertyDescriptor.Builder()
+    PropertyDescriptor USE_NATURAL_ORDERING = new PropertyDescriptor.Builder()
         .name("Use Natural Ordering")
         .description("If true, will pull files in the order in which they are naturally listed; otherwise, the order in which the files will be pulled is not defined")
         .allowableValues("true", "false")
@@ -205,34 +205,34 @@ public interface FileTransfer extends Closeable {
         .build();
 
     // PUT-specific properties
-    public static final String FILE_MODIFY_DATE_ATTR_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
+    String FILE_MODIFY_DATE_ATTR_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
 
-    public static final String CONFLICT_RESOLUTION_REPLACE = "REPLACE";
+    String CONFLICT_RESOLUTION_REPLACE = "REPLACE";
     AllowableValue CONFLICT_RESOLUTION_REPLACE_ALLOWABLE =
             new AllowableValue(CONFLICT_RESOLUTION_REPLACE, CONFLICT_RESOLUTION_REPLACE,
                     "Remote file is replaced with new file, FlowFile goes to success");
 
-    public static final String CONFLICT_RESOLUTION_RENAME = "RENAME";
+    String CONFLICT_RESOLUTION_RENAME = "RENAME";
     AllowableValue CONFLICT_RESOLUTION_RENAME_ALLOWABLE =
             new AllowableValue(CONFLICT_RESOLUTION_RENAME, CONFLICT_RESOLUTION_RENAME,
                     "New file is renamed with a one-up number at the beginning, FlowFile goes to success");
 
-    public static final String CONFLICT_RESOLUTION_IGNORE = "IGNORE";
+    String CONFLICT_RESOLUTION_IGNORE = "IGNORE";
     AllowableValue CONFLICT_RESOLUTION_IGNORE_ALLOWABLE =
             new AllowableValue(CONFLICT_RESOLUTION_IGNORE, CONFLICT_RESOLUTION_IGNORE,
                     "File is not transferred, FlowFile goes to success");
 
-    public static final String CONFLICT_RESOLUTION_REJECT = "REJECT";
+    String CONFLICT_RESOLUTION_REJECT = "REJECT";
     AllowableValue CONFLICT_RESOLUTION_REJECT_ALLOWABLE =
             new AllowableValue(CONFLICT_RESOLUTION_REJECT, CONFLICT_RESOLUTION_REJECT,
                     "File is not transferred, FlowFile goes to reject");
 
-    public static final String CONFLICT_RESOLUTION_FAIL = "FAIL";
+    String CONFLICT_RESOLUTION_FAIL = "FAIL";
     AllowableValue CONFLICT_RESOLUTION_FAIL_ALLOWABLE =
             new AllowableValue(CONFLICT_RESOLUTION_FAIL, CONFLICT_RESOLUTION_FAIL,
                     "File is not transferred, FlowFile goes to failure");
 
-    public static final String CONFLICT_RESOLUTION_NONE = "NONE";
+    String CONFLICT_RESOLUTION_NONE = "NONE";
     AllowableValue CONFLICT_RESOLUTION_NONE_ALLOWABLE =
             new AllowableValue(CONFLICT_RESOLUTION_NONE, CONFLICT_RESOLUTION_NONE,
                     "Do not check for conflict before transfer, FlowFile goes to success or failure");
@@ -245,20 +245,20 @@ public interface FileTransfer extends Closeable {
             CONFLICT_RESOLUTION_FAIL_ALLOWABLE,
             CONFLICT_RESOLUTION_NONE_ALLOWABLE};
 
-    public static final PropertyDescriptor CONFLICT_RESOLUTION = new PropertyDescriptor.Builder()
+    PropertyDescriptor CONFLICT_RESOLUTION = new PropertyDescriptor.Builder()
         .name("Conflict Resolution")
         .description("Determines how to handle the problem of filename collisions")
         .required(true)
         .allowableValues(CONFLICT_RESOLUTION_ALLOWABLE_VALUES)
         .defaultValue(CONFLICT_RESOLUTION_NONE_ALLOWABLE)
         .build();
-    public static final PropertyDescriptor REJECT_ZERO_BYTE = new PropertyDescriptor.Builder()
+    PropertyDescriptor REJECT_ZERO_BYTE = new PropertyDescriptor.Builder()
         .name("Reject Zero-Byte Files")
         .description("Determines whether or not Zero-byte files should be rejected without attempting to transfer")
         .allowableValues("true", "false")
         .defaultValue("true")
         .build();
-    public static final PropertyDescriptor DOT_RENAME = new PropertyDescriptor.Builder()
+    PropertyDescriptor DOT_RENAME = new PropertyDescriptor.Builder()
         .name("Dot Rename")
         .description("If true, then the filename of the sent file is prepended with a \".\" and then renamed back to the "
             + "original once the file is completely sent. Otherwise, there is no rename. This property is ignored if the "
@@ -266,7 +266,7 @@ public interface FileTransfer extends Closeable {
         .allowableValues("true", "false")
         .defaultValue("true")
         .build();
-    public static final PropertyDescriptor TEMP_FILENAME = new PropertyDescriptor.Builder()
+    PropertyDescriptor TEMP_FILENAME = new PropertyDescriptor.Builder()
         .name("Temporary Filename")
         .description("If set, the filename of the sent file will be equal to the value specified during the transfer and after successful "
             + "completion will be renamed to the original filename. If this value is set, the Dot Rename property is ignored.")
@@ -274,7 +274,7 @@ public interface FileTransfer extends Closeable {
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .required(false)
         .build();
-    public static final PropertyDescriptor LAST_MODIFIED_TIME = new PropertyDescriptor.Builder()
+    PropertyDescriptor LAST_MODIFIED_TIME = new PropertyDescriptor.Builder()
         .name("Last Modified Time")
         .description("The lastModifiedTime to assign to the file after transferring it. If not set, the lastModifiedTime will not be changed. "
             + "Format must be yyyy-MM-dd'T'HH:mm:ssZ. You may also use expression language such as ${file.lastModifiedTime}. If the value "
@@ -283,7 +283,7 @@ public interface FileTransfer extends Closeable {
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
-    public static final PropertyDescriptor PERMISSIONS = new PropertyDescriptor.Builder()
+    PropertyDescriptor PERMISSIONS = new PropertyDescriptor.Builder()
         .name("Permissions")
         .description("The permissions to assign to the file after transferring it. Format must be either UNIX rwxrwxrwx with a - in place of "
             + "denied permissions (e.g. rw-r--r--) or an octal number (e.g. 644). If not set, the permissions will not be changed. You may "
@@ -293,7 +293,7 @@ public interface FileTransfer extends Closeable {
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
-    public static final PropertyDescriptor REMOTE_OWNER = new PropertyDescriptor.Builder()
+    PropertyDescriptor REMOTE_OWNER = new PropertyDescriptor.Builder()
         .name("Remote Owner")
         .description("Integer value representing the User ID to set on the file after transferring it. If not set, the owner will not be set. "
             + "You may also use expression language such as ${file.owner}. If the value is invalid, the processor will not be invalid but "
@@ -302,7 +302,7 @@ public interface FileTransfer extends Closeable {
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
-    public static final PropertyDescriptor REMOTE_GROUP = new PropertyDescriptor.Builder()
+    PropertyDescriptor REMOTE_GROUP = new PropertyDescriptor.Builder()
         .name("Remote Group")
         .description("Integer value representing the Group ID to set on the file after transferring it. If not set, the group will not be set. "
             + "You may also use expression language such as ${file.group}. If the value is invalid, the processor will not be invalid but "
@@ -311,7 +311,7 @@ public interface FileTransfer extends Closeable {
         .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
         .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
         .build();
-    public static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
+    PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
         .name("Batch Size")
         .description("The maximum number of FlowFiles to send in a single connection")
         .required(true)

--- a/nifi-framework-api/src/main/java/org/apache/nifi/controller/Triggerable.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/controller/Triggerable.java
@@ -25,7 +25,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 
 public interface Triggerable {
 
-    public static final long MINIMUM_SCHEDULING_NANOS = 1L;
+    long MINIMUM_SCHEDULING_NANOS = 1L;
 
     /**
      * <p>

--- a/nifi-framework-api/src/main/java/org/apache/nifi/events/EventReporter.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/events/EventReporter.java
@@ -27,10 +27,7 @@ public interface EventReporter extends Serializable {
     /**
      * An Event Reporter that performs no action and ignores all given input
      */
-    public static final EventReporter NO_OP = new EventReporter() {
-        @Override
-        public void reportEvent(Severity severity, String category, String message) {
-        }
+    EventReporter NO_OP = (severity, category, message) -> {
     };
 
     void reportEvent(Severity severity, String category, String message);

--- a/nifi-framework-api/src/main/java/org/apache/nifi/provenance/IdentifierLookup.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/provenance/IdentifierLookup.java
@@ -64,7 +64,7 @@ public interface IdentifierLookup {
     }
 
 
-    public static final IdentifierLookup EMPTY = new IdentifierLookup() {
+    IdentifierLookup EMPTY = new IdentifierLookup() {
         @Override
         public List<String> getComponentIdentifiers() {
             return Collections.emptyList();

--- a/nifi-framework-api/src/main/java/org/apache/nifi/web/ViewableContent.java
+++ b/nifi-framework-api/src/main/java/org/apache/nifi/web/ViewableContent.java
@@ -24,9 +24,9 @@ import java.io.InputStream;
  */
 public interface ViewableContent {
 
-    public static final String CONTENT_REQUEST_ATTRIBUTE = "org.apache.nifi.web.content";
+    String CONTENT_REQUEST_ATTRIBUTE = "org.apache.nifi.web.content";
 
-    public enum DisplayMode {
+    enum DisplayMode {
 
         Original,
         Formatted,

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/authorization/EventAuthorizer.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/authorization/EventAuthorizer.java
@@ -72,7 +72,7 @@ public interface EventAuthorizer {
             .collect(Collectors.toSet());
     }
 
-    public static final EventAuthorizer GRANT_ALL = new EventAuthorizer() {
+    EventAuthorizer GRANT_ALL = new EventAuthorizer() {
         @Override
         public boolean isAuthorized(ProvenanceEventRecord event) {
             return true;
@@ -93,7 +93,7 @@ public interface EventAuthorizer {
         }
     };
 
-    public static final EventAuthorizer DENY_ALL = new EventAuthorizer() {
+    EventAuthorizer DENY_ALL = new EventAuthorizer() {
         @Override
         public boolean isAuthorized(ProvenanceEventRecord event) {
             return false;

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/authorization/EventTransformer.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/nifi-persistent-provenance-repository/src/main/java/org/apache/nifi/provenance/authorization/EventTransformer.java
@@ -32,11 +32,11 @@ public interface EventTransformer {
     /**
      * An EventTransformer that transforms any event into an Empty Optional
      */
-    public static final EventTransformer EMPTY_TRANSFORMER = event -> Optional.empty();
+    EventTransformer EMPTY_TRANSFORMER = event -> Optional.empty();
 
     /**
      * An EventTransformer that transforms any event into a Placeholder event
      */
-    public static final EventTransformer PLACEHOLDER_TRANSFORMER = event -> Optional.of(new PlaceholderProvenanceEvent(event));
+    EventTransformer PLACEHOLDER_TRANSFORMER = event -> Optional.of(new PlaceholderProvenanceEvent(event));
 
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/FlowSerializer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/FlowSerializer.java
@@ -26,8 +26,8 @@ import org.apache.nifi.controller.FlowController;
  */
 public interface FlowSerializer<T> {
 
-    public static final String ENC_PREFIX = "enc{";
-    public static final String ENC_SUFFIX = "}";
+    String ENC_PREFIX = "enc{";
+    String ENC_SUFFIX = "}";
 
     /**
      * Transforms the flow configuration of a controller instance into something that can serialized


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14771](https://issues.apache.org/jira/browse/NIFI-14771)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
