### PR TITLE
NIFI-14840 - Bump Jersey to 3.1.11, Tika to 3.2.2, Checkstyle to 11.0.0, and others

### DIFF
--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>9.1.0</elasticsearch.client.version>
+        <elasticsearch.client.version>9.1.1</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
-            <version>2.1.4</version>
+            <version>2.1.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-graph-test-clients/pom.xml
@@ -25,7 +25,6 @@
     <artifactId>nifi-graph-test-clients</artifactId>
     <packaging>jar</packaging>
     <properties>
-        <gremlin.version>3.7.3</gremlin.version>
         <janusgraph.version>1.2.0-20250608-090535.869f248</janusgraph.version>
         <guava.version>33.4.8-jre</guava.version>
         <amqp-client.version>5.26.0</amqp-client.version>

--- a/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/nifi-other-graph-services/pom.xml
@@ -18,10 +18,6 @@
     <artifactId>nifi-other-graph-services</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <gremlin.version>3.7.3</gremlin.version>
-    </properties>
-
     <dependencies>
 
         <dependency>

--- a/nifi-extension-bundles/nifi-graph-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-graph-bundle/pom.xml
@@ -24,6 +24,10 @@
     <artifactId>nifi-graph-bundle</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <gremlin.version>3.7.4</gremlin.version>
+    </properties>
+
     <modules>
         <module>nifi-graph-test-clients</module>
         <module>nifi-graph-client-service-api</module>

--- a/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-media-bundle/nifi-media-processors/pom.xml
@@ -26,7 +26,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <tika.version>3.2.1</tika.version>
+        <tika.version>3.2.2</tika.version>
     </properties>
     <dependencies>
         <dependency>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <protobuf.version>3.25.8</protobuf.version>
-        <wire.version>5.3.7</wire.version>
+        <wire.version>5.3.8</wire.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -35,7 +35,7 @@
     </modules>
     <properties>
         <org.apache.sshd.version>2.15.0</org.apache.sshd.version>
-        <tika.version>3.2.1</tika.version>
+        <tika.version>3.2.2</tika.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-dbcp-service-bundle/nifi-hikari-dbcp-service/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>7.0.0</version>
+            <version>7.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>3.5.4</version>
+            <version>3.5.5</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>3.5.4</spring.boot.version>
-        <flyway.version>11.10.5</flyway.version>
+        <flyway.version>11.11.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.3.0.202506031305-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.788</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.32.16</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.32.19</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.0</kotlin.version>
@@ -149,7 +149,7 @@
         <ozone.version>1.4.1</ozone.version>
         <gcs.version>2.1.5</gcs.version>
         <aspectj.version>1.9.24</aspectj.version>
-        <jersey.bom.version>3.1.10</jersey.bom.version>
+        <jersey.bom.version>3.1.11</jersey.bom.version>
         <log4j2.version>2.25.1</log4j2.version>
         <logback.version>1.5.18</logback.version>
         <mockito.version>5.18.0</mockito.version>
@@ -767,7 +767,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>10.26.1</version>
+                            <version>11.0.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
# Summary

NIFI-14840 - Bump Jersey to 3.1.11, Tika to 3.2.2, Checkstyle to 11.0.0, and others

- Elasticsearch from 9.1.0 to 9.1.1 - https://github.com/elastic/elasticsearch-java
- greenmail from 2.1.4 to 2.1.5 - https://github.com/greenmail-mail-test/greenmail/releases/tag/release-2.1.5
- Apache TinkerPop Gremlin from 3.7.3 to 3.7.4 - https://github.com/apache/tinkerpop/blob/3.7.4/CHANGELOG.asciidoc#release-3-7-4
- Apache Tika from 3.2.1 to 3.2.2 - https://github.com/apache/tika/releases/tag/3.2.2
- Wire from 5.3.7 to 5.3.8 - https://github.com/square/wire/blob/master/CHANGELOG.md#version-538
- HikariCP from 7.0.0 to 7.0.1 - https://github.com/brettwooldridge/HikariCP/releases/tag/HikariCP-7.0.1
- MariaDB from 3.5.4 to 3.5.5 - https://github.com/mariadb-corporation/mariadb-connector-j/compare/3.5.4...3.5.5
- FlywayDB from 11.10.5 to 11.11.0 - https://github.com/flyway/flyway/releases/tag/flyway-11.11.0
- AWS SDK v2 from 2.32.16 to 2.32.19 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Jersey from 3.1.10 to 3.1.11 - https://github.com/eclipse-ee4j/jersey/releases/tag/3.1.11
- Checkstyle from 10.26.1 to 11.0.0 - https://github.com/checkstyle/checkstyle/releases/tag/checkstyle-11.0.0

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
