### PR TITLE
NIFI-14724 Improve Maximum Read Size error message for Cache Server

### DIFF
--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/codec/CacheRequestDecoder.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/codec/CacheRequestDecoder.java
@@ -53,17 +53,17 @@ public class CacheRequestDecoder extends ByteToMessageDecoder {
 
     private final ComponentLog log;
 
-    private final int maxLength;
+    private final int maxReadSize;
 
     private final CacheOperation[] supportedOperations;
 
     public CacheRequestDecoder(
             final ComponentLog log,
-            final int maxLength,
+            final int maxReadSize,
             final CacheOperation[] supportedOperations
     ) {
         this.log = log;
-        this.maxLength = maxLength;
+        this.maxReadSize = maxReadSize;
         this.supportedOperations = supportedOperations;
     }
 
@@ -175,8 +175,8 @@ public class CacheRequestDecoder extends ByteToMessageDecoder {
 
         if (byteBuf.readableBytes() >= SHORT_LENGTH) {
             final int length = byteBuf.readUnsignedShort();
-            if (length > maxLength) {
-                throw new IllegalArgumentException(String.format("Maximum Operation Length [%d] exceeded [%d]", maxLength, length));
+            if (length > maxReadSize) {
+                throw new IllegalArgumentException(String.format("Maximum Read Size [%d] exceeded [%d]", maxReadSize, length));
             }
             if (byteBuf.readableBytes() >= length) {
                 unicodeString = byteBuf.readCharSequence(length, StandardCharsets.UTF_8).toString();
@@ -202,8 +202,8 @@ public class CacheRequestDecoder extends ByteToMessageDecoder {
         final int readableBytes = byteBuf.readableBytes();
         if (readableBytes >= INT_LENGTH) {
             integer = byteBuf.readInt();
-            if (integer > maxLength) {
-                throw new IllegalArgumentException(String.format("Maximum Length [%d] exceeded [%d]", maxLength, integer));
+            if (integer > maxReadSize) {
+                throw new IllegalArgumentException(String.format("Maximum Read Size [%d] exceeded [%d]", maxReadSize, integer));
             }
         } else {
             integer = null;

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/codec/MapCacheRequestDecoder.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/codec/MapCacheRequestDecoder.java
@@ -35,10 +35,10 @@ public class MapCacheRequestDecoder extends CacheRequestDecoder {
 
     public MapCacheRequestDecoder(
             final ComponentLog log,
-            final int maxLength,
+            final int maxReadSize,
             final CacheOperation[] supportedOperations
     ) {
-        super(log, maxLength, supportedOperations);
+        super(log, maxReadSize, supportedOperations);
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/StandardMapCacheServer.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-distributed-cache-services-bundle/nifi-distributed-cache-server/src/main/java/org/apache/nifi/distributed/cache/server/map/StandardMapCacheServer.java
@@ -57,7 +57,7 @@ public class StandardMapCacheServer extends EventCacheServer {
             final int maxCacheEntries,
             final EvictionPolicy evictionPolicy,
             final File persistencePath,
-            final int maxReadLength
+            final int maxReadSize
     ) throws IOException {
         super(log, port);
 
@@ -89,7 +89,7 @@ public class StandardMapCacheServer extends EventCacheServer {
                         mapRemoveResponseEncoder,
                         mapSizeResponseEncoder,
                         mapValueResponseEncoder,
-                        new MapCacheRequestDecoder(log, maxReadLength, MapOperation.values()),
+                        new MapCacheRequestDecoder(log, maxReadSize, MapOperation.values()),
                         mapCacheRequestHandler,
                         new CacheVersionRequestHandler(log, versionNegotiator)
                 )


### PR DESCRIPTION
# Summary

[NIFI-14724](https://issues.apache.org/jira/browse/NIFI-14724) Updates the exception message wording in the Cache Request Decoder for the Map Cache Server to use the phrase `Maximum Read Size` instead of `Maximum Length` or `Maximum Operation Length` to match the property name that controls the limitation. Additional changes include updating the variable name to match.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
