### PR TITLE
NIFI-14922 - Bump Zookeeper to 3.9.4, Google Cloud to 26.67.0, Jackson to 2.20.0, and others

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -19,8 +19,11 @@ on:
   push:
     paths:
       - '.github/workflows/docker-tests.yml'
+      - 'pom.xml'
       - 'nifi-assembly/**'
       - 'nifi-docker/**'
+      - 'nifi-registry/pom.xml'
+      - 'nifi-registry/nifi-registry-core/**'
       - 'nifi-registry/nifi-registry-assembly/**'
       - 'nifi-registry/nifi-registry-docker-maven/**'
       - 'nifi-toolkit/nifi-toolkit-assembly/**'
@@ -30,8 +33,11 @@ on:
   pull_request:
     paths:
       - '.github/workflows/docker-tests.yml'
+      - 'pom.xml'
       - 'nifi-assembly/**'
       - 'nifi-docker/**'
+      - 'nifi-registry/pom.xml'
+      - 'nifi-registry/nifi-registry-core/**'
       - 'nifi-registry/nifi-registry-assembly/**'
       - 'nifi-registry/nifi-registry-docker-maven/**'
       - 'nifi-toolkit/nifi-toolkit-assembly/**'

--- a/c2/c2-client-bundle/c2-client-base/src/main/java/org/apache/nifi/c2/serializer/C2JacksonSerializer.java
+++ b/c2/c2-client-bundle/c2-client-base/src/main/java/org/apache/nifi/c2/serializer/C2JacksonSerializer.java
@@ -40,7 +40,7 @@ public class C2JacksonSerializer implements C2Serializer {
     public C2JacksonSerializer() {
         objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
 
         SimpleModule module = new SimpleModule();

--- a/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/RunMiNiFi.java
+++ b/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/RunMiNiFi.java
@@ -269,7 +269,7 @@ public class RunMiNiFi implements ConfigurationFileHolder {
     private ObjectMapper getObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         return objectMapper;
     }
 

--- a/minifi/minifi-commons/minifi-commons-framework/src/main/java/org/apache/nifi/minifi/commons/service/StandardFlowSerDeService.java
+++ b/minifi/minifi-commons/minifi-commons-framework/src/main/java/org/apache/nifi/minifi/commons/service/StandardFlowSerDeService.java
@@ -39,8 +39,7 @@ public class StandardFlowSerDeService implements FlowSerDeService {
 
     public static StandardFlowSerDeService defaultInstance() {
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
+        objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.setAnnotationIntrospector(new JakartaXmlBindAnnotationIntrospector(objectMapper.getTypeFactory()));
         objectMapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
         return new StandardFlowSerDeService(objectMapper);

--- a/minifi/minifi-commons/minifi-commons-framework/src/test/java/org/apache/nifi/minifi/commons/service/StandardFlowEnrichServiceTest.java
+++ b/minifi/minifi-commons/minifi-commons-framework/src/test/java/org/apache/nifi/minifi/commons/service/StandardFlowEnrichServiceTest.java
@@ -174,8 +174,7 @@ public class StandardFlowEnrichServiceTest {
 
     private String flowToString(VersionedDataflow versionedDataflow) {
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
+        objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.setAnnotationIntrospector(new JakartaXmlBindAnnotationIntrospector(objectMapper.getTypeFactory()));
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-runtime/src/main/java/org/apache/nifi/minifi/bootstrap/BootstrapListener.java
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-runtime/src/main/java/org/apache/nifi/minifi/bootstrap/BootstrapListener.java
@@ -74,7 +74,7 @@ public class BootstrapListener implements BootstrapCommunicator {
         bootstrapRequestReader = new BootstrapRequestReader(secretKey);
 
         objectMapper = new ObjectMapper();
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         registerHandlers();
     }
 

--- a/minifi/minifi-toolkit/minifi-toolkit-configuration/src/main/java/org/apache/nifi/minifi/toolkit/configuration/json/ObjectMapperUtils.java
+++ b/minifi/minifi-toolkit/minifi-toolkit-configuration/src/main/java/org/apache/nifi/minifi/toolkit/configuration/json/ObjectMapperUtils.java
@@ -26,9 +26,7 @@ public class ObjectMapperUtils {
 
     public static ObjectMapper createObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setDefaultPropertyInclusion(
-                JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.setAnnotationIntrospector(new JakartaXmlBindAnnotationIntrospector(objectMapper.getTypeFactory()));
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         return objectMapper;

--- a/nifi-commons/nifi-metrics/pom.xml
+++ b/nifi-commons/nifi-metrics/pom.xml
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jvm</artifactId>
-            <version>4.2.34</version>
+            <version>4.2.36</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>4.2.34</version>
+            <version>4.2.36</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/nifi-elasticsearch-client-service/src/main/java/org/apache/nifi/elasticsearch/ElasticSearchClientServiceImpl.java
@@ -202,8 +202,8 @@ public class ElasticSearchClientServiceImpl extends AbstractControllerService im
     private void createObjectMapper(final ConfigurationContext context) {
         mapper = new ObjectMapper();
         if (ALWAYS_SUPPRESS.getValue().equals(context.getProperty(SUPPRESS_NULLS).getValue())) {
-            mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-            mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+            mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
+            mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY);
         }
         prettyPrintWriter = mapper.writerWithDefaultPrettyPrinter();
     }

--- a/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-elasticsearch-bundle/pom.xml
@@ -33,7 +33,7 @@ language governing permissions and limitations under the License. -->
     </modules>
 
     <properties>
-        <elasticsearch.client.version>9.1.2</elasticsearch.client.version>
+        <elasticsearch.client.version>9.1.3</elasticsearch.client.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-enrich-bundle/nifi-enrich-processors/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>com.maxmind.geoip2</groupId>
             <artifactId>geoip2</artifactId>
-            <version>4.3.1</version>
+            <version>4.4.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>

--- a/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/serialize/JacksonFlowSnapshotSerializer.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-git-flow-registry/src/main/java/org/apache/nifi/registry/flow/git/serialize/JacksonFlowSnapshotSerializer.java
@@ -36,7 +36,6 @@ import java.io.InputStream;
 public class JacksonFlowSnapshotSerializer implements FlowSnapshotSerializer {
 
     private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
-            .serializationInclusion(JsonInclude.Include.NON_NULL)
             .defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
             .annotationIntrospector(new JakartaXmlBindAnnotationIntrospector(TypeFactory.defaultInstance()))
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)

--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.66.0</google.libraries.version>
+        <google.libraries.version>26.67.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ConsumeSlack.java
+++ b/nifi-extension-bundles/nifi-slack-bundle/nifi-slack-processors/src/main/java/org/apache/nifi/processors/slack/ConsumeSlack.java
@@ -255,9 +255,9 @@ public class ConsumeSlack extends AbstractProcessor implements VerifiableProcess
     private List<ConsumeChannel> createChannels(final ProcessContext context, final App slackApp) throws SlackApiException, IOException {
         final ObjectMapper objectMapper = new ObjectMapper();
         if (context.getProperty(INCLUDE_NULL_FIELDS).asBoolean()) {
-            objectMapper.setSerializationInclusion(JsonInclude.Include.ALWAYS);
+            objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS);
         } else {
-            objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         }
 
         final ConsumeSlackClient client = initializeClient(slackApp);

--- a/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-lookup-services-bundle/nifi-lookup-services/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.maxmind.geoip2</groupId>
             <artifactId>geoip2</artifactId>
-            <version>4.3.1</version>
+            <version>4.4.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>

--- a/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.bom.version}</version>
+                <version>${jackson.annotations.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -121,7 +121,7 @@
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
-                <version>3.49.5</version>
+                <version>3.50.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-questdb-bundle/nifi-questdb/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.questdb</groupId>
             <artifactId>questdb</artifactId>
-            <version>9.0.2</version>
+            <version>9.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/io/TestJsonEntitySerializer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-cluster/src/test/java/org/apache/nifi/cluster/coordination/http/replication/io/TestJsonEntitySerializer.java
@@ -30,8 +30,7 @@ import org.apache.nifi.web.api.dto.ProcessorDTO;
 import org.apache.nifi.web.api.dto.util.TimeAdapter;
 import org.apache.nifi.web.api.entity.BulletinEntity;
 import org.apache.nifi.web.api.entity.ProcessorEntity;
-
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import org.junit.jupiter.api.Test;
@@ -44,7 +43,7 @@ public class TestJsonEntitySerializer {
     public void testSerializeProcessor() throws IOException {
         final ObjectMapper jsonCodec = new ObjectMapper();
         jsonCodec.registerModule(new JakartaXmlBindAnnotationModule());
-        jsonCodec.setSerializationInclusion(Include.NON_NULL);
+        jsonCodec.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
 
         // Test that we can properly serialize a ProcessorEntity because it has many nested levels, including a Map
         final JsonEntitySerializer serializer = new JsonEntitySerializer(jsonCodec);
@@ -70,7 +69,7 @@ public class TestJsonEntitySerializer {
     public void testBulletinEntity() throws Exception {
         final ObjectMapper jsonCodec = new ObjectMapper();
         jsonCodec.registerModule(new JakartaXmlBindAnnotationModule());
-        jsonCodec.setSerializationInclusion(Include.NON_NULL);
+        jsonCodec.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         jsonCodec.setConfig(jsonCodec.getSerializationConfig().with(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY));
 
         final Date timestamp = new Date();

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSerializer.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/VersionedFlowSerializer.java
@@ -36,8 +36,7 @@ public class VersionedFlowSerializer implements FlowSerializer<VersionedDataflow
     private final ExtensionManager extensionManager;
 
     static {
-        JSON_CODEC.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        JSON_CODEC.setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
+        JSON_CODEC.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         JSON_CODEC.setAnnotationIntrospector(new JakartaXmlBindAnnotationIntrospector(JSON_CODEC.getTypeFactory()));
         JSON_CODEC.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/api/ProcessGroupResource.java
@@ -157,8 +157,6 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
 
     private static final Logger logger = LoggerFactory.getLogger(ProcessGroupResource.class);
 
-    private static final String FLOW_ANALYSIS_REQUEST_TYPE = "flow-analysis-requests";
-
     private ProcessorResource processorResource;
     private InputPortResource inputPortResource;
     private OutputPortResource outputPortResource;
@@ -176,8 +174,7 @@ public class ProcessGroupResource extends FlowUpdateResource<ProcessGroupImportE
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     static {
-        MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        MAPPER.setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
+        MAPPER.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         MAPPER.setAnnotationIntrospector(new JakartaXmlBindAnnotationIntrospector(MAPPER.getTypeFactory()));
         MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }

--- a/nifi-framework-bundle/pom.xml
+++ b/nifi-framework-bundle/pom.xml
@@ -106,7 +106,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>oauth2-oidc-sdk</artifactId>
-                <version>11.27.1</version>
+                <version>11.28</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>
@@ -309,7 +309,7 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
-                <version>4.2.34</version>
+                <version>4.2.36</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>

--- a/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/RuntimeManifestGenerator.java
+++ b/nifi-manifest/nifi-runtime-manifest-core/src/main/java/org/apache/nifi/runtime/manifest/impl/RuntimeManifestGenerator.java
@@ -155,7 +155,7 @@ public class RuntimeManifestGenerator {
 
     private RuntimeManifestSerializer createRuntimeManifestSerializer() {
         final ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
 
         final ObjectWriter objectWriter = objectMapper.writerWithDefaultPrettyPrinter();
         return new JacksonRuntimeManifestSerializer(objectWriter);

--- a/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/serialization/jackson/ObjectMapperProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/serialization/jackson/ObjectMapperProvider.java
@@ -34,7 +34,6 @@ import org.springframework.context.annotation.Primary;
 public class ObjectMapperProvider {
 
     private static final ObjectMapper mapper = JsonMapper.builder()
-            .serializationInclusion(JsonInclude.Include.NON_NULL)
             .defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
             .annotationIntrospector(new JakartaXmlBindAnnotationIntrospector(TypeFactory.defaultInstance()))
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)

--- a/nifi-registry/nifi-registry-core/nifi-registry-jetty/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-jetty/pom.xml
@@ -97,6 +97,17 @@
             </exclusions>
             <scope>compile</scope>
         </dependency>
+        <!-- Explicit JSP implementation using new Mortbay coordinates -->
+        <dependency>
+            <groupId>org.mortbay.jasper</groupId>
+            <artifactId>mortbay-apache-jsp</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mortbay.jasper</groupId>
+            <artifactId>mortbay-apache-el</artifactId>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-security-cert-builder</artifactId>

--- a/nifi-registry/nifi-registry-core/pom.xml
+++ b/nifi-registry/nifi-registry-core/pom.xml
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>oauth2-oidc-sdk</artifactId>
-                <version>11.27.1</version>
+                <version>11.28</version>
             </dependency>
             <dependency>
                 <groupId>com.nimbusds</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -114,6 +114,19 @@
                 </exclusions>
                 <scope>compile</scope>
             </dependency>
+            <!-- Managed Mortbay Jasper dependencies providing JSP implementation with new coordinates -->
+            <dependency>
+                <groupId>org.mortbay.jasper</groupId>
+                <artifactId>mortbay-apache-jsp</artifactId>
+                <version>10.1.44</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mortbay.jasper</groupId>
+                <artifactId>mortbay-apache-el</artifactId>
+                <version>10.1.44</version>
+                <scope>compile</scope>
+            </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.http2</groupId>
                 <artifactId>jetty-http2-server</artifactId>

--- a/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/flow/registry/FileSystemFlowRegistryClient.java
+++ b/nifi-system-tests/nifi-system-test-extensions-bundle/nifi-system-test-extensions/src/main/java/org/apache/nifi/flow/registry/FileSystemFlowRegistryClient.java
@@ -72,8 +72,7 @@ public class FileSystemFlowRegistryClient extends AbstractFlowRegistryClient {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     {
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
+        objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/util/JacksonUtils.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/util/JacksonUtils.java
@@ -29,8 +29,7 @@ public class JacksonUtils {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     static {
-        MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        MAPPER.setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
+        MAPPER.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
         MAPPER.setAnnotationIntrospector(new JakartaXmlBindAnnotationIntrospector(MAPPER.getTypeFactory()));
         MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.788</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.32.31</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.33.0</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.10</kotlin.version>
@@ -137,7 +137,8 @@
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <derby.version>10.17.1.0</derby.version>
         <jetty.version>12.0.25</jetty.version>
-        <jackson.bom.version>2.19.2</jackson.bom.version>
+        <jackson.bom.version>2.20.0</jackson.bom.version>
+        <jackson.annotations.version>2.20</jackson.annotations.version>
         <avro.version>1.11.4</avro.version>
         <jaxb.runtime.version>4.0.5</jaxb.runtime.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
@@ -146,7 +147,7 @@
         <json.smart.version>2.6.0</json.smart.version>
         <groovy.version>5.0.0</groovy.version>
         <surefire.version>3.5.1</surefire.version>
-        <hadoop.version>3.4.1</hadoop.version>
+        <hadoop.version>3.4.2</hadoop.version>
         <ozone.version>1.4.1</ozone.version>
         <gcs.version>2.1.5</gcs.version>
         <aspectj.version>1.9.24</aspectj.version>
@@ -156,13 +157,13 @@
         <mockito.version>5.19.0</mockito.version>
         <junit.version>5.13.4</junit.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
-        <snakeyaml.version>2.4</snakeyaml.version>
+        <snakeyaml.version>2.5</snakeyaml.version>
         <netty.4.version>4.2.4.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.version>6.2.10</spring.version>
         <spring.security.version>6.5.3</spring.security.version>
         <swagger.annotations.version>2.2.36</swagger.annotations.version>
-        <zookeeper.version>3.9.3</zookeeper.version>
+        <zookeeper.version>3.9.4</zookeeper.version>
         <caffeine.version>3.2.2</caffeine.version>
         <hapi.version>2.6.0</hapi.version>
         <commons.dbcp2.version>2.13.0</commons.dbcp2.version>


### PR DESCRIPTION
# Summary

NIFI-14922 - Bump Zookeeper to 3.9.4, Google Cloud to 26.67.0, Jackson to 2.20.0, and others

- io.dropwizard.metrics core and jvm from 4.2.34 to 4.2.36 - https://github.com/dropwizard/metrics/releases/tag/v4.2.36
- Google Cloud SDK BOM from 26.66.0 to 26.67.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.67.0
- AWS SDK v2 from 2.32.31 to 2.33.0 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- geoip2 from 4.3.1 to 4.4.0 - https://github.com/maxmind/GeoIP2-java/releases/tag/v4.4.0
- checker-qual from 3.49.5 to 3.50.0 - https://github.com/typetools/checker-framework/releases/tag/checker-framework-3.50.0
- QuestDB from 9.0.2 to 9.0.3 - https://github.com/questdb/questdb/releases/tag/9.0.3
- oauth2-oidc-sdk from 11.27.1 to 11.28 - https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/master/CHANGELOG.txt
- Jackson from 2.19.2 to 2.20.0 - https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.20
- Apache Hadoop from 3.4.1 to 3.4.2 - https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/release/3.4.2/RELEASENOTES.3.4.2.html
- snakeyaml from 2.4 to 2.5 - https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes
- Apache Zookeeper from 3.9.3 to 3.9.4 - https://zookeeper.apache.org/doc/r3.9.4/releasenotes.html

And also fixing the use of deprecated `setSerializationInclusion()` method on Jackson Object Mapper

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
