### PR TITLE
NIFI-14791 - Bump Spring Security to 6.5.2, Commons Text to 1.14.0, Curator to 5.9.0, and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <ant.version>1.10.15</ant.version>
         <org.apache.sshd.version>2.15.0</org.apache.sshd.version>
-        <mime4j.version>0.8.12</mime4j.version>
+        <mime4j.version>0.8.13</mime4j.version>
     </properties>
 
     <!-- Managed Dependency Versions for referenced modules required based on different parent bundle project -->

--- a/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-amqp-bundle/nifi-amqp-processors/pom.xml
@@ -20,7 +20,7 @@ language governing permissions and limitations under the License. -->
     <packaging>jar</packaging>
 
     <properties>
-        <amqp-client.version>5.25.0</amqp-client.version>
+        <amqp-client.version>5.26.0</amqp-client.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -127,12 +127,12 @@
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-data</artifactId>
-            <version>7.0.1</version>
+            <version>7.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>
             <artifactId>kusto-ingest</artifactId>
-            <version>7.0.1</version>
+            <version>7.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-extension-bundles/nifi-box-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-box-bundle/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.box</groupId>
                 <artifactId>box-java-sdk</artifactId>
-                <version>4.16.2</version>
+                <version>4.16.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>9.0.3</elasticsearch.client.version>
+        <elasticsearch.client.version>9.0.4</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -25,7 +25,7 @@
     <artifactId>nifi-email-processors</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <spring.integration.version>6.5.0</spring.integration.version>
+        <spring.integration.version>6.5.1</spring.integration.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20250701-2.0.0</version>
+            <version>v3-rev20250717-2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.tdunning</groupId>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -28,7 +28,7 @@
         <gremlin.version>3.7.3</gremlin.version>
         <janusgraph.version>1.2.0-20250608-090535.869f248</janusgraph.version>
         <guava.version>33.4.8-jre</guava.version>
-        <amqp-client.version>5.25.0</amqp-client.version>
+        <amqp-client.version>5.26.0</amqp-client.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-media-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-media-bundle/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <poi.version>5.4.1</poi.version>
-        <mime4j.version>0.8.12</mime4j.version>
+        <mime4j.version>0.8.13</mime4j.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>6.3.1</version>
+            <version>6.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-kerberos-iaa-providers-bundle/nifi-kerberos-iaa-providers/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-kerberos-iaa-providers-bundle/nifi-kerberos-iaa-providers/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.springframework.security.kerberos</groupId>
             <artifactId>spring-security-kerberos-core</artifactId>
-            <version>2.1.1</version>
+            <version>2.2.0</version>
         </dependency>
         <!-- Include spring-security-crypto to support spring-security-kerberos-core -->
         <dependency>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.questdb</groupId>
             <artifactId>questdb</artifactId>
-            <version>9.0.0</version>
+            <version>9.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -24,7 +24,7 @@
     <packaging>pom</packaging>
     <description>NiFi: Framework Bundle</description>
     <properties>
-        <curator.version>5.8.0</curator.version>
+        <curator.version>5.9.0</curator.version>
         <guava.version>33.4.8-jre</guava.version>
         <org.opensaml.version>5.1.3</org.opensaml.version>
     </properties>
@@ -106,7 +106,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>oauth2-oidc-sdk</artifactId>
-                <version>11.26</version>
+                <version>11.26.1</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/pom.xml
@@ -197,7 +197,7 @@
         <dependency>
             <groupId>org.springframework.security.kerberos</groupId>
             <artifactId>spring-security-kerberos-core</artifactId>
-            <version>2.1.1</version>
+            <version>2.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>oauth2-oidc-sdk</artifactId>
-                <version>11.26</version>
+                <version>11.26.1</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -35,8 +35,8 @@
         <module>nifi-registry-docker-maven</module>
     </modules>
     <properties>
-        <spring.boot.version>3.5.3</spring.boot.version>
-        <flyway.version>11.10.3</flyway.version>
+        <spring.boot.version>3.5.4</spring.boot.version>
+        <flyway.version>11.10.4</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.3.0.202506031305-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,14 +110,14 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.788</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.32.4</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.32.8</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.0</kotlin.version>
         <okhttp.version>5.1.0</okhttp.version>
         <okio.version>3.15.0</okio.version>
         <org.apache.commons.cli.version>1.9.0</org.apache.commons.cli.version>
-        <org.apache.commons.codec.version>1.18.0</org.apache.commons.codec.version>
+        <org.apache.commons.codec.version>1.19.0</org.apache.commons.codec.version>
         <org.apache.commons.collections4.version>4.5.0</org.apache.commons.collections4.version>
         <org.apache.commons.compress.version>1.27.1</org.apache.commons.compress.version>
         <com.github.luben.zstd-jni.version>1.5.7-4</com.github.luben.zstd-jni.version>
