### PR TITLE
NIFI-14799 - Add common time range selection options for Status History dialog

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/status-history/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/status-history/index.ts
@@ -45,7 +45,7 @@ export interface ComponentDetails {
 
 export interface StatusHistoryAggregateSnapshot {
     timestamp: number;
-    statusMetrics: any[];
+    statusMetrics: any;
 }
 
 export interface NodeSnapshot {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/status-history/index.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/status-history/index.ts
@@ -42,3 +42,9 @@ export interface Stats {
     mean: string;
     nodes?: StatsNode[];
 }
+
+export interface StartOption {
+    label: string;
+    value: number;
+    formattedDate: string;
+}

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/status-history/status-history.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/status-history/status-history.component.html
@@ -73,13 +73,37 @@
                                                 <div class="flex flex-col">
                                                     <div>Start</div>
                                                     <div class="tertiary-color font-medium">
-                                                        {{ minDate }}
+                                                        <mat-form-field subscriptSizing="dynamic">
+                                                            <mat-select
+                                                                formControlName="start"
+                                                                (selectionChange)="startChanged($event.value)">
+                                                                <mat-select-trigger>
+                                                                    {{
+                                                                        formatSelectedStartTime(
+                                                                            statusHistoryForm.get('start')?.value
+                                                                        )
+                                                                    }}
+                                                                </mat-select-trigger>
+                                                                @for (option of startTimeOptions; track option) {
+                                                                    <mat-option [value]="option.value">
+                                                                        <div class="flex flex-col gap-y-1">
+                                                                            <div class="text-md">
+                                                                                {{ option.label }}
+                                                                            </div>
+                                                                            <div class="text-sm tertiary-color">
+                                                                                {{ option.formattedDate }}
+                                                                            </div>
+                                                                        </div>
+                                                                    </mat-option>
+                                                                }
+                                                            </mat-select>
+                                                        </mat-form-field>
                                                     </div>
                                                 </div>
                                                 <div class="flex flex-col">
                                                     <div>End</div>
                                                     <div class="tertiary-color font-medium">
-                                                        {{ maxDate }}
+                                                        {{ formattedMaxDate }}
                                                     </div>
                                                 </div>
                                                 <div class="flex flex-col">
@@ -110,7 +134,8 @@
                                                 </div>
                                                 @if (!!nodes && nodes.length > 0) {
                                                     <div class="flex flex-col">
-                                                        <div class="flex justify-between items-center border-b mr-1">
+                                                        <div
+                                                            class="flex justify-between items-center border-b mr-1 pb-1.5">
                                                             <mat-label class="font-bold secondary-color"
                                                                 >Nodes
                                                             </mat-label>
@@ -122,7 +147,7 @@
                                                                 "
                                                                 (change)="selectAllNodesChanged($event)"></mat-checkbox>
                                                         </div>
-                                                        <div>
+                                                        <div class="pt-1.5">
                                                             <div>Min / Max / Mean</div>
                                                             <div class="tertiary-color font-medium">
                                                                 {{ nodeStats.min }} / {{ nodeStats.max }} /
@@ -155,8 +180,9 @@
                                         </div>
                                         <div class="chart-panel grow flex flex-col">
                                             @if (fieldDescriptors$ | async) {
-                                                <div class="selected-descriptor-container">
-                                                    <mat-form-field>
+                                                <div class="selected-descriptor-container flex flex-col">
+                                                    <div>Metric</div>
+                                                    <mat-form-field subscriptSizing="dynamic">
                                                         <mat-select formControlName="fieldDescriptor">
                                                             @for (descriptor of fieldDescriptors; track descriptor) {
                                                                 @if (descriptor.description) {
@@ -183,7 +209,7 @@
                                                 </div>
                                             }
                                             <status-history-chart
-                                                [instances]="instances"
+                                                [instances]="filteredInstances()"
                                                 [visibleInstances]="instanceVisibility"
                                                 [selectedFieldDescriptor]="selectedDescriptor"
                                                 (nodeStats)="nodeStatsChanged($event)"

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/status-history/status-history.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/status-history/status-history.component.ts
@@ -15,7 +15,17 @@
  * limitations under the License.
  */
 
-import { AfterViewInit, Component, DestroyRef, HostListener, inject, Inject, OnInit } from '@angular/core';
+import {
+    AfterViewInit,
+    Component,
+    DestroyRef,
+    HostListener,
+    inject,
+    Inject,
+    OnInit,
+    signal,
+    WritableSignal
+} from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { StatusHistoryService } from '../../../service/status-history.service';
 import { AsyncPipe, NgStyle } from '@angular/common';
@@ -38,13 +48,13 @@ import {
 } from '../../../state/status-history/status-history.selectors';
 import { initialState } from '../../../state/status-history/status-history.reducer';
 import { filter, take } from 'rxjs';
-import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import * as d3 from 'd3';
 import { isDefinedAndNotNull, CloseOnEscapeDialog, NiFiCommon, NifiTooltipDirective, TextTip } from '@nifi/shared';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
-import { Instance, NIFI_NODE_CONFIG, Stats } from './index';
+import { Instance, NIFI_NODE_CONFIG, StartOption, Stats } from './index';
 import { StatusHistoryChart } from './status-history-chart/status-history-chart.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ErrorContextKey } from '../../../state/error';
@@ -67,7 +77,8 @@ import { ContextErrorBanner } from '../context-error-banner/context-error-banner
         NgStyle,
         ContextErrorBanner
     ],
-    styleUrls: ['./status-history.component.scss']
+    styleUrls: ['./status-history.component.scss'],
+    standalone: true
 })
 export class StatusHistory extends CloseOnEscapeDialog implements OnInit, AfterViewInit {
     request: StatusHistoryRequest;
@@ -81,8 +92,10 @@ export class StatusHistory extends CloseOnEscapeDialog implements OnInit, AfterV
 
     details: { key: string; value: string }[] = [];
 
-    minDate = '';
-    maxDate = '';
+    formattedMinDate = '';
+    formattedMaxDate = '';
+    minDate = 0;
+    maxDate = 0;
     statusHistoryForm: FormGroup;
 
     nodeStats: Stats = {
@@ -101,6 +114,8 @@ export class StatusHistory extends CloseOnEscapeDialog implements OnInit, AfterV
     nodes: any[] = [];
 
     instances: Instance[] = [];
+    filteredInstances: WritableSignal<Instance[]> = signal([]);
+    startTimeOptions: StartOption[] = [];
     instanceVisibility: any = {};
     selectedDescriptor: FieldDescriptor | null = null;
     private destroyRef: DestroyRef = inject(DestroyRef);
@@ -115,7 +130,8 @@ export class StatusHistory extends CloseOnEscapeDialog implements OnInit, AfterV
         super();
         this.request = dialogRequest;
         this.statusHistoryForm = this.formBuilder.group({
-            fieldDescriptor: ''
+            fieldDescriptor: '',
+            start: new FormControl(0, Validators.required)
         });
     }
 
@@ -175,8 +191,15 @@ export class StatusHistory extends CloseOnEscapeDialog implements OnInit, AfterV
                             return s.timestamp;
                         });
                     });
