### PR TITLE
NIFI-14897 - Fix Avro FIXED serialization to use GenericFixed

### DIFF
--- a/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
+++ b/nifi-extension-bundles/nifi-extension-utils/nifi-record-utils/nifi-avro-record-utils/src/test/java/org/apache/nifi/avro/TestAvroTypeUtil.java
@@ -804,8 +804,9 @@ public class TestAvroTypeUtil {
 
         final Schema fixedSchema = Schema.createFixed("blob", "blob", NAMESPACE, bytes.length);
         final Object converted = AvroTypeUtil.convertToAvroObject(blob, fixedSchema, StandardCharsets.UTF_8);
-        assertInstanceOf(ByteBuffer.class, converted);
-        assertEquals(inputBuffer, converted);
+        assertInstanceOf(GenericFixed.class, converted);
+        final GenericFixed genericFixed = (GenericFixed) converted;
+        assertEquals(inputBuffer, ByteBuffer.wrap(genericFixed.bytes()));
     }
 
     @Test

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
@@ -190,6 +190,8 @@
                         <exclude>src/test/resources/avro/avro_schemaless_decimal.avsc</exclude>
                         <exclude>src/test/resources/avro/datatypes.avsc</exclude>
                         <exclude>src/test/resources/avro/decimals.avsc</exclude>
+                        <exclude>src/test/resources/avro/decimals-bytes-fixed.avsc</exclude>
+                        <exclude>src/test/resources/avro/fixed16.avsc</exclude>
                         <exclude>src/test/resources/avro/logical-types.avsc</exclude>
                         <exclude>src/test/resources/avro/logical-types-nullable.avsc</exclude>
                         <exclude>src/test/resources/avro/multiple-types.avsc</exclude>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestWriteAvroResult.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/java/org/apache/nifi/avro/TestWriteAvroResult.java
@@ -20,8 +20,12 @@ package org.apache.nifi.avro;
 import org.apache.avro.Conversions;
 import org.apache.avro.LogicalType;
 import org.apache.avro.Schema;
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericData.Array;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.nifi.serialization.RecordSetWriter;
 import org.apache.nifi.serialization.SimpleRecordSchema;
@@ -34,6 +38,7 @@ import org.apache.nifi.serialization.record.RecordField;
 import org.apache.nifi.serialization.record.RecordFieldType;
 import org.apache.nifi.serialization.record.RecordSchema;
 import org.apache.nifi.serialization.record.RecordSet;
