### PR TITLE
NIFI-14785 Handle exception or null responses from fetching node stat…

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/StandardClusterDetailsFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/StandardClusterDetailsFactory.java
@@ -55,7 +55,20 @@ public class StandardClusterDetailsFactory implements ClusterDetailsFactory {
             connectionStatus = clusterCoordinator.getConnectionStatus(nodeIdentifier);
         } else {
             logger.debug("Fetching Connection Status for Node Identifier {} from Cluster Coordinator", nodeIdentifier.getId());
-            connectionStatus = clusterCoordinator.fetchConnectionStatus(nodeIdentifier);
+            NodeConnectionStatus fetchedConnectionStatus;
+            try {
+                fetchedConnectionStatus = clusterCoordinator.fetchConnectionStatus(nodeIdentifier);
+            } catch (final Exception e) {
+                logger.debug("Failed to fetch Connection Status for Node Identifier {} from Cluster Coordinator", nodeIdentifier.getId(), e);
+                fetchedConnectionStatus = null;
+            }
+
+            if (fetchedConnectionStatus == null) {
+                logger.debug("Fetched Connection Status for Node Identifier {} is null; falling back to local state", nodeIdentifier.getId());
+                connectionStatus = clusterCoordinator.getConnectionStatus(nodeIdentifier);
+            } else {
+                connectionStatus = fetchedConnectionStatus;
+            }
         }
 
         if (connectionStatus == null) {


### PR DESCRIPTION
…uses and fall back to local state

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14785](https://issues.apache.org/jira/browse/NIFI-14785)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
