### PR TITLE
NIFI-14826 Correct the enabling HTTP mode in the start.sh script

### DIFF
--- a/nifi-docker/dockerhub/README.md
+++ b/nifi-docker/dockerhub/README.md
@@ -15,6 +15,10 @@
 
 ## Latest changes
 
+### 2.6.0
+
+- Adding the `NIFI_WEB_HTTPS_ENABLE` environment variable to determine the NiFi is run with the HTTP or HTTPS mode.
+
 ### 2.0.0
 
 - Changed base image to bellsoft/liberica-openjdk-debian:21 as NiFi 2.0.0 requires Java 21

--- a/nifi-docker/dockerhub/sh/common.sh
+++ b/nifi-docker/dockerhub/sh/common.sh
@@ -29,6 +29,12 @@ uncomment() {
   sed -i -e "s|^\#$1|$1|" ${target_file}
 }
 
+comment() {
+  target_file=${2}
+  echo "File [${target_file}] commenting [${1}]"
+  sed -i -e "s|$1|\#$1|" ${target_file}
+}
+
 # 1 - property key to add or replace
 # 2 - property value to use
 # 3 - file to perform replacement inline


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14826](https://issues.apache.org/jira/browse/NIFI-14826)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

The verification steps are as follows:

- Preparing for the `Docker` environment and the `docker` command is available.
- Creating the `Dockerfile` and apply these modified `start.sh` and `common.sh` files.

```Dockerfile
FROM apache/nifi:2.5.0

COPY start.sh /opt/nifi/scripts/start.sh
COPY common.sh /opt/nifi/scripts/common.sh
RUN chown nifi:nifi /opt/nifi/scripts/start.sh && \
    chmod +x /opt/nifi/scripts/start.sh && \
    chown nifi:nifi /opt/nifi/scripts/common.sh &&\
    chmod +x /opt/nifi/scripts/common.sh
```

- Creating the `docker-compose.yml` file to define some configurations to enable the HTTP mode without the `NIFI_WEB_HTTPS_ENABLE` environment variable:

```yaml
services:
  # configuration manager for NiFi
  zookeeper:
    image: 'bitnami/zookeeper:latest'
    restart: on-failure
    environment:
      - ALLOW_ANONYMOUS_LOGIN=yes
  # data extraction, transformation and load service
  nifi:
    build: .
    restart: on-failure
    ports:
      - '8091:8080'
    environment:
      - NIFI_CLUSTER_IS_NODE=true
      - NIFI_CLUSTER_NODE_PROTOCOL_PORT=8082
      - NIFI_ZK_CONNECT_STRING=zookeeper:2181
      - NIFI_ELECTION_MAX_WAIT=30 sec
      - NIFI_SENSITIVE_PROPS_KEY=${NIFI_SENSITIVE_PROPS_KEY:-12345678901234567890A}
      - NIFI_REMOTE_INPUT_SECURE=false
      - NIFI_CLUSTER_PROTOCOL_IS_SECURE=false
    healthcheck:
      test: ["CMD", "curl", "http://nifi:8080/nifi-api/access/config"]
      interval: "60s"
      timeout: "3s"
      start_period: "5s"
      retries: 5
    volumes:
      - nifi_database_repository:/opt/nifi/nifi-current/database_repository
      - nifi_flowfile_repository:/opt/nifi/nifi-current/flowfile_repository
      - nifi_content_repository:/opt/nifi/nifi-current/content_repository
      - nifi_provenance_repository:/opt/nifi/nifi-current/provenance_repository
      - nifi_state:/opt/nifi/nifi-current/state
      - nifi_logs:/opt/nifi/nifi-current/logs

volumes:
  nifi_database_repository:
  nifi_flowfile_repository:
  nifi_content_repository:
  nifi_provenance_repository:
  nifi_state:
  nifi_logs:
```

- Once configuring the related files is completed, running the `docker compose up -d --build` to run the NiFi.
- It will expect to present the `NIFI_WEB_HTTPS_ENABLE was not set and disable the secure mode.` message when browsing this Docker container log.

```sh
$ docker compose logs nifi | grep 'NIFI_WEB_HTTPS_ENABLE' -A 5 -B 5
nifi-1  | File [/opt/nifi/nifi-current/conf/nifi.properties] replacing [nifi.web.proxy.host]
nifi-1  | File [/opt/nifi/nifi-current/conf/nifi.properties] replacing [nifi.remote.input.host]
nifi-1  | File [/opt/nifi/nifi-current/conf/nifi.properties] replacing [nifi.remote.input.socket.port]
nifi-1  | File [/opt/nifi/nifi-current/conf/nifi.properties] replacing [nifi.remote.input.secure]
nifi-1  | File [/opt/nifi/nifi-current/conf/nifi.properties] replacing [nifi.cluster.protocol.is.secure]
nifi-1  | NIFI_WEB_HTTPS_ENABLE was not set and disable the secure mode.
nifi-1  | File [/opt/nifi/nifi-current/conf/nifi.properties] commenting [nifi.web.https.port]
nifi-1  | File [/opt/nifi/nifi-current/conf/nifi.properties] commenting [nifi.web.https.host]
nifi-1  | File [/opt/nifi/nifi-current/conf/nifi.properties] replacing [nifi.web.http.port]
nifi-1  | File [/opt/nifi/nifi-current/conf/nifi.properties] replacing [nifi.web.http.host]
nifi-1  | File [/opt/nifi/nifi-current/conf/nifi.properties] replacing [nifi.security.keystore]
```

- Modifying the `docker-compose.yml` file to define some configurations to enable the HTTP mode with the `NIFI_WEB_HTTPS_ENABLE` environment variable:

```yaml
services:
  # configuration manager for NiFi
  zookeeper:
    image: 'bitnami/zookeeper:latest'
    restart: on-failure
    environment:
      - ALLOW_ANONYMOUS_LOGIN=yes
  # data extraction, transformation and load service
  nifi:
    build: .
    restart: on-failure
    ports:
      - '8091:8080'
    environment:
      - NIFI_CLUSTER_IS_NODE=true
      - NIFI_CLUSTER_NODE_PROTOCOL_PORT=8082
      - NIFI_ZK_CONNECT_STRING=zookeeper:2181
      - NIFI_ELECTION_MAX_WAIT=30 sec
      - NIFI_SENSITIVE_PROPS_KEY=${NIFI_SENSITIVE_PROPS_KEY:-12345678901234567890A}
      - NIFI_REMOTE_INPUT_SECURE=true
      - NIFI_CLUSTER_PROTOCOL_IS_SECURE=true
      - NIFI_WEB_HTTPS_ENABLE=true
    healthcheck:
      test: ["CMD", "curl", "http://nifi:8080/nifi-api/access/config"]
      interval: "60s"
      timeout: "3s"
      start_period: "5s"
      retries: 5
    volumes:
      - nifi_database_repository:/opt/nifi/nifi-current/database_repository
      - nifi_flowfile_repository:/opt/nifi/nifi-current/flowfile_repository
      - nifi_content_repository:/opt/nifi/nifi-current/content_repository
      - nifi_provenance_repository:/opt/nifi/nifi-current/provenance_repository
      - nifi_state:/opt/nifi/nifi-current/state
      - nifi_logs:/opt/nifi/nifi-current/logs

volumes:
  nifi_database_repository:
  nifi_flowfile_repository:
  nifi_content_repository:
  nifi_provenance_repository:
  nifi_state:
  nifi_logs:
```

- Once configuring the related files is completed, running the `docker compose stop` and `docker compose up -d --build` commands to run the NiFi.
- It will not present the `NIFI_WEB_HTTPS_ENABLE was not set and disable the secure mode.` message when browsing this Docker container log.

```sh
$ docker compose logs nifi | grep 'NIFI_WEB_HTTPS_ENABLE' -A 5 -B 5
$
```

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
