### PR TITLE
NIFI-14934 Switch Parent NAR to Services API for GitHub Bundle

### DIFF
--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/pom.xml
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/pom.xml
@@ -28,6 +28,7 @@
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -38,6 +39,10 @@
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
             <version>${github-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-nar/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-standard-shared-nar</artifactId>
+            <artifactId>nifi-standard-services-api-nar</artifactId>
             <version>2.6.0-SNAPSHOT</version>
             <type>nar</type>
         </dependency>

--- a/nifi-extension-bundles/nifi-github-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-github-bundle/pom.xml
@@ -16,10 +16,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>nifi-standard-shared-bom</artifactId>
+        <artifactId>nifi-extension-bundles</artifactId>
         <groupId>org.apache.nifi</groupId>
         <version>2.6.0-SNAPSHOT</version>
-        <relativePath>../nifi-standard-shared-bundle/nifi-standard-shared-bom</relativePath>
     </parent>
 
     <artifactId>nifi-github-bundle</artifactId>
@@ -27,6 +26,8 @@
 
     <properties>
         <github-api.version>1.329</github-api.version>
+        <!-- Override Jackson to 2.19.0 pending GitHub client upgrade to support Jackson 2.20.0 -->
+        <jackson.bom.version>2.19.0</jackson.bom.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
# Summary

[NIFI-14934](https://issues.apache.org/jira/browse/NIFI-14934) Switches the parent NAR for the GitHub bundle from `nifi-standard-shared-nar` to `nifi-standard-services-api-nar` to support overriding the version of Jackson to 2.19.0.

GitHub client version 1.329 is not compatible with Jackson 2.20.0 due to the use of a removed static reference for `com.fasterxml.jackson.databind.PropertyNamingStrategy`.

The current set of changes provide a maintainable workaround pending the release of a new GitHub client library version compatible with Jackson 2.20.0.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
