### PR TITLE
NIFI-14827 - Bump Jetty to 12.0.24, Nimbus JWT to 10.4.1, Jedis to 6.1.0, and others

### DIFF
--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <protobuf.version>3.25.8</protobuf.version>
-        <wire.version>5.3.5</wire.version>
+        <wire.version>5.3.7</wire.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <spring.data.redis.version>3.5.2</spring.data.redis.version>
-        <jedis.version>6.0.0</jedis.version>
+        <jedis.version>6.1.0</jedis.version>
     </properties>
 
     <modules>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <jline.version>3.30.4</jline.version>
+        <jline.version>3.30.5</jline.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.788</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.32.14</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.32.16</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.0</kotlin.version>
@@ -135,7 +135,7 @@
         <org.slf4j.version>2.0.17</org.slf4j.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <derby.version>10.17.1.0</derby.version>
-        <jetty.version>12.0.23</jetty.version>
+        <jetty.version>12.0.24</jetty.version>
         <jackson.bom.version>2.19.2</jackson.bom.version>
         <avro.version>1.11.4</avro.version>
         <jaxb.runtime.version>4.0.5</jaxb.runtime.version>
@@ -168,7 +168,7 @@
         <prometheus.version>0.16.0</prometheus.version>
         <velocity-engine-core.version>2.4.1</velocity-engine-core.version>
         <simple-syslog-5424.version>0.0.19</simple-syslog-5424.version>
-        <nimbus-jose-jwt.version>10.4</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>10.4.1</nimbus-jose-jwt.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
# Summary

NIFI-14827 - Bump Jetty to 12.0.24, Nimbus JWT to 10.4.1, Jedis to 6.1.0, and others

- Wire from 5.3.5 to 5.3.7 - https://github.com/square/wire/blob/master/CHANGELOG.md
- Jedis from 6.0.0 to 6.1.0 - https://github.com/redis/jedis/releases/tag/v6.1.0
- JLine from 3.30.4 to 3.30.5 - https://github.com/jline/jline3/releases/tag/3.30.5
- AWS SDK v2 from 2.32.14 to 2.32.16 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Jetty from 12.0.23 to 12.0.24 - https://github.com/jetty/jetty.project/releases/tag/jetty-12.0.24
- Nimbus JOSE JWT from 10.4 to 10.4.1 - https://bitbucket.org/connect2id/nimbus-jose-jwt/src/master/CHANGELOG.txt

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
