### PR TITLE
NIFI-14804 Replaced the use of deprecated GzipCompressorInputStream and ZstdCompressorOutputStream constructors with builder classes.

### DIFF
--- a/nifi-extension-bundles/nifi-compress-bundle/nifi-compress-processors/src/main/java/org/apache/nifi/processors/compress/ModifyCompression.java
+++ b/nifi-extension-bundles/nifi-compress-bundle/nifi-compress-processors/src/main/java/org/apache/nifi/processors/compress/ModifyCompression.java
@@ -275,11 +275,9 @@ public class ModifyCompression extends AbstractProcessor {
         return switch (compressionFormat) {
             case LZMA -> new LzmaInputStream(parentInputStream, new Decoder());
             case XZ_LZMA2 -> new XZInputStream(parentInputStream);
-            case BZIP2 -> {
-                // need this two-arg constructor to support concatenated streams
-                yield new BZip2CompressorInputStream(parentInputStream, true);
-            }
-            case GZIP -> new GzipCompressorInputStream(parentInputStream, true);
+            case BZIP2 -> // need this two-arg constructor to support concatenated streams
+                    new BZip2CompressorInputStream(parentInputStream, true);
+            case GZIP -> GzipCompressorInputStream.builder().setInputStream(parentInputStream).setDecompressConcatenated(true).get();
             case DEFLATE -> new InflaterInputStream(parentInputStream);
             case SNAPPY -> new SnappyInputStream(parentInputStream);
             case SNAPPY_HADOOP -> throw new IOException("Cannot decompress snappy-hadoop");
@@ -349,7 +347,7 @@ public class ModifyCompression extends AbstractProcessor {
             }
             case ZSTD -> {
                 final int outputCompressionLevel = compressionLevel * 2;
-                compressionOut = new ZstdCompressorOutputStream(parentOutputStream, outputCompressionLevel);
+                compressionOut = ZstdCompressorOutputStream.builder().setOutputStream(parentOutputStream).setLevel(outputCompressionLevel).get();
                 mimeTypeRef.set(CompressionStrategy.ZSTD.getMimeTypes()[0]);
             }
             case BROTLI -> {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CompressContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/CompressContent.java
@@ -350,7 +350,7 @@ public class CompressContent extends AbstractProcessor {
                                 break;
                             case COMPRESSION_FORMAT_ZSTD:
                                 final int zstdCompressionLevel = context.getProperty(COMPRESSION_LEVEL).asInteger() * 2;
-                                compressionOut = new ZstdCompressorOutputStream(bufferedOut, zstdCompressionLevel);
+                                compressionOut = ZstdCompressorOutputStream.builder().setOutputStream(bufferedOut).setLevel(zstdCompressionLevel).get();
                                 mimeTypeRef.set("application/zstd");
                                 break;
                             case COMPRESSION_FORMAT_BROTLI: {
@@ -375,7 +375,7 @@ public class CompressContent extends AbstractProcessor {
                             case COMPRESSION_FORMAT_BZIP2 ->
                                 // need this two-arg constructor to support concatenated streams
                                 new BZip2CompressorInputStream(bufferedIn, true);
-                            case COMPRESSION_FORMAT_GZIP -> new GzipCompressorInputStream(bufferedIn, true);
+                            case COMPRESSION_FORMAT_GZIP -> GzipCompressorInputStream.builder().setInputStream(bufferedIn).setDecompressConcatenated(true).get();
                             case COMPRESSION_FORMAT_DEFLATE -> new InflaterInputStream(bufferedIn);
                             case COMPRESSION_FORMAT_SNAPPY -> new SnappyInputStream(bufferedIn);
                             case COMPRESSION_FORMAT_SNAPPY_HADOOP -> throw new Exception("Cannot decompress snappy-hadoop.");


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14804](https://issues.apache.org/jira/browse/NIFI-14804)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
