### PR TITLE
NIFI-14788 - Fix attribute prefix handling in XML Reader

### DIFF
--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/XMLReader.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/XMLReader.java
@@ -160,7 +160,8 @@ public class XMLReader extends SchemaRegistryService implements RecordReaderFact
         final RecordSourceFactory<XmlNode> sourceFactory = (variables, contentStream) -> {
             String contentFieldName = trim(context.getProperty(CONTENT_FIELD_NAME).evaluateAttributeExpressions(variables).getValue());
             contentFieldName = (contentFieldName == null) ? "value" : contentFieldName;
-            return new XmlRecordSource(contentStream, contentFieldName, isMultipleRecords(context, variables), parseXmlAttributes);
+            final String attributePrefix = trim(context.getProperty(ATTRIBUTE_PREFIX).evaluateAttributeExpressions(variables).getValue());
+            return new XmlRecordSource(contentStream, contentFieldName, isMultipleRecords(context, variables), parseXmlAttributes, attributePrefix);
         };
         final Supplier<SchemaInferenceEngine<XmlNode>> schemaInference = () -> new XmlSchemaInference(new TimeValueInference(dateFormat, timeFormat, timestampFormat));
 

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/inference/XmlRecordSource.java
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/src/main/java/org/apache/nifi/xml/inference/XmlRecordSource.java
@@ -40,10 +40,16 @@ public class XmlRecordSource implements RecordSource<XmlNode> {
     private final XMLEventReader xmlEventReader;
     private final String contentFieldName;
     private final boolean parseXmlAttributes;
+    private final String attributePrefix;
 
     public XmlRecordSource(final InputStream in, final String contentFieldName, final boolean ignoreWrapper, final boolean parseXmlAttributes) throws IOException {
+        this(in, contentFieldName, ignoreWrapper, parseXmlAttributes, null);
+    }
+
+    public XmlRecordSource(final InputStream in, final String contentFieldName, final boolean ignoreWrapper, final boolean parseXmlAttributes, final String attributePrefix) throws IOException {
         this.contentFieldName = contentFieldName;
         this.parseXmlAttributes = parseXmlAttributes;
+        this.attributePrefix = attributePrefix;
         try {
             final XMLEventReaderProvider provider = new StandardXMLEventReaderProvider();
             xmlEventReader = provider.getEventReader(new StreamSource(in));
@@ -148,8 +154,9 @@ public class XmlRecordSource implements RecordSource<XmlNode> {
         final Iterator<?> attributeIterator = startElement.getAttributes();
         while (attributeIterator.hasNext()) {
             final Attribute attribute = (Attribute) attributeIterator.next();
-            final String attributeName = attribute.getName().getLocalPart();
-            childNodes.put(attributeName, new XmlTextNode(attributeName, attribute.getValue()));
+            final String rawName = attribute.getName().getLocalPart();
+            final String fieldName = attributePrefix == null ? rawName : attributePrefix + rawName;
+            childNodes.put(fieldName, new XmlTextNode(fieldName, attribute.getValue()));
         }
     }
 }


### PR DESCRIPTION
# Summary

NIFI-14788 - Fix attribute prefix handling in XML Reader

**Problem**: When using `XMLReader` with Parse XML Attributes set to `true`, Attribute Prefix set, and Schema Access Strategy set to `Infer Schema`, attribute fields were emitted without the prefix or as `null`

**Root Cause**: Schema inference created fields for attributes using raw names, while read-time attribute handling also validated against raw names only. With a configured prefix, the reader wrote prefixed fields but the schema did not match, leading to dropped/null values.

**Changes**

- `XMLReader:` Passes configured `attribute_prefix` into schema inference
    - Constructs `XmlRecordSource(contentStream, contentFieldName, ignoreWrapper, parseXmlAttributes, attributePrefix)`
- `XmlRecordSource`: Supports attribute prefix during schema inference
    - New constructor with `attributePrefix`; attributes are added to child nodes using the prefixed name when configured
- `XMLRecordReader`: Align attribute handling with schema and prefix
    - When Drop Unknown Fields is set to true, schema lookup now accepts either prefixed or raw attribute field names
    - Type coercion uses the data type from the matching schema field (prefixed if present, else raw)
    - Output field name always uses the configured prefix (when set), ensuring consistent record output

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
