### PR TITLE
NIFI-14909 - Bump Jedis to 6.2.0, Clojure to 1.12.2, brotli4j to 1.20.0, and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -76,7 +76,7 @@
             <dependency>
                 <groupId>org.apache.santuario</groupId>
                 <artifactId>xmlsec</artifactId>
-                <version>2.3.5</version>
+                <version>4.0.4</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.fasterxml.woodstox</groupId>

--- a/nifi-commons/nifi-xml-processing/pom.xml
+++ b/nifi-commons/nifi-xml-processing/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.8.6.6</version>
+                <version>4.9.4.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -44,7 +44,7 @@
                         <plugin>
                             <groupId>com.h3xstream.findsecbugs</groupId>
                             <artifactId>findsecbugs-plugin</artifactId>
-                            <version>1.12.0</version>
+                            <version>1.14.0</version>
                         </plugin>
                     </plugins>
                 </configuration>

--- a/nifi-commons/nifi-xml-processing/src/main/java/org/apache/nifi/xml/processing/validation/StandardSchemaValidator.java
+++ b/nifi-commons/nifi-xml-processing/src/main/java/org/apache/nifi/xml/processing/validation/StandardSchemaValidator.java
@@ -17,13 +17,13 @@
 package org.apache.nifi.xml.processing.validation;
 
 import org.apache.nifi.xml.processing.ProcessingException;
-import org.apache.nifi.xml.processing.ProcessingFeature;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
 import javax.xml.validation.Schema;
 import javax.xml.validation.Validator;
+
 import java.io.IOException;
 import java.util.Objects;
 
