### PR TITLE
NIFI-14731 Updates Couchbase plugin to support newest couchbase SDK 

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -1028,6 +1028,29 @@ language governing permissions and limitations under the License. -->
             </dependencies>
         </profile>
         <profile>
+            <id>include-couchbase</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>allProfiles</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-couchbase-nar</artifactId>
+                    <version>2.5.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.nifi</groupId>
+                    <artifactId>nifi-couchbase-services-api-nar</artifactId>
+                    <version>2.5.0-SNAPSHOT</version>
+                    <type>nar</type>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>targz</id>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/nifi-docs/src/main/asciidoc/developer-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/developer-guide.adoc
@@ -2707,6 +2707,7 @@ deprecationLogger.warn(
 | QuestDB Bundle         | include-questdb       | Adds support for persistent Status History using QuestDB
 | Snowflake Bundle       | include-snowflake     | Adds support for integration with the https://www.snowflake.com[Snowflake platform].
 | SQL Reporting Bundle   | include-sql-reporting | Adds reporting tasks that are designed to use SQL to update a RDBMS with metrics and other related data from Apache NiFi.
+| Couchbase Bundle       | include-couchbase     | Adds support for Couchbase storage
 |==================================================================================================================================================
 
 === Standard Build Instructions

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-nar/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-couchbase-bundle</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-couchbase-nar</artifactId>
+    <packaging>nar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-couchbase-services-api-nar</artifactId>
+            <version>2.5.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-couchbase-processors</artifactId>
+            <version>2.5.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-nar/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,232 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+APACHE NIFI SUBCOMPONENTS:
+
+The Apache NiFi project contains subcomponents with separate copyright
+notices and license terms. Your use of the source code for the these
+subcomponents is subject to the terms and conditions of the following
+licenses. 
+
+  The binary distribution of this product bundles 'Bouncy Castle JDK 1.5'
+  under an MIT style license.
+
+    Copyright (c) 2000 - 2015 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-nar/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,30 @@
+nifi-couchbase-nar
+Copyright 2014-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+******************
+Apache Software License v2
+******************
+
+The following binary components are provided under the Apache Software License v2
+
+    (ASLv2) Couchbase Java SDK
+      The following NOTICE information applies:
+        Couchbase Java SDK
+        Copyright 2014 Couchbase, Inc.
+
+    (ASLv2) RxJava
+      The following NOTICE information applies:
+        Couchbase Java SDK
+        Copyright 2012 Netflix, Inc.
+
+    (ASLv2) Apache Commons Lang
+      The following NOTICE information applies:
+        Apache Commons Lang
+        Copyright 2001-2017 The Apache Software Foundation
+
+        This product includes software from the Spring Framework,
+        under the Apache License 2.0 (see: StringUtils.containsWhitespace())
+

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-couchbase-bundle</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-couchbase-processors</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+            <version>2.5.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-couchbase-services-api</artifactId>
+            <version>2.5.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-distributed-cache-client-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-lookup-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-record-serialization-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <version>2.5.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/couchbase/CouchbaseClusterService.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/couchbase/CouchbaseClusterService.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.couchbase;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import com.couchbase.client.core.error.CouchbaseException;
+import com.couchbase.client.java.Cluster;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.DeprecationNotice;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.reporting.InitializationException;
+
+import com.couchbase.client.java.Bucket;
+
+/**
+ * Provides a centralized Couchbase connection and bucket passwords management.
+ */
+@CapabilityDescription("Provides a centralized Couchbase connection management.")
+@Tags({ "nosql", "couchbase", "database", "connection" })
+@DeprecationNotice(reason = "This component is deprecated and will be removed in NiFi 2.x.")
+public class CouchbaseClusterService extends AbstractControllerService implements CouchbaseClusterControllerService {
+
+    public static final PropertyDescriptor CONNECTION_STRING = new PropertyDescriptor
+            .Builder()
+            .name("Connection String")
+            .description("The hostnames or ip addresses of the bootstraping nodes and optional parameters."
+                    + " Syntax) couchbase://node1,node2,nodeN?param1=value1&param2=value2&paramN=valueN")
+            .required(true)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor USER_NAME = new PropertyDescriptor
+            .Builder()
+            .name("user-name")
+            .displayName("User Name")
+            .description("The user name to authenticate NiFi as a Couchbase client." +
+                    " This configuration can be used against Couchbase Server 5.0 or later" +
+                    " supporting Roll-Based Access Control.")
+            .required(false)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final PropertyDescriptor USER_PASSWORD = new PropertyDescriptor
+            .Builder()
+            .name("user-password")
+            .displayName("User Password")
+            .description("The user password to authenticate NiFi as a Couchbase client." +
+                    " This configuration can be used against Couchbase Server 5.0 or later" +
+                    " supporting Roll-Based Access Control.")
+            .required(false)
+            .sensitive(true)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    private static final List<PropertyDescriptor> properties;
+
+    static {
+        final List<PropertyDescriptor> props = new ArrayList<>();
+        props.add(CONNECTION_STRING);
+        props.add(USER_NAME);
+        props.add(USER_PASSWORD);
+
+        properties = Collections.unmodifiableList(props);
+    }
+
+    private volatile Cluster cluster;
+    private String connectionString;
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(
+            String propertyDescriptorName) {
+        return null;
+    }
+
+    @Override
+    protected Collection<ValidationResult> customValidate(ValidationContext context) {
+        final Collection<ValidationResult> results = new ArrayList<>();
+
+        final boolean isUserNameSet = context.getProperty(USER_NAME).isSet();
+        final boolean isUserPasswordSet = context.getProperty(USER_PASSWORD).isSet();
+        if ((isUserNameSet && !isUserPasswordSet) || (!isUserNameSet && isUserPasswordSet)) {
+            results.add(new ValidationResult.Builder()
+                    .subject("User Name and Password")
+                    .explanation("Both User Name and Password are required to use.")
+                    .build());
+        }
+
+        return results;
+    }
+
+    /**
+     * Establish a connection to a Couchbase cluster.
+     * @param context the configuration context
+     * @throws InitializationException if unable to connect a Couchbase cluster
+     */
+    @OnEnabled
+    public void onConfigured(final ConfigurationContext context) throws InitializationException {
+
+        connectionString = context.getProperty(CONNECTION_STRING).evaluateAttributeExpressions().getValue();
+        final String userName = context.getProperty(USER_NAME).evaluateAttributeExpressions().getValue();
+        final String userPassword = context.getProperty(USER_PASSWORD).evaluateAttributeExpressions().getValue();
+
+        try {
+            cluster = Cluster.connect(connectionString, userName, userPassword);
+        } catch (CouchbaseException e) {
+            throw new InitializationException(e);
+        }
+    }
+
+    @Override
+    public Bucket openBucket(String bucketName) {
+        return cluster.bucket(bucketName);
+    }
+
+    @Override
+    public com.couchbase.client.java.Collection openCollection(String bucketName, String scopeName, String collectionName) {
+        return cluster.bucket(bucketName).scope(scopeName).collection(collectionName);
+    }
+
+    @Override
+    public String connectionString() {
+        return connectionString;
+    }
+
+    /**
+     * Disconnect from the Couchbase cluster.
+     */
+    @OnDisabled
+    public void shutdown() {
+        if (cluster != null) {
+            cluster.disconnect();
+            cluster = null;
+        }
+    }
+
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/couchbase/CouchbaseUtils.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/couchbase/CouchbaseUtils.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.couchbase;
+
+import com.couchbase.client.core.error.DocumentNotFoundException;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.codec.Transcoder;
+import com.couchbase.client.java.json.JsonArray;
+import com.couchbase.client.java.json.JsonObject;
+import org.apache.nifi.distributed.cache.client.Deserializer;
+import org.apache.nifi.distributed.cache.client.Serializer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+public class CouchbaseUtils {
+
+    /**
+     * A convenient method to retrieve String value when Document type is unknown.
+     * This method uses LegacyDocument to get, then tries to convert content based on its class.
+     * @param collection the collection to get a document from
+     * @param id the id of the target document
+     * @return String representation of the stored value, or null if not found
+     */
+    public static String getStringContent(Collection collection, String id) {
+        try {
+            return new String(collection.get(id).contentAsBytes());
+        } catch (DocumentNotFoundException dnfe) {
+            return null;
+        }
+    }
+
+    public static String getStringContent(Object content) {
+        if (content instanceof String) {
+            return (String) content;
+        } else if (content instanceof byte[]) {
+            return new String((byte[]) content, StandardCharsets.UTF_8);
+        } else if (content instanceof ByteBuffer) {
+            final ByteBuffer byteBuf = (ByteBuffer) content;
+            byte[] bytes = byteBuf.array();
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        return content.toString();
+    }
+
+    /**
+     * A method to get sub-document paths from a JsonObject
+     * @param doc source object
+     * @param subDocPath dot-separated property path for the return value
+     * @return value at subDocPath
+     * @throws Exception will pass any exception up the stack
+     */
+    public static String getSubDocPath(JsonObject doc, String subDocPath) throws Exception {
+        JsonObject last = doc;
+        String[] parts = subDocPath.split("\\.");
+        for (int part = 0; part < parts.length; part++) {
+            String nextPath = parts[part];
+            int idx = nextPath.lastIndexOf('[');
+            if (idx == 0) {
+                throw new IllegalArgumentException("Invalid subdoc path, no subelement name provided before array index: " + subDocPath);
+            }
+            if (idx > -1) {
+                String nextName = nextPath.substring(0, idx);
+                if (!nextPath.endsWith("]")) {
+                    throw new IllegalArgumentException("Invalid subdoc path, missing closing bracket for array index: " + subDocPath);
+                }
+                int nextIdx = Integer.valueOf(nextPath.substring(idx + 1, nextPath.length() - 1));
+                JsonArray nextArray = last.getArray(nextName);
+                if (part == parts.length - 1) {
+                    return nextArray.get(nextIdx).toString();
+                }
+                last = nextArray.getObject(nextIdx);
+            } else {
+                if (part == parts.length - 1) {
+                    return last.getString(nextPath);
+                }
+                last = last.getObject(nextPath);
+            }
+        }
+
+        return null;
+    }
+
+    public static <V> Transcoder transcoder(Serializer<V> serializer, Deserializer<V> deserializer) {
+        return new Transcoder() {
+
+            @Override
+            public EncodedValue encode(Object o) {
+                ByteArrayOutputStream serialized = new ByteArrayOutputStream();
+                try {
+                    serializer.serialize((V) o, serialized);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                return new EncodedValue(serialized.toByteArray(), 0);
+            }
+
+            @Override
+            public <T> T decode(Class<T> aClass, byte[] bytes, int i) {
+                try {
+                    return (T) deserializer.deserialize(bytes);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/AbstractCouchbaseProcessor.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/AbstractCouchbaseProcessor.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.couchbase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.couchbase.client.core.error.CouchbaseException;
+import com.couchbase.client.java.Collection;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.couchbase.CouchbaseClusterControllerService;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+
+
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.BUCKET_NAME;
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.COLLECTION_NAME;
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.COUCHBASE_CLUSTER_SERVICE;
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.SCOPE_NAME;
+
+/**
+ * Provides common functionality for Couchbase processors.
+ */
+public abstract class AbstractCouchbaseProcessor extends AbstractProcessor {
+
+    static final PropertyDescriptor DOC_ID = new PropertyDescriptor.Builder()
+        .name("document-id")
+        .displayName("Document Id")
+        .description("A static, fixed Couchbase document id, or an expression to construct the Couchbase document id.")
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+        .build();
+
+
+    static final Relationship REL_ORIGINAL = new Relationship.Builder().name("original").build();
+    static final Relationship REL_SUCCESS = new Relationship.Builder().name("success").build();
+    static final Relationship REL_RETRY = new Relationship.Builder().name("retry").build();
+    static final Relationship REL_FAILURE = new Relationship.Builder().name("failure").build();
+
+    private List<PropertyDescriptor> descriptors;
+
+    private Set<Relationship> relationships;
+
+    private CouchbaseClusterControllerService clusterService;
+
+    @Override
+    protected final void init(final ProcessorInitializationContext context) {
+
+        final List<PropertyDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(COUCHBASE_CLUSTER_SERVICE);
+        descriptors.add(BUCKET_NAME);
+        descriptors.add(SCOPE_NAME);
+        descriptors.add(COLLECTION_NAME);
+        addSupportedProperties(descriptors);
+        this.descriptors = Collections.unmodifiableList(descriptors);
+
+        final Set<Relationship> relationships = new HashSet<>();
+        addSupportedRelationships(relationships);
+        this.relationships = Collections.unmodifiableSet(relationships);
+
+    }
+
+    /**
+     * Add processor specific properties.
+     *
+     * @param descriptors add properties to this list
+     */
+    protected void addSupportedProperties(List<PropertyDescriptor> descriptors) {
+        return;
+    }
+
+    /**
+     * Add processor specific relationships.
+     *
+     * @param relationships add relationships to this list
+     */
+    protected void addSupportedRelationships(Set<Relationship> relationships) {
+        return;
+    }
+
+    @Override
+    public final Set<Relationship> getRelationships() {
+        return filterRelationships(this.relationships);
+    }
+
+    protected Set<Relationship> filterRelationships(Set<Relationship> rels) {
+        return rels;
+    }
+
+    @Override
+    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return descriptors;
+    }
+
+    private CouchbaseClusterControllerService getClusterService(final ProcessContext context) {
+        synchronized (AbstractCouchbaseProcessor.class) {
+            if (clusterService == null) {
+                clusterService = context.getProperty(COUCHBASE_CLUSTER_SERVICE)
+                        .asControllerService(CouchbaseClusterControllerService.class);
+            }
+        }
+
+        return clusterService;
+    }
+
+    /**
+     * Open a collection connection using a CouchbaseClusterControllerService.
+     *
+     * @param context a process context
+     * @return a collection instance
+     */
+    protected final Collection openCollection(final ProcessContext context) {
+        return getClusterService(context).openCollection(
+                context.getProperty(BUCKET_NAME).evaluateAttributeExpressions().getValue(),
+                context.getProperty(SCOPE_NAME).evaluateAttributeExpressions().getValue(),
+                context.getProperty(COLLECTION_NAME).evaluateAttributeExpressions().getValue()
+        );
+    }
+
+    /**
+     * Generate a transit url.
+     *
+     * @param collection the target collection
+     * @param docId the target document
+     * @return a transit url based on the bucket name and the CouchbaseClusterControllerService name
+     */
+    protected String getTransitUrl(Collection collection, String docId) {
+        return String.format("couchbase://%s/%s/%s/%s",
+                collection.bucketName(),
+                collection.scopeName(),
+                collection.name(),
+                docId
+        );
+    }
+
+    /**
+     * Handles the thrown CouchbaseException accordingly.
+     *
+     * @param context a process context
+     * @param session a process session
+     * @param logger a logger
+     * @param inFile an input FlowFile
+     * @param e the thrown CouchbaseException
+     * @param errMsg a message to be logged
+     */
+    protected void handleCouchbaseException(final ProcessContext context, final ProcessSession session,
+        final ComponentLog logger, FlowFile inFile, CouchbaseException e,
+        String errMsg) {
+        logger.error(errMsg, e);
+        if (inFile != null) {
+            ErrorHandlingStrategy strategy = CouchbaseExceptionMappings.getStrategy(e);
+            switch (strategy.penalty()) {
+                case Penalize:
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Penalized: {}", inFile);
+                    }
+                    inFile = session.penalize(inFile);
+                    break;
+                case Yield:
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Yielded context: {}", inFile);
+                    }
+                    context.yield();
+                    break;
+                case None:
+                    break;
+            }
+
+            switch (strategy.result()) {
+                case ProcessException:
+                    throw new ProcessException(errMsg, e);
+                case Failure:
+                    inFile = session.putAttribute(inFile, CouchbaseAttributes.Exception.key(), e.getClass().getName());
+                    session.transfer(inFile, REL_FAILURE);
+                    break;
+                case Retry:
+                    inFile = session.putAttribute(inFile, CouchbaseAttributes.Exception.key(), e.getClass().getName());
+                    session.transfer(inFile, REL_RETRY);
+                    break;
+            }
+        }
+    }
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/CouchbaseAttributes.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/CouchbaseAttributes.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.couchbase;
+
+import org.apache.nifi.flowfile.attributes.FlowFileAttributeKey;
+
+/**
+ * Couchbase related attribute keys.
+ */
+public enum CouchbaseAttributes implements FlowFileAttributeKey {
+
+    /**
+     * A reference to the related cluster.
+     */
+    Cluster("couchbase.cluster"),
+    /**
+     * A related bucket name.
+     */
+    Bucket("couchbase.bucket"),
+    /**
+     * A related scope name.
+     */
+    Scope("couchbase.scope"),
+    /**
+     * A related bucket name.
+     */
+    Collection("couchbase.collection"),
+    /**
+     * The id of a related document.
+     */
+    DocId("couchbase.doc.id"),
+    /**
+     * The CAS value of a related document.
+     */
+    Cas("couchbase.doc.cas"),
+    /**
+     * The expiration of a related document.
+     */
+    Expiry("couchbase.doc.expiry"),
+    /**
+     * The thrown CouchbaseException class.
+     */
+    Exception("couchbase.exception");
+
+    private final String key;
+
+    private CouchbaseAttributes(final String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String key() {
+        return key;
+    }
+
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/CouchbaseExceptionMappings.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/CouchbaseExceptionMappings.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.couchbase;
+
+import static org.apache.nifi.processors.couchbase.ErrorHandlingStrategy.ConfigurationError;
+import static org.apache.nifi.processors.couchbase.ErrorHandlingStrategy.Fatal;
+import static org.apache.nifi.processors.couchbase.ErrorHandlingStrategy.InvalidInput;
+import static org.apache.nifi.processors.couchbase.ErrorHandlingStrategy.TemporalClusterError;
+import static org.apache.nifi.processors.couchbase.ErrorHandlingStrategy.TemporalFlowFileError;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.couchbase.client.core.error.AlreadyShutdownException;
+import com.couchbase.client.core.error.AuthenticationFailureException;
+import com.couchbase.client.core.error.BucketNotFoundDuringLoadException;
+import com.couchbase.client.core.error.CasMismatchException;
+import com.couchbase.client.core.error.CollectionNotFoundException;
+import com.couchbase.client.core.error.ConfigException;
+import com.couchbase.client.core.error.CouchbaseException;
+import com.couchbase.client.core.error.DocumentMutationLostException;
+import com.couchbase.client.core.error.DurabilityAmbiguousException;
+import com.couchbase.client.core.error.DurabilityImpossibleException;
+import com.couchbase.client.core.error.DurabilityLevelNotAvailableException;
+import com.couchbase.client.core.error.InvalidRequestException;
+import com.couchbase.client.core.error.ReplicaNotConfiguredException;
+import com.couchbase.client.core.error.RequestCanceledException;
+import com.couchbase.client.core.error.ScopeNotFoundException;
+import com.couchbase.client.core.error.ServerOutOfMemoryException;
+import com.couchbase.client.core.error.ServiceNotAvailableException;
+import com.couchbase.client.core.error.TemporaryFailureException;
+import com.couchbase.client.core.error.UnambiguousTimeoutException;
+import com.couchbase.client.core.error.ValueTooLargeException;
+import com.couchbase.client.core.json.MapperException;
+
+public class CouchbaseExceptionMappings {
+
+    private static final Map<Class<? extends CouchbaseException>, ErrorHandlingStrategy>mapping = new HashMap<>();
+
+    /*
+     * - Won't happen
+     * BucketAlreadyExistsException: never create a bucket
+     * CASMismatchException: cas-id and replace is not used yet
+     * DesignDocumentException: View is not used yet
+     * DocumentAlreadyExistsException: insert is not used yet
+     * DocumentDoesNotExistException: replace is not used yet
+     * FlushDisabledException: never call flush
+     * RepositoryMappingException: EntityDocument is not used
+     * TemporaryLockFailureException: we don't obtain locks
+     * ViewDoesNotExistException: View is not used yet
+     * NamedPreparedStatementException: N1QL is not used yet
+     * QueryExecutionException: N1QL is not used yet
+     */
+    static {
+        /*
+         * ConfigurationError
+         */
+        mapping.put(AuthenticationFailureException.class, ConfigurationError);
+        mapping.put(BucketNotFoundDuringLoadException.class, ConfigurationError);
+        mapping.put(ScopeNotFoundException.class, ConfigurationError);
+        mapping.put(CollectionNotFoundException.class, ConfigurationError);
+        mapping.put(ConfigException.class, ConfigurationError);
+        // when Couchbase doesn't have enough replica
+        mapping.put(ReplicaNotConfiguredException.class, ConfigurationError);
+        // when a particular Service(KV, View, Query, DCP) isn't running in a cluster
+        mapping.put(ServiceNotAvailableException.class, ConfigurationError);
+
+        /*
+         * InvalidInput
+         */
+        mapping.put(InvalidRequestException.class, InvalidInput);
+        mapping.put(ValueTooLargeException.class, InvalidInput);
+        mapping.put(MapperException.class, InvalidInput);
+
+        /*
+         * Temporal Cluster Error
+         */
+        mapping.put(ServerOutOfMemoryException.class, TemporalClusterError);
+        mapping.put(TemporaryFailureException.class, TemporalClusterError);
+        // occurs when a connection gets lost
+        mapping.put(RequestCanceledException.class, TemporalClusterError);
+
+        /*
+         * Temporal FlowFile Error
+         */
+        mapping.put(CasMismatchException.class, TemporalFlowFileError);
+        mapping.put(DocumentMutationLostException.class, TemporalFlowFileError);
+        mapping.put(DurabilityImpossibleException.class, TemporalFlowFileError);
+        mapping.put(DurabilityAmbiguousException.class, TemporalFlowFileError);
+        mapping.put(DurabilityLevelNotAvailableException.class, TemporalFlowFileError);
+
+        /*
+         * Fatal
+         */
+        mapping.put(AlreadyShutdownException.class, Fatal);
+        mapping.put(UnambiguousTimeoutException.class, Fatal);
+    }
+
+    /**
+     * Returns a registered error handling strategy.
+     * @param e the CouchbaseException
+     * @return a registered strategy, if it's not registered, then return Fatal
+     */
+    public static ErrorHandlingStrategy getStrategy(CouchbaseException e) {
+        ErrorHandlingStrategy strategy = mapping.get(e.getClass());
+        if (strategy == null) {
+            // Treat unknown Exception as Fatal.
+            return ErrorHandlingStrategy.Fatal;
+        }
+        return strategy;
+    }
+
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/ErrorHandlingStrategy.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/ErrorHandlingStrategy.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.couchbase;
+
+import static org.apache.nifi.processors.couchbase.ErrorHandlingStrategy.Penalty.None;
+import static org.apache.nifi.processors.couchbase.ErrorHandlingStrategy.Penalty.Penalize;
+import static org.apache.nifi.processors.couchbase.ErrorHandlingStrategy.Penalty.Yield;
+import static org.apache.nifi.processors.couchbase.ErrorHandlingStrategy.Result.Failure;
+import static org.apache.nifi.processors.couchbase.ErrorHandlingStrategy.Result.ProcessException;
+import static org.apache.nifi.processors.couchbase.ErrorHandlingStrategy.Result.Retry;
+
+
+public enum ErrorHandlingStrategy {
+
+    /**
+     * Processor setting has to be fixed, in order to NOT call failing processor
+     * frequently, this it be yielded.
+     */
+    ConfigurationError(ProcessException, Yield),
+    /**
+     * The input FlowFile will be sent to the failure relationship for further
+     * processing without penalizing. Basically, the FlowFile shouldn't be sent
+     * this processor again unless the issue has been solved.
+     */
+    InvalidInput(Failure, None),
+    /**
+     * Couchbase cluster is in unhealthy state. Retrying maybe successful,
+     * but it should be yielded for a while.
+     */
+    TemporalClusterError(Retry, Yield),
+    /**
+     * The FlowFile was not processed successfully due to some temporal error
+     * related to this specific FlowFile or document. Retrying maybe successful,
+     * but it should be penalized for a while.
+     */
+    TemporalFlowFileError(Retry, Penalize),
+    /**
+     * The error can't be recovered without DataFlow Manager intervention.
+     */
+    Fatal(Retry, Yield);
+
+    private final Result result;
+    private final Penalty penalty;
+    ErrorHandlingStrategy(Result result, Penalty penalty) {
+        this.result = result;
+        this.penalty = penalty;
+    }
+
+    public enum Result {
+        ProcessException, Failure, Retry
+    }
+
+    /**
+     * Indicating yield or penalize the processing when transfer the input FlowFile.
+     */
+    public enum Penalty {
+        Yield, Penalize, None
+    }
+
+    public Result result() {
+        return this.result;
+    }
+
+    public Penalty penalty() {
+        return this.penalty;
+    }
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/GetCouchbaseKey.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/GetCouchbaseKey.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.couchbase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import com.couchbase.client.core.error.CouchbaseException;
+import com.couchbase.client.core.error.DocumentNotFoundException;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.kv.GetOptions;
+import com.couchbase.client.java.kv.GetResult;
+import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.SystemResource;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.couchbase.CouchbaseUtils;
+import org.apache.nifi.expression.AttributeExpression;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.io.InputStreamCallback;
+import org.apache.nifi.processor.io.OutputStreamCallback;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.stream.io.StreamUtils;
+
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.COUCHBASE_CLUSTER_SERVICE;
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.DOCUMENT_TYPE;
+
+@Tags({"nosql", "couchbase", "database", "get"})
+@InputRequirement(Requirement.INPUT_REQUIRED)
+@CapabilityDescription("Get a document from Couchbase Server via Key/Value access. The ID of the document to fetch may be supplied by setting the <Document Id> property. "
+    + "NOTE: if the Document Id property is not set, the contents of the FlowFile will be read to determine the Document Id, which means that the contents of the entire "
+    + "FlowFile will be buffered in memory.")
+@WritesAttributes({
+    @WritesAttribute(attribute = "couchbase.cluster", description = "Cluster where the document was retrieved from."),
+    @WritesAttribute(attribute = "couchbase.bucket", description = "Bucket where the document was retrieved from."),
+    @WritesAttribute(attribute = "couchbase.scope", description = "Scope where the docuemnt was retrieved from."),
+    @WritesAttribute(attribute = "couchbase.collection", description = "Collection where the docuemnt was retrieved from."),
+    @WritesAttribute(attribute = "couchbase.doc.id", description = "Id of the document."),
+    @WritesAttribute(attribute = "couchbase.doc.cas", description = "CAS of the document."),
+    @WritesAttribute(attribute = "couchbase.doc.expiry", description = "Expiration of the document."),
+    @WritesAttribute(attribute = "couchbase.exception", description = "If Couchbase related error occurs the CouchbaseException class name will be captured here.")
+})
+@SystemResourceConsideration(resource = SystemResource.MEMORY)
+public class GetCouchbaseKey extends AbstractCouchbaseProcessor {
+
+    public static final PropertyDescriptor PUT_VALUE_TO_ATTRIBUTE = new PropertyDescriptor.Builder()
+        .name("put-to-attribute")
+        .displayName("Put Value to Attribute")
+        .description("If set, the retrieved value will be put into an attribute of the FlowFile instead of a the content of the FlowFile." +
+                " The attribute key to put to is determined by evaluating value of this property.")
+        .addValidator(StandardValidators.createAttributeExpressionLanguageValidator(AttributeExpression.ResultType.STRING))
+        .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+        .build();
+
+    private volatile boolean putToAttribute = false;
+
+    @Override
+    protected void addSupportedProperties(final List<PropertyDescriptor> descriptors) {
+        descriptors.add(DOCUMENT_TYPE);
+        descriptors.add(DOC_ID);
+        descriptors.add(PUT_VALUE_TO_ATTRIBUTE);
+    }
+
+    @Override
+    protected void addSupportedRelationships(final Set<Relationship> relationships) {
+        relationships.add(new Relationship.Builder().name(REL_ORIGINAL.getName())
+                .description("The original input FlowFile is routed to this relationship" +
+                        " when the value is retrieved from Couchbase Server and routed to 'success'.").build());
+        relationships.add(new Relationship.Builder().name(REL_SUCCESS.getName())
+                .description("Values retrieved from Couchbase Server are written as outgoing FlowFiles content" +
+                        " or put into an attribute of the incoming FlowFile and routed to this relationship.").build());
+        relationships.add(new Relationship.Builder().name(REL_RETRY.getName())
+                .description("All FlowFiles failed to fetch from Couchbase Server but can be retried are routed to this relationship.").build());
+        relationships.add(new Relationship.Builder().name(REL_FAILURE.getName())
+                .description("All FlowFiles failed to fetch from Couchbase Server and not retry-able are routed to this relationship.").build());
+    }
+
+    @Override
+    protected Set<Relationship> filterRelationships(Set<Relationship> rels) {
+        // If destination is attribute, then success == original.
+        return rels.stream().filter(rel -> !REL_ORIGINAL.equals(rel) || !putToAttribute).collect(Collectors.toSet());
+    }
+
+    @Override
+    public void onPropertyModified(PropertyDescriptor descriptor, String oldValue, String newValue) {
+        if (PUT_VALUE_TO_ATTRIBUTE.equals(descriptor)) {
+            putToAttribute = newValue == null || newValue.isEmpty();
+        }
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        FlowFile inFile = session.get();
+        if (inFile == null) {
+            return;
+        }
+
+        final long startNanos = System.nanoTime();
+        final ComponentLog logger = getLogger();
+        String docId = null;
+        if (context.getProperty(DOC_ID).isSet()) {
+            docId = context.getProperty(DOC_ID).evaluateAttributeExpressions(inFile).getValue();
+        } else {
+            final byte[] content = new byte[(int) inFile.getSize()];
+            session.read(inFile, new InputStreamCallback() {
+                @Override
+                public void process(final InputStream in) throws IOException {
+                    StreamUtils.fillBuffer(in, content, true);
+                }
+            });
+            docId = new String(content, StandardCharsets.UTF_8);
+        }
+
+        if (docId == null || docId.isEmpty()) {
+            throw new ProcessException("Please check 'Document Id' setting. Couldn't get document id from " + inFile);
+        }
+
+        String putTargetAttr = null;
+        if (context.getProperty(PUT_VALUE_TO_ATTRIBUTE).isSet()) {
+            putTargetAttr = context.getProperty(PUT_VALUE_TO_ATTRIBUTE).evaluateAttributeExpressions(inFile).getValue();
+            putToAttribute = true;
+            if (putTargetAttr == null || putTargetAttr.isEmpty()) {
+                inFile = session.putAttribute(inFile, CouchbaseAttributes.Exception.key(), "InvalidPutTargetAttributeName");
+                session.transfer(inFile, REL_FAILURE);
+                return;
+            }
+        }
+
+        final Collection collection = openCollection(context);
+        try {
+            GetResult gr = collection.get(docId, GetOptions.getOptions().withExpiry(true));
+
+            // A function to write a document into outgoing FlowFile content.
+            OutputStreamCallback outputStreamCallback = null;
+            final Map<String, String> updatedAttrs = new HashMap<>();
+
+            outputStreamCallback = out -> {
+                out.write(gr.contentAsBytes());
+                updatedAttrs.put(CoreAttributes.MIME_TYPE.key(), "application/json");
+            };
+
+            FlowFile outFile;
+            if (putToAttribute) {
+                outFile = inFile;
+                updatedAttrs.put(putTargetAttr, CouchbaseUtils.getStringContent(gr.contentAsBytes()));
+            } else {
+                outFile = session.create(inFile);
+                outFile = session.write(outFile, outputStreamCallback);
+                session.transfer(inFile, REL_ORIGINAL);
+            }
+
+            updatedAttrs.put(CouchbaseAttributes.Cluster.key(), context.getProperty(COUCHBASE_CLUSTER_SERVICE).getValue());
+            updatedAttrs.put(CouchbaseAttributes.Bucket.key(), collection.bucketName());
+            updatedAttrs.put(CouchbaseAttributes.Scope.key(), collection.scopeName());
+            updatedAttrs.put(CouchbaseAttributes.Collection.key(), collection.name());
+            updatedAttrs.put(CouchbaseAttributes.DocId.key(), docId);
+            updatedAttrs.put(CouchbaseAttributes.Cas.key(), String.valueOf(gr.cas()));
+            gr.expiryTime().ifPresent(expiryTime -> updatedAttrs.put(CouchbaseAttributes.Expiry.key(), expiryTime.toString()));
+            outFile = session.putAllAttributes(outFile, updatedAttrs);
+
+            final long fetchMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            session.getProvenanceReporter().fetch(outFile, getTransitUrl(collection, docId), fetchMillis);
+            session.transfer(outFile, REL_SUCCESS);
+
+        } catch (final DocumentNotFoundException dnfe) {
+            logger.warn("Document {} was not found in {}; routing {} to failure", docId, getTransitUrl(collection, docId), inFile);
+            inFile = session.putAttribute(inFile, CouchbaseAttributes.Exception.key(), DocumentNotFoundException.class.getName());
+            session.transfer(inFile, REL_FAILURE);
+        } catch (final CouchbaseException e) {
+            String errMsg = String.format("Getting document %s from Couchbase Server using %s failed due to %s", docId, inFile, e);
+            handleCouchbaseException(context, session, logger, inFile, e, errMsg);
+        }
+    }
+
+
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/PutCouchbaseKey.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/java/org/apache/nifi/processors/couchbase/PutCouchbaseKey.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.couchbase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.couchbase.client.core.error.CouchbaseException;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.codec.RawBinaryTranscoder;
+import com.couchbase.client.java.codec.RawJsonTranscoder;
+import com.couchbase.client.java.kv.MutationResult;
+import com.couchbase.client.java.kv.PersistTo;
+import com.couchbase.client.java.kv.ReplicateTo;
+import com.couchbase.client.java.kv.UpsertOptions;
+import org.apache.nifi.annotation.behavior.SystemResourceConsideration;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
+import org.apache.nifi.annotation.behavior.ReadsAttribute;
+import org.apache.nifi.annotation.behavior.ReadsAttributes;
+import org.apache.nifi.annotation.behavior.SystemResource;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.couchbase.DocumentType;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.io.InputStreamCallback;
+import org.apache.nifi.stream.io.StreamUtils;
+
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.COUCHBASE_CLUSTER_SERVICE;
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.DOCUMENT_TYPE;
+
+@Tags({"nosql", "couchbase", "database", "put"})
+@CapabilityDescription("Put a document to Couchbase Server via Key/Value access.")
+@InputRequirement(Requirement.INPUT_REQUIRED)
+@ReadsAttributes({
+    @ReadsAttribute(attribute = "uuid", description = "Used as a document id if 'Document Id' is not specified"),
+})
+@WritesAttributes({
+    @WritesAttribute(attribute = "couchbase.cluster", description = "Cluster where the document was stored."),
+    @WritesAttribute(attribute = "couchbase.bucket", description = "Bucket where the document was stored."),
+    @WritesAttribute(attribute = "couchbase.scope", description = "Scope where the document was stored."),
+    @WritesAttribute(attribute = "couchbase.collection", description = "Collection where the document was stored."),
+    @WritesAttribute(attribute = "couchbase.doc.id", description = "Id of the document."),
+    @WritesAttribute(attribute = "couchbase.doc.cas", description = "CAS of the document."),
+    @WritesAttribute(attribute = "couchbase.exception", description = "If Couchbase related error occurs the CouchbaseException class name will be captured here.")
+})
+@SystemResourceConsideration(resource = SystemResource.MEMORY)
+public class PutCouchbaseKey extends AbstractCouchbaseProcessor {
+
+
+    public static final PropertyDescriptor PERSIST_TO = new PropertyDescriptor.Builder()
+        .name("persist-to")
+        .displayName("Persist To")
+        .description("Durability constraint about disk persistence.")
+        .required(true)
+        .allowableValues(PersistTo.values())
+        .defaultValue(PersistTo.NONE.toString())
+        .build();
+
+    public static final PropertyDescriptor REPLICATE_TO = new PropertyDescriptor.Builder()
+        .name("replicate-to")
+        .displayName("Replicate To")
+        .description("Durability constraint about replication.")
+        .required(true)
+        .allowableValues(ReplicateTo.values())
+        .defaultValue(ReplicateTo.NONE.toString())
+        .build();
+
+    @Override
+    protected void addSupportedProperties(List<PropertyDescriptor> descriptors) {
+        descriptors.add(DOCUMENT_TYPE);
+        descriptors.add(DOC_ID);
+        descriptors.add(PERSIST_TO);
+        descriptors.add(REPLICATE_TO);
+    }
+
+    @Override
+    protected void addSupportedRelationships(Set<Relationship> relationships) {
+        relationships.add(new Relationship.Builder().name(REL_SUCCESS.getName())
+                .description("All FlowFiles that are written to Couchbase Server are routed to this relationship.").build());
+        relationships.add(new Relationship.Builder().name(REL_RETRY.getName())
+                .description("All FlowFiles failed to be written to Couchbase Server but can be retried are routed to this relationship.").build());
+        relationships.add(new Relationship.Builder().name(REL_FAILURE.getName())
+                .description("All FlowFiles failed to be written to Couchbase Server and not retry-able are routed to this relationship.").build());
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        final ComponentLog logger = getLogger();
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
+
+        final byte[] content = new byte[(int) flowFile.getSize()];
+        session.read(flowFile, new InputStreamCallback() {
+            @Override
+            public void process(final InputStream in) throws IOException {
+                StreamUtils.fillBuffer(in, content, true);
+            }
+        });
+
+        String docId = flowFile.getAttribute(CoreAttributes.UUID.key());
+        if (context.getProperty(DOC_ID).isSet()) {
+            docId = context.getProperty(DOC_ID).evaluateAttributeExpressions(flowFile).getValue();
+        }
+
+        try {
+            final DocumentType documentType = DocumentType.valueOf(context.getProperty(DOCUMENT_TYPE).getValue());
+            final PersistTo persistTo = PersistTo.valueOf(context.getProperty(PERSIST_TO).getValue());
+            final ReplicateTo replicateTo = ReplicateTo.valueOf(context.getProperty(REPLICATE_TO).getValue());
+            final Collection collection = openCollection(context);
+            UpsertOptions uo = UpsertOptions.upsertOptions()
+                    .durability(persistTo, replicateTo)
+                    .transcoder(documentType == DocumentType.Json ? RawJsonTranscoder.INSTANCE : RawBinaryTranscoder.INSTANCE);
+
+            MutationResult mr = collection.upsert(docId, content, uo);
+
+            final Map<String, String> updatedAttrs = new HashMap<>();
+            updatedAttrs.put(CouchbaseAttributes.Cluster.key(), context.getProperty(COUCHBASE_CLUSTER_SERVICE).getValue());
+            updatedAttrs.put(CouchbaseAttributes.Bucket.key(), collection.bucketName());
+            updatedAttrs.put(CouchbaseAttributes.Scope.key(), collection.scopeName());
+            updatedAttrs.put(CouchbaseAttributes.Collection.key(), collection.name());
+            updatedAttrs.put(CouchbaseAttributes.DocId.key(), docId);
+            if (mr != null) {
+                updatedAttrs.put(CouchbaseAttributes.Cas.key(), String.valueOf(mr.cas()));
+            }
+
+
+            flowFile = session.putAllAttributes(flowFile, updatedAttrs);
+            session.getProvenanceReporter().send(flowFile, getTransitUrl(collection, docId));
+            session.transfer(flowFile, REL_SUCCESS);
+        } catch (final CouchbaseException e) {
+            String errMsg = String.format("Writing document %s to Couchbase Server using %s failed due to %s", docId, flowFile, e);
+            handleCouchbaseException(context, session, logger, flowFile, e, errMsg);
+        }
+    }
+
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.couchbase.CouchbaseClusterService

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.processors.couchbase.GetCouchbaseKey
+org.apache.nifi.processors.couchbase.PutCouchbaseKey

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/resources/docs/org.apache.nifi.couchbase.CouchbaseMapCacheClient/additionalDetails.html
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/main/resources/docs/org.apache.nifi.couchbase.CouchbaseMapCacheClient/additionalDetails.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<head>
+    <meta charset="utf-8" />
+    <title>CouchbaseMapCacheClient</title>
+    <link rel="stylesheet" href="/nifi-docs/css/component-usage.css" type="text/css" />
+</head>
+
+<body>
+<h2>CouchbaseMapCacheClient</h2>
+
+<h3>Requirements</h3>
+
+<h4>Couchbase Server 7.0 or higher is required</h4>
+
+Couchbase processors were modified to work with scopes and collection and require a couchbase Server v7.0 or higher.
+
+</body>
+</html>

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/couchbase/AbstractCouchbaseNifiTest.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/couchbase/AbstractCouchbaseNifiTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.couchbase;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.COUCHBASE_CLUSTER_SERVICE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public abstract class AbstractCouchbaseNifiTest {
+    protected static final String SERVICE_ID = "couchbaseClusterService";
+    protected final String bucketName = "bucket-1";
+    protected final String scopeName = "scope-1";
+    protected final String collectionName = "collection-1";
+    protected TestRunner testRunner;
+
+    @BeforeEach
+    public void init() throws Exception {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info");
+        System.setProperty("org.slf4j.simpleLogger.showDateTime", "true");
+        System.setProperty("org.slf4j.simpleLogger.log.org.apache.nifi.processors.couchbase.GetCouchbaseKey", "debug");
+        System.setProperty("org.slf4j.simpleLogger.log.org.apache.nifi.processors.couchbase.TestGetCouchbaseKey", "debug");
+
+        testRunner = TestRunners.newTestRunner(processor());
+    }
+
+    protected abstract Class<? extends Processor> processor();
+
+    protected Collection setupMockCouchbase(String bucket, String scope, String collection) throws InitializationException {
+        Bucket bucketMock = mock(Bucket.class);
+        Scope scopeMock = mock(Scope.class);
+        Collection collectionMock = mock(Collection.class);
+        CouchbaseClusterControllerService service = mock(CouchbaseClusterControllerService.class);
+        when(bucketMock.name()).thenReturn(bucket);
+        when(service.getIdentifier()).thenReturn(SERVICE_ID);
+        when(service.openBucket(bucket)).thenReturn(bucketMock);
+        when(service.openCollection(bucket, scope, collection)).thenReturn(collectionMock);
+        when(bucketMock.scope(anyString())).thenReturn(scopeMock);
+        when(scopeMock.name()).thenReturn(scope);
+        when(scopeMock.collection(anyString())).thenReturn(collectionMock);
+        when(collectionMock.name()).thenReturn(collection);
+        when(collectionMock.bucketName()).thenReturn(bucket);
+        when(collectionMock.scopeName()).thenReturn(scope);
+        testRunner.addControllerService(SERVICE_ID, service);
+        testRunner.enableControllerService(service);
+        testRunner.setProperty(COUCHBASE_CLUSTER_SERVICE, SERVICE_ID);
+        return collectionMock;
+    }
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/couchbase/TestCouchbaseClusterService.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/couchbase/TestCouchbaseClusterService.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.couchbase;
+
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+public class TestCouchbaseClusterService {
+
+    private static final String SERVICE_ID = "couchbaseClusterService";
+    private TestRunner testRunner;
+
+    public static class SampleProcessor extends AbstractProcessor {
+        @Override
+        public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+
+        }
+    }
+
+    @BeforeEach
+    public void init() {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "info");
+        System.setProperty("org.slf4j.simpleLogger.showDateTime", "true");
+        System.setProperty("org.slf4j.simpleLogger.log.org.apache.nifi.processors.couchbase.PutCouchbaseKey", "debug");
+        System.setProperty("org.slf4j.simpleLogger.log.org.apache.nifi.couchbase.CouchbaseClusterService", "debug");
+        System.setProperty("org.slf4j.simpleLogger.log.org.apache.nifi.couchbase.TestCouchbaseClusterService", "debug");
+
+        testRunner = TestRunners.newTestRunner(SampleProcessor.class);
+        testRunner.setValidateExpressionUsage(false);
+    }
+
+    @Test
+    public void testConnectionFailure() throws InitializationException {
+        String connectionString = "invalid-protocol://invalid-hostname";
+        CouchbaseClusterControllerService service = new CouchbaseClusterService();
+        testRunner.addControllerService(SERVICE_ID, service);
+        testRunner.setProperty(service, CouchbaseClusterService.CONNECTION_STRING, connectionString);
+        assertThrows(AssertionError.class, () -> testRunner.enableControllerService(service));
+    }
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/TestGetCouchbaseKey.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/TestGetCouchbaseKey.java
@@ -1,0 +1,545 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.couchbase;
+
+import com.couchbase.client.core.error.AuthenticationFailureException;
+import com.couchbase.client.core.error.CouchbaseException;
+import com.couchbase.client.core.error.DocumentNotFoundException;
+import com.couchbase.client.core.error.DurabilityImpossibleException;
+import com.couchbase.client.core.error.InvalidRequestException;
+import com.couchbase.client.core.error.ServiceNotAvailableException;
+import com.couchbase.client.core.error.TemporaryFailureException;
+import com.couchbase.client.core.error.UnambiguousTimeoutException;
+import com.couchbase.client.core.error.context.CancellationErrorContext;
+import com.couchbase.client.core.error.context.ErrorContext;
+import com.couchbase.client.core.error.context.KeyValueErrorContext;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.kv.GetOptions;
+import com.couchbase.client.java.kv.GetResult;
+import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageException;
+import org.apache.nifi.couchbase.DocumentType;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.provenance.ProvenanceEventType;
+import org.apache.nifi.util.MockFlowFile;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.BUCKET_NAME;
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.COLLECTION_NAME;
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.DOCUMENT_TYPE;
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.SCOPE_NAME;
+import static org.apache.nifi.processors.couchbase.AbstractCouchbaseProcessor.DOC_ID;
+import static org.apache.nifi.processors.couchbase.AbstractCouchbaseProcessor.REL_FAILURE;
+import static org.apache.nifi.processors.couchbase.AbstractCouchbaseProcessor.REL_ORIGINAL;
+import static org.apache.nifi.processors.couchbase.AbstractCouchbaseProcessor.REL_RETRY;
+import static org.apache.nifi.processors.couchbase.AbstractCouchbaseProcessor.REL_SUCCESS;
+import static org.apache.nifi.processors.couchbase.CouchbaseAttributes.Exception;
+import static org.apache.nifi.processors.couchbase.GetCouchbaseKey.PUT_VALUE_TO_ATTRIBUTE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class TestGetCouchbaseKey extends org.apache.nifi.couchbase.AbstractCouchbaseNifiTest {
+
+    @Override
+    protected Class<? extends Processor> processor() {
+        return GetCouchbaseKey.class;
+    }
+
+    @Test
+    public void testStaticDocId() throws Exception {
+        String docId = "doc-a";
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        String content = "{\"key\":\"value\"}";
+        Instant expiry = Instant.now().plusSeconds(10);
+        long cas = 200L;
+        when(mcol.get(eq(docId), any(GetOptions.class)))
+                .thenReturn(new GetResult(content.getBytes(StandardCharsets.UTF_8), 0, cas, Optional.of(expiry), null));
+
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docId);
+        testRunner.enqueue(new byte[0]);
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        testRunner.assertTransferCount(REL_ORIGINAL, 1);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(content);
+
+        outFile.assertAttributeEquals(CouchbaseAttributes.Cluster.key(), SERVICE_ID);
+        outFile.assertAttributeEquals(CouchbaseAttributes.Bucket.key(), bucketName);
+        outFile.assertAttributeEquals(CouchbaseAttributes.DocId.key(), docId);
+        outFile.assertAttributeEquals(CouchbaseAttributes.Cas.key(), String.valueOf(cas));
+        outFile.assertAttributeEquals(CouchbaseAttributes.Expiry.key(), String.valueOf(expiry));
+    }
+
+
+    @Test
+    public void testDocIdExp() throws Exception {
+        String docIdExp = "${'someProperty'}";
+        String somePropertyValue = "doc-p";
+
+        String content = "{\"key\":\"value\"}";
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.get(eq(somePropertyValue), any(GetOptions.class)))
+                .thenReturn(new GetResult(content.getBytes(StandardCharsets.UTF_8), 0, 200L, Optional.empty(), null));
+
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docIdExp);
+
+        byte[] inFileData = "input FlowFile data".getBytes(StandardCharsets.UTF_8);
+        Map<String, String> properties = new HashMap<>();
+        properties.put("someProperty", somePropertyValue);
+        testRunner.enqueue(inFileData, properties);
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        testRunner.assertTransferCount(REL_ORIGINAL, 1);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(content);
+    }
+
+    @Test
+    public void testDocIdExpWithEmptyFlowFile() throws Exception {
+        String docIdExp = "doc-s";
+        String docId = "doc-s";
+
+        String content = "{\"key\":\"value\"}";
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.get(eq(docId), any(GetOptions.class)))
+                .thenReturn(new GetResult(content.getBytes(StandardCharsets.UTF_8), 0, 200L, Optional.empty(), null));
+
+        testRunner.setProperty(DOC_ID, docIdExp);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+
+        testRunner.enqueue(new byte[0]);
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        testRunner.assertTransferCount(REL_ORIGINAL, 1);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(content);
+    }
+
+    @Test
+    public void testDocIdExpWithInvalidExpression() throws Exception {
+        String docIdExp = "${nonExistingFunction('doc-s')}";
+        String docId = "doc-s";
+
+        String content = "{\"key\":\"value\"}";
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.get(eq(docId), any(GetOptions.class)))
+                .thenReturn(new GetResult(content.getBytes(StandardCharsets.UTF_8), 0, 200L, Optional.empty(), null));
+
+        testRunner.setProperty(DOC_ID, docIdExp);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.enqueue(new byte[0]);
+
+        AssertionError e = assertThrows(AssertionError.class, () -> testRunner.run());
+        assertEquals(AttributeExpressionLanguageException.class, e.getCause().getClass());
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+    }
+
+    @Test
+    public void testDocIdExpWithInvalidExpressionOnFlowFile() throws Exception {
+        String docIdExp = "${nonExistingFunction(someProperty)}";
+
+        setupMockCouchbase(bucketName, scopeName, collectionName);
+
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docIdExp);
+
+        String inputFileDataStr = "input FlowFile data";
+        byte[] inFileData = inputFileDataStr.getBytes(StandardCharsets.UTF_8);
+        Map<String, String> properties = new HashMap<>();
+        properties.put("someProperty", "someValue");
+        testRunner.enqueue(inFileData, properties);
+
+        AssertionError e = assertThrows(AssertionError.class, () -> testRunner.run());
+        assertEquals(AttributeExpressionLanguageException.class, e.getCause().getClass());
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+    }
+
+    @Test
+    public void testInputFlowFileContent() throws Exception {
+
+        String inFileDataStr = "doc-in";
+        String content = "{\"key\":\"value\"}";
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.get(eq(inFileDataStr), any(GetOptions.class)))
+            .thenReturn(new GetResult(content.getBytes(StandardCharsets.UTF_8), 0, 200L, Optional.empty(), null));
+
+
+        byte[] inFileData = inFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.enqueue(inFileData);
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        testRunner.assertTransferCount(REL_ORIGINAL, 1);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(content);
+        MockFlowFile orgFile = testRunner.getFlowFilesForRelationship(REL_ORIGINAL).get(0);
+        orgFile.assertContentEquals(inFileDataStr);
+    }
+
+    @Test
+    public void testPutToAttribute() throws Exception {
+
+        String inFileDataStr = "doc-in";
+        String content = "some-value";
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.get(eq(inFileDataStr), any(GetOptions.class)))
+                .thenReturn(new GetResult(content.getBytes(StandardCharsets.UTF_8), 0, 200L, Optional.empty(), null));
+
+        byte[] inFileData = inFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(PUT_VALUE_TO_ATTRIBUTE, "targetAttribute");
+        testRunner.enqueue(inFileData);
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        // Result is put to Attribute, so no need to pass it to original.
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(inFileDataStr);
+        outFile.assertAttributeEquals("targetAttribute", content);
+
+        assertEquals(1, testRunner.getProvenanceEvents().size());
+        assertEquals(ProvenanceEventType.FETCH, testRunner.getProvenanceEvents().get(0).getEventType());
+    }
+
+    @Test
+    public void testPutToAttributeNoTargetAttribute() throws Exception {
+
+        String inFileDataStr = "doc-in";
+        String content = "some-value";
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.get(eq(inFileDataStr), any(GetOptions.class)))
+                .thenReturn(new GetResult(content.getBytes(StandardCharsets.UTF_8), 0, 200L, Optional.empty(), null));
+
+        byte[] inFileData = inFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(PUT_VALUE_TO_ATTRIBUTE, "${expressionReturningNoValue}");
+        testRunner.enqueue(inFileData);
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 1);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_FAILURE).get(0);
+        outFile.assertContentEquals(inFileDataStr);
+    }
+
+    @Test
+    public void testBinaryDocument() throws Exception {
+
+        String inFileDataStr = "doc-in";
+        String content = "binary";
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.get(eq(inFileDataStr), any(GetOptions.class)))
+                .thenReturn(new GetResult(content.getBytes(StandardCharsets.UTF_8), 0, 200L, Optional.empty(), null));
+
+
+        byte[] inFileData = inFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.enqueue(inFileData);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOCUMENT_TYPE, DocumentType.Binary.toString());
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        testRunner.assertTransferCount(REL_ORIGINAL, 1);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(content);
+        MockFlowFile orgFile = testRunner.getFlowFilesForRelationship(REL_ORIGINAL).get(0);
+        orgFile.assertContentEquals(inFileDataStr);
+    }
+
+    @Test
+    public void testBinaryDocumentToAttribute() throws Exception {
+
+        String inFileDataStr = "doc-in";
+        String content = "binary";
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.get(eq(inFileDataStr), any(GetOptions.class)))
+                .thenReturn(new GetResult(content.getBytes(StandardCharsets.UTF_8), 0, 200L, Optional.empty(), null));
+
+        byte[] inFileData = inFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.enqueue(inFileData);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOCUMENT_TYPE, DocumentType.Binary.toString());
+        testRunner.setProperty(PUT_VALUE_TO_ATTRIBUTE, "targetAttribute");
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(inFileDataStr);
+        outFile.assertAttributeEquals("targetAttribute", "binary");
+    }
+
+
+    @Test
+    public void testCouchbaseFailure() throws Exception {
+
+        String inFileDataStr = "doc-in";
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.get(eq(inFileDataStr), any(GetOptions.class)))
+                .thenThrow(new ServiceNotAvailableException("Mock exception", mock(ErrorContext.class)));
+
+        byte[] inFileData = inFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.enqueue(inFileData);
+
+        AssertionError e = assertThrows(AssertionError.class, () -> testRunner.run());
+        assertEquals(ProcessException.class, e.getCause().getClass());
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+    }
+
+    @Test
+    public void testCouchbaseConfigurationError() throws Exception {
+        String docIdExp = "doc-c";
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.get(eq(docIdExp), any(GetOptions.class)))
+                .thenThrow(new AuthenticationFailureException("Test Exception", mock(ErrorContext.class), new ProcessException()));
+//        when(bucket.get(docIdExp, RawJsonDocument.class))
+//            .thenThrow(new AuthenticationException());
+//        setupMockCouchbase(bucket);
+
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docIdExp);
+
+        String inputFileDataStr = "input FlowFile data";
+        byte[] inFileData = inputFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.enqueue(inFileData);
+
+        AssertionError e = assertThrows(AssertionError.class, () -> testRunner.run());
+        assertEquals(ProcessException.class, e.getCause().getClass());
+        /* assertTrue(e.getCause().getCause().getClass().equals(AuthenticationException.class)); */
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+    }
+
+    @Test
+    public void testCouchbaseInvalidInputError() throws Exception {
+        String docIdExp = "doc-c";
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        Exception exception = new InvalidRequestException(mock(ErrorContext.class));
+        when(mcol.get(eq(docIdExp), any(GetOptions.class)))
+                .thenThrow(exception);
+
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docIdExp);
+
+        String inputFileDataStr = "input FlowFile data";
+        byte[] inFileData = inputFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.enqueue(inFileData);
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 1);
+        MockFlowFile orgFile = testRunner.getFlowFilesForRelationship(REL_FAILURE).get(0);
+        orgFile.assertContentEquals(inputFileDataStr);
+        orgFile.assertAttributeEquals(Exception.key(), exception.getClass().getName());
+    }
+
+    @Test
+    public void testCouchbaseTempClusterError() throws Exception {
+        String docIdExp = "doc-c";
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        CouchbaseException exception = new TemporaryFailureException(mock(ErrorContext.class));
+        when(mcol.get(eq(docIdExp), any(GetOptions.class)))
+                .thenThrow(exception);
+
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docIdExp);
+
+        String inputFileDataStr = "input FlowFile data";
+        byte[] inFileData = inputFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.enqueue(inFileData);
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 1);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile orgFile = testRunner.getFlowFilesForRelationship(REL_RETRY).get(0);
+        orgFile.assertContentEquals(inputFileDataStr);
+        orgFile.assertAttributeEquals(Exception.key(), exception.getClass().getName());
+    }
+
+
+    @Test
+    public void testCouchbaseTempFlowFileError() throws Exception {
+        String docIdExp = "doc-c";
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        // There is no suitable CouchbaseException for temp flowfile error, currently.
+        Exception exception = new DurabilityImpossibleException(mock(KeyValueErrorContext.class));
+        when(mcol.get(eq(docIdExp), any(GetOptions.class)))
+                .thenThrow(exception);
+
+        testRunner.setProperty(DOC_ID, docIdExp);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+
+        String inputFileDataStr = "input FlowFile data";
+        byte[] inFileData = inputFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.enqueue(inFileData);
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 1);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile orgFile = testRunner.getFlowFilesForRelationship(REL_RETRY).get(0);
+        orgFile.assertContentEquals(inputFileDataStr);
+        orgFile.assertAttributeEquals(Exception.key(), exception.getClass().getName());
+        assertTrue(orgFile.isPenalized());
+    }
+
+    @Test
+    public void testCouchbaseFatalError() throws Exception {
+        String docIdExp = "doc-c";
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        CouchbaseException exception = new UnambiguousTimeoutException("mock", mock(CancellationErrorContext.class));
+        when(mcol.get(eq(docIdExp), any(GetOptions.class)))
+                .thenThrow(exception);
+
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docIdExp);
+
+        String inputFileDataStr = "input FlowFile data";
+        byte[] inFileData = inputFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.enqueue(inFileData);
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 1);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile orgFile = testRunner.getFlowFilesForRelationship(REL_RETRY).get(0);
+        orgFile.assertContentEquals(inputFileDataStr);
+        orgFile.assertAttributeEquals(Exception.key(), exception.getClass().getName());
+    }
+
+    @Test
+    public void testDocumentNotFound() throws Exception {
+        String docIdExp = "doc-n";
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.get(eq(docIdExp), any(GetOptions.class)))
+                .thenThrow(new DocumentNotFoundException(mock(ErrorContext.class)));
+
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docIdExp);
+
+        String inputFileDataStr = "input FlowFile data";
+        byte[] inFileData = inputFileDataStr.getBytes(StandardCharsets.UTF_8);
+        testRunner.enqueue(inFileData);
+        testRunner.run();
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_ORIGINAL, 0);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 1);
+        MockFlowFile orgFile = testRunner.getFlowFilesForRelationship(REL_FAILURE).get(0);
+        orgFile.assertContentEquals(inputFileDataStr);
+        orgFile.assertAttributeEquals(Exception.key(), DocumentNotFoundException.class.getName());
+    }
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/TestPutCouchbaseKey.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-processors/src/test/java/org/apache/nifi/processors/couchbase/TestPutCouchbaseKey.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.couchbase;
+
+import com.couchbase.client.core.CoreKeyspace;
+import com.couchbase.client.core.api.kv.CoreMutationResult;
+import com.couchbase.client.core.error.CouchbaseException;
+import com.couchbase.client.core.error.DurabilityImpossibleException;
+import com.couchbase.client.core.error.ServiceNotAvailableException;
+import com.couchbase.client.core.error.context.ErrorContext;
+import com.couchbase.client.core.error.context.KeyValueErrorContext;
+import com.couchbase.client.core.io.CollectionIdentifier;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.kv.MutationResult;
+import com.couchbase.client.java.kv.PersistTo;
+import com.couchbase.client.java.kv.ReplicateTo;
+import com.couchbase.client.java.kv.UpsertOptions;
+import org.apache.nifi.attribute.expression.language.exception.AttributeExpressionLanguageException;
+import org.apache.nifi.couchbase.AbstractCouchbaseNifiTest;
+import org.apache.nifi.couchbase.DocumentType;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.Processor;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.util.MockFlowFile;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.BUCKET_NAME;
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.COLLECTION_NAME;
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.DOCUMENT_TYPE;
+import static org.apache.nifi.couchbase.CouchbaseConfigurationProperties.SCOPE_NAME;
+import static org.apache.nifi.processors.couchbase.AbstractCouchbaseProcessor.DOC_ID;
+import static org.apache.nifi.processors.couchbase.AbstractCouchbaseProcessor.REL_FAILURE;
+import static org.apache.nifi.processors.couchbase.AbstractCouchbaseProcessor.REL_RETRY;
+import static org.apache.nifi.processors.couchbase.AbstractCouchbaseProcessor.REL_SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+public class TestPutCouchbaseKey extends AbstractCouchbaseNifiTest {
+
+    @Test
+    public void testStaticDocId() throws Exception {
+        String bucketName = "bucket-1";
+        String docId = "doc-a";
+        long cas = 200L;
+
+        String inFileData = "{\"key\":\"value\"}";
+        byte[] inFileDataBytes = inFileData.getBytes(StandardCharsets.UTF_8);
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.upsert(eq(docId), any(), any(UpsertOptions.class)))
+                .thenReturn(new MutationResult(
+                        new CoreMutationResult(null,
+                                CoreKeyspace.from(new CollectionIdentifier(bucketName, Optional.of(scopeName), Optional.of(collectionName))),
+                                docId, cas, Optional.empty() )
+                ));
+
+        testRunner.enqueue(inFileDataBytes);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docId);
+        testRunner.run();
+
+        verify(mcol, times(1)).upsert(eq(docId), any(), any(UpsertOptions.class));
+
+        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS);
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(inFileData);
+        outFile.assertAttributeEquals(CouchbaseAttributes.Cluster.key(), SERVICE_ID);
+        outFile.assertAttributeEquals(CouchbaseAttributes.Bucket.key(), bucketName);
+        outFile.assertAttributeEquals(CouchbaseAttributes.DocId.key(), docId);
+        outFile.assertAttributeEquals(CouchbaseAttributes.Cas.key(), String.valueOf(cas));
+    }
+
+    @Test
+    public void testBinaryDoc() throws Exception {
+        String bucketName = "bucket-1";
+        String docId = "doc-a";
+        long cas = 200L;
+
+        String inFileData = "12345";
+        byte[] inFileDataBytes = inFileData.getBytes(StandardCharsets.UTF_8);
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.upsert(eq(docId), any(), any(UpsertOptions.class)))
+                .thenReturn(new MutationResult(new CoreMutationResult(null,
+                        CoreKeyspace.from(new CollectionIdentifier(bucketName, Optional.of(scopeName), Optional.of(collectionName))),
+                        docId, cas, Optional.empty()
+                )));
+
+        testRunner.enqueue(inFileDataBytes);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docId);
+        testRunner.setProperty(DOCUMENT_TYPE, DocumentType.Binary.name());
+        testRunner.run();
+
+        verify(mcol, times(1)).upsert(eq(docId), any(), any(UpsertOptions.class));
+
+        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS);
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(inFileData);
+        outFile.assertAttributeEquals(CouchbaseAttributes.Cluster.key(), SERVICE_ID);
+        outFile.assertAttributeEquals(CouchbaseAttributes.Bucket.key(), bucketName);
+        outFile.assertAttributeEquals(CouchbaseAttributes.DocId.key(), docId);
+        outFile.assertAttributeEquals(CouchbaseAttributes.Cas.key(), String.valueOf(cas));
+    }
+
+    @Test
+    public void testDurabilityConstraint() throws Exception {
+        String docId = "doc-a";
+        long cas = 200L;
+
+        String inFileData = "{\"key\":\"value\"}";
+        byte[] inFileDataBytes = inFileData.getBytes(StandardCharsets.UTF_8);
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.upsert(eq(docId), any(), any(UpsertOptions.class)))
+                .thenReturn(new MutationResult(new CoreMutationResult(null,
+                        CoreKeyspace.from(new CollectionIdentifier(bucketName, Optional.of(scopeName), Optional.of(collectionName))),
+                        docId, cas, Optional.empty()
+                )));
+
+        testRunner.enqueue(inFileDataBytes);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docId);
+        testRunner.setProperty(PutCouchbaseKey.PERSIST_TO, PersistTo.ONE.toString());
+        testRunner.setProperty(PutCouchbaseKey.REPLICATE_TO, ReplicateTo.ONE.toString());
+        testRunner.run();
+
+        verify(mcol, times(1)).upsert(eq(docId), any(), any(UpsertOptions.class));
+
+        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS);
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(inFileData);
+    }
+
+    @Test
+    public void testDocIdExp() throws Exception {
+        String docIdExp = "${'someProperty'}";
+        String somePropertyValue = "doc-p";
+
+        String inFileData = "{\"key\":\"value\"}";
+        byte[] inFileDataBytes = inFileData.getBytes(StandardCharsets.UTF_8);
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.upsert(eq(somePropertyValue), eq(inFileDataBytes), any(UpsertOptions.class)))
+                .thenReturn(new MutationResult(
+                        new CoreMutationResult(null,
+                                CoreKeyspace.from(new CollectionIdentifier(bucketName, Optional.of(scopeName), Optional.of(collectionName))),
+                                somePropertyValue, 200L, Optional.empty()
+                        )
+                ));
+
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docIdExp);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("someProperty", somePropertyValue);
+        testRunner.enqueue(inFileDataBytes, properties);
+        testRunner.run();
+
+        verify(mcol, times(1)).upsert(eq(somePropertyValue), eq(inFileDataBytes), any(UpsertOptions.class));
+
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(inFileData);
+    }
+
+    @Test
+    public void testInvalidDocIdExp() throws Exception {
+        String docIdExp = "${invalid_function(someProperty)}";
+        String somePropertyValue = "doc-p";
+
+        String inFileData = "{\"key\":\"value\"}";
+        byte[] inFileDataBytes = inFileData.getBytes(StandardCharsets.UTF_8);
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.upsert(eq(somePropertyValue), any(), any(UpsertOptions.class)))
+                .thenReturn(new MutationResult(new CoreMutationResult(null,
+                        CoreKeyspace.from(new CollectionIdentifier(bucketName, Optional.of(scopeName), Optional.of(collectionName))),
+                        somePropertyValue, 200L, Optional.empty()
+                )));
+
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docIdExp);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("someProperty", somePropertyValue);
+        testRunner.enqueue(inFileDataBytes, properties);
+
+        AssertionError e = assertThrows(AssertionError.class, () -> testRunner.run());
+        assertEquals(AttributeExpressionLanguageException.class, e.getCause().getClass());
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+    }
+
+    @Test
+    public void testInputFlowFileUuid() throws Exception {
+
+        String uuid = "00029362-5106-40e8-b8a9-bf2cecfbc0d7";
+        String inFileData = "{\"key\":\"value\"}";
+        byte[] inFileDataBytes = inFileData.getBytes(StandardCharsets.UTF_8);
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.upsert(anyString(), eq(inFileDataBytes), any(UpsertOptions.class)))
+                .thenReturn(new MutationResult(new CoreMutationResult(null,
+                        CoreKeyspace.from(new CollectionIdentifier(bucketName, Optional.of(scopeName), Optional.of(collectionName))),
+                        uuid, 200L, Optional.empty()
+                )));
+
+        Map<String, String> properties = new HashMap<>();
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        properties.put(CoreAttributes.UUID.key(), uuid);
+        testRunner.enqueue(inFileDataBytes, properties);
+        testRunner.run();
+
+        verify(mcol, times(1)).upsert(anyString(), eq(inFileDataBytes), any(UpsertOptions.class));
+
+        testRunner.assertTransferCount(REL_SUCCESS, 1);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile outFile = testRunner.getFlowFilesForRelationship(REL_SUCCESS).get(0);
+        outFile.assertContentEquals(inFileData);
+    }
+
+
+    @Test
+    public void testCouchbaseFailure() throws Exception {
+
+        String docId = "doc-a";
+
+        String inFileData = "{\"key\":\"value\"}";
+        byte[] inFileDataBytes = inFileData.getBytes(StandardCharsets.UTF_8);
+
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.upsert(eq(docId), eq(inFileDataBytes), any(UpsertOptions.class)))
+                .thenThrow(new ServiceNotAvailableException("mock", mock(ErrorContext.class)));
+
+
+        testRunner.enqueue(inFileDataBytes);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docId);
+        testRunner.setProperty(PutCouchbaseKey.REPLICATE_TO, ReplicateTo.ONE.toString());
+
+        AssertionError e = assertThrows(AssertionError.class, () -> testRunner.run());
+        assertEquals(ProcessException.class, e.getCause().getClass());
+
+        verify(mcol, times(1)).upsert(eq(docId), eq(inFileDataBytes), any(UpsertOptions.class));
+
+        testRunner.assertAllFlowFilesTransferred(REL_FAILURE);
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_RETRY, 0);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+    }
+
+    @Test
+    public void testCouchbaseTempFlowFileError() throws Exception {
+
+        String docId = "doc-a";
+
+        String inFileData = "{\"key\":\"value\"}";
+        byte[] inFileDataBytes = inFileData.getBytes(StandardCharsets.UTF_8);
+
+        CouchbaseException exception = new DurabilityImpossibleException(mock(KeyValueErrorContext.class));
+        Collection mcol = setupMockCouchbase(bucketName, scopeName, collectionName);
+        when(mcol.upsert(eq(docId), eq(inFileDataBytes), any(UpsertOptions.class)))
+                .thenThrow(exception);
+
+        testRunner.enqueue(inFileDataBytes);
+        testRunner.setProperty(BUCKET_NAME, bucketName);
+        testRunner.setProperty(SCOPE_NAME, scopeName);
+        testRunner.setProperty(COLLECTION_NAME, collectionName);
+        testRunner.setProperty(DOC_ID, docId);
+        testRunner.setProperty(PutCouchbaseKey.REPLICATE_TO, ReplicateTo.ONE.toString());
+        testRunner.run();
+
+        verify(mcol, times(1)).upsert(eq(docId), eq(inFileDataBytes), any(UpsertOptions.class));
+
+        testRunner.assertTransferCount(REL_SUCCESS, 0);
+        testRunner.assertTransferCount(REL_RETRY, 1);
+        testRunner.assertTransferCount(REL_FAILURE, 0);
+        MockFlowFile orgFile = testRunner.getFlowFilesForRelationship(REL_RETRY).get(0);
+        orgFile.assertContentEquals(inFileData);
+        orgFile.assertAttributeEquals(CouchbaseAttributes.Exception.key(), exception.getClass().getName());
+    }
+
+    @Override
+    protected Class<? extends Processor> processor() {
+        return PutCouchbaseKey.class;
+    }
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api-nar/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-couchbase-bundle</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-couchbase-services-api-nar</artifactId>
+    <packaging>nar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-services-api-nar</artifactId>
+            <version>2.5.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-couchbase-services-api</artifactId>
+            <version>2.5.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api-nar/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,21 @@
+nifi-couchbase-services-api-nar
+Copyright 2014-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+******************
+Apache Software License v2
+******************
+
+The following binary components are provided under the Apache Software License v2
+
+    (ASLv2) Couchbase Java SDK
+      The following NOTICE information applies:
+        Couchbase Java SDK
+        Copyright 2014 Couchbase, Inc.
+
+    (ASLv2) RxJava
+      The following NOTICE information applies:
+        Couchbase Java SDK
+        Copyright 2012 Netflix, Inc.

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api/pom.xml
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-couchbase-bundle</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-couchbase-services-api</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.couchbase.client</groupId>
+            <artifactId>java-client</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api/src/main/java/org/apache/nifi/couchbase/CouchbaseClusterControllerService.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api/src/main/java/org/apache/nifi/couchbase/CouchbaseClusterControllerService.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.couchbase;
+
+import com.couchbase.client.java.Collection;
+import org.apache.nifi.controller.ControllerService;
+
+import com.couchbase.client.java.Bucket;
+
+/**
+ * Provides a connection to a Couchbase Server cluster throughout a NiFi Data
+ * flow.
+ */
+public interface CouchbaseClusterControllerService extends ControllerService {
+
+    /**
+     * Open a bucket connection.
+     * @param bucketName the bucket name to access
+     * @return a connected bucket instance
+     */
+    Bucket openBucket(String bucketName);
+    Collection openCollection(String bucketName, String scopeName, String collectionName);
+
+    String connectionString();
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api/src/main/java/org/apache/nifi/couchbase/CouchbaseConfigurationProperties.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api/src/main/java/org/apache/nifi/couchbase/CouchbaseConfigurationProperties.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.couchbase;
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+
+public class CouchbaseConfigurationProperties {
+
+    public static final PropertyDescriptor COUCHBASE_CLUSTER_SERVICE = new PropertyDescriptor.Builder()
+            .name("cluster-controller-service")
+            .displayName("Couchbase Cluster Controller Service")
+            .description("A Couchbase Cluster Controller Service which manages connections to a Couchbase cluster.")
+            .required(true)
+            .identifiesControllerService(CouchbaseClusterControllerService.class)
+            .build();
+
+    public static final PropertyDescriptor BUCKET_NAME = new PropertyDescriptor.Builder()
+            .name("bucket-name")
+            .displayName("Bucket Name")
+            .description("The name of bucket to access.")
+            .required(true)
+            .addValidator(Validator.VALID)
+            .defaultValue("default")
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .build();
+
+    public static final PropertyDescriptor SCOPE_NAME = new PropertyDescriptor.Builder()
+            .name("scope-name")
+            .displayName("Scope Name")
+            .description("The name of scope to access.")
+            .required(true)
+            .addValidator(Validator.VALID)
+            .defaultValue("_default")
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .build();
+
+    public static final PropertyDescriptor COLLECTION_NAME = new PropertyDescriptor.Builder()
+            .name("collection-name")
+            .displayName("Collection Name")
+            .description("The name of collection to access.")
+            .required(true)
+            .addValidator(Validator.VALID)
+            .defaultValue("_default")
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .build();
+
+    public static final PropertyDescriptor DOCUMENT_TYPE = new PropertyDescriptor.Builder()
+            .name("document-type")
+            .displayName("Document Type")
+            .description("The type of contents.")
+            .required(true)
+            .allowableValues(DocumentType.values())
+            .defaultValue(DocumentType.Json.toString())
+            .build();
+
+    public static final PropertyDescriptor LOOKUP_SUB_DOC_PATH = new PropertyDescriptor.Builder()
+            .name("lookup-sub-doc-path")
+            .displayName("Lookup Sub-Document Path")
+            .description("The Sub-Document lookup path within the target JSON document.")
+            .required(false)
+            .addValidator(Validator.VALID)
+            .expressionLanguageSupported(ExpressionLanguageScope.ENVIRONMENT)
+            .build();
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api/src/main/java/org/apache/nifi/couchbase/DocumentType.java
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/nifi-couchbase-services-api/src/main/java/org/apache/nifi/couchbase/DocumentType.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.couchbase;
+
+
+/**
+ * Supported Couchbase document types.
+ *
+ * In order to handle a variety type of document classes such as JsonDocument,
+ * JsonLongDocument or JsonStringDocument, Couchbase processors use
+ * RawJsonDocument for Json type.
+ *
+ * The distinction between Json and Binary exists because BinaryDocument doesn't
+ * set Json flag when it stored on Couchbase Server even if the content byte
+ * array represents a Json string, and it can't be retrieved as a Json document.
+ */
+public enum DocumentType {
+
+    Json,
+    Binary
+
+}

--- a/nifi-extension-bundles/nifi-couchbase-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-couchbase-bundle/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-standard-shared-bom</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+        <relativePath>../nifi-standard-shared-bundle/nifi-standard-shared-bom</relativePath>
+    </parent>
+
+    <artifactId>nifi-couchbase-bundle</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>nifi-couchbase-services-api</module>
+        <module>nifi-couchbase-services-api-nar</module>
+        <module>nifi-couchbase-processors</module>
+        <module>nifi-couchbase-nar</module>
+    </modules>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.couchbase.client</groupId>
+                <artifactId>java-client</artifactId>
+                <version>3.8.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.couchbase.client</groupId>
+                <artifactId>core-io</artifactId>
+                <version>3.8.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.17.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/nifi-extension-bundles/pom.xml
+++ b/nifi-extension-bundles/pom.xml
@@ -95,5 +95,6 @@
         <module>nifi-github-bundle</module>
         <module>nifi-gitlab-bundle</module>
         <module>nifi-atlassian-bundle</module>
+        <module>nifi-couchbase-bundle</module>
     </modules>
 </project>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary
This is part of NIFI-14731 that re-introduces GetCouchbaseKey and PutCouchbaseKey processors.
[NIFI-14731](https://issues.apache.org/jira/browse/NIFI-14731)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check` (had some issues with tests from un-modified by the PR files)
- [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
