### PR TITLE
NIFI-14801 Adding registryClientUrl and sslContextServiceId to create-reg-client and update-reg-client toolkit commands

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
@@ -82,7 +82,8 @@ public enum CommandOption {
     REGISTRY_CLIENT_URL("rcu", "registryClientUrl", "The url of the registry client", true),
     REGISTRY_CLIENT_DESC("rcd", "registryClientDesc", "The description of the registry client", true),
     REGISTRY_CLIENT_TYPE("rct", "registryClientType", "The type of the registry client", true),
-
+    SSL_CONTEXT_SERVICE_ID("ssl", "sslContextServiceId", "The ID of SSL Context Service", true),
+    
     // NiFi - PGs
     PG_ID("pgid", "processGroupId", "The id of a process group", true),
     PG_NAME("pgn", "processGroupName", "The name of a process group", true),

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/CreateRegistryClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/CreateRegistryClient.java
@@ -27,6 +27,8 @@ import org.apache.nifi.web.api.dto.FlowRegistryClientDTO;
 import org.apache.nifi.web.api.entity.FlowRegistryClientEntity;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -50,6 +52,7 @@ public class CreateRegistryClient extends AbstractNiFiCommand<StringResult> {
         addOption(CommandOption.REGISTRY_CLIENT_NAME.createOption());
         addOption(CommandOption.REGISTRY_CLIENT_DESC.createOption());
         addOption(CommandOption.REGISTRY_CLIENT_TYPE.createOption());
+        addOption(CommandOption.REGISTRY_CLIENT_URL.createOption());
     }
 
     @Override
@@ -59,11 +62,19 @@ public class CreateRegistryClient extends AbstractNiFiCommand<StringResult> {
         final String name = getRequiredArg(properties, CommandOption.REGISTRY_CLIENT_NAME);
         final String type = getRequiredArg(properties, CommandOption.REGISTRY_CLIENT_TYPE);
         final String desc = getArg(properties, CommandOption.REGISTRY_CLIENT_DESC);
+        final String url = getArg(properties, CommandOption.REGISTRY_CLIENT_URL);
 
         final FlowRegistryClientDTO flowRegistryClientDTO = new FlowRegistryClientDTO();
         flowRegistryClientDTO.setName(name);
         flowRegistryClientDTO.setDescription(desc);
         flowRegistryClientDTO.setType(type);
+
+        // Set URL property if provided
+        if (url != null && !url.isEmpty()) {
+            final Map<String, String> clientProperties = new HashMap<>();
+            clientProperties.put("url", url);
+            flowRegistryClientDTO.setProperties(clientProperties);
+        }
 
         final FlowRegistryClientEntity clientEntity = new FlowRegistryClientEntity();
         clientEntity.setComponent(flowRegistryClientDTO);


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14801](https://issues.apache.org/jira/browse/NIFI-14801)
Adding registryClientUrl and sslContextServiceId to create-reg-client and update-reg-client toolkit commands
# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
- [x] JDK 21

### Licensing

- [x] No new dependencies

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
