### PR TITLE
NIFI-14814 Implemented PMD rule LooseCoupling.

### DIFF
--- a/c2/c2-protocol/c2-protocol-component-api/src/main/java/org/apache/nifi/c2/protocol/component/api/ConfigurableComponentDefinition.java
+++ b/c2/c2-protocol/c2-protocol-component-api/src/main/java/org/apache/nifi/c2/protocol/component/api/ConfigurableComponentDefinition.java
@@ -17,7 +17,6 @@
 
 package org.apache.nifi.c2.protocol.component.api;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,7 +27,7 @@ public interface ConfigurableComponentDefinition {
 
     Map<String, PropertyDescriptor> getPropertyDescriptors();
 
-    void setPropertyDescriptors(LinkedHashMap<String, PropertyDescriptor> propertyDescriptors);
+    void setPropertyDescriptors(Map<String, PropertyDescriptor> propertyDescriptors);
 
     boolean getSupportsDynamicProperties();
 

--- a/c2/c2-protocol/c2-protocol-component-api/src/main/java/org/apache/nifi/c2/protocol/component/api/ConfigurableExtensionDefinition.java
+++ b/c2/c2-protocol/c2-protocol-component-api/src/main/java/org/apache/nifi/c2/protocol/component/api/ConfigurableExtensionDefinition.java
@@ -19,7 +19,6 @@ package org.apache.nifi.c2.protocol.component.api;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,7 +38,7 @@ public abstract class ConfigurableExtensionDefinition extends ExtensionComponent
     }
 
     @Override
