### PR TITLE
NIFI-14728 Allow git Flow Registry sync interval to be user defined

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -1067,14 +1067,10 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
                 }
             }, 0L, 30L, TimeUnit.SECONDS);
 
-            // Parse flowcontroller sync delay/interval using FormatUtils
-            final String syncIntervalStr = nifiProperties.getProperty("nifi.flowcontroller.registry.sync.interval", "30 min");
+            final String registrySyncInterval = nifiProperties.getProperty("nifi.flowcontroller.registry.sync.interval", "30 min");
+            final long registrySyncIntervalSeconds = FormatUtils.getTimeDuration(registrySyncInterval, TimeUnit.SECONDS);
 
-            // Convert to seconds
-            final long syncIntervalSec = FormatUtils.getTimeDuration(syncIntervalStr, TimeUnit.SECONDS);
-
-            // Log resolved values
-            LOG.info("Flow registry will sync every {}", syncIntervalStr);
+            LOG.info("Scheduled Flow Registry synchronization every {}", registrySyncInterval);
 
             // Schedule the flow registry synchronization task
             timerDrivenEngineRef.get().scheduleWithFixedDelay(() -> {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -1085,7 +1085,7 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
                         LOG.error("Failed to synchronize {} with Flow Registry", group, e);
                     }
                 }
-            }, 300, syncIntervalSec, TimeUnit.SECONDS);
+            }, 300, registrySyncIntervalSeconds, TimeUnit.SECONDS);
 
             initialized.set(true);
         } finally {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/FlowController.java
@@ -1067,6 +1067,16 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
                 }
             }, 0L, 30L, TimeUnit.SECONDS);
 
+            // Parse flowcontroller sync delay/interval using FormatUtils
+            final String syncIntervalStr = nifiProperties.getProperty("nifi.flowcontroller.registry.sync.interval", "30 min");
+
+            // Convert to seconds
+            final long syncIntervalSec = FormatUtils.getTimeDuration(syncIntervalStr, TimeUnit.SECONDS);
+
+            // Log resolved values
+            LOG.info("Flow registry will sync every {}", syncIntervalStr);
+
+            // Schedule the flow registry synchronization task
             timerDrivenEngineRef.get().scheduleWithFixedDelay(() -> {
                 final ProcessGroup rootGroup = flowManager.getRootGroup();
                 final List<ProcessGroup> allGroups = rootGroup.findAllProcessGroups();
@@ -1079,7 +1089,7 @@ public class FlowController implements ReportingTaskProvider, FlowAnalysisRulePr
                         LOG.error("Failed to synchronize {} with Flow Registry", group, e);
                     }
                 }
-            }, 5, 30, TimeUnit.MINUTES);
+            }, 300, syncIntervalSec, TimeUnit.SECONDS);
 
             initialized.set(true);
         } finally {

--- a/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/pom.xml
@@ -31,6 +31,7 @@
         <!-- nifi.properties: core properties -->
         <nifi.flowcontroller.autoResumeState>true</nifi.flowcontroller.autoResumeState>
         <nifi.flowcontroller.graceful.shutdown.period>10 sec</nifi.flowcontroller.graceful.shutdown.period>
+        <nifi.flowcontroller.registry.sync.interval>30 min</nifi.flowcontroller.registry.sync.interval>
         <nifi.flowservice.writedelay.interval>500 ms</nifi.flowservice.writedelay.interval>
         <nifi.administrative.yield.duration>30 sec</nifi.administrative.yield.duration>
         <nifi.bored.yield.duration>10 millis</nifi.bored.yield.duration>

--- a/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
+++ b/nifi-framework-bundle/nifi-framework/nifi-resources/src/main/resources/conf/nifi.properties
@@ -22,6 +22,7 @@ nifi.flow.configuration.archive.max.storage=${nifi.flow.configuration.archive.ma
 nifi.flow.configuration.archive.max.count=
 nifi.flowcontroller.autoResumeState=${nifi.flowcontroller.autoResumeState}
 nifi.flowcontroller.graceful.shutdown.period=${nifi.flowcontroller.graceful.shutdown.period}
+nifi.flowcontroller.registry.sync.interval=${nifi.flowcontroller.registry.sync.interval}
 nifi.flowservice.writedelay.interval=${nifi.flowservice.writedelay.interval}
 nifi.administrative.yield.duration=${nifi.administrative.yield.duration}
 # If a component has no work to do (is "bored"), how long should we wait before checking again for work?


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14728](https://issues.apache.org/jira/browse/NIFI-14728)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