-                    this.minDate = this.nifiCommon.formatDateTime(new Date(minDate));
-                    this.maxDate = this.nifiCommon.formatDateTime(new Date(maxDate));
+                    this.formattedMinDate = this.nifiCommon.formatDateTime(new Date(minDate));
+                    this.formattedMaxDate = this.nifiCommon.formatDateTime(new Date(maxDate));
+
+                    this.minDate = minDate;
+                    this.maxDate = maxDate;
+                    this.updateStartTimeOptions();
+
+                    // Initialize filtered instances with all instances
+                    this.filteredInstances.set(this.instances);
                 }
             });
         this.fieldDescriptors$
@@ -308,6 +331,76 @@ export class StatusHistory extends CloseOnEscapeDialog implements OnInit, AfterV
         }
         return 'unset neutral-color';
     }
+
+    startChanged(value: number) {
+        if (value === 0) {
+            this.filteredInstances.set(this.instances);
+        } else {
+            const filtered = this.instances.map((instance: Instance) => {
+                const filteredSnapshots = instance.snapshots.filter(
+                    (snapshot) => snapshot.timestamp >= this.maxDate - value
+                );
+                return {
+                    id: instance.id,
+                    label: instance.label,
+                    snapshots: filteredSnapshots
+                };
+            });
+            // only include the instances that have snapshots that meet the filter criteria
+            this.filteredInstances.set(filtered.filter((instances) => instances.snapshots.length > 0));
+        }
+    }
+
+    formatSelectedStartTime(value: number) {
+        const selected = this.startTimeOptions.find((option) => option.value === value);
+        if (selected) {
+            return selected.label;
+        }
+        return this.startTimeOptions[0].label;
+    }
+
+    private updateStartTimeOptions() {
+        const selected = this.statusHistoryForm.get('start')?.value;
+        const options: StartOption[] = [{ label: 'All', value: 0, formattedDate: this.formattedMinDate }];
+        const diff = this.maxDate - this.minDate;
+
+        if (diff > this.fiveMinutes) {
+            options.push({
+                label: 'Last 5 minutes',
+                value: this.fiveMinutes,
+                formattedDate: this.nifiCommon.formatDateTime(new Date(this.maxDate - this.fiveMinutes))
+            });
+        }
+        if (diff > this.tenMinutes) {
+            options.push({
+                label: 'Last 10 minutes',
+                value: this.tenMinutes,
+                formattedDate: this.nifiCommon.formatDateTime(new Date(this.maxDate - this.tenMinutes))
+            });
+        }
+        if (diff > this.thirtyMinutes) {
+            options.push({
+                label: 'Last 30 minutes',
+                value: this.thirtyMinutes,
+                formattedDate: this.nifiCommon.formatDateTime(new Date(this.maxDate - this.thirtyMinutes))
+            });
+        }
+        if (diff > this.sixtyMinutes) {
+            options.push({
+                label: 'Last hour',
+                value: this.sixtyMinutes,
+                formattedDate: this.nifiCommon.formatDateTime(new Date(this.maxDate - this.sixtyMinutes))
+            });
+        }
+        this.startTimeOptions = options;
+        // trigger the charts to update with potentially new data
+        this.startChanged(selected);
+    }
+
+    private readonly fiveMinutes = 5 * NiFiCommon.MILLIS_PER_MINUTE;
+    private readonly tenMinutes = 10 * NiFiCommon.MILLIS_PER_MINUTE;
+    private readonly thirtyMinutes = 30 * NiFiCommon.MILLIS_PER_MINUTE;
+    private readonly sixtyMinutes = NiFiCommon.MILLIS_PER_HOUR;
 
     protected readonly NIFI_NODE_CONFIG = NIFI_NODE_CONFIG;
     protected readonly ErrorContextKey = ErrorContextKey;


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14799](https://issues.apache.org/jira/browse/NIFI-14799)

Users can now quickly filter status history charts by common time periods instead of viewing all historical data, improving analysis workflow and performance.

<img width="900" height="744" alt="Screenshot 2025-07-29 at 11 07 23" src="https://github.com/user-attachments/assets/5e26ef46-ac8c-49cc-bff5-2557632a5845" />


