### PR TITLE
NIFI-14835 Implemented PMD rule DoubleBraceInitialization.

### DIFF
--- a/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
+++ b/nifi-commons/nifi-record/src/test/java/org/apache/nifi/serialization/record/TestDataTypeUtils.java
@@ -359,11 +359,11 @@ public class TestDataTypeUtils {
 
     @Test
     void testConvertRecordFieldToObjectWithNestedRecord() {
-        final Record record = DataTypeUtils.toRecord(new LinkedHashMap<String, Object>() {{
-            put("firstName", "John");
-            put("age", 30);
-            put("addresses", new Object[] {"some string", DataTypeUtils.toRecord(Collections.singletonMap("address_1", "123 Fake Street"), "addresses")});
-        }}, "");
+        final Record record = DataTypeUtils.toRecord(Map.of(
+                "firstName", "John",
+                "age", 30,
+                "addresses", new Object[] {"some string", DataTypeUtils.toRecord(Map.of("address_1", "123 Fake Street"), "addresses")}
+        ), "");
 
         final Object obj = DataTypeUtils.convertRecordFieldtoObject(record, RecordFieldType.RECORD.getDataType());
         assertInstanceOf(Map.class, obj);

--- a/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/test/java/org/apache/nifi/processors/avro/TestSplitAvro.java
+++ b/nifi-extension-bundles/nifi-avro-bundle/nifi-avro-processors/src/test/java/org/apache/nifi/processors/avro/TestSplitAvro.java
@@ -40,8 +40,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 import static org.apache.nifi.flowfile.attributes.FragmentAttributes.FRAGMENT_COUNT;
@@ -113,9 +113,7 @@ public class TestSplitAvro {
         final TestRunner runner = TestRunners.newTestRunner(new SplitAvro());
 
         final String filename = "users.avro";
-        runner.enqueue(users.toByteArray(), new HashMap<>() {{
-            put(CoreAttributes.FILENAME.key(), filename);
-        }});
+        runner.enqueue(users.toByteArray(), Map.of(CoreAttributes.FILENAME.key(), filename));
         runner.run();
 
         runner.assertTransferCount(SplitAvro.REL_SPLIT, 100);

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchLookupService.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchLookupService.java
@@ -229,21 +229,14 @@ public class ElasticSearchLookupService extends JsonInferenceSchemaRegistryServi
     }
 
     private Map<String, Object> buildQuery(final Map<String, Object> coordinates) {
-        final Map<String, Object> query = new HashMap<>() {{
-            put("bool", new HashMap<String, Object>() {{
-                put("must", coordinates.entrySet().stream()
-                        .map(e -> new HashMap<String, Object>() {{
-                            if (e.getKey().contains(".")) {
-                                put("nested", getNested(e.getKey(), e.getValue()));
-                            } else {
-                                put("match", new HashMap<String, Object>() {{
-                                    put(e.getKey(), e.getValue());
-                                }});
-                            }
-                        }}).toList()
-                );
-            }});
-        }};
+        final Map<String, Object> query = Map.of("bool",
+                Map.of("must", coordinates.entrySet().stream()
+                        .map(e -> e.getKey().contains(".")
+                                        ? Map.of("nested", getNested(e.getKey(), e.getValue()))
+                                        : Map.of("match", Map.of(e.getKey(), e.getValue()))
+                        ).toList()
+                )
+        );
 
         return Map.of("size", 1, "query", query);
     }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchClientService_IT.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/test/java/org/apache/nifi/elasticsearch/integration/ElasticSearchClientService_IT.java
@@ -760,14 +760,12 @@ class ElasticSearchClientService_IT extends AbstractElasticsearch_IT {
         final List<IndexOperationRequest> payload = new ArrayList<>();
         for (int x = 0; x < 20; x++) {
             final String index = x % 2 == 0 ? "bulk_a" : "bulk_b";
-            payload.add(new IndexOperationRequest(index, type, String.valueOf(x), new HashMap<>() {{
-                put("msg", "test");
-            }}, IndexOperationRequest.Operation.Index, null, false, null, null));
+            payload.add(new IndexOperationRequest(index, type, String.valueOf(x), Map.of("msg", "test"),
+                    IndexOperationRequest.Operation.Index, null, false, null, null));
         }
         for (int x = 0; x < 5; x++) {
-            payload.add(new IndexOperationRequest("bulk_c", type, String.valueOf(x), new HashMap<>() {{
-                put("msg", "test");
-            }}, IndexOperationRequest.Operation.Index, null, false, null, null));
+            payload.add(new IndexOperationRequest("bulk_c", type, String.valueOf(x), Map.of("msg", "test"),
+                    IndexOperationRequest.Operation.Index, null, false, null, null));
         }
         final IndexOperationResponse response = service.bulk(payload, new ElasticsearchRequestOptions(Map.of("refresh", "true"), null));
         assertNotNull(response);

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/ConsumeElasticsearch.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/ConsumeElasticsearch.java
@@ -270,18 +270,17 @@ public class ConsumeElasticsearch extends SearchElasticsearch {
         // only retrieve documents with values greater than the last queried value (if present)
         final String trackingRangeValue = getTrackingRangeValueOrDefault(context);
         if (StringUtils.isNotBlank(trackingRangeValue)) {
-            filters.add(Collections.singletonMap("range", Collections.singletonMap(getTrackingRangeField(context),
-                    new HashMap<String, String>(3, 1) {{
-                        put("gt", trackingRangeValue);
-                        if (context.getProperty(RANGE_INITIAL_VALUE).isSet()) {
-                            if (context.getProperty(RANGE_DATE_FORMAT).isSet()) {
-                                put("format", context.getProperty(RANGE_DATE_FORMAT).getValue());
-                            }
-                            if (context.getProperty(RANGE_TIME_ZONE).isSet()) {
-                                put("time_zone", context.getProperty(RANGE_TIME_ZONE).getValue());
-                            }
-                        }
-                    }})));
+            final Map<String, String> innerValue = new HashMap<>(3, 1);
+            innerValue.put("gt", trackingRangeValue);
+            if (context.getProperty(RANGE_INITIAL_VALUE).isSet()) {
+                if (context.getProperty(RANGE_DATE_FORMAT).isSet()) {
+                    innerValue.put("format", context.getProperty(RANGE_DATE_FORMAT).getValue());
+                }
+                if (context.getProperty(RANGE_TIME_ZONE).isSet()) {
+                    innerValue.put("time_zone", context.getProperty(RANGE_TIME_ZONE).getValue());
+                }
+            }
+            filters.add(Map.of("range", Map.of(getTrackingRangeField(context), innerValue)));
         }
 
         // add any additional filters specified as a property, allowing for one (Object) or multiple (Array of Objects) filters

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-restapi-processors/src/main/java/org/apache/nifi/processors/elasticsearch/PutElasticsearchRecord.java
@@ -467,10 +467,10 @@ public class PutElasticsearchRecord extends AbstractPutElasticsearch {
                 stopWatch.getDuration(TimeUnit.MILLISECONDS)
         );
 
-        input = session.putAllAttributes(input, new HashMap<>() {{
-            put("elasticsearch.put.error.count", String.valueOf(errorRecords.get()));
-            put("elasticsearch.put.success.count", String.valueOf(successfulRecords.get()));
-        }});
+        input = session.putAllAttributes(input, Map.of(
+                "elasticsearch.put.error.count", String.valueOf(errorRecords.get()),
+                "elasticsearch.put.success.count", String.valueOf(successfulRecords.get())
+        ));
 
         session.transfer(input, REL_ORIGINAL);
     }

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/src/main/java/org/apache/nifi/graph/TinkerpopClientService.java
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/src/main/java/org/apache/nifi/graph/TinkerpopClientService.java
@@ -428,9 +428,7 @@ public class TinkerpopClientService extends AbstractControllerService implements
                 if (obj instanceof Map) {
                     handler.process((Map) obj, iterator.hasNext());
                 } else {
-                    handler.process(new HashMap<>() {{
-                        put("result", obj);
-                    }}, iterator.hasNext());
+                    handler.process(Map.of("result", obj), iterator.hasNext());
                 }
                 count++;
             }

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/CalculateParquetOffsetsTest.java
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/CalculateParquetOffsetsTest.java
@@ -27,9 +27,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.nifi.parquet.utils.ParquetAttribute;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
@@ -128,12 +130,10 @@ public class CalculateParquetOffsetsTest {
     @Test
     public void testSubPartitioningWithCountAndOffset() throws Exception {
         runner.setProperty(PROP_RECORDS_PER_SPLIT, "3");
-        runner.enqueue(PARQUET_PATH, createAttributes(new HashMap<>() {
-            {
-                put(ParquetAttribute.RECORD_COUNT, "7");
-                put(ParquetAttribute.RECORD_OFFSET, "2");
-            }
-        }));
+        runner.enqueue(PARQUET_PATH, createAttributes(Map.of(
+                ParquetAttribute.RECORD_COUNT, "7",
+                ParquetAttribute.RECORD_OFFSET, "2"
+        )));
         runner.run();
         runner.assertAllFlowFilesTransferred(REL_SUCCESS, 3);
 
@@ -256,12 +256,10 @@ public class CalculateParquetOffsetsTest {
     @Test
     public void testEmptyInputWithOffsetAndCountAttributes() {
         runner.setProperty(PROP_RECORDS_PER_SPLIT, "3");
-        runner.enqueue("", createAttributes(new HashMap<>() {
-            {
-                put(ParquetAttribute.RECORD_OFFSET, "2");
-                put(ParquetAttribute.RECORD_COUNT, "4");
-            }
-        }));
+        runner.enqueue("", createAttributes(Map.of(
+                ParquetAttribute.RECORD_OFFSET, "2",
+                ParquetAttribute.RECORD_COUNT, "4"
+        )));
         runner.run();
         runner.assertAllFlowFilesTransferred(REL_SUCCESS, 2);
 
@@ -319,12 +317,10 @@ public class CalculateParquetOffsetsTest {
     @Test
     public void testUnrecognizedInputWithOffsetAndCountAttributes() throws IOException {
         runner.setProperty(PROP_RECORDS_PER_SPLIT, "3");
-        runner.enqueue(NOT_PARQUET_PATH, createAttributes(new HashMap<>() {
-            {
-                put(ParquetAttribute.RECORD_OFFSET, "2");
-                put(ParquetAttribute.RECORD_COUNT, "4");
-            }
-        }));
+        runner.enqueue(NOT_PARQUET_PATH, createAttributes(Map.of(
+                ParquetAttribute.RECORD_OFFSET, "2",
+                ParquetAttribute.RECORD_COUNT, "4"
+        )));
         runner.run();
         runner.assertAllFlowFilesTransferred(REL_SUCCESS, 2);
 
@@ -342,8 +338,7 @@ public class CalculateParquetOffsetsTest {
     }
 
     private Map<String, String> createAttributes(Map<String, String> additionalAttributes) {
-        return new HashMap<>(PRESERVED_ATTRIBUTES) {{
-            putAll(additionalAttributes);
-        }};
+        return Stream.concat(PRESERVED_ATTRIBUTES.entrySet().stream(), additionalAttributes.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 }

--- a/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/test/java/org/apache/nifi/processors/salesforce/util/TestRecordExtender.java
+++ b/nifi-extension-bundles/nifi-salesforce-bundle/nifi-salesforce-processors/src/test/java/org/apache/nifi/processors/salesforce/util/TestRecordExtender.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Map;
 
 import static org.apache.nifi.processors.salesforce.util.RecordExtender.ATTRIBUTES_RECORD_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -94,22 +94,17 @@ class TestRecordExtender {
         int referenceId = 0;
         String objectType = "Account";
 
-        MapRecord testRecord = new MapRecord(ORIGINAL_SCHEMA, new HashMap<>() {{
-            put("testRecordField1", "testRecordValue1");
-            put("testRecordField2", "testRecordValue2");
-        }});
+        MapRecord testRecord = new MapRecord(ORIGINAL_SCHEMA, Map.of(
+                "testRecordField1", "testRecordValue1",
+                "testRecordField2", "testRecordValue2"
+        ));
 
 
-        MapRecord expectedRecord = new MapRecord(EXPECTED_EXTENDED_SCHEMA, new HashMap<>() {{
-            put("attributes",
-                    new MapRecord(ATTRIBUTES_RECORD_SCHEMA, new HashMap<>() {{
-                        put("type", objectType);
-                        put("referenceId", referenceId);
-                    }})
-            );
-            put("testRecordField1", "testRecordValue1");
-            put("testRecordField2", "testRecordValue2");
-        }});
+        MapRecord expectedRecord = new MapRecord(EXPECTED_EXTENDED_SCHEMA, Map.of(
+                "attributes", new MapRecord(ATTRIBUTES_RECORD_SCHEMA, Map.of("type", objectType, "referenceId", referenceId)),
+                "testRecordField1", "testRecordValue1",
+                "testRecordField2", "testRecordValue2"
+        ));
 
         MapRecord actualRecord = testSubject.getExtendedRecord(objectType, referenceId, testRecord);
 

--- a/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/GetSmbFileTest.java
+++ b/nifi-extension-bundles/nifi-smb-bundle/nifi-smb-processors/src/test/java/org/apache/nifi/processors/smb/GetSmbFileTest.java
@@ -168,9 +168,7 @@ public class GetSmbFileTest {
     @Test
     public void testOpenFileCalled() {
         FileIdBothDirectoryInformation file1 = mockFile(DIRECTORY, "file1.txt", "abc");
-        mockDir(DIRECTORY, new ArrayList<>() {{
-            add(file1);
-        }});
+        mockDir(DIRECTORY, List.of(file1));
         testRunner.run();
         verifyOpenFile(DIRECTORY, "file1.txt", 1);
         verifyOpenFile(DIRECTORY, "file2.txt", 0);
@@ -181,10 +179,7 @@ public class GetSmbFileTest {
         testRunner.setProperty(GetSmbFile.IGNORE_HIDDEN_FILES, "true");
         FileIdBothDirectoryInformation file1 = mockFile(DIRECTORY, "file1.txt", "abc", FileAttributes.FILE_ATTRIBUTE_HIDDEN.getValue());
         FileIdBothDirectoryInformation file2 = mockFile(DIRECTORY, "file2.txt", "abc", FileAttributes.FILE_ATTRIBUTE_NORMAL.getValue());
-        mockDir(DIRECTORY, new ArrayList<>() {{
-            add(file1);
-            add(file2);
-        }});
+        mockDir(DIRECTORY, List.of(file1, file2));
         testRunner.run();
         verifyOpenFile(DIRECTORY, "file1.txt", 0);
         verifyOpenFile(DIRECTORY, "file2.txt", 1);
@@ -193,11 +188,11 @@ public class GetSmbFileTest {
     @Test
     public void testFileFilter() {
         testRunner.setProperty(GetSmbFile.FILE_FILTER, "file[0-9]\\.txt");
-        mockDir(DIRECTORY, new ArrayList<>() {{
-            add(mockFile(DIRECTORY, "something_else.txt", "abc"));
-            add(mockFile(DIRECTORY, "file1.txt", "abc"));
-            add(mockFile(DIRECTORY, "file2.txt", "abc"));
-        }});
+        mockDir(DIRECTORY, List.of(
+                mockFile(DIRECTORY, "something_else.txt", "abc"),
+                mockFile(DIRECTORY, "file1.txt", "abc"),
+                mockFile(DIRECTORY, "file2.txt", "abc")
+        ));
         testRunner.run();
         verifyOpenFile(DIRECTORY, "something_else.txt", 0);
         verifyOpenFile(DIRECTORY, "file1.txt", 1);
@@ -209,13 +204,11 @@ public class GetSmbFileTest {
     public void testNonRecurse() {
         testRunner.setProperty(GetSmbFile.RECURSE, "false");
         String subdir = DIRECTORY + "\\subdir1";
-        mockDir(DIRECTORY, new ArrayList<>() {{
-            add(mockFile(DIRECTORY, "file1.txt", "abc"));
-            add(mockFile(DIRECTORY, "file2.txt", "abc"));
-            add(mockDir(subdir, new ArrayList<>() {{
-                add(mockFile(subdir, "file3.txt", "abc"));
-            }}));
-        }});
+        mockDir(DIRECTORY, List.of(
+                mockFile(DIRECTORY, "file1.txt", "abc"),
+                mockFile(DIRECTORY, "file2.txt", "abc"),
+                mockDir(subdir, List.of(mockFile(subdir, "file3.txt", "abc")))
+        ));
 
         testRunner.run();
         verifyOpenFile(DIRECTORY, "file1.txt", 1);
@@ -228,13 +221,12 @@ public class GetSmbFileTest {
     public void testRecurse() {
         testRunner.setProperty(GetSmbFile.RECURSE, "true");
         String subdir = DIRECTORY + "\\subdir1";
-        mockDir(DIRECTORY, new ArrayList<>() {{
-            add(mockFile(DIRECTORY, "file1.txt", "abc"));
-            add(mockFile(DIRECTORY, "file2.txt", "abc"));
-            add(mockDir(subdir, new ArrayList<>() {{
-                add(mockFile(subdir, "file3.txt", "abc"));
-            }}));
-        }});
+        mockDir(DIRECTORY, List.of(
+                mockFile(DIRECTORY, "file1.txt", "abc"),
+                mockFile(DIRECTORY, "file2.txt", "abc"),
+                mockDir(subdir, List.of(mockFile(subdir, "file3.txt", "abc")))
+            )
+        );
 
 
         testRunner.run();
@@ -251,17 +243,11 @@ public class GetSmbFileTest {
         String subdir1 = DIRECTORY + "\\subdir1";
         String subdir2 = DIRECTORY + "\\subdir2";
         String subdir3 = DIRECTORY + "\\foo";
-        mockDir(DIRECTORY, new ArrayList<>() {{
-            add(mockDir(subdir1, new ArrayList<>() {{
-                add(mockFile(subdir1, "file1.txt", "abc"));
-            }}));
-            add(mockDir(subdir2, new ArrayList<>() {{
-                add(mockFile(subdir2, "file2.txt", "abc"));
-            }}));
-            add(mockDir(subdir3, new ArrayList<>() {{
-                add(mockFile(subdir3, "file3.txt", "abc"));
-            }}));
-        }});
+        mockDir(DIRECTORY, List.of(
+                mockDir(subdir1, List.of(mockFile(subdir1, "file1.txt", "abc"))),
+                mockDir(subdir2, List.of(mockFile(subdir2, "file2.txt", "abc"))),
+                mockDir(subdir3, List.of(mockFile(subdir3, "file3.txt", "abc")))
+        ));
 
 
         testRunner.run();

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/DefaultAvroSqlWriter.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/sql/DefaultAvroSqlWriter.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.nifi.util.db.JdbcCommon.AvroConversionOptions;
@@ -35,9 +34,7 @@ public class DefaultAvroSqlWriter implements SqlWriter {
 
     private final AvroConversionOptions options;
 
-    private final Map<String, String> attributesToAdd = new HashMap<>() {{
-        put(CoreAttributes.MIME_TYPE.key(), JdbcCommon.MIME_TYPE_AVRO_BINARY);
-    }};
+    private final Map<String, String> attributesToAdd = Map.of(CoreAttributes.MIME_TYPE.key(), JdbcCommon.MIME_TYPE_AVRO_BINARY);
 
     public DefaultAvroSqlWriter(AvroConversionOptions options) {
         this.options = options;

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
@@ -1511,9 +1511,7 @@ public class TestPutSQL {
 
         recreateTable("PERSONS", createPersons);
 
-        runner.enqueue("This statement should be ignored".getBytes(), new HashMap<>() {{
-            put("row.id", "1");
-        }});
+        runner.enqueue("This statement should be ignored".getBytes(), Map.of("row.id", "1"));
         runner.run();
 
         runner.assertAllFlowFilesTransferred(PutSQL.REL_SUCCESS, 1);
@@ -1530,9 +1528,7 @@ public class TestPutSQL {
         }
 
         runner.setProperty(PutSQL.SQL_STATEMENT, "UPDATE PERSONS SET NAME='George' WHERE ID=${row.id}");
-        runner.enqueue("This statement should be ignored".getBytes(), new HashMap<>() {{
-            put("row.id", "1");
-        }});
+        runner.enqueue("This statement should be ignored".getBytes(), Map.of("row.id", "1"));
         runner.run();
 
         try (final Connection conn = service.getConnection()) {

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/json/TestJsonTreeRowRecordReader.java
@@ -890,16 +890,16 @@ class TestJsonTreeRowRecordReader {
         ));
 
         List<Object> expected = Arrays.asList(
-            new MapRecord(expectedSchema, new HashMap<>() {{
-                put("integer", 1);
-                put("boolean", true);
-                put("booleanOrString", true);
-            }}),
-            new MapRecord(expectedSchema, new HashMap<>() {{
-                put("integer", 2);
-                put("string", "stringValue2");
-                put("booleanOrString", "booleanOrStringValue2");
-            }})
+            new MapRecord(expectedSchema, Map.of(
+                    "integer", 1,
+                    "boolean", true,
+                    "booleanOrString", true
+            )),
+            new MapRecord(expectedSchema, Map.of(
+                    "integer", 2,
+                    "string", "stringValue2",
+                    "booleanOrString", "booleanOrStringValue2"
+            ))
         );
 
         testReadRecords(jsonPath, expected);
@@ -925,18 +925,22 @@ class TestJsonTreeRowRecordReader {
         ));
 
         List<Object> expected = Arrays.asList(
-            new MapRecord(expectedRecordChoiceSchema, new HashMap<>() {{
-                put("record", new MapRecord(expectedRecordSchema1, new HashMap<>() {{
-                    put("integer", 1);
-                    put("boolean", true);
-                }}));
-            }}),
-            new MapRecord(expectedRecordChoiceSchema, new HashMap<>() {{
-                put("record", new MapRecord(expectedRecordSchema2, new HashMap<>() {{
-                    put("integer", 2);
-                    put("string", "stringValue2");
-                }}));
-            }})
+            new MapRecord(expectedRecordChoiceSchema, Map.of(
+                    "record", new MapRecord(expectedRecordSchema1, Map.of(
+                            "integer", 1,
+                            "boolean", true
+                        )
+                    )
+                )
+            ),
+            new MapRecord(expectedRecordChoiceSchema, Map.of(
+                    "record", new MapRecord(expectedRecordSchema2, Map.of(
+                            "integer", 2,
+                            "string", "stringValue2"
+                        )
+                    )
+                )
+            )
         );
 
         testReadRecords(jsonPath, expected);
@@ -1181,10 +1185,10 @@ class TestJsonTreeRowRecordReader {
         ));
 
         List<Object> expected = Collections.singletonList(
-                new MapRecord(expectedRecordSchema, new HashMap<>() {{
-                    put("nestedLevel2Int", 111);
-                    put("nestedLevel2String", "root.level1.level2:string");
-                }})
+                new MapRecord(expectedRecordSchema, Map.of(
+                        "nestedLevel2Int", 111,
+                        "nestedLevel2String", "root.level1.level2:string"
+                ))
         );
 
         testReadRecords(jsonPath, recordSchema, expected, StartingFieldStrategy.NESTED_FIELD,

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/yaml/TestYamlTreeRowRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/yaml/TestYamlTreeRowRecordReader.java
@@ -614,16 +614,20 @@ class TestYamlTreeRowRecordReader {
         ));
 
         List<Object> expected = Arrays.asList(
-            new MapRecord(expectedSchema, new HashMap<>() {{
-                put("integer", 1);
-                put("boolean", true);
-                put("booleanOrString", true);
-            }}),
-            new MapRecord(expectedSchema, new HashMap<>() {{
+            new MapRecord(expectedSchema, Map.of(
+                    "integer", 1,
+                    "boolean", true,
+                    "booleanOrString", true
+            )),
+            new MapRecord(expectedSchema, Map.of(
+                    "integer", 2,
+                    "string", "stringValue2",
+                    "booleanOrString", "booleanOrStringValue2"
+            )/*new HashMap<>() {{
                 put("integer", 2);
                 put("string", "stringValue2");
                 put("booleanOrString", "booleanOrStringValue2");
-            }})
+            }}*/)
         );
 
         testReadRecords(yamlPath, expected);
@@ -649,18 +653,16 @@ class TestYamlTreeRowRecordReader {
         ));
 
         List<Object> expected = Arrays.asList(
-            new MapRecord(expectedRecordChoiceSchema, new HashMap<>() {{
-                put("record", new MapRecord(expectedRecordSchema1, new HashMap<>() {{
-                    put("integer", 1);
-                    put("boolean", true);
-                }}));
-            }}),
-            new MapRecord(expectedRecordChoiceSchema, new HashMap<>() {{
-                put("record", new MapRecord(expectedRecordSchema2, new HashMap<>() {{
-                    put("integer", 2);
-                    put("string", "stringValue2");
-                }}));
-            }})
+            new MapRecord(expectedRecordChoiceSchema, Map.of(
+                    "record", new MapRecord(expectedRecordSchema1, Map.of(
+                            "integer", 1,
+                            "boolean", true))
+            )),
+            new MapRecord(expectedRecordChoiceSchema, Map.of(
+                    "record", new MapRecord(expectedRecordSchema2, Map.of(
+                            "integer", 2,
+                            "string", "stringValue2"))
+            ))
         );
 
         testReadRecords(yamlPath, expected);
@@ -712,34 +714,32 @@ class TestYamlTreeRowRecordReader {
         //  while the explicit schema defines only (INT, BOOLEAN) and (INT, STRING) we can't tell which record schema to chose
         //  so we take the first one (INT, BOOLEAN) - as best effort - for both cases
         List<Object> expected = Arrays.asList(
-            new MapRecord(expectedRecordChoiceSchema, new HashMap<>() {{
-                put("record", new Object[]{
-                        new MapRecord(expectedChildSchema1, new HashMap<>() {{
-                            put("integer", 11);
-                            put("boolean", true);
-                            put("extraString", "extraStringValue11");
-                        }}),
-                        new MapRecord(expectedChildSchema1, new HashMap<>() {{
-                            put("integer", 12);
-                            put("boolean", false);
-                            put("extraString", "extraStringValue12");
-                        }})
-                });
-            }}),
-            new MapRecord(expectedRecordChoiceSchema, new HashMap<>() {{
-                put("record", new Object[]{
-                        new MapRecord(expectedChildSchema1, new HashMap<>() {{
-                            put("integer", 21);
-                            put("extraString", "extraStringValue21");
-                            put("string", "stringValue21");
-                        }}),
-                        new MapRecord(expectedChildSchema1, new HashMap<>() {{
-                            put("integer", 22);
-                            put("extraString", "extraStringValue22");
-                            put("string", "stringValue22");
-                        }})
-                });
-            }})
+            new MapRecord(expectedRecordChoiceSchema, Map.of("record", new Object[]{
+                        new MapRecord(expectedChildSchema1, Map.of(
+                                "integer", 11,
+                                "boolean", true,
+                                "extraString", "extraStringValue11"
+                        )),
+                        new MapRecord(expectedChildSchema1, Map.of(
+                                "integer", 12,
+                                "boolean", false,
+                                "extraString", "extraStringValue12"
+                        ))
+                })
+            ),
+            new MapRecord(expectedRecordChoiceSchema, Map.of("record", new Object[]{
+                        new MapRecord(expectedChildSchema1, Map.of(
+                                "integer", 21,
+                                "extraString", "extraStringValue21",
+                                "string", "stringValue21"
+                        )),
+                        new MapRecord(expectedChildSchema1, Map.of(
+                                "integer", 22,
+                                "extraString", "extraStringValue22",
+                                "string", "stringValue22"
+                        ))
+                })
+            )
         );
 
         testReadRecords(yamlPath, schema, expected);
@@ -755,14 +755,14 @@ class TestYamlTreeRowRecordReader {
         ));
 
         List<Object> expected = Arrays.asList(
-                new MapRecord(expectedRecordSchema, new HashMap<>() {{
-                    put("id", 42);
-                    put("balance", 4750.89);
-                }}),
-                new MapRecord(expectedRecordSchema, new HashMap<>() {{
-                    put("id", 43);
-                    put("balance", 48212.38);
-                }})
+                new MapRecord(expectedRecordSchema, Map.of(
+                        "id", 42,
+                        "balance", 4750.89
+                )),
+                new MapRecord(expectedRecordSchema, Map.of(
+                        "id", 43,
+                        "balance", 48212.38
+                ))
         );
 
         testNestedReadRecords(yamlPath, expected, "accounts");
@@ -778,10 +778,10 @@ class TestYamlTreeRowRecordReader {
         ));
 
         List<Object> expected = Collections.singletonList(
-                new MapRecord(expectedRecordSchema, new HashMap<>() {{
-                    put("id", 42);
-                    put("balance", 4750.89);
-                }})
+                new MapRecord(expectedRecordSchema, Map.of(
+                        "id", 42,
+                        "balance", 4750.89
+                ))
         );
 
         testNestedReadRecords(yamlPath, expected, "account");
@@ -797,14 +797,14 @@ class TestYamlTreeRowRecordReader {
         ));
 
         List<Object> expected = Arrays.asList(
-                    new MapRecord(expectedRecordSchema, new HashMap<>() {{
-                        put("id", "n312kj3");
-                        put("type", "employee");
-                    }}),
-                    new MapRecord(expectedRecordSchema, new HashMap<>() {{
-                        put("id", "dl2kdff");
-                        put("type", "security");
-                    }})
+                    new MapRecord(expectedRecordSchema, Map.of(
+                            "id", "n312kj3",
+                            "type", "employee"
+                    )),
+                    new MapRecord(expectedRecordSchema, Map.of(
+                            "id", "dl2kdff",
+                            "type", "security"
+                    ))
         );
 
         testNestedReadRecords(yamlPath, expected, "accountIds");
@@ -837,14 +837,14 @@ class TestYamlTreeRowRecordReader {
         ));
 
         List<Object> expected = Arrays.asList(
-                new MapRecord(expectedRecordSchema, new HashMap<>() {{
-                    put("id", 42);
-                    put("balance", 4750.89);
-                }}),
-                new MapRecord(expectedRecordSchema, new HashMap<>() {{
-                    put("id", 43);
-                    put("balance", 48212.38);
-                }})
+                new MapRecord(expectedRecordSchema, Map.of(
+                        "id", 42,
+                        "balance", 4750.89
+                )),
+                new MapRecord(expectedRecordSchema, Map.of(
+                        "id", 43,
+                        "balance", 48212.38
+                ))
         );
 
         testNestedReadRecords(yamlPath, expectedRecordSchema, expected, "accounts", SchemaApplicationStrategy.SELECTED_PART);
@@ -864,10 +864,10 @@ class TestYamlTreeRowRecordReader {
         ));
 
         List<Object> expected = Collections.singletonList(
-                new MapRecord(accountSchema, new HashMap<>() {{
-                    put("id", 42);
-                    put("balance", 4750.89);
-                }})
+                new MapRecord(accountSchema, Map.of(
+                        "id", 42,
+                        "balance", 4750.89
+                ))
         );
 
         testNestedReadRecords(yamlPath, recordSchema, expected, "account", SchemaApplicationStrategy.WHOLE_JSON);
@@ -887,14 +887,14 @@ class TestYamlTreeRowRecordReader {
         ));
 
         List<Object> expected = Arrays.asList(
-                new MapRecord(accountSchema, new HashMap<>() {{
-                    put("id", 42);
-                    put("balance", 4750.89);
-                }}),
-                new MapRecord(accountSchema, new HashMap<>() {{
-                    put("id", 43);
-                    put("balance", 48212.38);
-                }})
+                new MapRecord(accountSchema, Map.of(
+                        "id", 42,
+                        "balance", 4750.89
+                )),
+                new MapRecord(accountSchema, Map.of(
+                        "id", 43,
+                        "balance", 48212.38
+                ))
         );
 
         testNestedReadRecords(yamlPath, recordSchema, expected, "accounts", SchemaApplicationStrategy.WHOLE_JSON);
@@ -927,10 +927,10 @@ class TestYamlTreeRowRecordReader {
         ));
 
         List<Object> expected = Collections.singletonList(
-                new MapRecord(expectedRecordSchema, new HashMap<>() {{
-                    put("nestedLevel2Int", 111);
-                    put("nestedLevel2String", "root.level1.level2:string");
-                }})
+                new MapRecord(expectedRecordSchema, Map.of(
+                        "nestedLevel2Int", 111,
+                        "nestedLevel2String", "root.level1.level2:string"
+                ))
         );
 
         testNestedReadRecords(yamlPath, recordSchema, expected, "nestedLevel2Record", SchemaApplicationStrategy.WHOLE_JSON);

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/src/main/java/org/apache/nifi/questdb/QueryResultProcessor.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/src/main/java/org/apache/nifi/questdb/QueryResultProcessor.java
@@ -18,17 +18,16 @@ package org.apache.nifi.questdb;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 
 public interface QueryResultProcessor<R> {
-    Map<Class<?>, BiFunction<Integer, QueryRowContext, ?>> ENTRY_FILLERS = new HashMap<>() {{
-        put(Integer.class, (p, r) -> r.getInt(p));
-        put(Long.class, (p, r) -> r.getLong(p));
-        put(String.class, (p, r) -> r.getString(p));
-        put(Instant.class, (p, r) -> microsToInstant(r.getTimestamp(p)));
-    }};
+    Map<Class<?>, BiFunction<Integer, QueryRowContext, ?>> ENTRY_FILLERS = Map.of(
+            Integer.class, (p, r) -> r.getInt(p),
+            Long.class, (p, r) -> r.getLong(p),
+            String.class, (p, r) -> r.getString(p),
+            Instant.class, (p, r) -> microsToInstant(r.getTimestamp(p))
+    );
 
     private static Instant microsToInstant(final long micros) {
         return Instant.EPOCH.plus(micros, ChronoUnit.MICROS);

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/x509/X509AuthenticationProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/x509/X509AuthenticationProviderTest.java
@@ -134,9 +134,7 @@ public class X509AuthenticationProviderTest {
     @Test
     public void testAnonymousWithOneProxy() {
         // override the setting to enable anonymous authentication
-        final Map<String, String> additionalProperties = new HashMap<>() {{
-            put(NiFiProperties.SECURITY_ANONYMOUS_AUTHENTICATION, Boolean.TRUE.toString());
-        }};
+        final Map<String, String> additionalProperties = Map.of(NiFiProperties.SECURITY_ANONYMOUS_AUTHENTICATION, Boolean.TRUE.toString());
         final NiFiProperties properties = NiFiProperties.createBasicNiFiProperties(null, additionalProperties);
         x509AuthenticationProvider = new X509AuthenticationProvider(certificateIdentityProvider, authorizer, properties);
 

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -34,6 +34,7 @@ under the License.
 
     <rule ref="category/java/bestpractices.xml/AvoidMessageDigestField" />
     <rule ref="category/java/bestpractices.xml/AvoidReassigningCatchVariables" />
+    <rule ref="category/java/bestpractices.xml/DoubleBraceInitialization" />
     <rule ref="category/java/bestpractices.xml/ExhaustiveSwitchHasDefault" />
     <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach" />
     <rule ref="category/java/bestpractices.xml/LooseCoupling">


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14835](https://issues.apache.org/jira/browse/NIFI-14835)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `mvn clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
