### PR TITLE
NIFI-14269 - Account for assets when removing a parameter coming via a parameter provider

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -3576,10 +3576,11 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
                             parameterEntity = currentParameterEntities.get(parameterName);
                             if (parameterEntity != null) {
                                 final ParameterDTO parameterDTO = parameterEntity.getParameter();
-                                // These three fields must be null in order for ParameterContextDAO to recognize this as a parameter deletion
+                                // These fields must be null in order for ParameterContextDAO to recognize this as a parameter deletion
                                 parameterDTO.setDescription(null);
                                 parameterDTO.setSensitive(null);
                                 parameterDTO.setValue(null);
+                                parameterDTO.setReferencedAssets(null);
                                 updatedParameterEntities.add(parameterEntity);
                             }
                         } else {


### PR DESCRIPTION
# Summary

[NIFI-14269](https://issues.apache.org/jira/browse/NIFI-14269) - Account for assets when removing a parameter coming via a parameter provider

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
