### PR TITLE
NIFI-14818 - Bump GCP SDK to 26.65.0, Azure SDK to 1.2.37 and others

### DIFF
--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <!-- when changing the Azure SDK version, also update msal4j to the version that is required by azure-identity -->
-        <azure.sdk.bom.version>1.2.36</azure.sdk.bom.version>
+        <azure.sdk.bom.version>1.2.37</azure.sdk.bom.version>
         <msal4j.version>1.21.0</msal4j.version>
         <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.64.0</google.libraries.version>
+        <google.libraries.version>26.65.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -110,20 +110,20 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.788</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.32.13</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.32.14</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.0</kotlin.version>
         <okhttp.version>5.1.0</okhttp.version>
         <okio.version>3.16.0</okio.version>
-        <org.apache.commons.cli.version>1.9.0</org.apache.commons.cli.version>
+        <org.apache.commons.cli.version>1.10.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.19.0</org.apache.commons.codec.version>
         <org.apache.commons.collections4.version>4.5.0</org.apache.commons.collections4.version>
         <org.apache.commons.compress.version>1.28.0</org.apache.commons.compress.version>
         <com.github.luben.zstd-jni.version>1.5.7-4</com.github.luben.zstd-jni.version>
         <org.apache.commons.configuration.version>2.12.0</org.apache.commons.configuration.version>
         <org.apache.commons.lang3.version>3.18.0</org.apache.commons.lang3.version>
-        <org.apache.commons.net.version>3.11.1</org.apache.commons.net.version>
+        <org.apache.commons.net.version>3.12.0</org.apache.commons.net.version>
         <org.apache.commons.io.version>2.20.0</org.apache.commons.io.version>
         <org.apache.commons.text.version>1.14.0</org.apache.commons.text.version>
         <org.apache.commons.csv.version>1.14.1</org.apache.commons.csv.version>
@@ -142,7 +142,7 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
-        <json.smart.version>2.5.2</json.smart.version>
+        <json.smart.version>2.6.0</json.smart.version>
         <groovy.version>4.0.28</groovy.version>
         <surefire.version>3.5.1</surefire.version>
         <hadoop.version>3.4.1</hadoop.version>


### PR DESCRIPTION
# Summary

NIFI-14818 - Bump GCP SDK to 26.65.0, Azure SDK to 1.2.37 and others

- Azure SDK from 1.2.36 to 1.2.37 - https://github.com/Azure/azure-sdk-for-java/releases/tag/azure-sdk-bom_1.2.37
- Google Cloud SDK from 26.64.0 to 26.65.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.65.0
- AWS v2 SDK from 2.32.13 to 2.32.14 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Apache Commons CLI from 1.9.0 to 1.10.0 - https://github.com/apache/commons-cli/blob/master/RELEASE-NOTES.txt
- Apache Commons Net from 3.11.1 to 3.12.0 - https://downloads.apache.org/commons/net/RELEASE-NOTES.txt
- JSON Smart from 2.5.2 to 2.6.0 - https://github.com/netplex/json-smart-v2/releases/tag/v2.6.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
