### PR TITLE
NIFI-14903: Fix initial value reference for RPG proxy config fields

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/remote-process-group/edit-remote-process-group/edit-remote-process-group.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/pages/flow-designer/ui/canvas/items/remote-process-group/edit-remote-process-group/edit-remote-process-group.component.ts
@@ -77,10 +77,10 @@ export class EditRemoteProcessGroup extends CloseOnEscapeDialog {
             urls: new FormControl(request.entity.component.targetUris, Validators.required),
             transportProtocol: new FormControl(request.entity.component.transportProtocol, Validators.required),
             localNetworkInterface: new FormControl(request.entity.component.localNetworkInterface),
-            httpProxyServerHostname: new FormControl(request.entity.component.httpProxyServerHostname),
-            httpProxyServerPort: new FormControl(request.entity.component.httpProxyServerPort),
-            httpProxyUser: new FormControl(request.entity.component.httpProxyUser),
-            httpProxyPassword: new FormControl(request.entity.component.httpProxyPassword),
+            httpProxyServerHostname: new FormControl(request.entity.component.proxyHost),
+            httpProxyServerPort: new FormControl(request.entity.component.proxyPort),
+            httpProxyUser: new FormControl(request.entity.component.proxyUser),
+            httpProxyPassword: new FormControl(request.entity.component.proxyPassword),
             communicationsTimeout: new FormControl(request.entity.component.communicationsTimeout, Validators.required),
             yieldDuration: new FormControl(request.entity.component.yieldDuration, Validators.required)
         });


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14903](https://issues.apache.org/jira/browse/NIFI-14903)

Initial fields values for RPG proxy configurations are not being displayed in the UI because the values passed to the form control are referencing the form control name used on the frontend instead of the field name being returned from the backend.

### Further Considerations

This wasn't caught by the TS compiler because entity is of type `any`. In the file where that type interface is declared, we use `any` over 30 other times. This is a great example of why it would be greatly beneficial for this project to start using generated types based on the backend response's data model instead of manually providing types by hand.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
