### PR TITLE
NIFI-14798 - Upgrade MongoDB bundle to latest versions

### DIFF
--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/pom.xml
@@ -114,7 +114,7 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <mongo.docker.string>mongo:5</mongo.docker.string>
+                <mongo.docker.string>mongo:8</mongo.docker.string>
             </properties>
             <build>
                 <pluginManagement>

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/AbstractMongoIT.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/test/java/org/apache/nifi/processors/mongodb/AbstractMongoIT.java
@@ -26,7 +26,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 public class AbstractMongoIT {
-    private static final String DOCKER_IMAGE = System.getProperty("mongo.docker.image", "mongo:5");
+    private static final String DOCKER_IMAGE = System.getProperty("mongo.docker.image", "mongo:8");
     @Container
     protected static final MongoDBContainer MONGO_CONTAINER = new MongoDBContainer(DockerImageName.parse(DOCKER_IMAGE));
 }

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/pom.xml
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/pom.xml
@@ -101,7 +101,7 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <mongo.docker.string>mongo:5</mongo.docker.string>
+                <mongo.docker.string>mongo:8</mongo.docker.string>
             </properties>
             <build>
                 <pluginManagement>

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/test/java/org/apache/nifi/mongodb/AbstractMongoIT.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/test/java/org/apache/nifi/mongodb/AbstractMongoIT.java
@@ -26,7 +26,7 @@ import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 public class AbstractMongoIT {
-    private static final String DOCKER_IMAGE = System.getProperty("mongo.docker.image");
+    private static final String DOCKER_IMAGE = System.getProperty("mongo.docker.image", "mongo:8");
     @Container
     protected static final MongoDBContainer MONGO_CONTAINER = new MongoDBContainer(DockerImageName.parse(DOCKER_IMAGE));
 }

--- a/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
@@ -34,6 +34,6 @@
     </modules>
 
     <properties>
-        <mongo.driver.version>4.11.5</mongo.driver.version>
+        <mongo.driver.version>5.5.1</mongo.driver.version>
     </properties>
 </project>


### PR DESCRIPTION
# Summary

[NIFI-14798](https://issues.apache.org/jira/browse/NIFI-14798) - Upgrade MongoDB bundle to latest versions

Changes have been tested against an Atlas MongoDB Server instance running in GCP

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
