### PR TITLE
NIFI-14805 Improve Response Relationship description for InvokeHTTP

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -544,7 +544,8 @@ public class InvokeHTTP extends AbstractProcessor {
             .name("Response")
             .description("""
             Response FlowFiles transferred when receiving HTTP responses with a status code between 200 and 299.
-            Enabling [Response Generation Required] changes routing behavior and sends FlowFiles to the Response relationship regardless of status code received.
+            Enabling [Response Generation Required] changes routing behavior, sending unsuccessful responses to their corresponding relationships
+            and also sending FlowFiles to the Response relationship as well, regardless of status code received.
             """
             )
             .build();


### PR DESCRIPTION
# Summary

[NIFI-14805](https://issues.apache.org/jira/browse/NIFI-14805) Improves the description of the `Response` relationship for the `InvokeHTTP` Processor to make it clear that enabling the `Response Generation Required` property changes routing behavior and sends FlowFiles to `Response` regardless of status code received.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
