### PR TITLE
[NIFI-9653] Fix PutSQL to route duplicate key exceptions to failure

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -902,23 +902,19 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
 
     
     private boolean isDuplicateKeyException(SQLException e) {
-    // SQLState 23000 is integrity constraint violation (ANSI SQL)
       if ("23000".equals(e.getSQLState())) {
         return true;
        }
-    // MySQL: 1062, PostgreSQL: 23505
         int errorCode = e.getErrorCode();
         if (errorCode == 1062 || errorCode == 23505) {
         return true;
         }
-    // Recursively check cause
         Throwable cause = e.getCause();
         if (cause instanceof SQLException) {
          return isDuplicateKeyException((SQLException) cause);
         }
      return false;
 }
-// ...existing code...
 
     /**
      * A FlowFileFilter that is responsible for ensuring that the FlowFiles returned either belong

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -659,17 +659,17 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
 
         exceptionHandler = new ExceptionHandler<>();
         exceptionHandler.mapException(e -> {
-          if (e instanceof SQLException sqlEx) {
-            if (isDuplicateKeyException(sqlEx)) {
-                getLogger().debug("Detected duplicate key/integrity constraint violation: {}", sqlEx);
-                return ErrorTypes.InvalidInput; // Route to failure
-            }
-            if (sqlEx instanceof SQLNonTransientException) {
-                return ErrorTypes.InvalidInput;
-            }
-            return ErrorTypes.TemporalFailure;
-        } else {
-            return ErrorTypes.UnknownFailure;
+            if (e instanceof SQLException sqlEx) {
+                if (isDuplicateKeyException(sqlEx)) {
+                    getLogger().debug("Detected duplicate key/integrity constraint violation: {}", sqlEx);
+                    return ErrorTypes.InvalidInput; // Route to failure
+                }
+                if (sqlEx instanceof SQLNonTransientException) {
+                    return ErrorTypes.InvalidInput;
+                }
+                return ErrorTypes.TemporalFailure;
+            } else {
+                return ErrorTypes.UnknownFailure;
             }
         });
         adjustError = RollbackOnFailure.createAdjustError(getLogger());
@@ -906,6 +906,7 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
         return true;
        }
         int errorCode = e.getErrorCode();
+        // MySQL error code 1062 and PostgreSQL error code 23505 indicate a duplicate key violation
         if (errorCode == 1062 || errorCode == 23505) {
         return true;
         }

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/PutSQL.java
@@ -661,17 +661,17 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
         exceptionHandler.mapException(e -> {
           if (e instanceof SQLException sqlEx) {
             if (isDuplicateKeyException(sqlEx)) {
-            getLogger().debug("Detected duplicate key/integrity constraint violation: {}", sqlEx);
-            return ErrorTypes.InvalidInput; // Route to failure
+                getLogger().debug("Detected duplicate key/integrity constraint violation: {}", sqlEx);
+                return ErrorTypes.InvalidInput; // Route to failure
             }
             if (sqlEx instanceof SQLNonTransientException) {
-            return ErrorTypes.InvalidInput;
-          }
-        return ErrorTypes.TemporalFailure;
+                return ErrorTypes.InvalidInput;
+            }
+            return ErrorTypes.TemporalFailure;
         } else {
             return ErrorTypes.UnknownFailure;
-        }
-    });
+            }
+        });
         adjustError = RollbackOnFailure.createAdjustError(getLogger());
         exceptionHandler.adjustError(adjustError);
     }
@@ -914,7 +914,7 @@ public class PutSQL extends AbstractSessionFactoryProcessor {
          return isDuplicateKeyException((SQLException) cause);
         }
      return false;
-}
+    }
 
     /**
      * A FlowFileFilter that is responsible for ensuring that the FlowFiles returned either belong

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestPutSQL.java
@@ -545,6 +545,25 @@ public class TestPutSQL {
         }
     }
 
+    @Test
+    public void testDuplicateKeyExceptionRoutedToFailure() throws InitializationException, ProcessException, SQLException {
+        final TestRunner runner = initTestRunner();
+
+        recreateTable("PERSONS", createPersons);
+
+        runner.enqueue("INSERT INTO PERSONS (ID, NAME, CODE) VALUES (1, 'Mark', 84)".getBytes());
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutSQL.REL_SUCCESS, 1);
+
+        runner.clearTransferState();
+
+        runner.enqueue("INSERT INTO PERSONS (ID, NAME, CODE) VALUES (1, 'George', 99)".getBytes());
+        runner.run();
+        runner.assertAllFlowFilesTransferred(PutSQL.REL_FAILURE, 1);
+
+        assertSQLExceptionRelatedAttributes(runner, PutSQL.REL_FAILURE);
+    }    
+
     // Not specifying a format for the date fields here to continue to test backwards compatibility
     @Test
     public void testUsingTimestampValuesEpochAndString() throws InitializationException, ProcessException, SQLException {


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-9653](https://issues.apache.org/jira/browse/NIFI-9653)
Handle duplicate key SQL exceptions correctly in PutSQL processor

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
