### PR TITLE
NIFI-14783 Stop Node Protocol Listener before Controller

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
@@ -648,7 +648,7 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
                     }
 
                     if (completeExceptionallyOnFailure) {
-                        future.completeExceptionally(new IllegalStateException("Cannot enable " + this + " because it is not valid"));
+                        future.completeExceptionally(new IllegalStateException("Cannot enable " + StandardControllerServiceNode.this + " because it is not valid"));
                     }
 
                     return;

--- a/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/FlowSynchronizationIT.java
+++ b/nifi-system-tests/nifi-system-test-suite/src/test/java/org/apache/nifi/tests/system/clustering/FlowSynchronizationIT.java
@@ -456,7 +456,6 @@ public class FlowSynchronizationIT extends NiFiSystemIT {
         getClientUtil().startProcessGroupComponents(group.getId());
         getClientUtil().startProcessor(terminate);
         getClientUtil().startProcessor(generate);
-        getClientUtil().waitForProcessorState(count.getId(), RUNNING_STATE);
 
         // Stop & restart Node 2.
         getNiFiInstance().getNodeInstance(2).stop();
@@ -486,6 +485,13 @@ public class FlowSynchronizationIT extends NiFiSystemIT {
         assertEquals(2, node2GroupContents.getConnections().size());
         assertEquals(1, node2GroupContents.getProcessors().size());
 
+        final ControllerServiceEntity node2SleepService = getNifiClient().getControllerServicesClient(DO_NOT_REPLICATE).getControllerService(sleepService.getId());
+        assertEquals(sleepService.getId(), node2SleepService.getId());
+        waitFor(() -> {
+            final ControllerServiceDTO updatedNode2SleepService = getNifiClient().getControllerServicesClient(DO_NOT_REPLICATE).getControllerService(sleepService.getId()).getComponent();
+            return updatedNode2SleepService.getState().equals("ENABLED");
+        });
+
         final Set<ControllerServiceEntity> groupServices = getNifiClient().getFlowClient(DO_NOT_REPLICATE).getControllerServices(group.getId()).getControllerServices();
         assertEquals(1, groupServices.size());
 
@@ -495,9 +501,17 @@ public class FlowSynchronizationIT extends NiFiSystemIT {
         assertEquals(serviceId, procProperties.get("Count Service"));
         assertEquals(countService.getId(), serviceId);
         assertEquals(count.getId(), node2CountProc.getId());
+
+        waitFor(() -> {
+            final ControllerServiceDTO updatedNode2CountService = getNifiClient().getControllerServicesClient(DO_NOT_REPLICATE).getControllerService(countService.getId()).getComponent();
+            return updatedNode2CountService.getState().equals("ENABLED");
+        });
+
         waitFor(() -> {
             final ProcessorDTO updatedNode2CountProc = getNifiClient().getProcessorClient(DO_NOT_REPLICATE).getProcessor(node2CountProc.getId()).getComponent();
-            return updatedNode2CountProc.getState().equals(RUNNING_STATE);
+            final String processorState = updatedNode2CountProc.getState();
+            logger.info("CountFlowFiles Processor [{}] State [{}]", node2CountProc.getId(), processorState);
+            return RUNNING_STATE.equals(processorState);
         });
 
         final PortDTO node2InputPort = node2GroupContents.getInputPorts().iterator().next().getComponent();
@@ -514,13 +528,6 @@ public class FlowSynchronizationIT extends NiFiSystemIT {
         waitFor(() -> {
             final PortDTO updatedNode2OutputPort = getNifiClient().getOutputPortClient(DO_NOT_REPLICATE).getOutputPort(node2OutputPort.getId()).getComponent();
             return updatedNode2OutputPort.getState().equals(RUNNING_STATE);
-        });
-
-        final ControllerServiceEntity node2SleepService = getNifiClient().getControllerServicesClient(DO_NOT_REPLICATE).getControllerService(sleepService.getId());
-        assertEquals(sleepService.getId(), node2SleepService.getId());
-        waitFor(() -> {
-            final ControllerServiceDTO updatedNode2SleepService = getNifiClient().getControllerServicesClient(DO_NOT_REPLICATE).getControllerService(sleepService.getId()).getComponent();
-            return updatedNode2SleepService.getState().equals("ENABLED");
         });
 
         waitFor(() -> {


### PR DESCRIPTION
# Summary

[NIFI-14783](https://issues.apache.org/jira/browse/NIFI-14783) Changes the `StandardFlowService.stop()` method to stop the Node Protocol Sender Listener before shutting down the Flow Controller. This change prevents the node from receiving additional cluster status messages while the shutdown is in process.

Reviewing the logs for unstable system tests highlighted the fact that one node was receiving and processing a reconnect request while shutting down. This led to failures when trying to persist the cluster configuration in some cases, due to the receiving node shutting down collaborating components like the State Manager. Stopping the Node Protocol Sender Listener before shutting down the controller limits the potential for receiving and attempting to handle additional cluster communication messages.

Additional changes include waiting for the `ENABLED` state for the required Controller Service in `testComponentsRecreatedOnRestart` and correcting the Controller Service Node reference in an exception message when failing to enable a Controller Service.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