+import org.apache.nifi.serialization.record.util.IllegalTypeConversionException;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -52,16 +57,19 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class TestWriteAvroResult {
 
@@ -320,6 +328,114 @@ public abstract class TestWriteAvroResult {
         try (final InputStream in = new ByteArrayInputStream(data)) {
             final GenericRecord avroRecord = readRecord(in, schema);
             assertMatch(record, avroRecord);
+        }
+    }
+
+    @Test
+    public void testFixedFieldWritesAsGenericFixed() throws IOException {
+        // Avro schema with a single fixed(16) field
+        final Schema schema = new Schema.Parser().parse(new File("src/test/resources/avro/fixed16.avsc"));
+
+        // NiFi record schema: represent FIXED as an array of BYTEs
+        final List<RecordField> fields = Collections.singletonList(
+                new RecordField("fixed", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType())));
+
+        final RecordSchema recordSchema = new SimpleRecordSchema(fields);
+
+        // 16-byte value (e.g., UUID bytes). Use NiFi's typical byte[] -> Object[]
+        // conversion path
+        final byte[] bytes = new byte[16];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) i;
+        }
+        final Map<String, Object> values = new HashMap<>();
+        values.put("fixed", AvroTypeUtil.convertByteArray(bytes));
+        final Record record = new MapRecord(recordSchema, values);
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (final RecordSetWriter writer = new WriteAvroResultWithSchema(schema, out, CodecFactory.nullCodec())) {
+            writer.write(RecordSet.of(record.getSchema(), record));
+        }
+
+        // Read back and verify Fixed value is written as GenericFixed with matching
+        // bytes
+        final byte[] written = out.toByteArray();
+        try (final DataFileStream<GenericRecord> dfs = new DataFileStream<>(new ByteArrayInputStream(written), new GenericDatumReader<>())) {
+            final GenericRecord rec = dfs.next();
+            assertNotNull(rec);
+            final Object fixedObj = rec.get("fixed");
+            assertInstanceOf(GenericFixed.class, fixedObj);
+            final byte[] actual = ((GenericFixed) fixedObj).bytes();
+            assertArrayEquals(bytes, actual);
+        }
+    }
+
+    @Test
+    public void testFixedFieldWrongLength() throws IOException {
+        final Schema schema = new Schema.Parser().parse(new File("src/test/resources/avro/fixed16.avsc"));
+
+        final List<RecordField> fields = Collections.singletonList(
+                new RecordField("fixed", RecordFieldType.ARRAY.getArrayDataType(RecordFieldType.BYTE.getDataType())));
+        final RecordSchema recordSchema = new SimpleRecordSchema(fields);
+
+        // Wrong length: 15 bytes instead of required 16
+        final byte[] bytes = new byte[15];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) i;
+        }
+        final Map<String, Object> values = new HashMap<>();
+        values.put("fixed", AvroTypeUtil.convertByteArray(bytes));
+        final Record record = new MapRecord(recordSchema, values);
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (final RecordSetWriter writer = new WriteAvroResultWithSchema(schema, out, CodecFactory.nullCodec())) {
+            assertThrows(IllegalTypeConversionException.class, () -> writer.write(RecordSet.of(record.getSchema(), record)));
+        }
+    }
+
+    @Test
+    public void testDecimalBytesAndFixedRoundTrip() throws IOException {
+        final Schema schema = new Schema.Parser().parse(new File("src/test/resources/avro/decimals-bytes-fixed.avsc"));
+
+        // Both fields are DECIMAL(9,2) in NiFi's record schema
+        final List<RecordField> fields = Arrays.asList(
+                new RecordField("dec_bytes", RecordFieldType.DECIMAL.getDecimalDataType(9, 2)),
+                new RecordField("dec_fixed", RecordFieldType.DECIMAL.getDecimalDataType(9, 2)));
+        final RecordSchema recordSchema = new SimpleRecordSchema(fields);
+
+        final BigDecimal expected = new BigDecimal("12345.67");
+        final Map<String, Object> values = new HashMap<>();
+        values.put("dec_bytes", expected);
+        values.put("dec_fixed", expected);
+        final Record record = new MapRecord(recordSchema, values);
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (final RecordSetWriter writer = new WriteAvroResultWithSchema(schema, out, CodecFactory.nullCodec())) {
+            writer.write(RecordSet.of(record.getSchema(), record));
+        }
+
+        // Read back the values and convert from logical decimal representations
+        final byte[] written = out.toByteArray();
+        try (final DataFileStream<GenericRecord> dfs = new DataFileStream<>(new ByteArrayInputStream(written), new GenericDatumReader<>())) {
+            final GenericRecord rec = dfs.next();
+            assertNotNull(rec);
+
+            // BYTES logical decimal → ByteBuffer
+            final Schema bytesFieldSchema = schema.getField("dec_bytes").schema();
+            final LogicalType bytesLogicalType = bytesFieldSchema.getLogicalType();
+            final Object bytesObj = rec.get("dec_bytes");
+            assertInstanceOf(ByteBuffer.class, bytesObj);
+            final BigDecimal fromBytes = new Conversions.DecimalConversion().fromBytes((ByteBuffer) bytesObj, bytesFieldSchema, bytesLogicalType);
+
+            // FIXED logical decimal → GenericFixed
+            final Schema fixedFieldSchema = schema.getField("dec_fixed").schema();
+            final LogicalType fixedLogicalType = fixedFieldSchema.getLogicalType();
+            final Object fixedObj = rec.get("dec_fixed");
+            assertInstanceOf(GenericFixed.class, fixedObj);
+            final BigDecimal fromFixed = new Conversions.DecimalConversion().fromFixed((GenericFixed) fixedObj, fixedFieldSchema, fixedLogicalType);
+
+            assertEquals(expected, fromBytes);
+            assertEquals(expected, fromFixed);
         }
     }
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/avro/decimals-bytes-fixed.avsc
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/avro/decimals-bytes-fixed.avsc
@@ -1,0 +1,28 @@
+{
+  "namespace": "nifi",
+  "name": "decimal_types",
+  "type": "record",
+  "fields": [
+    {
+      "name": "dec_bytes",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 9,
+        "scale": 2
+      }
+    },
+    {
+      "name": "dec_fixed",
+      "type": {
+        "type": "fixed",
+        "name": "decfixed",
+        "size": 4,
+        "logicalType": "decimal",
+        "precision": 9,
+        "scale": 2
+      }
+    }
+  ]
+}
+

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/avro/fixed16.avsc
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/test/resources/avro/fixed16.avsc
@@ -1,0 +1,16 @@
+{
+  "namespace": "nifi",
+  "name": "data_types",
+  "type": "record",
+  "fields": [
+    {
+      "name": "fixed",
+      "type": {
+        "type": "fixed",
+        "name": "fixed16",
+        "size": 16
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
# Summary

NIFI-14897 - Fix Avro FIXED serialization to use GenericFixed

- Fixes ClassCastException when writing Avro FIXED: use GenericData.Fixed instead of ByteBuffer
- Preserves logical decimal behavior (BYTES to ByteBuffer; FIXED to GenericFixed)
- Adds unit tests to validate FIXED handling

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
