### PR TITLE
NIFI-14858: Make SNI checking configurable

### DIFF
--- a/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
+++ b/nifi-commons/nifi-jetty-configuration/src/main/java/org/apache/nifi/jetty/configuration/connector/StandardServerConnectorFactory.java
@@ -70,6 +70,10 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
 
     private int requestHeaderSize = 8192;
 
+    private boolean sniRequired = true;
+
+    private boolean sniHostCheck = true;
+
     /**
      * Standard Server Connector Factory Constructor with required properties
      *
@@ -181,6 +185,24 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
         this.requestHeaderSize = requestHeaderSize;
     }
 
+    /**
+     * Set to true if a SNI certificate is required, else requests will be rejected with 400 response.
+     *
+     * @param sniRequired SNI Required status
+     */
+    public void setSniRequired(final boolean sniRequired) {
+        this.sniRequired = sniRequired;
+    }
+
+    /**
+     * Set to true if the SNI Host name must match when there is an SNI certificate.
+     *
+     * @param sniHostCheck SNI Host Check status
+     */
+    public void setSniHostCheck(final boolean sniHostCheck) {
+        this.sniHostCheck = sniHostCheck;
+    }
+
     protected Server getServer() {
         return server;
     }
@@ -195,6 +217,8 @@ public class StandardServerConnectorFactory implements ServerConnectorFactory {
             httpConfiguration.setSendServerVersion(SEND_SERVER_VERSION);
 
             final SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
+            secureRequestCustomizer.setSniRequired(sniRequired);
+            secureRequestCustomizer.setSniHostCheck(sniHostCheck);
             httpConfiguration.addCustomizer(secureRequestCustomizer);
         }
 

--- a/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
+++ b/nifi-commons/nifi-properties/src/main/java/org/apache/nifi/util/NiFiProperties.java
@@ -206,6 +206,8 @@ public class NiFiProperties extends ApplicationProperties {
     public static final String WEB_HTTPS_CIPHERSUITES_INCLUDE = "nifi.web.https.ciphersuites.include";
     public static final String WEB_HTTPS_CIPHERSUITES_EXCLUDE = "nifi.web.https.ciphersuites.exclude";
     public static final String WEB_HTTPS_NETWORK_INTERFACE_PREFIX = "nifi.web.https.network.interface.";
+    public static final String WEB_HTTPS_SNI_REQUIRED = "nifi.web.https.sni.required";
+    public static final String WEB_HTTPS_SNI_HOST_CHECK = "nifi.web.https.sni.host.check";
     public static final String WEB_WORKING_DIR = "nifi.web.jetty.working.directory";
     public static final String WEB_THREADS = "nifi.web.jetty.threads";
     public static final String WEB_MAX_HEADER_SIZE = "nifi.web.max.header.size";
@@ -708,6 +710,14 @@ public class NiFiProperties extends ApplicationProperties {
     public Set<String> getWebHttpsApplicationProtocols() {
         final String protocols = getProperty(WEB_HTTPS_APPLICATION_PROTOCOLS, DEFAULT_WEB_HTTPS_APPLICATION_PROTOCOLS);
         return Arrays.stream(protocols.split("\\s+")).collect(Collectors.toSet());
+    }
+
+    public boolean isWebHttpsSniRequired() {
+        return Boolean.parseBoolean(getProperty(WEB_HTTPS_SNI_REQUIRED, "true"));
+    }
+
+    public boolean isWebHttpsSniHostCheck() {
+        return Boolean.parseBoolean(getProperty(WEB_HTTPS_SNI_HOST_CHECK, "true"));
     }
 
     public String getWebMaxHeaderSize() {

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-jetty/src/main/java/org/apache/nifi/web/server/connector/FrameworkServerConnectorFactory.java
@@ -83,6 +83,10 @@ public class FrameworkServerConnectorFactory extends StandardServerConnectorFact
 
             // Set Transport Layer Security Protocols based on platform configuration
             setIncludeSecurityProtocols(TlsPlatform.getPreferredProtocols().toArray(new String[0]));
+
+            // Set SNI configuration from properties
+            setSniRequired(properties.isWebHttpsSniRequired());
+            setSniHostCheck(properties.isWebHttpsSniHostCheck());
         }
     }
 


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Introduces two new properties:
- nifi.web.https.sni.required
- nifi.web.https.sni.host.check

[NIFI-14858](https://issues.apache.org/jira/browse/NIFI-14858)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
