### PR TITLE
NIFI-14170: Fix WebSocket NullPointerExceptions

### DIFF
--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketServer.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketServer.java
@@ -235,7 +235,9 @@ public class JettyWebSocketServer extends AbstractJettyWebSocketService implemen
         @Override
         public Object createWebSocket(JettyServerUpgradeRequest servletUpgradeRequest, JettyServerUpgradeResponse servletUpgradeResponse) {
             final URI requestURI = servletUpgradeRequest.getRequestURI();
-            final int port = ((InetSocketAddress) servletUpgradeRequest.getLocalSocketAddress()).getPort();
+
+
+            final int port = getPort(servletUpgradeRequest);
             final JettyWebSocketServer service = portToControllerService.get(port);
 
             if (service == null) {
@@ -252,6 +254,21 @@ public class JettyWebSocketServer extends AbstractJettyWebSocketService implemen
 
             return new RoutingWebSocketListener(router);
         }
+    }
+
+    private static int getPort(JettyServerUpgradeRequest servletUpgradeRequest) {
+        final Object localSocketAddress = servletUpgradeRequest.getLocalSocketAddress();
+        if (localSocketAddress == null) {
+            throw new RuntimeException("Local socket address is null");
+        }
+
+        // Check if the local socket address is an instance of InetSocketAddress
+        if (!(localSocketAddress instanceof InetSocketAddress)) {
+            throw new RuntimeException("Local socket address is not an instance of InetSocketAddress: " + localSocketAddress.getClass().getName());
+        }
+
+        final int port = ((InetSocketAddress) localSocketAddress).getPort();
+        return port;
     }
 
     @OnEnabled

--- a/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketSession.java
+++ b/nifi-extension-bundles/nifi-websocket-bundle/nifi-websocket-services-jetty/src/main/java/org/apache/nifi/websocket/jetty/JettyWebSocketSession.java
@@ -66,7 +66,12 @@ public class JettyWebSocketSession extends AbstractWebSocketSession {
 
     @Override
     public boolean isSecure() {
-        return session.isSecure();
+        try {
+            return session.isSecure();
+        } catch (NullPointerException e) {
+            // Handle the case where ServletApiRequest.getRequest() returns null
+            return false;
+        }
     }
 
 }


### PR DESCRIPTION


<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14170](https://issues.apache.org/jira/browse/NIFI-14170)

Fixed three different NullPointerExceptions in the WebSocket implementation:

1. In AbstractWebSocketGatewayProcessor:
   - Added null checks for local and remote addresses in enqueueMessage method
   - Used fallback value "unknown" when addresses are null

2. In JettyWebSocketServer:
   - Added proper null and type checking for localSocketAddress
   - Added descriptive error messages for failure cases

3. In JettyWebSocketSession:
   - Added try-catch for NullPointerException in isSecure method
   - Returns false when exception occurs

These changes improve robustness by handling edge cases where socket addresses might be null or when the session's secure status can't be determined.
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
