### PR TITLE
NIFI-14940 - Bump Azure SDK to 1.2.38, AWS SDK v2 to 2.33.3, and others

### DIFF
--- a/nifi-commons/nifi-xml-processing/pom.xml
+++ b/nifi-commons/nifi-xml-processing/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.9.4.0</version>
+                <version>4.9.4.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -28,8 +28,8 @@
 
     <properties>
         <!-- when changing the Azure SDK version, also update msal4j to the version that is required by azure-identity -->
-        <azure.sdk.bom.version>1.2.37</azure.sdk.bom.version>
-        <msal4j.version>1.21.0</msal4j.version>
+        <azure.sdk.bom.version>1.2.38</azure.sdk.bom.version>
+        <msal4j.version>1.22.0</msal4j.version>
         <qpid.proton.version>0.34.1</qpid.proton.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/nifi-gcp-processors/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20250819-2.0.0</version>
+            <version>v3-rev20250829-2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.tdunning</groupId>

--- a/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-mqtt-bundle/nifi-mqtt-processors/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.hivemq</groupId>
             <artifactId>hivemq-mqtt-client</artifactId>
-            <version>1.3.8</version>
+            <version>1.3.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -36,7 +36,7 @@
     </modules>
     <properties>
         <spring.boot.version>3.5.5</spring.boot.version>
-        <flyway.version>11.11.2</flyway.version>
+        <flyway.version>11.12.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.3.0.202506031305-r</jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
-        <com.amazonaws.version>1.12.788</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.33.1</software.amazon.awssdk.version>
+        <com.amazonaws.version>1.12.790</com.amazonaws.version>
+        <software.amazon.awssdk.version>2.33.3</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.10</kotlin.version>
@@ -758,7 +758,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>11.0.0</version>
+                            <version>11.0.1</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -803,7 +803,7 @@
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>3.0.71</version>
+                    <version>3.0.72</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
# Summary

NIFI-14940 - Bump Azure SDK to 1.2.38, AWS SDK v2 to 2.33.3, and others

- Spotbugs Maven Plugin from 4.9.4.0 to 4.9.4.1 - https://github.com/spotbugs/spotbugs-maven-plugin/releases/tag/spotbugs-maven-plugin-4.9.4.1
- Azure SDK BOM from 1.2.37 to 1.2.38 - https://github.com/Azure/azure-sdk-for-java/releases/tag/azure-sdk-bom_1.2.38
- MSAL4J from 1.21.0 to 1.22.0 - https://github.com/AzureAD/microsoft-authentication-library-for-java/releases/tag/v1.22.0
- Google Drive from v3-rev20250819-2.0.0 to v3-rev20250829-2.0.0 - https://github.com/googleapis/google-api-java-client-services/blob/main/clients/google-api-services-drive/v3/2.0.0/README.md
- HiveMQ MQTT client from 1.3.8 to 1.3.9 - https://github.com/hivemq/hivemq-mqtt-client/releases/tag/v1.3.9
- FlywayDB from 11.11.2 to 11.12.0 - https://github.com/flyway/flyway/releases/tag/flyway-11.12.0
- AWS SDK v1 from 1.12.788 to 1.12.790 - https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md
- AWS SDK v2 from 2.33.1 to 2.33.3 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Checkstyle from 11.0.0 to 11.0.1 - https://github.com/checkstyle/checkstyle/releases/tag/checkstyle-11.0.1
- Swagger Codegen Maven Plugin from 3.0.71 to 3.0.72 - https://github.com/swagger-api/swagger-codegen/releases/tag/v3.0.72

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
