### PR TITLE
NIFI-14800 - Shorten y-axis integer labels when 100,000 or more using standard abbreviations

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/status-history/status-history-chart/status-history-chart.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/status-history/status-history-chart/status-history-chart.component.ts
@@ -111,6 +111,28 @@ export class StatusHistoryChart implements OnDestroy {
             return this.nifiCommon.formatFloat(d / 1000000);
         }
     };
+
+    // Formatters for y-axis use with compact notation for large numbers
+    private yAxisFormatters: any = {
+        DURATION: (d: number) => {
+            return this.nifiCommon.formatDuration(d);
+        },
+        COUNT: (d: number) => {
+            // need to handle floating point number since this formatter
+            // will also be used for average values
+            if (d % 1 === 0) {
+                return this.nifiCommon.formatInteger(d, true); // Enable compact notation for y-axis
+            } else {
+                return this.nifiCommon.formatFloat(d);
+            }
+        },
+        DATA_SIZE: (d: number) => {
+            return this.nifiCommon.formatDataSize(d);
+        },
+        FRACTION: (d: number) => {
+            return this.nifiCommon.formatFloat(d / 1000000);
+        }
+    };
     private brushSelection: any = null;
 
     // private selectedDescriptor: FieldDescriptor | null = null;
@@ -188,7 +210,7 @@ export class StatusHistoryChart implements OnDestroy {
 
         // define the y axis
         const y = d3.scaleLinear().range([height, 0]);
-        const yAxis: any = d3.axisLeft(y).tickFormat(this.formatters[selectedDescriptor.formatter]);
+        const yAxis: any = d3.axisLeft(y).tickFormat(this.yAxisFormatters[selectedDescriptor.formatter]);
 
         // status line
         const line = d3
@@ -349,7 +371,7 @@ export class StatusHistoryChart implements OnDestroy {
         const yControlAxis = d3
             .axisLeft(yControl)
             .tickValues(y.domain())
-            .tickFormat(this.formatters[selectedDescriptor.formatter]);
+            .tickFormat(this.yAxisFormatters[selectedDescriptor.formatter]);
 
         // status line
         const controlLine = d3

--- a/nifi-frontend/src/main/frontend/libs/shared/src/services/nifi-common.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/services/nifi-common.service.spec.ts
@@ -30,4 +30,43 @@ describe('Common', () => {
     it('should be created', () => {
         expect(service).toBeTruthy();
     });
+
+    describe('formatInteger', () => {
+        it('should format small numbers with commas', () => {
+            expect(service.formatInteger(0)).toBe('0');
+            expect(service.formatInteger(1)).toBe('1');
+            expect(service.formatInteger(123)).toBe('123');
+            expect(service.formatInteger(1234)).toBe('1,234');
+            expect(service.formatInteger(12345)).toBe('12,345');
+            expect(service.formatInteger(99999)).toBe('99,999');
+        });
+
+        it('should format numbers >= 100,000 with compact notation', () => {
+            expect(service.formatInteger(100000)).toBe('100K');
+            expect(service.formatInteger(150000)).toBe('150K');
+            expect(service.formatInteger(1000000)).toBe('1M');
+            expect(service.formatInteger(1250000)).toBe('1.25M');
+            expect(service.formatInteger(1000000000)).toBe('1B');
+            expect(service.formatInteger(2750000000)).toBe('2.75B');
+            expect(service.formatInteger(1000000000000)).toBe('1T');
+        });
+
+        it('should handle negative numbers correctly', () => {
+            expect(service.formatInteger(-1234)).toBe('-1,234');
+            expect(service.formatInteger(-99999)).toBe('-99,999');
+            expect(service.formatInteger(-100000)).toBe('-100K');
+            expect(service.formatInteger(-1250000)).toBe('-1.25M');
+        });
+
+        it('should handle edge cases around the 100,000 threshold', () => {
+            expect(service.formatInteger(99999)).toBe('99,999');
+            expect(service.formatInteger(100000)).toBe('100K');
+            expect(service.formatInteger(100001)).toBe('100K');
+        });
+
+        it('should format very large numbers with appropriate suffixes', () => {
+            expect(service.formatInteger(1234567890)).toBe('1.23B');
+            expect(service.formatInteger(12345678901234)).toBe('12.35T');
+        });
+    });
 });

--- a/nifi-frontend/src/main/frontend/libs/shared/src/services/nifi-common.service.spec.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/services/nifi-common.service.spec.ts
@@ -32,41 +32,69 @@ describe('Common', () => {
     });
 
     describe('formatInteger', () => {
-        it('should format small numbers with commas', () => {
-            expect(service.formatInteger(0)).toBe('0');
-            expect(service.formatInteger(1)).toBe('1');
-            expect(service.formatInteger(123)).toBe('123');
-            expect(service.formatInteger(1234)).toBe('1,234');
-            expect(service.formatInteger(12345)).toBe('12,345');
-            expect(service.formatInteger(99999)).toBe('99,999');
+        describe('traditional formatting (default)', () => {
+            it('should format small numbers with commas', () => {
+                expect(service.formatInteger(0)).toBe('0');
+                expect(service.formatInteger(1)).toBe('1');
+                expect(service.formatInteger(123)).toBe('123');
+                expect(service.formatInteger(1234)).toBe('1,234');
+                expect(service.formatInteger(12345)).toBe('12,345');
+                expect(service.formatInteger(99999)).toBe('99,999');
+            });
+
+            it('should format large numbers with commas when compact notation is disabled', () => {
+                expect(service.formatInteger(100000)).toBe('100,000');
+                expect(service.formatInteger(150000)).toBe('150,000');
+                expect(service.formatInteger(1000000)).toBe('1,000,000');
+                expect(service.formatInteger(1250000)).toBe('1,250,000');
+                expect(service.formatInteger(1000000000)).toBe('1,000,000,000');
+            });
+
+            it('should handle negative numbers correctly with traditional formatting', () => {
+                expect(service.formatInteger(-1234)).toBe('-1,234');
+                expect(service.formatInteger(-99999)).toBe('-99,999');
+                expect(service.formatInteger(-100000)).toBe('-100,000');
+                expect(service.formatInteger(-1250000)).toBe('-1,250,000');
+            });
         });
 
-        it('should format numbers >= 100,000 with compact notation', () => {
-            expect(service.formatInteger(100000)).toBe('100K');
-            expect(service.formatInteger(150000)).toBe('150K');
-            expect(service.formatInteger(1000000)).toBe('1M');
-            expect(service.formatInteger(1250000)).toBe('1.25M');
-            expect(service.formatInteger(1000000000)).toBe('1B');
-            expect(service.formatInteger(2750000000)).toBe('2.75B');
-            expect(service.formatInteger(1000000000000)).toBe('1T');
-        });
+        describe('compact notation formatting', () => {
+            it('should format small numbers with commas even when compact notation is enabled', () => {
+                expect(service.formatInteger(0, true)).toBe('0');
+                expect(service.formatInteger(1, true)).toBe('1');
+                expect(service.formatInteger(123, true)).toBe('123');
+                expect(service.formatInteger(1234, true)).toBe('1,234');
+                expect(service.formatInteger(12345, true)).toBe('12,345');
+                expect(service.formatInteger(99999, true)).toBe('99,999');
+            });
 
-        it('should handle negative numbers correctly', () => {
-            expect(service.formatInteger(-1234)).toBe('-1,234');
-            expect(service.formatInteger(-99999)).toBe('-99,999');
-            expect(service.formatInteger(-100000)).toBe('-100K');
-            expect(service.formatInteger(-1250000)).toBe('-1.25M');
-        });
+            it('should format numbers >= 100,000 with compact notation when enabled', () => {
+                expect(service.formatInteger(100000, true)).toBe('100K');
+                expect(service.formatInteger(150000, true)).toBe('150K');
+                expect(service.formatInteger(1000000, true)).toBe('1M');
+                expect(service.formatInteger(1250000, true)).toBe('1.25M');
+                expect(service.formatInteger(1000000000, true)).toBe('1B');
+                expect(service.formatInteger(2750000000, true)).toBe('2.75B');
+                expect(service.formatInteger(1000000000000, true)).toBe('1T');
+            });
 
-        it('should handle edge cases around the 100,000 threshold', () => {
-            expect(service.formatInteger(99999)).toBe('99,999');
-            expect(service.formatInteger(100000)).toBe('100K');
-            expect(service.formatInteger(100001)).toBe('100K');
-        });
+            it('should handle negative numbers correctly with compact notation', () => {
+                expect(service.formatInteger(-1234, true)).toBe('-1,234');
+                expect(service.formatInteger(-99999, true)).toBe('-99,999');
+                expect(service.formatInteger(-100000, true)).toBe('-100K');
+                expect(service.formatInteger(-1250000, true)).toBe('-1.25M');
+            });
 
-        it('should format very large numbers with appropriate suffixes', () => {
-            expect(service.formatInteger(1234567890)).toBe('1.23B');
-            expect(service.formatInteger(12345678901234)).toBe('12.35T');
+            it('should handle edge cases around the 100,000 threshold with compact notation', () => {
+                expect(service.formatInteger(99999, true)).toBe('99,999');
+                expect(service.formatInteger(100000, true)).toBe('100K');
+                expect(service.formatInteger(100001, true)).toBe('100K');
+            });
+
+            it('should format very large numbers with appropriate suffixes', () => {
+                expect(service.formatInteger(1234567890, true)).toBe('1.23B');
+                expect(service.formatInteger(12345678901234, true)).toBe('12.35T');
+            });
         });
     });
 });

--- a/nifi-frontend/src/main/frontend/libs/shared/src/services/nifi-common.service.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/services/nifi-common.service.ts
@@ -655,19 +655,20 @@ export class NiFiCommon {
      * point this does not take into account any locales.
      *
      * @param {integer} integer
+     * @param {boolean} useCompactNotation - Whether to use compact notation (100K, 1M, etc.) for large numbers
      */
-    public formatInteger(integer: number): string {
+    public formatInteger(integer: number, useCompactNotation: boolean = false): string {
         const locale: string = (navigator && navigator.language) || 'en';
 
-        // For values >= 100,000, use compact notation (100K, 1M, 2.5B, etc.)
-        if (Math.abs(integer) >= 100000) {
+        // For values >= 100,000 and when compact notation is requested, use compact notation (100K, 1M, 2.5B, etc.)
+        if (useCompactNotation && Math.abs(integer) >= 100000) {
             return new Intl.NumberFormat(locale, {
                 notation: 'compact',
                 maximumFractionDigits: 2
             }).format(integer);
         }
 
-        // For values < 100,000, use the existing format with commas
+        // For all other cases, use the traditional format with commas
         return integer.toLocaleString(locale, { maximumFractionDigits: 0 });
     }
 

--- a/nifi-frontend/src/main/frontend/libs/shared/src/services/nifi-common.service.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/services/nifi-common.service.ts
@@ -658,6 +658,16 @@ export class NiFiCommon {
      */
     public formatInteger(integer: number): string {
         const locale: string = (navigator && navigator.language) || 'en';
+
+        // For values >= 100,000, use compact notation (100K, 1M, 2.5B, etc.)
+        if (Math.abs(integer) >= 100000) {
+            return new Intl.NumberFormat(locale, {
+                notation: 'compact',
+                maximumFractionDigits: 2
+            }).format(integer);
+        }
+
+        // For values < 100,000, use the existing format with commas
         return integer.toLocaleString(locale, { maximumFractionDigits: 0 });
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14800](https://issues.apache.org/jira/browse/NIFI-14800)


### Changes Made:

**1. Enhanced `formatInteger` method in `NiFiCommon` service:**
- **Purpose:** Solve y-axis label clipping issues in charts when displaying large numbers
- **Implementation:** 
  - Optional argument `useCompactNotation` added to support new behavior
  - Numbers ≥ 100,000 now use compact notation via `Intl.NumberFormat` with `notation: 'compact'`
  - Shows up to 2 decimal places for precision (`maximumFractionDigits: 2`)
  - Numbers < 100,000 continue using existing comma formatting
  - Examples: `100000` → `"100K"`, `1250000` → `"1.25M"`, `2750000000` → `"2.75B"`

**2. Comprehensive test coverage:**
- **Added:** new test cases covering:
  - Small numbers with comma formatting (0 to 99,999)
  - Large numbers with compact notation (≥ 100,000)
  - Negative number handling
  - Edge cases around the 100,000 threshold
  - Very large numbers (billions, trillions)

### Impact:
This change directly addresses chart label clipping issues by making large integer labels significantly shorter while maintaining readability. The status history chart component will automatically benefit from this improvement since it uses the `formatInteger` method through its formatters.


#### Before (labels aren't quite long enough to force clipping, but big enough to convey the idea)
<img width="895" height="741" alt="Screenshot 2025-07-29 at 13 17 23" src="https://github.com/user-attachments/assets/b04df586-e7f1-482f-8295-5b488fb2238a" />


#### After abbreviating the y axis labels
<img width="899" height="741" alt="Screenshot 2025-07-30 at 11 18 25" src="https://github.com/user-attachments/assets/22c05235-c11d-4faf-b607-af64b4b2574e" />

