### PR TITLE
NIFI-14783 Start Embedded ZooKeeper before State Manager operations

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceNode.java
@@ -648,7 +648,7 @@ public class StandardControllerServiceNode extends AbstractComponentNode impleme
                     }
 
                     if (completeExceptionallyOnFailure) {
-                        future.completeExceptionally(new IllegalStateException("Cannot enable " + this + " because it is not valid"));
+                        future.completeExceptionally(new IllegalStateException("Cannot enable " + StandardControllerServiceNode.this + " because it is not valid"));
                     }
 
                     return;

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSynchronizer.java
@@ -233,7 +233,7 @@ public class VersionedFlowSynchronizer implements FlowSynchronizer {
         final AffectedComponentSet existing = activeSet.toExistingSet();
         final AffectedComponentSet noLongerExisting = activeSet.minus(existing);
         if (!noLongerExisting.isEmpty()) {
-            logger.info("After synchronizing flow, the followinging components will not be restarted because they no longer exist: {}", noLongerExisting);
+            logger.info("After synchronizing flow, the following components will not be restarted because they no longer exist: {}", noLongerExisting);
         }
 
         final AffectedComponentSet startable = existing.toStartableSet();


### PR DESCRIPTION
# Summary

[NIFI-14783](https://issues.apache.org/jira/browse/NIFI-14783) Includes the following changes to improve stability in system tests with more predictable behavior when starting and stopping nodes:

- Start embedded ZooKeeper before other State Manager operations for earlier Cluster Coordinator detection
- Stopped Node Protocol Listener before Controller
- Added wait for enabled Controller Service in FlowSynchronizationIT
- Corrected exception message reference to Controller Service Node when validation failed

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `mvn clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
