### PR TITLE
NIFI-14806 Change OIDC and SAML login timeout to 5 minutes

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/OidcSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/OidcSecurityConfiguration.java
@@ -85,7 +85,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Configuration
 public class OidcSecurityConfiguration {
-    private static final Duration REQUEST_EXPIRATION = Duration.ofSeconds(60);
+    private static final Duration REQUEST_EXPIRATION = Duration.ofMinutes(5);
 
     private static final long AUTHORIZATION_REQUEST_CACHE_SIZE = 1000;
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/configuration/SamlAuthenticationSecurityConfiguration.java
@@ -86,7 +86,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Configuration
 public class SamlAuthenticationSecurityConfiguration {
-    private static final Duration REQUEST_EXPIRATION = Duration.ofSeconds(60);
+    private static final Duration REQUEST_EXPIRATION = Duration.ofMinutes(5);
 
     private static final long REQUEST_MAXIMUM_CACHE_SIZE = 1000;
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/cookie/StandardApplicationCookieService.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/cookie/StandardApplicationCookieService.java
@@ -39,7 +39,7 @@ public class StandardApplicationCookieService implements ApplicationCookieServic
 
     private static final Duration MAX_AGE_REMOVE = Duration.ZERO;
 
-    private static final Duration MAX_AGE_STANDARD = Duration.ofSeconds(60);
+    private static final Duration MAX_AGE_STANDARD = Duration.ofMinutes(5);
 
     private static final String DEFAULT_PATH = "/";
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/cookie/StandardApplicationCookieServiceTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/cookie/StandardApplicationCookieServiceTest.java
@@ -53,7 +53,7 @@ public class StandardApplicationCookieServiceTest {
 
     private static final String CONTEXT_RESOURCE_URI = String.format("https://%s%s", DOMAIN, CONTEXT_PATH);
 
-    private static final int EXPECTED_MAX_AGE = 60;
+    private static final int EXPECTED_MAX_AGE = 300;
 
     private static final int SESSION_MAX_AGE = -1;
 


### PR DESCRIPTION
# Summary

[NIFI-14806](https://issues.apache.org/jira/browse/NIFI-14806) Changes the cookie expiration and request expiration for OIDC and SAML logins from 60 seconds to 5 minutes.

The cookie expiration controls how long browsers consider the cookie to be valid. These cookies provide temporary storage for login and logout identifiers.

The request expiration controls how long the NiFi application caches authentication requests for OIDC and SAML. Extending the timeout from 60 seconds to 5 minutes allows a more reasonable amount of time for completion of the login process through an identity provider, which can take longer for multi-factor authentication steps.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
