### PR TITLE
NIFI-14938 Reduce logging to DEBUG for Certificate Authentication

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/NiFiAuthenticationFilter.java
@@ -69,7 +69,7 @@ public abstract class NiFiAuthenticationFilter extends GenericFilterBean {
         try {
             final Authentication authenticationRequest = attemptAuthentication(request);
             if (authenticationRequest != null) {
-                log.info("Authentication Started {} [{}] {} {}", request.getRemoteAddr(), authenticationRequest, request.getMethod(), request.getRequestURL());
+                log.debug("Authentication Started {} [{}] {} {}", request.getRemoteAddr(), authenticationRequest, request.getMethod(), request.getRequestURL());
 
                 // attempt to authenticate the user
                 final Authentication authenticated = authenticationManager.authenticate(authenticationRequest);
@@ -113,7 +113,7 @@ public abstract class NiFiAuthenticationFilter extends GenericFilterBean {
      * @param authResult The Authentication 'token'/object created by one of the various NiFiAuthenticationFilter subclasses.
      */
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, Authentication authResult) {
-        log.info("Authentication Success [{}] {} {} {}", authResult, request.getRemoteAddr(), request.getMethod(), request.getRequestURL());
+        log.debug("Authentication Success [{}] {} {} {}", authResult, request.getRemoteAddr(), request.getMethod(), request.getRequestURL());
 
         SecurityContextHolder.getContext().setAuthentication(authResult);
         ProxiedEntitiesUtils.successfulAuthentication(request, response);


### PR DESCRIPTION
# Summary

[NIFI-14938](https://issues.apache.org/jira/browse/NIFI-14938) Reduces the logging level from `INFO` to `DEBUG` for `Authentication Started` and `Authentication Success` messages with X.509 Client Certificate authentication.

The abstract `NiFiAuthenticationFilter` is limited to X.509 Client Certificates, and the logged information is duplicative of HTTP request details written to the HTTP access log.

Other authentication strategies do not use the `NiFiAuthenticationFilter`.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
