### PR TITLE
NIFI-14856 allow QuestDB Status History to display greater than 24 hours of data

### DIFF
--- a/nifi-docs/src/main/asciidoc/user-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/user-guide.adoc
@@ -2492,7 +2492,7 @@ The Summary page also includes the following elements:
 
 While the Summary table and the canvas show numeric statistics pertaining to the performance of a component over the
 past five minutes, it is often useful to have a view of historical statistics as well. This information is available
-by right-clicking on a component and choosing the "Status History" menu option or by clicking on the Status History in the Summary page (see <<Summary_Page>>
+by right-clicking on a component and choosing the "View Status History" menu option or by clicking on the Status History in the Summary page (see <<Summary_Page>>
 for more information).
 
 The amount of historical information that is stored is configurable in the NiFi properties but defaults to `24 hours`. For specific
@@ -3058,11 +3058,11 @@ recent change to the dataflow has caused a problem and needs to be fixed. The DF
 adjust the flow as needed to fix the problem. While NiFi does not have an "undo" feature, the DFM can make new changes to the
 dataflow that will fix the problem.
 
-Select Node Status History to view instance specific metrics from the last 24 hours or if the instance runs for less time, then
+Select Node Status History to view instance-specific metrics from the last 24 hours or longer if the status repository implementation
+supports it. If the instance runs for less than the maximum configured time, then metrics will be available for the period of time
 since it has been started. The status history can help the DFM in troubleshooting performance issues and provides a general
-view on the health of the node. The status history includes information about the memory usage and disk usage among other things.
+view on the health of the node. The status history includes information about the memory and disk usage, CPU utilzation and garbage collection.
 
-Two other tools in the Global Menu are Controller Settings and Users. The Controller Settings page provides the ability to change
-the name of the NiFi instance, add comments describing the NiFi instance, and set the maximum number of threads that are available
+Two other tools in the Global Menu are Controller Settings and Users. The Controller Settings page provides the ability to set the maximum number of threads that are available
 to the application. It also provides tabs where DFMs may add and configure <<Controller_Services>> and <<Reporting_Tasks>>. The Users page is used to manage user access, which is described in
 the link:administration-guide.html[System Administrator's Guide].

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb-status-history/src/main/java/org/apache/nifi/controller/status/history/questdb/EmbeddedQuestDbStatusHistoryRepository.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb-status-history/src/main/java/org/apache/nifi/controller/status/history/questdb/EmbeddedQuestDbStatusHistoryRepository.java
@@ -101,7 +101,7 @@ public class EmbeddedQuestDbStatusHistoryRepository implements StatusHistoryRepo
                 .build();
 
         storage = new BufferedStatusHistoryStorage(
-                new QuestDbStatusHistoryStorage(databaseManager.acquireClient()),
+                new QuestDbStatusHistoryStorage(databaseManager.acquireClient(), getDaysToKeepNodeData(niFiProperties), getDaysToKeepComponentData(niFiProperties)),
                 FormatUtils.getTimeDuration(niFiProperties.getQuestDbStatusRepositoryPersistFrequency(), TimeUnit.MILLISECONDS),
                 niFiProperties.getQuestDbStatusRepositoryPersistBatchSize()
         );


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

The UI currently limits Status History graphs to 24 hours even when using the persistent QuestDB repo implementation. This implementation, EmbeddedQuestDbStatusHistoryRepository, was updated to graph the full duration as specified by values in nifi.properties.

nifi.status.repository.questdb.persist.node.days=
nifi.status.repository.questdb.persist.component.days=

There is little documentation in the User Guide that is affected by this change, but it was updated where it specifically mentioned 24 hours.

[NIFI-13856](https://issues.apache.org/jira/browse/NIFI-14856)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Verification was performed in the UI. Configure NiFi to use EmbeddedQuestDbStatusHistoryRepository. This also requires obtaining the NAR for this implementation, nifi-questdb-status-history-nar-2.6.0-SNAPSHOT.nar, and applying it to the running NiFi instance. Set properties in nifi.properties:

nifi.components.status.repository.implementation=org.apache.nifi.controller.status.history.questdb.EmbeddedQuestDbStatusHistoryRepository
nifi.status.repository.questdb.persist.node.days=14
nifi.status.repository.questdb.persist.component.days=3

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [X] Documentation formatting appears as expected in rendered files
