### PR TITLE
NIFI-14639: Explicitly popping off the top back navigation when the u…

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/app.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/app.component.ts
@@ -30,7 +30,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { NiFiState } from './state';
 import { Store } from '@ngrx/store';
 import { BackNavigation } from './state/navigation';
-import { popBackNavigation, pushBackNavigation } from './state/navigation/navigation.actions';
+import { popBackNavigationByRouteBoundary, pushBackNavigation } from './state/navigation/navigation.actions';
 import { filter, map, tap } from 'rxjs';
 import { concatLatestFrom } from '@ngrx/operators';
 import { selectBackNavigation } from './state/navigation/navigation.selectors';
@@ -95,7 +95,7 @@ export class AppComponent implements OnDestroy {
                     );
                 } else if (previousBackNavigation) {
                     this.store.dispatch(
-                        popBackNavigation({
+                        popBackNavigationByRouteBoundary({
                             url: event.url
                         })
                     );

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/navigation/navigation.actions.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/navigation/navigation.actions.ts
@@ -23,4 +23,9 @@ export const pushBackNavigation = createAction(
     props<{ backNavigation: BackNavigation }>()
 );
 
-export const popBackNavigation = createAction('[Navigation] Pop Back Navigation', props<{ url: string }>());
+export const popBackNavigationByRouteBoundary = createAction(
+    '[Navigation] Pop Back Navigation By Route Boundary',
+    props<{ url: string }>()
+);
+
+export const popBackNavigation = createAction('[Navigation] Pop Back Navigation');

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/navigation/navigation.reducer.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/state/navigation/navigation.reducer.ts
@@ -17,7 +17,7 @@
 
 import { createReducer, on } from '@ngrx/store';
 import { NavigationState } from './index';
-import { popBackNavigation, pushBackNavigation } from './navigation.actions';
+import { popBackNavigation, popBackNavigationByRouteBoundary, pushBackNavigation } from './navigation.actions';
 import { produce } from 'immer';
 
 export const initialState: NavigationState = {
@@ -40,7 +40,7 @@ export const navigationReducer = createReducer(
             }
         });
     }),
-    on(popBackNavigation, (state, { url }) => {
+    on(popBackNavigationByRouteBoundary, (state, { url }) => {
         return produce(state, (draftState) => {
             // pop any back navigation that is outside the bounds of the current url
             while (draftState.backNavigations.length > 0) {
@@ -50,6 +50,13 @@ export const navigationReducer = createReducer(
                 } else {
                     break;
                 }
+            }
+        });
+    }),
+    on(popBackNavigation, (state) => {
+        return produce(state, (draftState) => {
+            if (draftState.backNavigations.length > 0) {
+                draftState.backNavigations.pop();
             }
         });
     })

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/navigation/navigation.component.html
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/navigation/navigation.component.html
@@ -223,7 +223,7 @@
     </nav>
     @if (backNavigation(); as navigation) {
         <div class="pl-2 py-2">
-            <a [routerLink]="navigation.route">
+            <a (click)="popBackNavigation()" [routerLink]="navigation.route">
                 <i class="fa fa-arrow-left primary-color mr-2"></i>
                 Back to {{ navigation.context }}
             </a>

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/navigation/navigation.component.spec.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/navigation/navigation.component.spec.ts
@@ -18,7 +18,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { Navigation } from './navigation.component';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { selectCurrentUser } from '../../../state/current-user/current-user.selectors';
@@ -32,10 +32,12 @@ import { selectLoginConfiguration } from '../../../state/login-configuration/log
 import * as fromLoginConfiguration from '../../../state/login-configuration/login-configuration.reducer';
 import { currentUserFeatureKey } from '../../../state/current-user';
 import { navigationFeatureKey } from '../../../state/navigation';
+import { popBackNavigation } from '../../../state/navigation/navigation.actions';
 
 describe('Navigation', () => {
     let component: Navigation;
     let fixture: ComponentFixture<Navigation>;
+    let store: MockStore;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -67,6 +69,8 @@ describe('Navigation', () => {
                 })
             ]
         });
+
+        store = TestBed.inject(MockStore);
         fixture = TestBed.createComponent(Navigation);
         component = fixture.componentInstance;
         fixture.detectChanges();
@@ -74,5 +78,13 @@ describe('Navigation', () => {
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    it('should pop back navigation', () => {
+        const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+        component.popBackNavigation();
+
+        expect(dispatchSpy).toHaveBeenCalledWith(popBackNavigation());
     });
 });

--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/navigation/navigation.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/navigation/navigation.component.ts
@@ -46,6 +46,7 @@ import {
 import { selectClusterSummary } from '../../../state/cluster-summary/cluster-summary.selectors';
 import { selectLoginConfiguration } from '../../../state/login-configuration/login-configuration.selectors';
 import { selectBackNavigation } from '../../../state/navigation/navigation.selectors';
+import { popBackNavigation } from '../../../state/navigation/navigation.actions';
 
 @Component({
     selector: 'navigation',
@@ -157,5 +158,9 @@ export class Navigation implements OnInit, OnDestroy {
         this.disableAnimations = disableAnimations;
         this.storage.setItem('disable-animations', this.disableAnimations.toString());
         window.location.reload();
+    }
+
+    popBackNavigation(): void {
+        this.store.dispatch(popBackNavigation());
     }
 }


### PR DESCRIPTION
…ser clicks the back link.

The underlying issue can be reproduced by following the Go To Service option from a Processor to a Service. Then in the Service following the Go To Service option on another Service reference. So the flow would have a Processor dependent on a Service which is dependent on another Service. Once the user has followed this navigation, current `main` branch wouldn't allow the user to navigate all the way back to the Processor. This PR changes how we previously visited routes are popped off the stack to ensure that they user can break free from a given route boundary.
