### PR TITLE
NIFI-14810 Upgrade OpenTelemetry Proto from 1.1.0 to 1.7.0

### DIFF
--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/nifi-opentelemetry-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/nifi-opentelemetry-processors/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>io.opentelemetry.proto</groupId>
             <artifactId>opentelemetry-proto</artifactId>
-            <version>1.1.0-alpha</version>
+            <version>1.7.0-alpha</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
@@ -32,7 +32,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
-                <version>3.25.8</version>
+                <version>4.31.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
# Summary

[NIFI-14810](https://issues.apache.org/jira/browse/NIFI-14810) Upgrades the OpenTelemetry Proto library from 1.1.0 to [1.7.0](https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.7.0) incorporating the latest version of the [OTLP Specification](https://opentelemetry.io/docs/specs/otlp/).

The upgrade includes moving from 3.25.8 to 4.31.0 of the Google Protobuf library as required by OpenTelemetry Proto and Jackson Datatype Protobuf libraries that support the `ListenOTLP` Processor.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
