### PR TITLE
NIFI-14937 - Bump Netty to 4.2.5.Final, Kafka to 4.1.0, Parquet to 1.16.0, and others

### DIFF
--- a/nifi-extension-bom/pom.xml
+++ b/nifi-extension-bom/pom.xml
@@ -225,13 +225,13 @@
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-jsp</artifactId>
-                <version>10.1.44</version>
+                <version>10.1.44.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-el</artifactId>
-                <version>10.1.44</version>
+                <version>10.1.44.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
@@ -302,7 +302,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>4.0.0</version>
+            <version>4.1.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/nifi-extension-bundles/nifi-kafka-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-kafka-bundle/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
-        <kafka-clients.version>4.0.0</kafka-clients.version>
+        <kafka-clients.version>4.1.0</kafka-clients.version>
     </properties>
 
     <modules>

--- a/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>1.15.2</version>
+            <version>1.16.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.xerial.snappy</groupId>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <protobuf.version>3.25.8</protobuf.version>
-        <wire.version>5.3.11</wire.version>
+        <wire.version>5.4.0</wire.version>
     </properties>
 
     <dependencies>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -118,13 +118,13 @@
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-jsp</artifactId>
-                <version>10.1.44</version>
+                <version>10.1.44.1</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>org.mortbay.jasper</groupId>
                 <artifactId>mortbay-apache-el</artifactId>
-                <version>10.1.44</version>
+                <version>10.1.44.1</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.788</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.33.0</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.33.1</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.10</kotlin.version>
@@ -158,7 +158,7 @@
         <junit.version>5.13.4</junit.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.5</snakeyaml.version>
-        <netty.4.version>4.2.4.Final</netty.4.version>
+        <netty.4.version>4.2.5.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.version>6.2.10</spring.version>
         <spring.security.version>6.5.3</spring.security.version>


### PR DESCRIPTION
# Summary

NIFI-14937 - Bump Netty to 4.2.5.Final, Kafka to 4.1.0, Parquet to 1.16.0, and others

- Mortbay Jasper EL/JSP from 10.1.44 to 10.1.44.1
- Kafka from 4.0.0 to 4.1.0 - https://downloads.apache.org/kafka/4.1.0/RELEASE_NOTES.html
- Apache Parquet Avro from 1.15.2 to 1.16.0 - https://github.com/apache/parquet-java/releases/tag/apache-parquet-1.16.0
- Wire from 5.3.11 to 5.4.0 - https://github.com/square/wire/blob/master/CHANGELOG.md#version-540
- AWS SDK v2 from 2.33.0 to 2.33.1 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Netty from 4.2.4.Final to 4.2.5.Final - https://netty.io/news/2025/09/03/4-2-5.html

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