-    public void setPropertyDescriptors(LinkedHashMap<String, PropertyDescriptor> propertyDescriptors) {
+    public void setPropertyDescriptors(Map<String, PropertyDescriptor> propertyDescriptors) {
         this.propertyDescriptors = propertyDescriptors;
     }
 

--- a/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/util/OrderedProperties.java
+++ b/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/util/OrderedProperties.java
@@ -38,7 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class OrderedProperties extends Properties {
     private final Map<String, String> textBeforeMap = new HashMap<>();
-    private final LinkedHashSet<Object> orderedKeys = new LinkedHashSet<>();
+    private final Set<Object> orderedKeys = new LinkedHashSet<>();
 
     @Override
     public synchronized Object put(Object key, Object value) {

--- a/minifi/minifi-commons/minifi-commons-api/src/main/java/org/apache/nifi/minifi/commons/api/MiNiFiProperties.java
+++ b/minifi/minifi-commons/minifi-commons-api/src/main/java/org/apache/nifi/minifi/commons/api/MiNiFiProperties.java
@@ -27,6 +27,7 @@ import static org.apache.nifi.minifi.commons.api.MiNiFiProperties.ValidatorNames
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -139,7 +140,7 @@ public enum MiNiFiProperties {
         this.validator = validator;
     }
 
-    public static LinkedHashMap<String, MiNiFiProperties> sortedPropertiesByKey() {
+    public static Map<String, MiNiFiProperties> sortedPropertiesByKey() {
         return Arrays.stream(values())
             .sorted()
             .collect(Collectors.toMap(MiNiFiProperties::getKey, Function.identity(), (x, y) -> y, LinkedHashMap::new));

--- a/minifi/minifi-commons/minifi-commons-framework/src/test/java/org/apache/nifi/minifi/commons/service/StandardFlowPropertyEncryptorTest.java
+++ b/minifi/minifi-commons/minifi-commons-framework/src/test/java/org/apache/nifi/minifi/commons/service/StandardFlowPropertyEncryptorTest.java
@@ -286,7 +286,7 @@ public class StandardFlowPropertyEncryptorTest {
         return controllerServiceDefinition;
     }
 
-    private LinkedHashMap<String, PropertyDescriptor> convertVersionedPropertyDescriptorMapToPropertyDescriptorMap(Map<String, VersionedPropertyDescriptor> propertyDescriptors) {
+    private Map<String, PropertyDescriptor> convertVersionedPropertyDescriptorMapToPropertyDescriptorMap(Map<String, VersionedPropertyDescriptor> propertyDescriptors) {
         return propertyDescriptors.values()
             .stream()
             .map(propertyDescriptor -> entry(propertyDescriptor.getName(), convertPropertyDescriptor(propertyDescriptor)))

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/command/UpdatePropertiesPropertyProvider.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/c2/command/UpdatePropertiesPropertyProvider.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.nifi.c2.client.service.operation.OperandPropertiesProvider;
 import org.apache.nifi.minifi.commons.api.MiNiFiProperties;
@@ -48,7 +49,7 @@ public class UpdatePropertiesPropertyProvider implements OperandPropertiesProvid
     public Map<String, Object> getProperties() {
         Map<String, String> bootstrapProperties = getBootstrapProperties();
 
-        LinkedHashSet<UpdatableProperty> updatableProperties = sortedPropertiesByKey().values()
+        Set<UpdatableProperty> updatableProperties = sortedPropertiesByKey().values()
             .stream()
             .filter(property -> !property.isSensitive())
             .filter(MiNiFiProperties::isModifiable)

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/UpdatePropertiesPropertyProviderTest.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/c2/command/UpdatePropertiesPropertyProviderTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.nifi.minifi.commons.api.MiNiFiProperties;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,7 +65,7 @@ class UpdatePropertiesPropertyProviderTest {
 
         Map<String, Object> result = updatePropertiesPropertyProvider.getProperties();
 
-        LinkedHashSet<UpdatableProperty> expected = getUpdatableProperties(props);
+        Set<UpdatableProperty> expected = getUpdatableProperties(props);
 
         assertEquals(Collections.singletonMap(AVAILABLE_PROPERTIES, expected), result);
     }
@@ -76,7 +77,7 @@ class UpdatePropertiesPropertyProviderTest {
         assertEquals(Collections.singletonMap(AVAILABLE_PROPERTIES, getUpdatableProperties(new Properties())), properties);
     }
 
-    private static LinkedHashSet<UpdatableProperty> getUpdatableProperties(Properties props) {
+    private static Set<UpdatableProperty> getUpdatableProperties(Properties props) {
         return sortedPropertiesByKey().values()
             .stream()
             .filter(property -> !property.isSensitive())

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/status/StatusConfigReporterTest.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/test/java/org/apache/nifi/minifi/status/StatusConfigReporterTest.java
@@ -57,6 +57,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.nifi.minifi.commons.status.util.StatusReportPopulator.addConnectionStatus;
 import static org.apache.nifi.minifi.commons.status.util.StatusReportPopulator.addControllerServiceStatus;
@@ -606,7 +607,7 @@ public class StatusConfigReporterTest {
         if (addBulletins) {
             addBulletins("Bulletin message", controllerServiceNode.getIdentifier());
         }
-        HashSet<ControllerServiceNode> controllerServiceNodes = new HashSet<>();
+        Set<ControllerServiceNode> controllerServiceNodes = new HashSet<>();
         controllerServiceNodes.add(controllerServiceNode);
         when(mockFlowController.getFlowManager().getAllControllerServices()).thenReturn(controllerServiceNodes);
     }
@@ -626,7 +627,7 @@ public class StatusConfigReporterTest {
         ReportingTaskNode reportingTaskNode = mock(ReportingTaskNode.class);
         addReportingTaskNodeVariables(reportingTaskNode);
 
-        HashSet<ReportingTaskNode> reportingTaskNodes = new HashSet<>();
+        Set<ReportingTaskNode> reportingTaskNodes = new HashSet<>();
         reportingTaskNodes.add(reportingTaskNode);
 
         when(mockFlowController.getAllReportingTasks()).thenReturn(reportingTaskNodes);

--- a/minifi/minifi-toolkit/minifi-toolkit-schema/src/test/java/org/apache/nifi/minifi/toolkit/schema/ConfigSchemaTest.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-schema/src/test/java/org/apache/nifi/minifi/toolkit/schema/ConfigSchemaTest.java
@@ -118,7 +118,7 @@ public class ConfigSchemaTest {
     @Test
     public void testNifiPropertyOverrides() {
         Map<Object, Object> map = new HashMap<>();
-        HashMap<Object, Object> overrides = new HashMap<>();
+        Map<Object, Object> overrides = new HashMap<>();
         overrides.put("nifi.flowfile.repository.directory", "./flowfile_repository_override");
         overrides.put("nifi.content.repository.directory.default", "./content_repository_override");
         overrides.put("nifi.database.directory", "./database_repository_override");

--- a/nifi-commons/nifi-hl7-query-language/src/main/java/org/apache/nifi/hl7/query/HL7Query.java
+++ b/nifi-commons/nifi-hl7-query-language/src/main/java/org/apache/nifi/hl7/query/HL7Query.java
@@ -291,7 +291,7 @@ public class HL7Query {
     public QueryResult evaluate(final HL7Message message) {
 
         int totalIterations = 1;
-        final LinkedHashMap<String, List<Object>> possibleValueMap = new LinkedHashMap<>();
+        final Map<String, List<Object>> possibleValueMap = new LinkedHashMap<>();
         for (final Declaration declaration : declarations) {
             final Object value = declaration.getDeclaredValue(message);
             if (value == null && declaration.isRequired()) {
@@ -342,7 +342,7 @@ public class HL7Query {
      * between multiple invocations of this method.
      * package protected for testing visibility
      */
-    static Map<String, Object> assignAliases(final LinkedHashMap<String, List<Object>> possibleValues, final int iteration) {
+    static Map<String, Object> assignAliases(final Map<String, List<Object>> possibleValues, final int iteration) {
         final Map<String, Object> aliasMap = new HashMap<>();
 
         int divisor = 1;

--- a/nifi-commons/nifi-hl7-query-language/src/test/java/org/apache/nifi/hl7/query/TestHL7Query.java
+++ b/nifi-commons/nifi-hl7-query-language/src/test/java/org/apache/nifi/hl7/query/TestHL7Query.java
@@ -67,7 +67,7 @@ public class TestHL7Query {
 
     @Test
     public void testAssignAliases() {
-        final LinkedHashMap<String, List<Object>> possibleValueMap = new LinkedHashMap<>();
+        final Map<String, List<Object>> possibleValueMap = new LinkedHashMap<>();
 
         final List<Object> valuesA = new ArrayList<>();
         valuesA.add("a");

--- a/nifi-commons/nifi-property-utils/src/test/java/org/apache/nifi/util/StringUtilsTest.java
+++ b/nifi-commons/nifi-property-utils/src/test/java/org/apache/nifi/util/StringUtilsTest.java
@@ -98,7 +98,7 @@ public class StringUtilsTest {
 
   @Test
   public void testJoin() {
-    final ArrayList<String> collection = new ArrayList<>();
+    final List<String> collection = new ArrayList<>();
     assertEquals("", StringUtils.join(collection, ","));
 
     collection.add("test1");

--- a/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/util/AbstractWalkerTest.java
+++ b/nifi-commons/nifi-record-path/src/test/java/org/apache/nifi/record/path/util/AbstractWalkerTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractWalkerTest {
     }
 
     protected Object[] buildMapRecordArray(int seed, int count) {
-        final ArrayList<MapRecord> list = new ArrayList<>();
+        final List<MapRecord> list = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             list.add(new MapRecord(getMapRecordSchema(), buildMapRecord(seed)));
             seed++;

--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestMapRecord.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestMapRecord.java
@@ -361,7 +361,7 @@ class TestMapRecord {
         fields.add(new RecordField(timestampFieldName, RecordFieldType.TIMESTAMP.getDataType()));
 
         final RecordSchema schema = new SimpleRecordSchema(fields);
-        final HashMap<String, Object> item = new HashMap<>();
+        final Map<String, Object> item = new HashMap<>();
         item.put(timestampFieldName, input);
         final MapRecord testRecord = new MapRecord(schema, item);
 

--- a/nifi-commons/nifi-security-kerberos/src/main/java/org/apache/nifi/security/krb/PasswordConfiguration.java
+++ b/nifi-commons/nifi-security-kerberos/src/main/java/org/apache/nifi/security/krb/PasswordConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.nifi.security.krb;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * JAAS Configuration to use when logging in with username/password.
@@ -27,7 +28,7 @@ public class PasswordConfiguration extends Configuration {
 
     @Override
     public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
-        HashMap<String, String> options = new HashMap<>();
+        Map<String, String> options = new HashMap<>();
         options.put("storeKey", "true");
         options.put("refreshKrb5Config", "true");
 

--- a/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerSelector.java
+++ b/nifi-commons/nifi-site-to-site-client/src/main/java/org/apache/nifi/remote/client/PeerSelector.java
@@ -172,11 +172,11 @@ public class PeerSelector {
      * @param unsortedMap the unordered map of peers to weights
      * @return the sorted (desc) map (by value)
      */
-    private static LinkedHashMap<PeerStatus, Double> sortMapByWeight(Map<PeerStatus, Double> unsortedMap) {
+    private static Map<PeerStatus, Double> sortMapByWeight(Map<PeerStatus, Double> unsortedMap) {
         List<Map.Entry<PeerStatus, Double>> list = new ArrayList<>(unsortedMap.entrySet());
         list.sort(Map.Entry.comparingByValue());
 
-        LinkedHashMap<PeerStatus, Double> result = new LinkedHashMap<>();
+        Map<PeerStatus, Double> result = new LinkedHashMap<>();
         for (int i = list.size() - 1; i >= 0; i--) {
             Map.Entry<PeerStatus, Double> entry = list.get(i);
             result.put(entry.getKey(), entry.getValue());
@@ -312,13 +312,13 @@ public class PeerSelector {
      * @param direction the direction of transfer ({@code SEND} weights the destinations higher if they have more flowfiles, {@code RECEIVE} weights them higher if they have fewer)
      * @return the ordered map of each peer to its relative weight
      */
-    LinkedHashMap<PeerStatus, Double> buildWeightedPeerMap(final Set<PeerStatus> statuses, final TransferDirection direction) {
+    Map<PeerStatus, Double> buildWeightedPeerMap(final Set<PeerStatus> statuses, final TransferDirection direction) {
         // Get all the destinations with their relative weights
         final Map<PeerStatus, Double> peerWorkloads = createDestinationMap(statuses, direction);
 
         if (!peerWorkloads.isEmpty()) {
             // This map is sorted, but not by key, so it cannot use SortedMap
-            LinkedHashMap<PeerStatus, Double> sortedPeerWorkloads = sortMapByWeight(peerWorkloads);
+            Map<PeerStatus, Double> sortedPeerWorkloads = sortMapByWeight(peerWorkloads);
 
             // Print the expected distribution of the peers
             printDistributionStatistics(sortedPeerWorkloads, direction);

--- a/nifi-extension-bundles/nifi-asana-bundle/nifi-asana-processors/src/main/java/org/apache/nifi/processors/asana/utils/GenericAsanaObjectFetcher.java
+++ b/nifi-extension-bundles/nifi-asana-bundle/nifi-asana-processors/src/main/java/org/apache/nifi/processors/asana/utils/GenericAsanaObjectFetcher.java
@@ -80,7 +80,7 @@ public abstract class GenericAsanaObjectFetcher<T extends Resource> extends Abst
     @Override
     public void loadState(Map<String, String> state) {
         if (state.containsKey(this.getClass().getName() + LAST_FINGERPRINTS)) {
-            Type type = new TypeToken<HashMap<String, String>>() { }.getType();
+            Type type = new TypeToken<Map<String, String>>() { }.getType();
             try {
                 lastFingerprints = Json.getInstance().fromJson(decompress(state.get(this.getClass().getName() + LAST_FINGERPRINTS)), type);
             } catch (IOException e) {

--- a/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/main/java/com/beanit/asn1bean/compiler/BerClassWriterFactory.java
+++ b/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/main/java/com/beanit/asn1bean/compiler/BerClassWriterFactory.java
@@ -22,7 +22,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 
 public class BerClassWriterFactory {
-    public static BerClassWriter createBerClassWriter(HashMap<String, AsnModule> modulesByName, Path asnOutDir) {
+    public static BerClassWriter createBerClassWriter(HashMap<String, AsnModule> modulesByName, Path asnOutDir) { // NOPMD
         BerClassWriter berClassWriter = new BerClassWriter(
                 modulesByName,
                 asnOutDir.toString(),

--- a/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/main/java/org/apache/nifi/jasn1/JASN1Reader.java
+++ b/nifi-extension-bundles/nifi-asn1-bundle/nifi-asn1-services/src/main/java/org/apache/nifi/jasn1/JASN1Reader.java
@@ -275,7 +275,7 @@ public class JASN1Reader extends AbstractConfigurableComponent implements Record
             throw new ProcessException("Could not create temporary directory for compiled ASN.1 files", e);
         }
 
-        HashMap<String, AsnModule> modulesByName = new HashMap<>();
+        HashMap<String, AsnModule> modulesByName = new HashMap<>(); // NOPMD
 
         Exception parseException = null;
         for (String asn1File : asnFilePaths) {

--- a/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/test/java/org/apache/nifi/processors/avro/TestExtractAvroMetadata.java
+++ b/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/test/java/org/apache/nifi/processors/avro/TestExtractAvroMetadata.java
@@ -19,6 +19,7 @@ package org.apache.nifi.processors.avro;
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
@@ -172,11 +173,11 @@ public class TestExtractAvroMetadata {
 
         final Schema schema = new Schema.Parser().parse(new File("src/test/resources/array.avsc"));
 
-        final GenericData.Array<String> data = new GenericData.Array<>(schema, Arrays.asList("one", "two", "three"));
-        final DatumWriter<GenericData.Array<String>> datumWriter = new GenericDatumWriter<>(schema);
+        final GenericArray<String> data = new GenericData.Array<>(schema, Arrays.asList("one", "two", "three"));
+        final DatumWriter<GenericArray<String>> datumWriter = new GenericDatumWriter<>(schema);
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        final DataFileWriter<GenericData.Array<String>> dataFileWriter = new DataFileWriter<>(datumWriter);
+        final DataFileWriter<GenericArray<String>> dataFileWriter = new DataFileWriter<>(datumWriter);
         dataFileWriter.create(schema, out);
         dataFileWriter.append(data);
         dataFileWriter.append(data);
@@ -201,11 +202,11 @@ public class TestExtractAvroMetadata {
 
         final Schema schema = new Schema.Parser().parse(new File("src/test/resources/array.avsc"));
 
-        final GenericData.Array<String> data = new GenericData.Array<>(schema, Arrays.asList("one", "two", "three"));
-        final DatumWriter<GenericData.Array<String>> datumWriter = new GenericDatumWriter<>(schema);
+        final GenericArray<String> data = new GenericData.Array<>(schema, Arrays.asList("one", "two", "three"));
+        final DatumWriter<GenericArray<String>> datumWriter = new GenericDatumWriter<>(schema);
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        final DataFileWriter<GenericData.Array<String>> dataFileWriter = new DataFileWriter<>(datumWriter);
+        final DataFileWriter<GenericArray<String>> dataFileWriter = new DataFileWriter<>(datumWriter);
         dataFileWriter.setCodec(CodecFactory.deflateCodec(1));
         dataFileWriter.create(schema, out);
         dataFileWriter.append(data);

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/service/AWSCredentialsProviderControllerService.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/credentials/provider/service/AWSCredentialsProviderControllerService.java
@@ -346,7 +346,7 @@ public class AWSCredentialsProviderControllerService extends AbstractControllerS
     @Override
     protected Collection<ValidationResult> customValidate(final ValidationContext validationContext) {
         final CredentialsStrategy selectedStrategy = selectPrimaryStrategy(validationContext);
-        final ArrayList<ValidationResult> validationFailureResults = new ArrayList<>();
+        final List<ValidationResult> validationFailureResults = new ArrayList<>();
 
         for (CredentialsStrategy strategy : strategies) {
             final Collection<ValidationResult> strategyValidationFailures = strategy.validate(validationContext,

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/PutKinesisStream.java
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/kinesis/stream/PutKinesisStream.java
@@ -140,8 +140,8 @@ public class PutKinesisStream extends AbstractAwsSyncProcessor<KinesisClient, Ki
 
         final List<FlowFile> flowFiles = KinesisProcessorUtils.filterMessagesByMaxSize(session, batchSize, maxBufferSizeBytes, AWS_KINESIS_ERROR_MESSAGE, getLogger());
 
-        final HashMap<String, List<FlowFile>> hashFlowFiles = new HashMap<>();
-        final HashMap<String, List<PutRecordsRequestEntry>> recordHash = new HashMap<>();
+        final Map<String, List<FlowFile>> hashFlowFiles = new HashMap<>();
+        final Map<String, List<PutRecordsRequestEntry>> recordHash = new HashMap<>();
 
         final KinesisClient client = getClient(context);
 

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ConsumeBoxEvents.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/main/java/org/apache/nifi/processors/box/ConsumeBoxEvents.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -100,7 +101,7 @@ public class ConsumeBoxEvents extends AbstractProcessor implements VerifiablePro
 
     private volatile BoxAPIConnection boxAPIConnection;
     private volatile EventStream eventStream;
-    protected volatile LinkedBlockingQueue<BoxEvent> events;
+    protected volatile BlockingQueue<BoxEvent> events;
     private volatile AtomicLong position = new AtomicLong(0);
 
     @Override
@@ -135,7 +136,7 @@ public class ConsumeBoxEvents extends AbstractProcessor implements VerifiablePro
             events = new LinkedBlockingQueue<>(queueCapacity);
         } else {
             // create new one with events from the old queue in case capacity has changed
-            final LinkedBlockingQueue<BoxEvent> newQueue = new LinkedBlockingQueue<>(queueCapacity);
+            final BlockingQueue<BoxEvent> newQueue = new LinkedBlockingQueue<>(queueCapacity);
             newQueue.addAll(events);
             events = newQueue;
         }

--- a/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/ConsumeBoxEventsTest.java
+++ b/nifi-extension-bundles/nifi-box-bundle/nifi-box-processors/src/test/java/org/apache/nifi/processors/box/ConsumeBoxEventsTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(MockitoExtension.class)
 public class ConsumeBoxEventsTest extends AbstractBoxFileTest {
 
-    private final LinkedBlockingQueue<BoxEvent> queue = new LinkedBlockingQueue<>();
+    private final BlockingQueue<BoxEvent> queue = new LinkedBlockingQueue<>();
 
     @BeforeEach
     void setUp() throws Exception {

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchLookupService.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchLookupService.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -87,7 +88,7 @@ public class ElasticSearchLookupService extends JsonInferenceSchemaRegistryServi
     private String type;
     private ObjectMapper mapper;
 
-    private volatile ConcurrentHashMap<String, RecordPath> recordPathMappings;
+    private volatile ConcurrentMap<String, RecordPath> recordPathMappings;
 
     private final List<PropertyDescriptor> descriptors;
 

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcCommonConvertToAvro.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-database-utils/src/test/java/org/apache/nifi/util/db/TestJdbcCommonConvertToAvro.java
@@ -31,6 +31,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -58,7 +59,7 @@ public class TestJdbcCommonConvertToAvro {
         typeWithPrecisionRange.put(SMALLINT, range(1, 5));
         typeWithPrecisionRange.put(INTEGER, range(1, 9));
 
-        ArrayList<TestParams> params = new ArrayList<>();
+        List<TestParams> params = new ArrayList<>();
 
         typeWithPrecisionRange.forEach( (sqlType, precisions) -> {
             for (int precision : precisions) {

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-listed-entity/src/main/java/org/apache/nifi/processor/util/list/AbstractListProcessor.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-listed-entity/src/main/java/org/apache/nifi/processor/util/list/AbstractListProcessor.java
@@ -470,7 +470,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
             return;
         }
 
-        final TreeMap<Long, List<T>> orderedEntries = new TreeMap<>();
+        final Map<Long, List<T>> orderedEntries = new TreeMap<>();
         for (final T entity : entityList) {
             List<T> entitiesForTimestamp = orderedEntries.computeIfAbsent(entity.getTimestamp(), k -> new ArrayList<>());
             entitiesForTimestamp.add(entity);
@@ -511,7 +511,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
 
         long currentTime = getCurrentTime();
 
-        final TreeMap<Long, List<T>> orderedEntries = new TreeMap<>();
+        final Map<Long, List<T>> orderedEntries = new TreeMap<>();
         try {
             List<T> entityList = performListing(context, lowerBoundInclusiveTimestamp, ListingMode.EXECUTION);
 
@@ -662,7 +662,7 @@ public abstract class AbstractListProcessor<T extends ListableEntity> extends Ab
         }
 
         Long latestListedEntryTimestampThisCycleMillis = null;
-        final TreeMap<Long, List<T>> orderedEntries = new TreeMap<>();
+        final TreeMap<Long, List<T>> orderedEntries = new TreeMap<>(); // NOPMD
 
         // Build a sorted map to determine the latest possible entries
         boolean targetSystemHasMilliseconds = false;

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/main/java/org/apache/nifi/avro/AvroTypeUtil.java
@@ -50,6 +50,7 @@ import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.Schema.Type;
+import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Array;
 import org.apache.avro.generic.GenericFixed;
@@ -1147,7 +1148,7 @@ public class AvroTypeUtil {
                     }
                     return valueArray;
                 } else {
-                    final GenericData.Array<?> array = (GenericData.Array<?>) value;
+                    final GenericArray<?> array = (GenericArray<?>) value;
                     final Object[] valueArray = new Object[array.size()];
                     for (int i = 0; i < array.size(); i++) {
                         final Schema elementSchema = avroSchema.getElementType();

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
@@ -42,6 +42,7 @@ import org.apache.avro.Schema.Field;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericDatumReader;
@@ -304,7 +305,7 @@ public class TestAvroTypeUtil {
         GenericRecordBuilder builder = new GenericRecordBuilder(avroSchema);
         Record r = builder.build();
         @SuppressWarnings("unchecked")
-        GenericData.Array<Integer> values = (GenericData.Array<Integer>) r.get("listOfInt");
+        GenericArray<Integer> values = (GenericArray<Integer>) r.get("listOfInt");
         assertEquals(values.size(), 1);
         RecordSchema record = AvroTypeUtil.createSchema(avroSchema);
         RecordField field = record.getField("listOfInt").get();
@@ -326,7 +327,7 @@ public class TestAvroTypeUtil {
         GenericRecordBuilder builder = new GenericRecordBuilder(avroSchema);
         Record r = builder.build();
         @SuppressWarnings("unchecked")
-        GenericData.Array<Integer> values = (GenericData.Array<Integer>) r.get("listOfInt");
+        GenericArray<Integer> values = (GenericArray<Integer>) r.get("listOfInt");
         assertArrayEquals(new Object[] {1, 2}, values.toArray());
         RecordSchema record = AvroTypeUtil.createSchema(avroSchema);
         RecordField field = record.getField("listOfInt").get();
@@ -351,8 +352,7 @@ public class TestAvroTypeUtil {
         Record r = builder.build();
 
         @SuppressWarnings("unchecked")
-        GenericData.Array<Integer> values = (GenericData.Array<Integer>) ((GenericRecord) r.get("field1"))
-                .get("listOfInt");
+        GenericArray<Integer> values = (GenericArray<Integer>) ((GenericRecord) r.get("field1")).get("listOfInt");
         assertArrayEquals(new Object[] {0}, values.toArray());
         RecordSchema record = AvroTypeUtil.createSchema(avroSchema);
         RecordField field = record.getField("field1").get();
@@ -381,8 +381,7 @@ public class TestAvroTypeUtil {
        Record r = builder.build();
 
        @SuppressWarnings("unchecked")
-       GenericData.Array<Integer> values = (GenericData.Array<Integer>) ((GenericRecord) r.get("field1"))
-               .get("listOfInt");
+       GenericArray<Integer> values = (GenericArray<Integer>) ((GenericRecord) r.get("field1")).get("listOfInt");
        assertArrayEquals(new Object[] {1, 2, 3}, values.toArray());
        RecordSchema record = AvroTypeUtil.createSchema(avroSchema);
        RecordField field = record.getField("field1").get();
@@ -909,7 +908,7 @@ public class TestAvroTypeUtil {
         final GenericRecord result = AvroTypeUtil.createAvroRecord(nifiRecord, avroSchema);
 
         // then
-        final HashMap<String, Object> numbers = (HashMap<String, Object>) result.get("numbers");
+        final Map<String, Object> numbers = (HashMap<String, Object>) result.get("numbers");
         assertInstanceOf(Long.class, numbers.get("number1"));
         assertInstanceOf(Long.class, numbers.get("number2"));
     }

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/schema/access/InferenceSchemaStrategyTest.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/schema/access/InferenceSchemaStrategyTest.java
@@ -112,7 +112,7 @@ public class InferenceSchemaStrategyTest {
     }
 
     private Map<String, Object> givenContent() {
-        final HashMap<String, Object> result = new HashMap<>();
+        final Map<String, Object> result = new HashMap<>();
 
         for (final Object[] contentField : CONTENT_FIELDS) {
             result.put((String) contentField[0], contentField[1]);
@@ -122,7 +122,7 @@ public class InferenceSchemaStrategyTest {
     }
 
     private Map<String, DataType> givenExpected() {
-        final HashMap<String, DataType> result = new HashMap<>();
+        final Map<String, DataType> result = new HashMap<>();
 
         for (final Object[] contentField : CONTENT_FIELDS) {
             result.put((String) contentField[0], (DataType) contentField[2]);

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonPathRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-json-record-utils/src/main/java/org/apache/nifi/json/JsonPathRowRecordReader.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,13 +50,13 @@ import java.util.Optional;
 public class JsonPathRowRecordReader extends AbstractJsonRowRecordReader {
 
     private final ComponentLog logger;
-    private final LinkedHashMap<String, JsonPath> jsonPaths;
+    private final Map<String, JsonPath> jsonPaths;
     private final InputStream in;
     private final RecordSchema schema;
     private final Configuration providerConfiguration;
 
     public JsonPathRowRecordReader(
-            final LinkedHashMap<String, JsonPath> jsonPaths,
+            final Map<String, JsonPath> jsonPaths,
             final RecordSchema schema,
             final InputStream in,
             final ComponentLog logger,

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/factory/CredentialsFactory.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/credentials/factory/CredentialsFactory.java
@@ -78,7 +78,7 @@ public class CredentialsFactory {
      */
     public Collection<ValidationResult> validate(final ValidationContext validationContext) {
         final CredentialsStrategy selectedStrategy = selectPrimaryStrategy(validationContext);
-        final ArrayList<ValidationResult> validationFailureResults = new ArrayList<>();
+        final List<ValidationResult> validationFailureResults = new ArrayList<>();
 
         for (CredentialsStrategy strategy : strategies) {
             final Collection<ValidationResult> strategyValidationFailures = strategy.validate(validationContext,

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/PutGCSObject.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/main/java/org/apache/nifi/processors/gcp/storage/PutGCSObject.java
@@ -398,7 +398,7 @@ public class PutGCSObject extends AbstractGCSProcessor {
                     blobWriteOptions.add(Storage.BlobWriteOption.disableGzipContent());
                 }
 
-                final HashMap<String, String> userMetadata = new HashMap<>();
+                final Map<String, String> userMetadata = new HashMap<>();
                 for (final Map.Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
                     if (entry.getKey().isDynamic()) {
                         final String value = context.getProperty(

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/src/test/java/org/apache/nifi/processors/gcp/drive/ListGoogleDriveTestRunnerTest.java
@@ -279,8 +279,7 @@ public class ListGoogleDriveTestRunnerTest implements OutputChecker {
         inputFlowFileAttributes.put(GoogleDriveAttributes.LISTED_FOLDER_NAME, folderName);
         inputFlowFileAttributes.put(GoogleDriveAttributes.SHARED_DRIVE_ID, driveId);
         inputFlowFileAttributes.put(GoogleDriveAttributes.SHARED_DRIVE_NAME, driveName);
-
-        HashSet<Map<String, String>> expectedAttributes = new HashSet<>(singletonList(inputFlowFileAttributes));
+        Set<Map<String, String>> expectedAttributes = new HashSet<>(singletonList(inputFlowFileAttributes));
 
         testRunner.run();
 

--- a/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScriptTest.java
+++ b/nifi-extension-bundles/nifi-groovyx-bundle/nifi-groovyx-processors/src/test/java/org/apache/nifi/processors/groovyx/ExecuteGroovyScriptTest.java
@@ -575,8 +575,8 @@ public class ExecuteGroovyScriptTest {
     }
 
 
-    private HashMap<String, String> map(String key, String value) {
-        HashMap<String, String> attrs = new HashMap<>();
+    private Map<String, String> map(String key, String value) {
+        Map<String, String> attrs = new HashMap<>();
         attrs.put(key, value);
         return attrs;
     }

--- a/nifi-extension-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/src/main/java/org/apache/nifi/hazelcast/services/cacheclient/HazelcastMapCacheClient.java
+++ b/nifi-extension-bundles/nifi-hazelcast-bundle/nifi-hazelcast-services/src/main/java/org/apache/nifi/hazelcast/services/cacheclient/HazelcastMapCacheClient.java
@@ -112,7 +112,7 @@ public class HazelcastMapCacheClient extends AbstractControllerService implement
 
     @Override
     public <K> Set<K> keySet(Deserializer<K> keyDeserializer) throws IOException {
-        final HashSet<K> keySet = new HashSet<>();
+        final Set<K> keySet = new HashSet<>();
         for (String key : cache.keySet()) {
             keySet.add(parseCacheEntryKey(key, keyDeserializer));
         }

--- a/nifi-extension-bundles/nifi-iotdb-bundle/nifi-iotdb-processors/src/main/java/org/apache/nifi/processors/model/DatabaseField.java
+++ b/nifi-extension-bundles/nifi-iotdb-bundle/nifi-iotdb-processors/src/main/java/org/apache/nifi/processors/model/DatabaseField.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.processors.model;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.tsfile.file.metadata.enums.CompressionType;
@@ -29,10 +30,10 @@ public class DatabaseField {
     private TSEncoding encoding;
     private CompressionType compressionType;
 
-    private static final HashMap<String, TSDataType> typeMap = new HashMap<>();
-    private static final HashMap<String, TSEncoding> encodingMap = new HashMap<>();
+    private static final Map<String, TSDataType> typeMap = new HashMap<>();
+    private static final Map<String, TSEncoding> encodingMap = new HashMap<>();
 
-    private static final HashMap<String, CompressionType> compressionMap = new HashMap<>();
+    private static final Map<String, CompressionType> compressionMap = new HashMap<>();
 
     static {
         typeMap.put("INT32", TSDataType.INT32);

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryHandler.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/JndiJmsConnectionFactoryHandler.java
@@ -93,7 +93,7 @@ public class JndiJmsConnectionFactoryHandler extends CachedJMSConnectionFactoryH
 
 
     private Context createInitialContext() throws NamingException {
-        final Hashtable<String, String> env = new Hashtable<>();
+        final Hashtable<String, String> env = new Hashtable<>(); //NOPMD
         env.put(Context.INITIAL_CONTEXT_FACTORY, context.getProperty(JNDI_INITIAL_CONTEXT_FACTORY).evaluateAttributeExpressions().getValue().trim());
         env.put(Context.PROVIDER_URL, context.getProperty(JNDI_PROVIDER_URL).evaluateAttributeExpressions().getValue().trim());
 

--- a/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/Utils.java
+++ b/nifi-extension-bundles/nifi-jms-bundle/nifi-jms-processors/src/main/java/org/apache/nifi/jms/cf/Utils.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 
 public final class Utils {
 
@@ -70,7 +71,7 @@ public final class Utils {
      */
     public static Method[] findMethods(String name, Class<?> targetClass) {
         Class<?> searchType = targetClass;
-        ArrayList<Method> fittingMethods = new ArrayList<>();
+        List<Method> fittingMethods = new ArrayList<>();
         while (searchType != null) {
             Method[] methods = (searchType.isInterface() ? searchType.getMethods() : searchType.getDeclaredMethods());
             for (Method method : methods) {

--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/gridfs/DeleteGridFS.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-processors/src/main/java/org/apache/nifi/processors/mongodb/gridfs/DeleteGridFS.java
@@ -91,7 +91,7 @@ public class DeleteGridFS extends AbstractGridFSProcessor {
 
     @Override
     protected Collection<ValidationResult> customValidate(final ValidationContext validationContext) {
-        ArrayList<ValidationResult> problems = new ArrayList<>();
+        List<ValidationResult> problems = new ArrayList<>();
 
         boolean fileName = validationContext.getProperty(FILE_NAME).isSet();
         boolean query    = validationContext.getProperty(QUERY).isSet();

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/ConsumeMQTT.java
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/main/java/org/apache/nifi/processors/mqtt/ConsumeMQTT.java
@@ -69,6 +69,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -195,7 +196,7 @@ public class ConsumeMQTT extends AbstractMQTTProcessor {
     private volatile String topicFilter;
     private final AtomicBoolean scheduled = new AtomicBoolean(false);
 
-    private volatile LinkedBlockingQueue<ReceivedMqttMessage> mqttQueue;
+    private volatile BlockingQueue<ReceivedMqttMessage> mqttQueue;
 
     public static final Relationship REL_MESSAGE = new Relationship.Builder()
             .name("Message")
@@ -251,7 +252,7 @@ public class ConsumeMQTT extends AbstractMQTTProcessor {
                     logger.warn("New receive buffer size ({}) is smaller than the number of messages pending ({}), ignoring resize request. Processor will be invalid.", newSize, msgPending);
                     return;
                 }
-                LinkedBlockingQueue<ReceivedMqttMessage> newBuffer = new LinkedBlockingQueue<>(newSize);
+                BlockingQueue<ReceivedMqttMessage> newBuffer = new LinkedBlockingQueue<>(newSize);
                 mqttQueue.drainTo(newBuffer);
                 mqttQueue = newBuffer;
             }

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestConsumeMQTT.java
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/src/test/java/org/apache/nifi/processors/mqtt/TestConsumeMQTT.java
@@ -44,7 +44,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.apache.nifi.processors.mqtt.ConsumeMQTT.BROKER_ATTRIBUTE_KEY;
 import static org.apache.nifi.processors.mqtt.ConsumeMQTT.IS_DUPLICATE_ATTRIBUTE_KEY;
@@ -404,7 +403,7 @@ public class TestConsumeMQTT {
         final Field f = ConsumeMQTT.class.getDeclaredField("mqttQueue");
         f.setAccessible(true);
         @SuppressWarnings("unchecked")
-        final LinkedBlockingQueue<ReceivedMqttMessage> queue = (LinkedBlockingQueue<ReceivedMqttMessage>) f.get(consumeMQTT);
+        final BlockingQueue<ReceivedMqttMessage> queue = (BlockingQueue<ReceivedMqttMessage>) f.get(consumeMQTT);
         queue.add(testMessage);
 
         consumeMQTT.onUnscheduled(testRunner.getProcessContext());

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/CalculateParquetOffsetsTest.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/CalculateParquetOffsetsTest.java
@@ -341,7 +341,7 @@ public class CalculateParquetOffsetsTest {
         results.forEach(flowFile -> PRESERVED_ATTRIBUTES.forEach(flowFile::assertAttributeEquals));
     }
 
-    private HashMap<String, String> createAttributes(Map<String, String> additionalAttributes) {
+    private Map<String, String> createAttributes(Map<String, String> additionalAttributes) {
         return new HashMap<>(PRESERVED_ATTRIBUTES) {{
             putAll(additionalAttributes);
         }};

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/FetchParquetTest.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/FetchParquetTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.io.IOUtils;
@@ -551,7 +552,7 @@ public class FetchParquetTest {
                 user.put("favorite_number", i);
 
 
-                final GenericData.Array<String> colors = new GenericData.Array<>(1, favoriteColorsSchema);
+                final GenericArray<String> colors = new GenericData.Array<>(1, favoriteColorsSchema);
                 colors.add("blue" + i);
 
                 user.put("favorite_color", colors);
@@ -579,7 +580,7 @@ public class FetchParquetTest {
                 user.put("favorite_number", i);
 
 
-                final GenericData.Array<String> colors = new GenericData.Array<>(1, favoriteColorsSchema);
+                final GenericArray<String> colors = new GenericData.Array<>(1, favoriteColorsSchema);
                 colors.add("blue" + i);
 
                 user.put("favorite_color", colors);

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/impl/FilteredPropertiesValidationContextAdapter.java
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/src/main/java/org/apache/nifi/script/impl/FilteredPropertiesValidationContextAdapter.java
@@ -32,7 +32,7 @@ import org.apache.nifi.components.ValidationContext;
  */
 public class FilteredPropertiesValidationContextAdapter extends ValidationContextAdapter {
 
-    private HashMap<PropertyDescriptor, String> properties;
+    private final Map<PropertyDescriptor, String> properties;
 
     public FilteredPropertiesValidationContextAdapter(ValidationContext validationContext, Set<PropertyDescriptor> removedProperties) {
         super(validationContext);

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/ListSmbTest.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/ListSmbTest.java
@@ -46,6 +46,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.nifi.distributed.cache.client.DistributedMapCacheClient;
 import org.apache.nifi.logging.ComponentLog;
@@ -330,7 +331,7 @@ class ListSmbTest {
     }
 
     private DistributedMapCacheClient mockDistributedMap() throws IOException {
-        final Map<String, ConcurrentHashMap<String, ListedEntity>> store = new ConcurrentHashMap<>();
+        final Map<String, ? extends ConcurrentMap<String, ListedEntity>> store = new ConcurrentHashMap<>();
         final DistributedMapCacheClient cacheService = mock(DistributedMapCacheClient.class);
         when(cacheService.putIfAbsent(any(), any(), any(), any())).thenReturn(false);
         when(cacheService.containsKey(any(), any())).thenReturn(false);

--- a/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
+++ b/nifi-extension-bundles/nifi-snmp-bundle/nifi-snmp-processors/src/test/java/org/apache/nifi/snmp/operations/SNMPTrapReceiverTest.java
@@ -108,7 +108,7 @@ class SNMPTrapReceiverTest {
         when(mockAddress.toString()).thenReturn("127.0.0.1/62");
         when(mockAddress.isValid()).thenReturn(true);
 
-        final Vector<VariableBinding> vbs = new Vector<>();
+        final List<VariableBinding> vbs = new Vector<>();
         doReturn(vbs).when(mockV1Pdu).getVariableBindings();
         when(mockEvent.getPDU()).thenReturn(mockV1Pdu);
         when(mockEvent.getPeerAddress()).thenReturn(mockAddress);
@@ -132,7 +132,7 @@ class SNMPTrapReceiverTest {
         when(mockPdu.getType()).thenReturn(PDU.TRAP);
         when(mockPdu.getErrorIndex()).thenReturn(123);
         when(mockPdu.getErrorStatusText()).thenReturn("test error status text");
-        final Vector<VariableBinding> vbs = new Vector<>();
+        final List<VariableBinding> vbs = new Vector<>();
 
         final Address mockAddress = mock(Address.class);
         when(mockAddress.toString()).thenReturn("127.0.0.1/62");
@@ -164,7 +164,7 @@ class SNMPTrapReceiverTest {
         final Address mockAddress = mock(Address.class);
         when(mockAddress.isValid()).thenReturn(false);
 
-        final Vector<VariableBinding> vbs = new Vector<>();
+        final List<VariableBinding> vbs = new Vector<>();
         doReturn(vbs).when(mockPdu).getVariableBindings();
         when(mockEvent.getPDU()).thenReturn(mockPdu);
         when(mockEvent.getPeerAddress()).thenReturn(mockAddress);

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/GetSplunk.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/GetSplunk.java
@@ -416,7 +416,7 @@ public class GetSplunk extends AbstractProcessor implements ClassloaderIsolation
         final String timeZone = context.getProperty(TIME_ZONE).getValue();
         final String timeFieldStrategy = context.getProperty(TIME_FIELD_STRATEGY).getValue();
 
-        final JobExportArgs exportArgs = new JobExportArgs();
+        final JobExportArgs exportArgs = new JobExportArgs(); //NOPMD
         exportArgs.setSearchMode(JobExportArgs.SearchMode.NORMAL);
         exportArgs.setOutputMode(JobExportArgs.OutputMode.valueOf(outputMode));
 
@@ -537,7 +537,7 @@ public class GetSplunk extends AbstractProcessor implements ClassloaderIsolation
     }
 
     protected Service createSplunkService(final ProcessContext context) {
-        final ServiceArgs serviceArgs = new ServiceArgs();
+        final ServiceArgs serviceArgs = new ServiceArgs(); //NOPMD
 
         final String scheme = context.getProperty(SCHEME).getValue();
         serviceArgs.setScheme(scheme);

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/SplunkAPICall.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/main/java/org/apache/nifi/processors/splunk/SplunkAPICall.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
+@SuppressWarnings("PMD.LooseCoupling")
 abstract class SplunkAPICall extends AbstractProcessor {
     private static final String REQUEST_CHANNEL_HEADER_NAME = "X-Splunk-Request-Channel";
 

--- a/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestGetSplunk.java
+++ b/nifi-extension-bundles/nifi-splunk-bundle/nifi-splunk-processors/src/test/java/org/apache/nifi/processors/splunk/TestGetSplunk.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("PMD.LooseCoupling")
 public class TestGetSplunk {
 
     private Service service;
@@ -373,6 +374,7 @@ public class TestGetSplunk {
     /**
      * Custom args matcher for JobExportArgs.
      */
+    @SuppressWarnings("PMD.LooseCoupling")
     private static class JobExportArgsMatcher implements ArgumentMatcher<JobExportArgs> {
 
         private JobExportArgs expected;

--- a/nifi-extension-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/datasources/ProvenanceDataSource.java
+++ b/nifi-extension-bundles/nifi-sql-reporting-bundle/nifi-sql-reporting-tasks/src/main/java/org/apache/nifi/reporting/sql/datasources/ProvenanceDataSource.java
@@ -116,7 +116,7 @@ public class ProvenanceDataSource implements ResettableDataSource {
         final String processGroupId = componentMapHolder.getProcessGroupId(provenanceEvent.getComponentId(), provenanceEvent.getComponentType());
         final String groupName = componentMapHolder.getComponentName(processGroupId);
 
-        final ArrayList<Object> rowList = new ArrayList<>();
+        final List<Object> rowList = new ArrayList<>();
         rowList.add(provenanceEvent.getEventId());
         rowList.add(provenanceEvent.getEventType().name());
         rowList.add(provenanceEvent.getEventTime());

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToCSV.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/AttributesToCSV.java
@@ -245,9 +245,9 @@ public class AttributesToCSV extends AbstractProcessor {
         return result;
     }
 
-    private LinkedHashSet<String> attributeListStringToSet(String attributeList) {
+    private Set<String> attributeListStringToSet(String attributeList) {
         //take the user specified attribute list string and convert to list of strings.
-        LinkedHashSet<String> result = new LinkedHashSet<>();
+        Set<String> result = new LinkedHashSet<>();
         if (StringUtils.isNotBlank(attributeList)) {
             String[] ats = attributeList.split(SPLIT_REGEX);
             for (String str : ats) {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeduplicateRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/DeduplicateRecord.java
@@ -565,9 +565,9 @@ public class DeduplicateRecord extends AbstractProcessor {
 
     private static class HashSetFilterWrapper extends FilterWrapper {
 
-        private final HashSet<String> filter;
+        private final HashSet<String> filter; //NOPMD
 
-        public HashSetFilterWrapper(HashSet<String> filter) {
+        public HashSetFilterWrapper(HashSet<String> filter) { //NOPMD
             this.filter = filter;
         }
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteStreamCommand.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ExecuteStreamCommand.java
@@ -360,8 +360,8 @@ public class ExecuteStreamCommand extends AbstractProcessor {
             return;
         }
 
-        final ArrayList<String> args = new ArrayList<>();
-        final ArrayList<String> argumentAttributeValue = new ArrayList<>();
+        final List<String> args = new ArrayList<>();
+        final List<String> argumentAttributeValue = new ArrayList<>();
         final boolean putToAttribute = context.getProperty(PUT_OUTPUT_IN_ATTRIBUTE).isSet();
         final PropertyValue argumentsStrategyPropertyValue = context.getProperty(ARGUMENTS_STRATEGY);
         final boolean useDynamicPropertyArguments = argumentsStrategyPropertyValue.isSet() && argumentsStrategyPropertyValue.getValue().equals(DYNAMIC_PROPERTY_ARGUMENTS_STRATEGY.getValue());

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SampleRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SampleRecord.java
@@ -451,7 +451,7 @@ public class SampleRecord extends AbstractProcessor {
     static class ReservoirSamplingStrategy implements SamplingStrategy {
         final RecordSetWriter writer;
         final int reservoirSize;
-        final ArrayList<Record> reservoir;
+        final List<Record> reservoir;
         int currentCount = 0;
         final Random randomNumberGenerator;
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/SplitContent.java
@@ -242,7 +242,7 @@ public class SplitContent extends AbstractProcessor {
         });
 
         long lastOffsetPlusSize = -1L;
-        final ArrayList<FlowFile> splitList = new ArrayList<>();
+        final List<FlowFile> splitList = new ArrayList<>();
 
         if (splits.isEmpty()) {
             FlowFile clone = session.clone(flowFile);
@@ -298,7 +298,7 @@ public class SplitContent extends AbstractProcessor {
         final String originalFilename = source.getAttribute(CoreAttributes.FILENAME.key());
 
         final String fragmentId = UUID.randomUUID().toString();
-        final ArrayList<FlowFile> newList = new ArrayList<>(splits);
+        final List<FlowFile> newList = new ArrayList<>(splits);
         splits.clear();
         for (int i = 1; i <= newList.size(); i++) {
             FlowFile ff = newList.get(i - 1);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/UnpackContent.java
@@ -707,7 +707,7 @@ public class UnpackContent extends AbstractProcessor {
         }
 
         // second pass adds fragment attributes
-        ArrayList<FlowFile> newList = new ArrayList<>(unpacked);
+        List<FlowFile> newList = new ArrayList<>(unpacked);
         unpacked.clear();
         for (FlowFile ff : newList) {
             FlowFile newFF = session.putAllAttributes(ff, Map.of(

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Wait.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/Wait.java
@@ -355,7 +355,7 @@ public class Wait extends AbstractProcessor {
         final boolean replaceOriginalAttributes = ATTRIBUTE_COPY_REPLACE.getValue().equals(attributeCopyMode);
         final AtomicReference<Signal> signalRef = new AtomicReference<>();
         // This map contains original counts before those are consumed to release incoming FlowFiles.
-        final HashMap<String, Long> originalSignalCounts = new HashMap<>();
+        final Map<String, Long> originalSignalCounts = new HashMap<>();
 
         final Consumer<FlowFile> transferToFailure = flowFile -> {
             flowFile = session.penalize(flowFile);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/AbstractTestTailFileScenario.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/AbstractTestTailFileScenario.java
@@ -56,7 +56,7 @@ public class AbstractTestTailFileScenario {
     protected AtomicLong timeAdjustment;
     protected AtomicBoolean rolloverSwitchPending;
 
-    protected LinkedList<Long> nulPositions;
+    protected List<Long> nulPositions;
 
     protected List<String> expected;
     private Random random;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestFTP.java
@@ -182,8 +182,8 @@ public class TestFTP {
 
         runner.clearProvenanceEvents();
         runner.clearTransferState();
-        HashMap<String, String> map1 = new HashMap<>();
-        HashMap<String, String> map2 = new HashMap<>();
+        Map<String, String> map1 = new HashMap<>();
+        Map<String, String> map2 = new HashMap<>();
         map1.put(CoreAttributes.FILENAME.key(), "randombytes-xx");
         map2.put(CoreAttributes.FILENAME.key(), "randombytes-yy");
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLogMessage.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestLogMessage.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -71,8 +72,7 @@ public class TestLogMessage {
 
         runner.setProperty(LogMessage.LOG_MESSAGE, "This should help the operator to follow the flow: ${foobar}");
         runner.setProperty(LogMessage.LOG_LEVEL, LogMessage.MessageLogLevel.info.toString());
-
-        HashMap<String, String> flowAttributes = new HashMap<>();
+        Map<String, String> flowAttributes = new HashMap<>();
         flowAttributes.put("foobar", "baz");
 
         runner.enqueue("This is a message!", flowAttributes);
@@ -96,7 +96,7 @@ public class TestLogMessage {
         runner.setProperty(LogMessage.LOG_MESSAGE, "This should help the operator to follow the flow: ${foobar}");
         runner.setProperty(LogMessage.LOG_LEVEL, LogMessage.MessageLogLevel.info.toString());
 
-        HashMap<String, String> flowAttributes = new HashMap<>();
+        Map<String, String> flowAttributes = new HashMap<>();
         flowAttributes.put("foobar", "baz");
 
         runner.enqueue("This is a message!", flowAttributes);

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestMonitorActivity.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestMonitorActivity.java
@@ -667,7 +667,7 @@ public class TestMonitorActivity {
         runner.enqueue("Incoming data");
 
         // Set future timestamp in state
-        final HashMap<String, String> existingState = new HashMap<>();
+        final Map<String, String> existingState = new HashMap<>();
         final long existingTimestamp = currentTimeMillis() - 1_000;
         existingState.put(MonitorActivity.STATE_KEY_COMMON_FLOW_ACTIVITY_INFO,
                 String.valueOf(existingTimestamp));
@@ -701,7 +701,7 @@ public class TestMonitorActivity {
         runner.enqueue("Incoming data");
 
         // Set future timestamp in state
-        final HashMap<String, String> existingState = new HashMap<>();
+        final Map<String, String> existingState = new HashMap<>();
         final long existingTimestamp = currentTimeMillis() + 10_000;
         existingState.put(MonitorActivity.STATE_KEY_COMMON_FLOW_ACTIVITY_INFO,
                 String.valueOf(existingTimestamp));
@@ -733,7 +733,7 @@ public class TestMonitorActivity {
         runner.setProperty(MonitorActivity.THRESHOLD, "1 ms");
         runner.setProperty(MonitorActivity.COPY_ATTRIBUTES, "true");
 
-        final HashMap<String, String> attributes = new HashMap<>();
+        final Map<String, String> attributes = new HashMap<>();
         attributes.put("key1", "value1");
         attributes.put("key2", "value2");
         runner.enqueue("Incoming data", attributes);
@@ -855,7 +855,7 @@ public class TestMonitorActivity {
         runner.clearTransferState();
 
         // Activity restored
-        final HashMap<String, String> attributes = new HashMap<>();
+        final Map<String, String> attributes = new HashMap<>();
         attributes.put("key1", "value1");
         attributes.put("key2", "value2");
         runner.enqueue("Incoming data", attributes);
@@ -893,7 +893,7 @@ public class TestMonitorActivity {
         runner.clearTransferState();
 
         // Activity restored
-        final HashMap<String, String> attributes = new HashMap<>();
+        final Map<String, String> attributes = new HashMap<>();
         attributes.put("key1", "value1");
         attributes.put("key2", "value2");
         runner.enqueue("Incoming data", attributes);
@@ -928,7 +928,7 @@ public class TestMonitorActivity {
         runner.clearTransferState();
 
         // Activity restored
-        final HashMap<String, String> attributes = new HashMap<>();
+        final Map<String, String> attributes = new HashMap<>();
         attributes.put("key1", "value1");
         attributes.put("key2", "value2");
         runner.enqueue("Incoming data", attributes);
@@ -967,7 +967,7 @@ public class TestMonitorActivity {
         runner.clearTransferState();
 
         // Activity restored
-        final HashMap<String, String> attributes = new HashMap<>();
+        final Map<String, String> attributes = new HashMap<>();
         attributes.put("key1", "value1");
         attributes.put("key2", "value2");
         runner.enqueue("Incoming data", attributes);
@@ -1002,7 +1002,7 @@ public class TestMonitorActivity {
         runner.clearTransferState();
 
         // Activity restored, even if this node doesn't have activity, other node updated the cluster state.
-        final HashMap<String, String> clusterState = new HashMap<>();
+        final Map<String, String> clusterState = new HashMap<>();
         clusterState.put(MonitorActivity.STATE_KEY_COMMON_FLOW_ACTIVITY_INFO, String.valueOf(currentTimeMillis()));
         clusterState.put("key1", "value1");
         clusterState.put("key2", "value2");
@@ -1042,7 +1042,7 @@ public class TestMonitorActivity {
         runner.clearTransferState();
 
         // Activity restored, even if this node doesn't have activity, other node updated the cluster state.
-        final HashMap<String, String> clusterState = new HashMap<>();
+        final Map<String, String> clusterState = new HashMap<>();
         clusterState.put(MonitorActivity.STATE_KEY_COMMON_FLOW_ACTIVITY_INFO, String.valueOf(currentTimeMillis()));
         clusterState.put("key1", "value1");
         clusterState.put("key2", "value2");
@@ -1078,7 +1078,7 @@ public class TestMonitorActivity {
         runner.clearTransferState();
 
         // Activity restored, even if this node doesn't have activity, other node updated the cluster state.
-        final HashMap<String, String> clusterState = new HashMap<>();
+        final Map<String, String> clusterState = new HashMap<>();
         clusterState.put(MonitorActivity.STATE_KEY_COMMON_FLOW_ACTIVITY_INFO, String.valueOf(currentTimeMillis()));
         clusterState.put("key1", "value1");
         clusterState.put("key2", "value2");

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutEmail.java
@@ -65,7 +65,7 @@ public class TestPutEmail {
      */
     private static final class PutEmailExtension extends PutEmail {
         private MessagingException e;
-        private final ArrayList<Message> messages = new ArrayList<>();
+        private final List<Message> messages = new ArrayList<>();
 
         @Override
         protected void send(Message msg) throws MessagingException {

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSampleRecord.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestSampleRecord.java
@@ -266,7 +266,7 @@ public class TestSampleRecord {
         Random randomAge = new Random();
         final List<Record> records = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
-            HashMap<String, Object> recordMap = new HashMap<>();
+            Map<String, Object> recordMap = new HashMap<>();
             Object name = UUID.randomUUID();
             Object age = randomAge.nextInt();
             recordMap.put("name", name);

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/CSVRecordLookupService.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/src/main/java/org/apache/nifi/lookup/CSVRecordLookupService.java
@@ -83,7 +83,7 @@ public class CSVRecordLookupService extends AbstractCSVLookupService implements 
                     logger.debug("Loading lookup table from file: {}", csvFile);
                 }
 
-                ConcurrentHashMap<String, Record> cache = new ConcurrentHashMap<>();
+                ConcurrentMap<String, Record> cache = new ConcurrentHashMap<>();
                 try (final InputStream is = new FileInputStream(csvFile)) {
                     try (final InputStreamReader reader = new InputStreamReader(is, charset)) {
                         final CSVParser records = csvFormat.builder().setHeader().setSkipHeaderRecord(true).get().parse(reader);

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonPathReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/json/JsonPathReader.java
@@ -75,7 +75,7 @@ public class JsonPathReader extends SchemaRegistryService implements RecordReade
     private volatile String dateFormat;
     private volatile String timeFormat;
     private volatile String timestampFormat;
-    private volatile LinkedHashMap<String, JsonPath> jsonPaths;
+    private volatile Map<String, JsonPath> jsonPaths;
     private volatile ObjectMapper objectMapper;
     private volatile TokenParserFactory tokenParserFactory;
 
@@ -116,7 +116,7 @@ public class JsonPathReader extends SchemaRegistryService implements RecordReade
         final boolean allowComments = context.getProperty(AbstractJsonRowRecordReader.ALLOW_COMMENTS).asBoolean();
         this.tokenParserFactory = new JsonParserFactory(streamReadConstraints, allowComments);
 
-        final LinkedHashMap<String, JsonPath> compiled = new LinkedHashMap<>();
+        final Map<String, JsonPath> compiled = new LinkedHashMap<>();
         for (final PropertyDescriptor descriptor : context.getProperties().keySet()) {
             if (!descriptor.isDynamic()) {
                 continue;

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestWriteAvroResult.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestWriteAvroResult.java
@@ -20,6 +20,7 @@ package org.apache.nifi.avro;
 import org.apache.avro.Conversions;
 import org.apache.avro.LogicalType;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericData.Array;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.nifi.serialization.RecordSetWriter;
@@ -343,7 +344,7 @@ public abstract class TestWriteAvroResult {
                 }
             } else if (recordValue instanceof Object[]) {
                 assertInstanceOf(Array.class, avroValue, fieldName + " should have been instanceof Array");
-                final Array<?> avroArray = (Array<?>) avroValue;
+                final GenericArray<?> avroArray = (GenericArray<?>) avroValue;
                 final Object[] recordArray = (Object[]) recordValue;
                 assertEquals(recordArray.length, avroArray.size(),
                         fieldName + " not equal");

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonPathRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonPathRowRecordReader.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -54,7 +55,7 @@ class TestJsonPathRowRecordReader {
     private final String timeFormat = RecordFieldType.TIME.getDefaultFormat();
     private final String timestampFormat = RecordFieldType.TIMESTAMP.getDefaultFormat();
 
-    private final LinkedHashMap<String, JsonPath> allJsonPaths = new LinkedHashMap<>();
+    private final Map<String, JsonPath> allJsonPaths = new LinkedHashMap<>();
 
     private final ObjectMapper mapper = new ObjectMapper();
     private final TokenParserFactory parserFactory = new JsonParserFactory();
@@ -176,7 +177,7 @@ class TestJsonPathRowRecordReader {
         final List<RecordField> recordFields = Collections.singletonList(new RecordField("timestamp", RecordFieldType.TIMESTAMP.getDataType()));
         final RecordSchema schema = new SimpleRecordSchema(recordFields);
 
-        final LinkedHashMap<String, JsonPath> jsonPaths = new LinkedHashMap<>();
+        final Map<String, JsonPath> jsonPaths = new LinkedHashMap<>();
         jsonPaths.put("timestamp", JsonPath.compile("$.timestamp"));
         jsonPaths.put("field_not_in_schema", JsonPath.compile("$.field_not_in_schema"));
 
@@ -199,7 +200,7 @@ class TestJsonPathRowRecordReader {
 
     @Test
     void testElementWithNestedData() throws IOException, MalformedRecordException {
-        final LinkedHashMap<String, JsonPath> jsonPaths = new LinkedHashMap<>(allJsonPaths);
+        final Map<String, JsonPath> jsonPaths = new LinkedHashMap<>(allJsonPaths);
         jsonPaths.put("account", JsonPath.compile("$.account"));
 
         final DataType accountType = RecordFieldType.RECORD.getRecordDataType(getAccountSchema());
@@ -235,7 +236,7 @@ class TestJsonPathRowRecordReader {
 
     @Test
     void testElementWithNestedArray() throws IOException, MalformedRecordException {
-        final LinkedHashMap<String, JsonPath> jsonPaths = new LinkedHashMap<>(allJsonPaths);
+        final Map<String, JsonPath> jsonPaths = new LinkedHashMap<>(allJsonPaths);
         jsonPaths.put("accounts", JsonPath.compile("$.accounts"));
 
         final DataType accountRecordType = RecordFieldType.RECORD.getRecordDataType(getAccountSchema());
@@ -314,7 +315,7 @@ class TestJsonPathRowRecordReader {
 
     @Test
     void testReadArrayDifferentSchemasWithOverride() throws IOException, MalformedRecordException {
-        final LinkedHashMap<String, JsonPath> jsonPaths = new LinkedHashMap<>(allJsonPaths);
+        final Map<String, JsonPath> jsonPaths = new LinkedHashMap<>(allJsonPaths);
         jsonPaths.put("address2", JsonPath.compile("$.address2"));
 
         final List<RecordField> fields = getDefaultFields();
@@ -349,7 +350,7 @@ class TestJsonPathRowRecordReader {
 
     @Test
     void testPrimitiveTypeArrays() throws IOException, MalformedRecordException {
-        final LinkedHashMap<String, JsonPath> jsonPaths = new LinkedHashMap<>(allJsonPaths);
+        final Map<String, JsonPath> jsonPaths = new LinkedHashMap<>(allJsonPaths);
         jsonPaths.put("accountIds", JsonPath.compile("$.accountIds"));
 
         final List<RecordField> fields = getDefaultFields();

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/test/java/org/apache/nifi/record/sink/TestEmailRecordSink.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-sink-service-bundle/nifi-record-sink-service/src/test/java/org/apache/nifi/record/sink/TestEmailRecordSink.java
@@ -61,7 +61,7 @@ public class TestEmailRecordSink {
      */
     private static final class EmailRecordSinkExtension extends EmailRecordSink {
         private MessagingException e;
-        private final ArrayList<Message> messages = new ArrayList<>();
+        private final List<Message> messages = new ArrayList<>();
 
         @Override
         protected void send(Message msg) throws MessagingException {

--- a/nifi-extension-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-processors/src/main/java/org/apache/nifi/processors/stateful/analysis/AttributeRollingWindow.java
+++ b/nifi-extension-bundles/nifi-stateful-analysis-bundle/nifi-stateful-analysis-processors/src/main/java/org/apache/nifi/processors/stateful/analysis/AttributeRollingWindow.java
@@ -154,8 +154,7 @@ public class AttributeRollingWindow extends AbstractProcessor {
         if (microBatchTime == null || microBatchTime == 0) {
             StateManager stateManager = context.getStateManager();
             StateMap state = stateManager.getState(SCOPE);
-            HashMap<String, String> tempMap = new HashMap<>();
-            tempMap.putAll(state.toMap());
+            Map<String, String> tempMap = new HashMap<>(state.toMap());
             if (!tempMap.containsKey(COUNT_KEY)) {
                 tempMap.put(COUNT_KEY, "0");
                 context.getStateManager().setState(tempMap, SCOPE);

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb-status-history/src/main/java/org/apache/nifi/controller/status/history/questdb/BufferedStatusHistoryStorage.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb-status-history/src/main/java/org/apache/nifi/controller/status/history/questdb/BufferedStatusHistoryStorage.java
@@ -175,7 +175,7 @@ final class BufferedStatusHistoryStorage implements StatusHistoryStorage {
         }
 
         private <T> void flush(final BlockingQueue<T> source, final Consumer<Collection<T>> target) {
-            final ArrayList<T> statusEntries = new ArrayList<>(persistBatchSize);
+            final List<T> statusEntries = new ArrayList<>(persistBatchSize);
             source.drainTo(statusEntries, persistBatchSize);
 
             if (!statusEntries.isEmpty()) {

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/FlowSnippetDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/FlowSnippetDTO.java
@@ -184,7 +184,7 @@ public class FlowSnippetDTO {
     }
 
     private <T extends ComponentDTO> Set<T> orderedById(Set<T> dtos) {
-        TreeSet<T> components = new TreeSet<>(Comparator.comparing(ComponentDTO::getId));
+        Set<T> components = new TreeSet<>(Comparator.comparing(ComponentDTO::getId));
         components.addAll(dtos);
         return components;
     }
@@ -293,7 +293,7 @@ public class FlowSnippetDTO {
     }
 
     private <T extends RemoteProcessGroupPortDTO> Set<T> orderedRemotePortsById(Set<T> dtos) {
-        TreeSet<T> components = new TreeSet<>(Comparator.comparing((RemoteProcessGroupPortDTO c) -> UUID.fromString(c.getId())));
+        Set<T> components = new TreeSet<>(Comparator.comparing((RemoteProcessGroupPortDTO c) -> UUID.fromString(c.getId())));
         components.addAll(dtos);
         return components;
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/StatusHistoryDTO.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-client-dto/src/main/java/org/apache/nifi/web/api/dto/status/StatusHistoryDTO.java
@@ -22,8 +22,8 @@ import org.apache.nifi.web.api.dto.util.TimeAdapter;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * DTO for serializing the status history of a single component across the cluster.
@@ -33,7 +33,7 @@ public class StatusHistoryDTO {
 
     private Date generated;
 
-    private LinkedHashMap<String, String> componentDetails;
+    private Map<String, String> componentDetails;
     private List<StatusDescriptorDTO> fieldDescriptors;
     private List<StatusSnapshotDTO> aggregateSnapshots;
     private List<NodeStatusSnapshotsDTO> nodeSnapshots;
@@ -57,11 +57,11 @@ public class StatusHistoryDTO {
      * @return key/value pairs that describe the component that the status history belongs to
      */
     @Schema(description = "A Map of key/value pairs that describe the component that the status history belongs to")
-    public LinkedHashMap<String, String> getComponentDetails() {
+    public Map<String, String> getComponentDetails() {
         return componentDetails;
     }
 
-    public void setComponentDetails(LinkedHashMap<String, String> componentDetails) {
+    public void setComponentDetails(Map<String, String> componentDetails) {
         this.componentDetails = componentDetails;
     }
 

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/StatusHistoryEndpointMerger.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/http/endpoints/StatusHistoryEndpointMerger.java
@@ -43,7 +43,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -116,7 +115,7 @@ public class StatusHistoryEndpointMerger implements EndpointResponseMerger {
         boolean includeCounters = true;
         StatusHistoryDTO lastStatusHistory = null;
         final List<NodeStatusSnapshotsDTO> nodeStatusSnapshots = new ArrayList<>(successfulResponses.size());
-        LinkedHashMap<String, String> noReadPermissionsComponentDetails = null;
+        Map<String, String> noReadPermissionsComponentDetails = null;
         for (final NodeResponse nodeResponse : successfulResponses) {
             final StatusHistoryEntity nodeResponseEntity = nodeResponse == clientResponse ? responseEntity : nodeResponse.getClientResponse().readEntity(StatusHistoryEntity.class);
             final StatusHistoryDTO nodeStatus = nodeResponseEntity.getStatusHistory();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/node/NodeClusterCoordinator.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/main/java/org/apache/nifi/cluster/coordination/node/NodeClusterCoordinator.java
@@ -86,6 +86,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -126,7 +127,7 @@ public class NodeClusterCoordinator implements ClusterCoordinator, ProtocolHandl
     private volatile boolean requireElection = true;
 
     private final ConcurrentMap<String, NodeConnectionStatus> nodeStatuses = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, CircularFifoQueue<NodeEvent>> nodeEvents = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, CircularFifoQueue<NodeEvent>> nodeEvents = new ConcurrentHashMap<>(); //NOPMD
 
     private final List<ClusterTopologyEventListener> eventListeners = new CopyOnWriteArrayList<>();
 
@@ -853,7 +854,7 @@ public class NodeClusterCoordinator implements ClusterCoordinator, ProtocolHandl
 
     @Override
     public List<NodeEvent> getNodeEvents(final NodeIdentifier nodeId) {
-        final CircularFifoQueue<NodeEvent> eventQueue = nodeEvents.get(nodeId.getId());
+        final Queue<NodeEvent> eventQueue = nodeEvents.get(nodeId.getId());
         if (eventQueue == null) {
             return Collections.emptyList();
         }
@@ -877,7 +878,7 @@ public class NodeClusterCoordinator implements ClusterCoordinator, ProtocolHandl
 
     private void addNodeEvent(final NodeIdentifier nodeId, final Severity severity, final String message) {
         final NodeEvent event = new Event(nodeId.toString(), message, severity);
-        final CircularFifoQueue<NodeEvent> eventQueue = nodeEvents.computeIfAbsent(nodeId.getId(), id -> new CircularFifoQueue<>());
+        final Queue<NodeEvent> eventQueue = nodeEvents.computeIfAbsent(nodeId.getId(), id -> new CircularFifoQueue<>());
         synchronized (eventQueue) {
             eventQueue.add(event);
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/AnalyzeFlowRequestEndpointMergerTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/endpoints/AnalyzeFlowRequestEndpointMergerTest.java
@@ -129,7 +129,7 @@ public class AnalyzeFlowRequestEndpointMergerTest {
         testSubject.mergeResponses(clientDto, dtoMap, null, null);
 
         // THEN
-        HashSet<String> actualFailures = new HashSet<>(Arrays.asList(clientDto.getFailureReason().split("\n")));
+        Set<String> actualFailures = new HashSet<>(Arrays.asList(clientDto.getFailureReason().split("\n")));
 
         Assertions.assertEquals(expectedFailures, actualFailures);
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceResolver.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/controller/service/StandardControllerServiceResolver.java
@@ -74,7 +74,7 @@ public class StandardControllerServiceResolver implements ControllerServiceResol
                 .map(serviceNode -> flowMapper.mapControllerService(serviceNode, controllerServiceProvider, new HashSet<>(), new HashMap<>()))
                 .collect(Collectors.toSet());
 
-        final Stack<Set<VersionedControllerService>> serviceHierarchyStack = new Stack<>();
+        final Stack<Set<VersionedControllerService>> serviceHierarchyStack = new Stack<>(); //NOPMD
         serviceHierarchyStack.push(ancestorServices);
 
         final Set<String> unresolvedServices = new HashSet<>();
@@ -84,7 +84,7 @@ public class StandardControllerServiceResolver implements ControllerServiceResol
 
     private void resolveInheritedControllerServices(final FlowSnapshotContainer flowSnapshotContainer, final VersionedProcessGroup versionedGroup,
                                                     final Map<String, ExternalControllerServiceReference> externalControllerServiceReferences,
-                                                    final Stack<Set<VersionedControllerService>> serviceHierarchyStack,
+                                                    final Stack<Set<VersionedControllerService>> serviceHierarchyStack, //NOPMD
                                                     final Set<String> unresolvedServices) {
 
         final Set<VersionedControllerService> currentGroupServices = versionedGroup.getControllerServices() == null ? Collections.emptySet() : versionedGroup.getControllerServices();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContext.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/parameter/StandardParameterContext.java
@@ -524,7 +524,7 @@ public class StandardParameterContext implements ParameterContext {
      * @param parameterContexts A list of proposed ParameterContexts
      */
     private void verifyNoCycles(final List<ParameterContext> parameterContexts) {
-        final Stack<String> traversedIds = new Stack<>();
+        final Stack<String> traversedIds = new Stack<>(); //NOPMD
         traversedIds.push(id);
         verifyNoCycles(traversedIds, parameterContexts);
     }
@@ -536,7 +536,7 @@ public class StandardParameterContext implements ParameterContext {
      * @param parameterContexts The ParameterContexts for which to check for cycles
      * @throws IllegalStateException If a cycle was detected
      */
-    private void verifyNoCycles(final Stack<String> traversedIds, final List<ParameterContext> parameterContexts) {
+    private void verifyNoCycles(final Stack<String> traversedIds, final List<ParameterContext> parameterContexts) { //NOPMD
         for (final ParameterContext parameterContext : parameterContexts) {
             final String id = parameterContext.getIdentifier();
             if (traversedIds.contains(id)) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/queue/SwappablePriorityQueue.java
@@ -82,8 +82,8 @@ public class SwappablePriorityQueue {
     // keeping these separate, we are able to guarantee that FlowFiles are swapped in in the same order
     // that they are swapped out.
     // Guarded by lock.
-    private PriorityQueue<FlowFileRecord> activeQueue;
-    private ArrayList<FlowFileRecord> swapQueue;
+    private Queue<FlowFileRecord> activeQueue;
+    private List<FlowFileRecord> swapQueue;
     private boolean swapMode = false;
     private volatile long topPenaltyExpiration = -1L;
 
@@ -122,7 +122,7 @@ public class SwappablePriorityQueue {
         try {
             this.priorities = new ArrayList<>(newPriorities);
 
-            final PriorityQueue<FlowFileRecord> newQueue = new PriorityQueue<>(Math.max(20, activeQueue.size()), new QueuePrioritizer(newPriorities));
+            final Queue<FlowFileRecord> newQueue = new PriorityQueue<>(Math.max(20, activeQueue.size()), new QueuePrioritizer(newPriorities));
             newQueue.addAll(activeQueue);
             activeQueue = newQueue;
         } finally {
@@ -181,7 +181,7 @@ public class SwappablePriorityQueue {
         // whatever data we don't write out to a swap file (because there isn't enough to fill a swap file) will be added back to the swap queue.
         // Since the swap queue cannot be processed until all swap files, we want to ensure that only the lowest priority data goes back onto it. Which means
         // that we must swap out the highest priority data that is currently on the swap queue.
-        final PriorityQueue<FlowFileRecord> tempQueue = new PriorityQueue<>(swapQueue.size(), new QueuePrioritizer(getPriorities()));
+        final Queue<FlowFileRecord> tempQueue = new PriorityQueue<>(swapQueue.size(), new QueuePrioritizer(getPriorities()));
         tempQueue.addAll(swapQueue);
 
         long bytesSwappedOut = 0L;
@@ -318,7 +318,7 @@ public class SwappablePriorityQueue {
         }
 
         // Swap Queue is not currently ordered. We want to migrate the highest priority FlowFiles to the Active Queue, then re-queue the lowest priority items.
-        final PriorityQueue<FlowFileRecord> tempQueue = new PriorityQueue<>(swapQueue.size(), new QueuePrioritizer(getPriorities()));
+        final Queue<FlowFileRecord> tempQueue = new PriorityQueue<>(swapQueue.size(), new QueuePrioritizer(getPriorities()));
         tempQueue.addAll(swapQueue);
 
         int recordsMigrated = 0;

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/StatusHistoryUtil.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/StatusHistoryUtil.java
@@ -39,7 +39,7 @@ public class StatusHistoryUtil {
     public static StatusHistoryDTO createStatusHistoryDTO(final StatusHistory statusHistory) {
         final List<StatusSnapshotDTO> snapshotDtos = new ArrayList<>();
         final Set<MetricDescriptor<?>> metricDescriptors = new LinkedHashSet<>();
-        final LinkedHashMap<String, String> componentDetails = new LinkedHashMap<>(statusHistory.getComponentDetails());
+        final Map<String, String> componentDetails = new LinkedHashMap<>(statusHistory.getComponentDetails());
 
         final Set<String> metricNames = new HashSet<>();
         for (final StatusSnapshot snapshot : statusHistory.getStatusSnapshots()) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/VolatileComponentStatusRepository.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/status/history/VolatileComponentStatusRepository.java
@@ -175,7 +175,7 @@ public class VolatileComponentStatusRepository implements StatusHistoryRepositor
     public StatusHistory getNodeStatusHistory(final Date start, final Date end) {
         final List<NodeStatus> nodeStatusList = nodeStatuses.asList();
         final List<List<GarbageCollectionStatus>> gcStatusList = gcStatuses.asList();
-        final LinkedList<StatusSnapshot> snapshots = new LinkedList<>();
+        final List<StatusSnapshot> snapshots = new LinkedList<>();
 
         final Set<MetricDescriptor<?>> metricDescriptors = new HashSet<>();
         final Set<MetricDescriptor<NodeStatus>> nodeStatusDescriptors = new HashSet<>(DEFAULT_NODE_METRICS);

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/events/NodeBulletinProcessingStrategy.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/events/NodeBulletinProcessingStrategy.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.events;
 
 import java.util.HashSet;
+import java.util.Queue;
 import java.util.Set;
 
 import org.apache.commons.collections4.queue.CircularFifoQueue;
@@ -27,7 +28,7 @@ import org.apache.nifi.reporting.Bulletin;
  */
 public class NodeBulletinProcessingStrategy implements BulletinProcessingStrategy {
     static final int MAX_ENTRIES = 5;
-    private final CircularFifoQueue<Bulletin> ringBuffer = new CircularFifoQueue<>(MAX_ENTRIES);
+    private final Queue<Bulletin> ringBuffer = new CircularFifoQueue<>(MAX_ENTRIES);
 
     @Override
     public synchronized void update(final Bulletin bulletin) {

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/nar/StandardNarManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/nar/StandardNarManager.java
@@ -367,7 +367,7 @@ public class StandardNarManager implements NarManager, InitializingBean, Closeab
         // If any NARs being loaded are parents of other NARs being loaded, we need to ensure parents load before children, otherwise a child NAR may
         // select a compatible parent NAR from the other NARs provided by NiFi, rather than selecting the parent NAR from within the NAR Manager
         final int numNarInfos = narInfos.size();
-        final Stack<NarPersistenceInfo> narHierarchy = new Stack<>();
+        final Stack<NarPersistenceInfo> narHierarchy = new Stack<>(); //NOPMD
         createNarHierarchy(narInfos, narHierarchy);
 
         // Create a new list and add the layers of the Stack from top to bottom which gets parents ahead of children
@@ -381,7 +381,7 @@ public class StandardNarManager implements NarManager, InitializingBean, Closeab
         return orderedNarInfos;
     }
 
-    private void createNarHierarchy(final Collection<NarPersistenceInfo> narInfos, final Stack<NarPersistenceInfo> narHierarchy) {
+    private void createNarHierarchy(final Collection<NarPersistenceInfo> narInfos, final Stack<NarPersistenceInfo> narHierarchy) { //NOPMD
         if (narInfos == null || narInfos.isEmpty()) {
             return;
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/validation/StandardRuleViolationsManager.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/validation/StandardRuleViolationsManager.java
@@ -143,7 +143,7 @@ public class StandardRuleViolationsManager implements RuleViolationsManager {
 
     @Override
     public Collection<RuleViolation> getRuleViolationsForSubject(String subjectId) {
-        HashSet<RuleViolation> ruleViolationsForSubject = Optional.ofNullable(subjectIdToRuleViolation.get(subjectId))
+        Set<RuleViolation> ruleViolationsForSubject = Optional.ofNullable(subjectIdToRuleViolation.get(subjectId))
             .map(Map::values)
             .map(HashSet::new)
             .orElse(new HashSet<>());

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/StandardControllerServiceProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/service/StandardControllerServiceProviderTest.java
@@ -39,6 +39,7 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -113,7 +114,7 @@ public class StandardControllerServiceProviderTest {
 
     private ControllerServiceNode populateControllerService(ControllerServiceNode requiredService) { // Collection<ControllerServiceNode> serviceNodes) {
         ControllerServiceNode controllerServiceNode = mock(ControllerServiceNode.class);
-        ArrayList<ControllerServiceNode> requiredServices = new ArrayList<>();
+        List<ControllerServiceNode> requiredServices = new ArrayList<>();
         if (requiredService != null) {
             requiredServices.add(requiredService);
         }
@@ -130,7 +131,7 @@ public class StandardControllerServiceProviderTest {
         when(scheduler.enableControllerService(any())).thenReturn(future);
         ControllerServiceProvider provider = new StandardControllerServiceProvider(scheduler, null, Mockito.mock(FlowManager.class), Mockito.mock(ExtensionManager.class));
 
-        final ArrayList<ControllerServiceNode> serviceNodes = new ArrayList<>();
+        final List<ControllerServiceNode> serviceNodes = new ArrayList<>();
         serviceNodes.add(populateControllerService(null));
         serviceNodes.add(populateControllerService(null));
         provider.enableControllerServices(serviceNodes);
@@ -147,7 +148,7 @@ public class StandardControllerServiceProviderTest {
         when(scheduler.enableControllerService(any())).thenReturn(future);
         ControllerServiceProvider provider = new StandardControllerServiceProvider(scheduler, null, Mockito.mock(FlowManager.class), Mockito.mock(ExtensionManager.class));
 
-        final ArrayList<ControllerServiceNode> serviceNodes = new ArrayList<>();
+        final List<ControllerServiceNode> serviceNodes = new ArrayList<>();
         ControllerServiceNode disabledController = populateControllerService(null);
         // Do not start because disabledController is not in the serviceNodes (list of services to start)
         serviceNodes.add(populateControllerService(disabledController));

--- a/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarClassLoader.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/main/java/org/apache/nifi/nar/NarClassLoader.java
@@ -212,7 +212,7 @@ public class NarClassLoader extends AbstractNativeLibHandlingClassLoader {
     }
 
     private static List<File> initNativeLibDirList(File narWorkingDirectory) {
-        ArrayList<File> nativeLibDirList = new ArrayList<>();
+        List<File> nativeLibDirList = new ArrayList<>();
 
         nativeLibDirList.add(getNARNativeLibDir(narWorkingDirectory));
 

--- a/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/test/java/org/apache/nifi/nar/AbstractNativeLibHandlingClassLoaderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-nar-utils/src/test/java/org/apache/nifi/nar/AbstractNativeLibHandlingClassLoaderTest.java
@@ -379,7 +379,7 @@ public class AbstractNativeLibHandlingClassLoaderTest {
                 .map(File::getAbsolutePath)
                 .collect(Collectors.joining(File.pathSeparator));
 
-        HashSet<File> expected = new HashSet<>();
+        Set<File> expected = new HashSet<>();
         expected.add(dir1.toFile());
         expected.add(dir2.toFile());
         expected.add(dir3.toFile());

--- a/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/protocol/http/TestHttpFlowFileServerProtocol.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-site-to-site/src/test/java/org/apache/nifi/remote/protocol/http/TestHttpFlowFileServerProtocol.java
@@ -272,7 +272,7 @@ public class TestHttpFlowFileServerProtocol {
 
         transferFlowFiles(serverProtocol, transactionId, peer, processSession -> {
             final MockFlowFile flowFile = processSession.createFlowFile("Server content".getBytes());
-            final HashMap<String, String> attributes = new HashMap<>();
+            final Map<String, String> attributes = new HashMap<>();
             attributes.put("uuid", "server-uuid");
             attributes.put("filename", "server-filename");
             attributes.put("server-attr-1", "server-attr-1-value");
@@ -311,7 +311,7 @@ public class TestHttpFlowFileServerProtocol {
 
         transferFlowFiles(serverProtocol, transactionId, peer, processSession -> {
             final MockFlowFile flowFile = processSession.createFlowFile("Server content".getBytes());
-            final HashMap<String, String> attributes = new HashMap<>();
+            final Map<String, String> attributes = new HashMap<>();
             attributes.put("uuid", "server-uuid");
             attributes.put("filename", "server-filename");
             attributes.put("server-attr-1", "server-attr-1-value");
@@ -368,7 +368,7 @@ public class TestHttpFlowFileServerProtocol {
         transferFlowFiles(serverProtocol, transactionId, peer, processSession ->
             IntStream.of(1, 2).mapToObj(i -> {
                 final MockFlowFile flowFile = processSession.createFlowFile(("Server content " + i).getBytes());
-                final HashMap<String, String> attributes = new HashMap<>();
+                final Map<String, String> attributes = new HashMap<>();
                 attributes.put("uuid", "server-uuid-" + i);
                 attributes.put("filename", "server-filename-" + i);
                 attributes.put("server-attr-" + i + "-1", "server-attr-" + i + "-1-value");

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/dto/DtoFactory.java
@@ -474,7 +474,7 @@ public final class DtoFactory {
        final StateMapDTO dto = new StateMapDTO();
        dto.setScope(scope.toString());
 
-       final TreeMap<String, String> sortedState = new TreeMap<>(SortedStateUtils.getKeyComparator());
+       final Map<String, String> sortedState = new TreeMap<>(SortedStateUtils.getKeyComparator());
        final Map<String, String> state = stateMap.toMap();
        sortedState.putAll(state);
 

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerSearchService.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/controller/ControllerSearchService.java
@@ -132,7 +132,7 @@ public class ControllerSearchService {
     }
 
     private List<ProcessGroup> getLineage(final ProcessGroup group) {
-        final LinkedList<ProcessGroup> result = new LinkedList<>();
+        final List<ProcessGroup> result = new LinkedList<>();
         ProcessGroup current = group;
 
         while (current != null) {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/TestFlowResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/test/java/org/apache/nifi/web/api/TestFlowResource.java
@@ -59,7 +59,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -521,7 +520,7 @@ public class TestFlowResource {
     }
 
     private Map<String, List<Sample>> convertJsonResponseToMap(final Response response) throws IOException {
-        final TypeReference<HashMap<String, List<Sample>>> typeReference = new TypeReference<>() {
+        final TypeReference<Map<String, List<Sample>>> typeReference = new TypeReference<>() {
         };
         final ObjectMapper mapper = new ObjectMapper();
         final SimpleModule module = new SimpleModule();

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/revocation/StandardTokenRevocationResponseClient.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/oidc/revocation/StandardTokenRevocationResponseClient.java
@@ -28,6 +28,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestOperations;
 
@@ -95,7 +96,7 @@ public class StandardTokenRevocationResponseClient implements TokenRevocationRes
             requestEntity = null;
             logger.info("OIDC Revocation Endpoint not found");
         } else {
-            final LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+            final MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
             parameters.add(OAuth2ParameterNames.TOKEN, revocationRequest.getToken());
 
             final String tokenTypeHint = revocationRequest.getTokenTypeHint();
@@ -103,7 +104,7 @@ public class StandardTokenRevocationResponseClient implements TokenRevocationRes
                 parameters.add(OAuth2ParameterNames.TOKEN_TYPE_HINT, tokenTypeHint);
             }
 
-            final HttpHeaders headers = new HttpHeaders();
+            final HttpHeaders headers = new HttpHeaders(); //NOPMD
             final String clientId = clientRegistration.getClientId();
             final String clientSecret = clientRegistration.getClientSecret();
             headers.setBasicAuth(clientId, clientSecret, StandardCharsets.UTF_8);

--- a/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/StandardRuntimeManifestBuilder.java
+++ b/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/StandardRuntimeManifestBuilder.java
@@ -543,7 +543,7 @@ public class StandardRuntimeManifestBuilder implements RuntimeManifestBuilder {
     private void populateConfigurableComponent(final Extension extension, final ConfigurableComponentDefinition configurableComponentDefinition) {
         final List<Property> properties = extension.getProperties();
         if (isNotEmpty(properties)) {
-            final LinkedHashMap<String, PropertyDescriptor> propertyDescriptors = new LinkedHashMap<>();
+            final Map<String, PropertyDescriptor> propertyDescriptors = new LinkedHashMap<>();
             properties.forEach(property -> addPropertyDescriptor(propertyDescriptors, property));
             configurableComponentDefinition.setPropertyDescriptors(propertyDescriptors);
         }

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/serialization/jackson/JacksonSerializer.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/serialization/jackson/JacksonSerializer.java
@@ -29,7 +29,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A Serializer that uses Jackson for serializing/deserializing.
@@ -110,9 +110,9 @@ public abstract class JacksonSerializer<T> implements VersionedSerializer<T> {
         logger.debug("headerObjectStr={}", headerObjectStr);
 
         try {
-            final TypeReference<HashMap<String, String>> typeRef = new TypeReference<>() {
+            final TypeReference<Map<String, String>> typeRef = new TypeReference<>() {
             };
-            final HashMap<String, String> header = objectMapper.readValue(headerObjectStr, typeRef);
+            final Map<String, String> header = objectMapper.readValue(headerObjectStr, typeRef);
             if (!header.containsKey(DATA_MODEL_VERSION)) {
                 throw new SerializationException("Missing " + DATA_MODEL_VERSION);
             }

--- a/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/oidc/StandardOidcIdentityProvider.java
@@ -255,7 +255,7 @@ public class StandardOidcIdentityProvider implements OidcIdentityProvider {
             throw new IOException("Unable to download OpenId Connect Provider metadata from " + url + ": Status code " + httpResponse.getStatusCode());
         }
 
-        final JSONObject jsonObject = httpResponse.getBodyAsJSONObject();
+        final JSONObject jsonObject = httpResponse.getBodyAsJSONObject(); //NOPMD
         return OIDCProviderMetadata.parse(jsonObject);
     }
 

--- a/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/session/AsynchronousCommitTracker.java
+++ b/nifi-stateless/nifi-stateless-bundle/nifi-stateless-engine/src/main/java/org/apache/nifi/stateless/session/AsynchronousCommitTracker.java
@@ -40,8 +40,8 @@ public class AsynchronousCommitTracker {
     private static final Logger logger = LoggerFactory.getLogger(AsynchronousCommitTracker.class);
 
     private final ProcessGroup rootGroup;
-    private final LinkedHashSet<Connectable> ready = new LinkedHashSet<>();
-    private final Stack<CommitCallbacks> commitCallbacks = new Stack<>();
+    private final LinkedHashSet<Connectable> ready = new LinkedHashSet<>(); // NOPMD
+    private final Stack<CommitCallbacks> commitCallbacks = new Stack<>(); //NOPMD
     private int flowFilesProduced = 0;
     private long bytesProduced = 0L;
     private boolean progressMade = false;

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/bucket/UpdateBucketPolicy.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/bucket/UpdateBucketPolicy.java
@@ -31,8 +31,6 @@ import org.apache.nifi.toolkit.cli.impl.result.StringResult;
 import org.apache.nifi.util.StringUtils;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -74,7 +72,7 @@ public class UpdateBucketPolicy extends AbstractNiFiRegistryCommand<StringResult
         final String groupIds = getArg(properties, CommandOption.GROUP_ID_LIST);
 
         final String policyAction = getRequiredArg(properties, CommandOption.POLICY_ACTION);
-        final HashSet<String> permittedActions = new HashSet<>(Arrays.asList("read", "write", "delete"));
+        final Set<String> permittedActions = Set.of("read", "write", "delete");
         if (!permittedActions.contains(policyAction)) {
             throw new IllegalArgumentException("Only read, write, delete actions permitted");
         }

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -36,6 +36,22 @@ under the License.
     <rule ref="category/java/bestpractices.xml/AvoidReassigningCatchVariables" />
     <rule ref="category/java/bestpractices.xml/ExhaustiveSwitchHasDefault" />
     <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach" />
+    <rule ref="category/java/bestpractices.xml/LooseCoupling">
+        <!--Classes below excluded from this rule due to their prevalence within the code base.-->
+        <properties>
+            <property name="allowedTypes"
+                      value="java.util.EnumSet,
+                             java.util.Properties,
+                             java.util.jar.Attributes,
+                             jakarta.ws.rs.core.MultivaluedHashMap,
+                             com.google.api.services.drive.model.File,
+                             org.bson.Document,
+                             com.nimbusds.oauth2.sdk.Scope,
+                             org.apache.nifi.attribute.expression.language.ValueLookup
+                             org.apache.nifi.processor.util.listen.queue.TrackingLinkedBlockingQueue
+            " />
+        </properties>
+    </rule>
     <rule ref="category/java/bestpractices.xml/MissingOverride" />
     <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation" />
     <rule ref="category/java/bestpractices.xml/SimplifiableTestAssertion" />


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14814](https://issues.apache.org/jira/browse/NIFI-14814)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
