### PR TITLE
NIFI-14772 Fix System Test for components recreated

### DIFF
--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/FlowSynchronizationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/FlowSynchronizationIT.java
@@ -449,13 +449,14 @@ public class FlowSynchronizationIT extends NiFiSystemIT {
         getClientUtil().updateReportingTaskProperties(reportingTask, reportingTaskProperties);
 
         // Start everything up on Node 1.
-        getClientUtil().enableControllerService(countService);
         getClientUtil().enableControllerService(sleepService);
+        getClientUtil().enableControllerService(countService);
         getClientUtil().startReportingTask(reportingTask);
         getClientUtil().waitForValidProcessor(count.getId()); // Now that service was enabled, wait for processor to become valid.
         getClientUtil().startProcessGroupComponents(group.getId());
         getClientUtil().startProcessor(terminate);
         getClientUtil().startProcessor(generate);
+        getClientUtil().waitForProcessorState(count.getId(), RUNNING_STATE);
 
         // Stop & restart Node 2.
         getNiFiInstance().getNodeInstance(2).stop();


### PR DESCRIPTION
# Summary

[NIFI-14772](https://issues.apache.org/jira/browse/NIFI-14772) Improves the behavior of the system test `FlowSynchronizationIT.testComponentsRecreatedOnRestart()` by waiting for the Count Processor to be running before stopping node 2.

Part of the current problem is that is that the dependent `StandardCountService` cannot be disabled because the Count Processor is still running. Waiting for the Processor to reach the `RUNNING` state on the cluster ensures that both nodes are synchronized before stopping node 2 and proceeding with the rest of the test method.

Initial evaluation resulted in a successful run, although additional changes may be necessary if the test continues to fail intermittently.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
