### PR TITLE
NIFI-14776 - Rename Catalog property in PutDatabaseRecord

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutDatabaseRecord.java
@@ -228,9 +228,12 @@ public class PutDatabaseRecord extends AbstractProcessor {
 
     static final PropertyDescriptor CATALOG_NAME = new Builder()
             .name("put-db-record-catalog-name")
-            .displayName("Catalog Name")
-            .description("The name of the catalog that the statement should update. This may not apply for the database that you are updating. In this case, leave the field empty. Note that if the "
-                    + "property is set and the database is case-sensitive, the catalog name must match the database's catalog name exactly.")
+            .displayName("Database Name")
+            .description("""
+                    The name of the database (or the name of the catalog, depending on the destination system) that the statement should update. This may not apply
+                    for the database that you are updating. In this case, leave the field empty. Note that if the  property is set and the database is case-sensitive,
+                    the catalog name must match the database's catalog name exactly.
+                    """)
             .required(false)
             .expressionLanguageSupported(FLOWFILE_ATTRIBUTES)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)


### PR DESCRIPTION
# Summary

[NIFI-14776](https://issues.apache.org/jira/browse/NIFI-14776) - Rename Catalog property in PutDatabaseRecord

We currently have a "Catalog Name" property in PutDatabaseRecord and while this is technically correct from a JDBC point of view, this can confuse people/users and they would not understand that, in most cases, that would be the property where the database name is specified. I suggest renaming this property to Database Name in order to be more user friendly and to adjust the description to mention the catalog aspect.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
