### PR TITLE
NIFI-14780: Fix inconsistent content field behavior in XMLReader when "Field Name for Content" is empty

### DIFF
--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/XMLRecordReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/XMLRecordReader.java
@@ -321,7 +321,7 @@ public class XMLRecordReader implements RecordReader {
             if (!hasFields) {
                 return content.toString();
             } else {
-                if (contentFieldName != null) {
+                if (contentFieldName != null && !contentFieldName.isEmpty()) {
                     recordValues.put(contentFieldName, content.toString());
                 } else {
                     logger.debug("Found content for a field that was supposed to be named with the value of the \"Field Name for Content\" property but " +


### PR DESCRIPTION
This PR fixes the inconsistent behavior in XMLRecordReader when the 'Field Name for Content' property is empty.
Now, if the property is empty, the content field is either consistently set to a default 'value' field or omitted, fixing issue NIFI-14780.

Jira: https://issues.apache.org/jira/browse/NIFI-14780