@@ -125,7 +125,7 @@
         <org.apache.commons.lang3.version>3.18.0</org.apache.commons.lang3.version>
         <org.apache.commons.net.version>3.11.1</org.apache.commons.net.version>
         <org.apache.commons.io.version>2.20.0</org.apache.commons.io.version>
-        <org.apache.commons.text.version>1.13.1</org.apache.commons.text.version>
+        <org.apache.commons.text.version>1.14.0</org.apache.commons.text.version>
         <org.apache.httpcomponents.httpclient.version>4.5.14</org.apache.httpcomponents.httpclient.version>
         <org.apache.httpcomponents.httpcore.version>4.4.16</org.apache.httpcomponents.httpcore.version>
         <org.bouncycastle.version>1.81</org.bouncycastle.version>
@@ -142,7 +142,7 @@
         <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
         <json.smart.version>2.5.2</json.smart.version>
-        <groovy.version>4.0.27</groovy.version>
+        <groovy.version>4.0.28</groovy.version>
         <surefire.version>3.5.1</surefire.version>
         <hadoop.version>3.4.1</hadoop.version>
         <ozone.version>1.4.1</ozone.version>
@@ -157,7 +157,7 @@
         <netty.4.version>4.2.3.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.version>6.2.9</spring.version>
-        <spring.security.version>6.5.1</spring.security.version>
+        <spring.security.version>6.5.2</spring.security.version>
         <swagger.annotations.version>2.2.34</swagger.annotations.version>
         <h2.version>2.3.232</h2.version>
         <zookeeper.version>3.9.3</zookeeper.version>


### PR DESCRIPTION
# Summary

[NIFI-14791](https://issues.apache.org/jira/browse/NIFI-14791) - Bump Spring Security to 6.5.2, Commons Text to 1.14.0, Curator to 5.9.0, and others

- Apache James MIME4J from 0.8.12 to 0.8.13 - https://github.com/apache/james-mime4j/blob/master/CHANGELOG.md
- RabbitMQ AMQP Client from 5.25.0 to 5.26.0 - https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.26.0
- Microsoft Kusto from 7.0.1 to 7.0.2 - https://github.com/Azure/azure-kusto-java/releases/tag/v7.0.2
- Box SDK from 4.16.2 to 4.16.3 - https://github.com/box/box-java-sdk/releases/tag/v4.16.3
- Elasticsearch from 9.0.3 to 9.0.4 - https://github.com/elastic/elasticsearch-java/releases/tag/v9.0.4
- Spring Integration from 6.5.0 to 6.5.1 - https://github.com/spring-projects/spring-integration/releases/tag/v6.5.1
- Google Drive from v3-rev20250701-2.0.0 to v3-rev20250717-2.0.0 - https://github.com/googleapis/google-api-java-client-services/blob/main/clients/google-api-services-drive/v3/2.0.0/README.md
- HikariCP from 6.3.1 to 6.3.2 - https://github.com/brettwooldridge/HikariCP/releases/tag/HikariCP-6.3.2
- Spring Security Kerberos from 2.1.1 to 2.2.0 - https://github.com/spring-projects/spring-security-kerberos
- QuestDB from 9.0.0 to 9.0.1 - https://github.com/questdb/questdb/releases/tag/9.0.1
- Apache Curator from 5.8.0 to 5.9.0 - https://github.com/apache/curator/releases/tag/apache-curator-5.9.0
- Nimbus OAuth2 OIDC SDK from 11.26 to 11.26.1 - https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/master/CHANGELOG.txt
- Spring Boot from 3.5.3 to 3.5.4 - https://github.com/spring-projects/spring-boot/releases/tag/v3.5.4
- FlywayDB from 11.10.3 to 11.10.4 - https://github.com/flyway/flyway/releases/tag/flyway-11.10.4
- AWS SDK v2 from 2.32.4 to 2.32.8 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Apache Codec from 1.18.0 to 1.19.0 - https://commons.apache.org/proper/commons-codec/changes.html#a1.19.0
- Apache Commons Text from 1.13.1 to 1.14.0 - https://commons.apache.org/proper/commons-text/changes.html#a1.14.0
- Apache Groovy from 4.0.27 to 4.0.28 - https://groovy-lang.org/changelogs/changelog-4.0.28.html
- Spring Security from 6.5.1 to 6.5.2 - https://github.com/spring-projects/spring-security/releases/tag/6.5.2

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
