### PR TITLE
NIFI-14795 Restore use of getConnectionStatus in ClusterDecommissionTask

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/lifecycle/ClusterDecommissionTask.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/lifecycle/ClusterDecommissionTask.java
@@ -135,13 +135,7 @@ public class ClusterDecommissionTask implements DecommissionTask {
 
     private void waitForState(final Set<NodeConnectionState> acceptableStates) throws InterruptedException {
         while (true) {
-            final NodeConnectionStatus status = clusterCoordinator.fetchConnectionStatus(localNodeIdentifier);
-            if (status == null) {
-                logger.debug("Node connection status is null. Will wait {} seconds and check again", DELAY_SECONDS);
-                TimeUnit.SECONDS.sleep(DELAY_SECONDS);
-                continue;
-            }
-
+            final NodeConnectionStatus status = clusterCoordinator.getConnectionStatus(localNodeIdentifier);
             final NodeConnectionState state = status.getState();
             logger.debug("Node state is {}", state);
 
@@ -158,7 +152,7 @@ public class ClusterDecommissionTask implements DecommissionTask {
 
         int iterations = 0;
         while (true) {
-            final NodeConnectionStatus status = clusterCoordinator.fetchConnectionStatus(localNodeIdentifier);
+            final NodeConnectionStatus status = clusterCoordinator.getConnectionStatus(localNodeIdentifier);
             final NodeConnectionState state = status.getState();
             if (state == NodeConnectionState.OFFLOADED) {
                 return;
@@ -190,7 +184,7 @@ public class ClusterDecommissionTask implements DecommissionTask {
         logger.info("Waiting for Node to be completely removed from cluster");
 
         while (true) {
-            final NodeConnectionStatus status = clusterCoordinator.fetchConnectionStatus(localNodeIdentifier);
+            final NodeConnectionStatus status = clusterCoordinator.getConnectionStatus(localNodeIdentifier);
             if (status == null) {
                 return;
             }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14795](https://issues.apache.org/jira/browse/NIFI-14795)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
