### PR TITLE
NIFI-14874 Unable to move destination of a Connection to a Process Group when source component is running

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/connectable/StandardConnection.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/connectable/StandardConnection.java
@@ -271,12 +271,6 @@ public final class StandardConnection implements Connection {
         }
 
         try {
-            getSource().verifyCanUpdate();
-        } catch (final IllegalStateException ise) {
-            throw new IllegalStateException("Cannot update the relationships for Connection", ise);
-        }
-
-        try {
             this.relationships.set(new ArrayList<>(newRelationships));
             getSource().updateConnection(this);
         } catch (final RuntimeException e) {

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/edit-connection/edit-connection.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/edit-connection/edit-connection.component.html
@@ -16,7 +16,9 @@
   -->
 
 <h2 mat-dialog-title>
-    {{ connectionReadonly || sourceReadonly || destinationReadonly ? 'Connection Details' : 'Edit Connection' }}
+    {{ connectionReadonly 
+    || sourceReadonly  && destinationType != ComponentType.ProcessGroup && destinationType != ComponentType.RemoteProcessGroup
+    || destinationReadonly ? 'Connection Details' : 'Edit Connection' }}
 </h2>
 <form class="edit-connection-form" [formGroup]="editConnectionForm">
     <context-error-banner [context]="ErrorContextKey.CONNECTION"></context-error-banner>
@@ -252,7 +254,9 @@
     </mat-tab-group>
     @if ({ value: (saving$ | async)! }; as saving) {
         <mat-dialog-actions align="end">
-            @if (connectionReadonly || sourceReadonly || destinationReadonly) {
+            @if (connectionReadonly 
+                || sourceReadonly && destinationType != ComponentType.ProcessGroup && destinationType != ComponentType.RemoteProcessGroup
+                || destinationReadonly) {
                 <button mat-flat-button mat-dialog-close>Close</button>
             } @else {
                 <button mat-button mat-dialog-close="CANCELLED">Cancel</button>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/edit-connection/edit-connection.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/connection/edit-connection/edit-connection.component.ts
@@ -302,7 +302,9 @@ export class EditConnectionComponent extends TabbedDialog {
     }
 
     updateControlValueAccessorsForReadOnly(): void {
-        const disabled = this.connectionReadonly || this.sourceReadonly || this.destinationReadonly;
+        const disabled = this.connectionReadonly 
+            || this.sourceReadonly && this.destinationType != ComponentType.ProcessGroup && this.destinationType != ComponentType.RemoteProcessGroup
+            || this.destinationReadonly;
 
         // sourceReadonly is used to update the readonly / disable state of the form controls, note that
         // the source control for local and remote groups is always disabled (see above) in this edit


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14874](https://issues.apache.org/jira/browse/NIFI-14874)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-14874`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-14874`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

To reproduce, create any two processors, Processor A and Processor B, with a Connection from Processor A (source) to Processor B (destination.) Also, create a Process Group which contains an Input Port within it. Start Processor A.

Attempt to move the destination of the Connection from Processor B to the Process Group's Input Port.
It should allow to edit connection and select input port 

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
