### PR TITLE
NIFI-14926 Update StandardNiFiUser String to include All Groups

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/main/java/org/apache/nifi/authorization/user/StandardNiFiUser.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/main/java/org/apache/nifi/authorization/user/StandardNiFiUser.java
@@ -107,11 +107,10 @@ public class StandardNiFiUser implements NiFiUser {
             return false;
         }
 
-        if (!(obj instanceof NiFiUser)) {
+        if (!(obj instanceof NiFiUser other)) {
             return false;
         }
 
-        final NiFiUser other = (NiFiUser) obj;
         return Objects.equals(this.identity, other.getIdentity());
     }
 
@@ -125,13 +124,13 @@ public class StandardNiFiUser implements NiFiUser {
     @Override
     public String toString() {
         final String formattedGroups;
-        if (groups == null) {
-            formattedGroups = "none";
+        if (allGroups == null || allGroups.isEmpty()) {
+            formattedGroups = "";
         } else {
-            formattedGroups = String.join(", ", groups);
+            formattedGroups = String.join(", ", allGroups);
         }
 
-        return String.format("identity[%s], groups[%s]", getIdentity(), formattedGroups);
+        return "Identity [%s] Groups [%s]".formatted(identity, formattedGroups);
     }
 
     /**

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/test/java/org/apache/nifi/authorization/user/StandardNiFiUserTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-authorization/src/test/java/org/apache/nifi/authorization/user/StandardNiFiUserTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.authorization.user;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardNiFiUserTest {
+
+    private static final String IDENTITY = "username";
+
+    private static final String MEMBERS_GROUP = "members";
+
+    private static final String ADMINISTRATORS_GROUP = "administrators";
+
+    private static final Set<String> GROUPS = Set.of(MEMBERS_GROUP, ADMINISTRATORS_GROUP);
+
+    private static final String PROVIDED_GROUP = "provided";
+
+    private static final String CLIENT_ADDRESS = "127.0.0.1";
+
+    @Test
+    void testBuilderStandardProperties() {
+        final NiFiUser user = new StandardNiFiUser.Builder()
+                .identity(IDENTITY)
+                .groups(GROUPS)
+                .clientAddress(CLIENT_ADDRESS)
+                .build();
+
+        assertEquals(IDENTITY, user.getIdentity());
+        assertEquals(GROUPS, user.getGroups());
+        assertEquals(GROUPS, user.getAllGroups());
+        assertEquals(CLIENT_ADDRESS, user.getClientAddress());
+        assertFalse(user.isAnonymous());
+    }
+
+    @Test
+    void testAnonymousUser() {
+        final NiFiUser user = StandardNiFiUser.ANONYMOUS;
+
+        assertEquals(StandardNiFiUser.ANONYMOUS_IDENTITY, user.getIdentity());
+        assertTrue(user.isAnonymous());
+        assertNull(user.getGroups());
+        assertTrue(user.getAllGroups().isEmpty());
+    }
+
+    @Test
+    void testToStringContainsIdentityAndGroups() {
+        final NiFiUser user = new StandardNiFiUser.Builder()
+                .identity(IDENTITY)
+                .groups(GROUPS)
+                .identityProviderGroups(Set.of(PROVIDED_GROUP))
+                .build();
+
+        final String string = user.toString();
+        assertTrue(string.contains(IDENTITY), "Identity not found");
+        assertTrue(string.contains(MEMBERS_GROUP), "Members Group not found");
+        assertTrue(string.contains(ADMINISTRATORS_GROUP), "Administrators Group not found");
+        assertTrue(string.contains(PROVIDED_GROUP), "Identity Provider Group not found");
+    }
+}


### PR DESCRIPTION
# Summary

[NIFI-14926](https://issues.apache.org/jira/browse/NIFI-14926) Updates the `StandardNiFiUser.toString()` method to return all groups, which includes Identity Provider Groups, instead of just groups retrieved from a `UserGroupProvider` implementation. This update improves troubleshooting in some scenarios where Identity Provider Groups are not shown.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