@@ -31,6 +31,8 @@ import java.util.Objects;
  * Standard implementation of XML Schema Validator with secure processing enabled
  */
 public class StandardSchemaValidator implements SchemaValidator {
+    private static final boolean SECURE_PROCESSING_ENABLED = true;
+
     /**
      * Validate Source using Schema
      *
@@ -45,7 +47,7 @@ public class StandardSchemaValidator implements SchemaValidator {
         final Validator validator = schema.newValidator();
 
         try {
-            validator.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, ProcessingFeature.SECURE_PROCESSING.isEnabled());
+            validator.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, SECURE_PROCESSING_ENABLED);
         } catch (final SAXException e) {
             throw new ProcessingException("Validator configuration failed", e);
         }

--- a/nifi-extension-bom/pom.xml
+++ b/nifi-extension-bom/pom.xml
@@ -208,19 +208,30 @@
             <dependency>
                 <groupId>org.eclipse.jetty.ee10</groupId>
                 <artifactId>jetty-ee10-apache-jsp</artifactId>
+                <exclusions>
+                    <!-- Exclude legacy Mortbay coordinates; use mortbay-apache-* instead -->
+                    <exclusion>
+                        <groupId>org.mortbay.jasper</groupId>
+                        <artifactId>apache-jsp</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.mortbay.jasper</groupId>
+                        <artifactId>apache-el</artifactId>
+                    </exclusion>
+                </exclusions>
                 <version>${jetty.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
-                <artifactId>apache-jsp</artifactId>
-                <version>10.1.43</version>
+                <artifactId>mortbay-apache-jsp</artifactId>
+                <version>10.1.44</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
-                <artifactId>apache-el</artifactId>
-                <version>10.1.43</version>
+                <artifactId>mortbay-apache-el</artifactId>
+                <version>10.1.44</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -238,7 +249,7 @@
             <dependency>
                 <groupId>org.eclipse.jdt</groupId>
                 <artifactId>ecj</artifactId>
-                <version>3.40.0</version>
+                <version>3.42.0</version>
                 <scope>provided</scope>
             </dependency>
             <!-- Jetty EE10 Glassfish JSTL and deps -->
@@ -414,11 +425,11 @@
         </dependency>
         <dependency>
             <groupId>org.mortbay.jasper</groupId>
-            <artifactId>apache-jsp</artifactId>
+            <artifactId>mortbay-apache-jsp</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mortbay.jasper</groupId>
-            <artifactId>apache-el</artifactId>
+            <artifactId>mortbay-apache-el</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.el</groupId>
@@ -503,8 +514,8 @@
                         <dependency>org.ow2.asm:asm-commons</dependency>
                         <dependency>org.ow2.asm:asm-tree</dependency>
                         <dependency>org.eclipse.jetty.ee10:jetty-ee10-apache-jsp</dependency>
-                        <dependency>org.mortbay.jasper:apache-jsp</dependency>
-                        <dependency>org.mortbay.jasper:apache-el</dependency>
+                        <dependency>org.mortbay.jasper:mortbay-apache-jsp</dependency>
+                        <dependency>org.mortbay.jasper:mortbay-apache-el</dependency>
                         <dependency>jakarta.el:jakarta.el-api</dependency>
                         <dependency>jakarta.servlet.jsp:jakarta.servlet.jsp-api</dependency>
                         <dependency>org.eclipse.jdt:ecj</dependency>

--- a/nifi-extension-bundles/nifi-compress-bundle/nifi-compress-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-compress-bundle/nifi-compress-processors/pom.xml
@@ -42,7 +42,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.aayushatharva.brotli4j</groupId>
             <artifactId>brotli4j</artifactId>
-            <version>1.18.0</version>
+            <version>1.20.0</version>
         </dependency>
         <dependency>
             <groupId>org.tukaani</groupId>

--- a/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-email-bundle/nifi-email-processors/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>
-            <version>2.1.3</version>
+            <version>2.1.4</version>
         </dependency>
         <dependency>
             <groupId>jakarta.activation</groupId>

--- a/nifi-extension-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <spring.data.redis.version>3.5.3</spring.data.redis.version>
-        <jedis.version>6.1.0</jedis.version>
+        <jedis.version>6.2.0</jedis.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-scripting-bundle/nifi-scripting-processors/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>clojure</artifactId>
-            <version>1.12.1</version>
+            <version>1.12.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -76,7 +76,7 @@
             <dependency>
                 <groupId>jakarta.mail</groupId>
                 <artifactId>jakarta.mail-api</artifactId>
-                <version>2.1.3</version>
+                <version>2.1.4</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.angus</groupId>
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>com.aayushatharva.brotli4j</groupId>
                 <artifactId>brotli4j</artifactId>
-                <version>1.18.0</version>
+                <version>1.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.tukaani</groupId>

--- a/nifi-framework-bundle/nifi-jetty-nar/pom.xml
+++ b/nifi-framework-bundle/nifi-jetty-nar/pom.xml
@@ -169,16 +169,26 @@
         <dependency>
             <groupId>org.eclipse.jetty.ee10</groupId>
             <artifactId>jetty-ee10-apache-jsp</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jasper</groupId>
+                    <artifactId>apache-jsp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jasper</groupId>
+                    <artifactId>apache-el</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mortbay.jasper</groupId>
-            <artifactId>apache-jsp</artifactId>
+            <artifactId>mortbay-apache-jsp</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mortbay.jasper</groupId>
-            <artifactId>apache-el</artifactId>
+            <artifactId>mortbay-apache-el</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/nifi-registry/nifi-registry-core/nifi-registry-jetty/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-jetty/pom.xml
@@ -85,6 +85,16 @@
         <dependency>
             <groupId>org.eclipse.jetty.ee10</groupId>
             <artifactId>jetty-ee10-apache-jsp</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jasper</groupId>
+                    <artifactId>apache-jsp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jasper</groupId>
+                    <artifactId>apache-el</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -102,6 +102,16 @@
             <dependency>
                 <groupId>org.eclipse.jetty.ee10</groupId>
                 <artifactId>jetty-ee10-apache-jsp</artifactId>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.mortbay.jasper</groupId>
+                        <artifactId>apache-jsp</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.mortbay.jasper</groupId>
+                        <artifactId>apache-el</artifactId>
+                    </exclusion>
+                </exclusions>
                 <scope>compile</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.788</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.32.29</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.32.31</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.10</kotlin.version>
@@ -926,6 +926,9 @@
                                         <exclude>commons-logging:commons-logging:*</exclude>
                                         <!-- Apache Xalan is no longer maintained and is bundled in the standard JRE -->
                                         <exclude>xalan:xalan</exclude>
+                                        <!-- Enforce migration to new Mortbay coordinates; block old artifacts -->
+                                        <exclude>org.mortbay.jasper:apache-jsp:*</exclude>
+                                        <exclude>org.mortbay.jasper:apache-el:*</exclude>
                                         <!-- As of Bouncycastle 1.71 Java 8 is the minimum required so jdk15on artifacts not allowed -->
                                         <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
                                         <exclude>org.bouncycastle:bcpg-jdk15on</exclude>


### PR DESCRIPTION
# Summary

NIFI-14909 - Bump Jedis to 6.2.0, Clojure to 1.12.2, brotli4j to 1.20.0, and others

- XML Santuario from 2.3.5 to 4.0.4 - https://github.com/apache/santuario-xml-security-java/releases
- Spotbugs Maven Plugin from 4.8.6.6 to 4.9.4.0 - https://github.com/spotbugs/spotbugs-maven-plugin/releases
- FindSecBugs Plugin from 1.12.0 to 1.14.0 - https://github.com/find-sec-bugs/find-sec-bugs/releases
- Mortbay JSP and EL from 10.1.43 to 10.1.44
- Eclipse JDT ECJ from 3.40.0 to 3.42.0
- brotli4j from 1.18.0 to 1.20.0 - https://github.com/hyperxpro/Brotli4j/releases
- Jakarta Mail API from 2.1.3 to 2.1.4 - https://github.com/jakartaee/mail-api
- Clojure from 1.12.1 to 1.12.2 - https://clojure.org/news/2025/08/25/clojure-1-12-2
- AWS SDK v2 from 2.32.29 to 2.32.31 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Jedis from 6.1.0 to 6.2.0 - https://github.com/redis/jedis/releases

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
