### PR TITLE
NIFI-14599 - Use parameter context revision when updating multiple PCs via parameter groups from parameter provider

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/ParameterUpdateManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/util/ParameterUpdateManager.java
@@ -169,7 +169,12 @@ public class ParameterUpdateManager {
             for (final ParameterContextEntity updatedContextEntity : updatedContextEntities) {
                 logger.info("Updating Parameter Context with ID {}", updatedContextEntity.getId());
 
-                updatedEntities.add(performParameterContextUpdate(asyncRequest, uri, replicateRequest, revision, updatedContextEntity));
+                final Revision contextRevision = new Revision(
+                        updatedContextEntity.getRevision().getVersion(),
+                        updatedContextEntity.getRevision().getClientId(),
+                        updatedContextEntity.getId());
+
+                updatedEntities.add(performParameterContextUpdate(asyncRequest, uri, replicateRequest, contextRevision, updatedContextEntity));
                 logger.info("Successfully updated Parameter Context with ID {}", updatedContextEntity.getId());
             }
             asyncRequest.markStepComplete();

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/parameter/tests/system/PropertiesParameterProvider.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/parameter/tests/system/PropertiesParameterProvider.java
@@ -16,8 +16,10 @@
  */
 package org.apache.nifi.parameter.tests.system;
 
+import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.parameter.AbstractParameterProvider;
 import org.apache.nifi.parameter.Parameter;
 import org.apache.nifi.parameter.ParameterGroup;
@@ -27,15 +29,19 @@ import org.apache.nifi.processor.util.StandardValidators;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**
  * Parameters are provided by properties-style configuration.
  */
+@DynamicProperty(name = "Parameter Group Name", value = "Parameters for the group",
+        expressionLanguageScope = ExpressionLanguageScope.NONE,
+        description = "Specifies parameters in a properties file format for the group")
 public class PropertiesParameterProvider extends AbstractParameterProvider implements ParameterProvider {
 
     private PropertyDescriptor PARAMETERS = new PropertyDescriptor.Builder()
@@ -52,12 +58,33 @@ public class PropertiesParameterProvider extends AbstractParameterProvider imple
     }
 
     @Override
-    public List<ParameterGroup> fetchParameters(final ConfigurationContext context) {
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
+        return new PropertyDescriptor.Builder()
+                .name(propertyDescriptorName)
+                .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+                .dynamic(true)
+                .required(false)
+                .build();
+    }
 
-        final List<Parameter> parameters = context.getProperty(PARAMETERS).isSet()
-                ? fetchParametersFromProperties(context.getProperty(PARAMETERS).getValue())
-                : Collections.emptyList();
-        return Arrays.asList(new ParameterGroup("Parameters", parameters));
+    @Override
+    public List<ParameterGroup> fetchParameters(final ConfigurationContext context) {
+        final List<ParameterGroup> groups = new ArrayList<>();
+
+        if (context.getProperty(PARAMETERS).isSet()) {
+            final List<Parameter> parameters = fetchParametersFromProperties(context.getProperty(PARAMETERS).getValue());
+            groups.add(new ParameterGroup("Parameters", parameters));
+        }
+
+        for (final Map.Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
+            if (entry.getKey().isDynamic()) {
+                final String groupName = entry.getKey().getName();
+                final List<Parameter> parameters = fetchParametersFromProperties(entry.getValue());
+                groups.add(new ParameterGroup(groupName, parameters));
+            }
+        }
+
+        return groups;
     }
 
     private List<Parameter> fetchParametersFromProperties(final String parametersPropertiesValue) {


### PR DESCRIPTION
# Summary

[NIFI-14599](https://issues.apache.org/jira/browse/NIFI-14599) - Use parameter context revision when updating multiple PCs via parameter groups from parameter provider

Note that the system test being added here does not, unfortunately, expose the problem because of the way the client ID is set via the system test NiFi Client Util. But since I created this test as part of investigating the issue and since this is still a good test to have, I kept it as part of this PR.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
