### PR TITLE
NIFI-14808 Introduce MockParameterLookup class for parameters passing

### DIFF
--- a/nifi-mock/src/main/java/org/apache/nifi/util/MockParameterLookup.java
+++ b/nifi-mock/src/main/java/org/apache/nifi/util/MockParameterLookup.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.util;
+
+import org.apache.nifi.parameter.Parameter;
+import org.apache.nifi.parameter.ParameterLookup;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public class MockParameterLookup implements ParameterLookup {
+    private final Map<String, String> parameters;
+    private final AtomicLong version = new AtomicLong(1);
+
+    public MockParameterLookup(final Map<String, String> parameters) {
+        this.parameters = parameters == null ? new HashMap<>() : new HashMap<>(parameters);
+    }
+
+    @Override
+    public Optional<Parameter> getParameter(final String parameterName) {
+        final String value = parameters.get(parameterName);
+        if (value == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new Parameter.Builder()
+            .name(parameterName)
+            .value(value)
+            .build());
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return parameters.isEmpty();
+    }
+
+    @Override
+    public long getVersion() {
+        return version.get();
+    }
+}

--- a/nifi-mock/src/test/java/org/apache/nifi/util/TestMockParameterLookup.java
+++ b/nifi-mock/src/test/java/org/apache/nifi/util/TestMockParameterLookup.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.util;
+
+import org.apache.nifi.parameter.Parameter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+class TestMockParameterLookup {
+
+    @ParameterizedTest
+    @MethodSource("getParameters")
+    void shouldRetrieveExistingParameter(final String key, final String value) {
+        final Map<String, String> parameters = new HashMap<>();
+        parameters.put(key, value);
+
+        final MockParameterLookup lookup = new MockParameterLookup(parameters);
+
+        final Optional<Parameter> parameter = lookup.getParameter(key);
+        assertTrue(parameter.isPresent());
+        assertEquals(key, parameter.get().getDescriptor().getName());
+        assertEquals(value, parameter.get().getValue());
+        assertFalse(parameter.get().getDescriptor().isSensitive());
+    }
+
+    private static Stream<Arguments> getParameters() {
+        return Stream.of(
+            Arguments.of("test.param", "test-value"),
+            Arguments.of("empty-param", "")
+        );
+    }
+
+    @Test
+    void shouldNotFailOnEmptyOrNullParametersMap() {
+        final MockParameterLookup emptyLookup = new MockParameterLookup(new HashMap<>());
+        assertTrue(emptyLookup.isEmpty());
+
+        final MockParameterLookup nullLookup = new MockParameterLookup(null);
+        assertTrue(nullLookup.isEmpty());
+    }
+
+    @Test
+    void shouldNotRetrieveNonExistingParameter() {
+        final Map<String, String> parameters = new HashMap<>();
+        parameters.put("existing.param", "value");
+
+        final MockParameterLookup lookup = new MockParameterLookup(parameters);
+
+        final Optional<Parameter> parameter = lookup.getParameter("non.existing.param");
+        assertFalse(parameter.isPresent());
+    }
+
+    @Test
+    void shouldNotRetrieveParameterWithNullValue() {
+        final Map<String, String> parameters = new HashMap<>();
+        parameters.put("null_param", null);
+
+        final MockParameterLookup lookup = new MockParameterLookup(parameters);
+
+        final Optional<Parameter> parameter = lookup.getParameter("null_param");
+        assertFalse(parameter.isPresent());
+    }
+}


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14808](https://issues.apache.org/jira/browse/NIFI-14808)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
