### PR TITLE
NIFI-14916 - MongoDBControllerService fails with X509 authentication mechanism

### DIFF
--- a/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/nifi-mongodb-services/src/main/java/org/apache/nifi/mongodb/MongoDBControllerService.java
@@ -131,6 +131,14 @@ public class MongoDBControllerService extends AbstractControllerService implemen
                     case PLAIN -> builder.credential(MongoCredential.createPlainCredential(user, database, passw.toCharArray()));
                     default -> throw new IllegalArgumentException("Unsupported authentication mechanism with username and password: " + mechanism);
                 }
+            } else if (authMechanism != null) {
+                final AuthenticationMechanism mechanism = AuthenticationMechanism.fromMechanismName(authMechanism.toUpperCase());
+                switch (mechanism) {
+                    case MONGODB_X509 -> builder.credential(MongoCredential.createMongoX509Credential(user));
+                    case MONGODB_OIDC -> builder.credential(MongoCredential.createOidcCredential(user));
+                    case GSSAPI -> builder.credential(MongoCredential.createGSSAPICredential(user));
+                    default -> throw new IllegalArgumentException("Unsupported authentication mechanism with username only: " + mechanism);
+                }
             } else if (user != null && passw != null) {
                 final MongoCredential credential = MongoCredential.createCredential(user, database, passw.toCharArray());
                 builder.credential(credential);


### PR DESCRIPTION
# Summary

NIFI-14916 - MongoDBControllerService fails with X509 authentication mechanism

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
