### PR TITLE
NIFI-14781: Adding ParameterProvider support in resolving compatible …

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/BundleUtils.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/BundleUtils.java
@@ -18,6 +18,7 @@ package org.apache.nifi.util;
 
 import org.apache.nifi.bundle.Bundle;
 import org.apache.nifi.bundle.BundleCoordinate;
+import org.apache.nifi.flow.ParameterProviderReference;
 import org.apache.nifi.flow.VersionedConfigurableExtension;
 import org.apache.nifi.flow.VersionedProcessGroup;
 import org.apache.nifi.flow.VersionedReportingTaskSnapshot;
@@ -27,6 +28,7 @@ import org.apache.nifi.nar.PythonBundle;
 import org.apache.nifi.web.api.dto.BundleDTO;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -238,6 +240,19 @@ public final class BundleUtils {
         if (reportingTaskSnapshot.getControllerServices() != null) {
             reportingTaskSnapshot.getControllerServices().forEach(controllerService -> discoverCompatibleBundle(extensionManager, controllerService));
         }
+    }
+
+    public static void discoverCompatibleBundles(final ExtensionManager extensionManager, final Map<String, ParameterProviderReference> parameterProviders) {
+        if (parameterProviders != null) {
+            parameterProviders.values().forEach(parameterProvider -> discoverCompatibleBundle(extensionManager, parameterProvider));
+        }
+    }
+
+    public static void discoverCompatibleBundle(final ExtensionManager extensionManager, final ParameterProviderReference parameterProviderReference) {
+        final BundleDTO dto = createBundleDto(parameterProviderReference.getBundle());
+        final BundleCoordinate coordinate = getOptionalCompatibleBundle(extensionManager, parameterProviderReference.getType(), dto).orElse(
+                new BundleCoordinate(dto.getGroup(), dto.getArtifact(), dto.getVersion()));
+        parameterProviderReference.setBundle(createBundle(coordinate));
     }
 
     public static void discoverCompatibleBundle(final ExtensionManager extensionManager, final VersionedConfigurableExtension extension) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/NiFiServiceFacade.java
@@ -2783,6 +2783,14 @@ public interface NiFiServiceFacade {
     void discoverCompatibleBundles(VersionedProcessGroup versionedGroup);
 
     /**
+     * Discovers the compatible bundle details for the components in the specified Parameter Providers and updates them
+     * to reflect the appropriate bundles.
+     *
+     * @param parameterProviders the parameter provider map
+     */
+    void discoverCompatibleBundles(Map<String, ParameterProviderReference> parameterProviders);
+
+    /**
      * Discovers the compatible bundle details for the components in the specified snapshot and updates the snapshot to reflect the appropriate bundles.
      *
      * @param reportingTaskSnapshot the snapshot

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -4108,6 +4108,10 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         BundleUtils.discoverCompatibleBundles(controllerFacade.getExtensionManager(), versionedGroup);
     }
 
+    public void discoverCompatibleBundles(final Map<String, ParameterProviderReference> parameterProviders) {
+        BundleUtils.discoverCompatibleBundles(controllerFacade.getExtensionManager(), parameterProviders);
+    }
+
     @Override
     public void discoverCompatibleBundles(final VersionedReportingTaskSnapshot reportingTaskSnapshot) {
         BundleUtils.discoverCompatibleBundles(controllerFacade.getExtensionManager(), reportingTaskSnapshot);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowUpdateResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/FlowUpdateResource.java
@@ -193,6 +193,7 @@ public abstract class FlowUpdateResource<T extends ProcessGroupDescriptorEntity,
         // The new flow may not contain the same versions of components in existing flow. As a result, we need to update
         // the flow snapshot to contain compatible bundles.
         serviceFacade.discoverCompatibleBundles(flowSnapshot.getFlowContents());
+        serviceFacade.discoverCompatibleBundles(flowSnapshot.getParameterProviders());
 
         // If there are any Controller Services referenced that are inherited from the parent group, resolve those to point to the appropriate Controller Service, if we are able to.
         final Set<String> unresolvedControllerServices = serviceFacade.resolveInheritedControllerServices(flowSnapshotContainer, groupId, user);


### PR DESCRIPTION
…bundles during PG replace-request

# Summary

To validate, start with a fresh NiFi instance, set the admin password, and start up NiFi.
Create a process group, and enter it.  Copy the process group ID from the URL.

Download the following process group replacement entity: 
[NiFi_Flow.json](https://github.com/user-attachments/files/21395687/NiFi_Flow.json)

```
# In the directory where NiFi_Flow.json is located...
PASSWORD=<your NiFi password>
TOKEN=$(curl -k -s -X POST "https://localhost:8443/nifi-api/access/token" \
    -H "Content-Type: application/x-www-form-urlencoded" \
    -d "username=admin&password=$PASSWORD")

PROCESS_GROUP_ID=<The copied process group ID>
curl -k -X POST https://localhost:8443/nifi-api/process-groups/$PROCESS_GROUP_ID/replace-requests  \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -d @NiFi_Flow.json

# If necessary, you can grab the latest revision from https://localhost:8443/nifi-api/flow/process-groups/$PROCESS_GROUP_ID?uiOnly=true to specify the next version in the NiFi_Flow.json.
```

The POST command should result in a parameter provider being successfully created, despite it being saved as version 2.5.0-SNAPSHOT in NiFi_Flow.json.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
