### PR TITLE
NIFI-14927 - Expose Assume Role (ARN/Session Name) for AWS_MSK_IAM in AmazonMSKConnectionService

### DIFF
--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionService.java
@@ -53,6 +53,8 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
                 // Add AWS MSK properties
                 descriptors.add(AWS_SASL_MECHANISM);
                 descriptors.add(KafkaClientComponent.AWS_PROFILE_NAME);
+                descriptors.add(KafkaClientComponent.AWS_ASSUME_ROLE_ARN);
+                descriptors.add(KafkaClientComponent.AWS_ASSUME_ROLE_SESSION_NAME);
             }
         }
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionService.java
@@ -19,8 +19,10 @@ package org.apache.nifi.kafka.service.aws;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.migration.PropertyConfiguration;
 import org.apache.nifi.kafka.service.Kafka3ConnectionService;
 import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
+import org.apache.nifi.kafka.shared.property.AwsRoleSource;
 import org.apache.nifi.kafka.shared.property.SaslMechanism;
 
 import java.util.ArrayList;
@@ -65,5 +67,14 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return supportedPropertyDescriptors;
+    }
+
+    @Override
+    public void migrateProperties(final PropertyConfiguration config) {
+        // For backward compatibility: if an AWS Profile Name was configured previously,
+        // set AWS Role Source to SPECIFIED_PROFILE
+        if (config.isPropertySet(KafkaClientComponent.AWS_PROFILE_NAME)) {
+            config.setProperty(KafkaClientComponent.AWS_ROLE_SOURCE, AwsRoleSource.SPECIFIED_PROFILE.name());
+        }
     }
 }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionService.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-service-aws/src/main/java/org/apache/nifi/kafka/service/aws/AmazonMSKConnectionService.java
@@ -52,6 +52,7 @@ public class AmazonMSKConnectionService extends Kafka3ConnectionService {
                 descriptors.remove();
                 // Add AWS MSK properties
                 descriptors.add(AWS_SASL_MECHANISM);
+                descriptors.add(KafkaClientComponent.AWS_ROLE_SOURCE);
                 descriptors.add(KafkaClientComponent.AWS_PROFILE_NAME);
                 descriptors.add(KafkaClientComponent.AWS_ASSUME_ROLE_ARN);
                 descriptors.add(KafkaClientComponent.AWS_ASSUME_ROLE_SESSION_NAME);

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
@@ -114,7 +114,7 @@ public interface KafkaClientComponent {
                     " Specified Profile selects a named profile, or Specified Role configures a Role ARN and Session Name.")
             .required(true)
             .allowableValues(AwsRoleSource.class)
-            .defaultValue(AwsRoleSource.DEFAULT_PROFILE.getValue())
+            .defaultValue(AwsRoleSource.DEFAULT_PROFILE)
             .dependsOn(
                     SASL_MECHANISM,
                     SaslMechanism.AWS_MSK_IAM
@@ -129,15 +129,15 @@ public interface KafkaClientComponent {
                     KafkaClientComponent.AWS_ROLE_SOURCE,
                     AwsRoleSource.SPECIFIED_PROFILE
             )
-            .required(false)
+            .required(true)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
     PropertyDescriptor AWS_ASSUME_ROLE_ARN = new PropertyDescriptor.Builder()
-            .name("Assume Role ARN")
+            .name("AWS Assume Role ARN")
             .description("The AWS Role ARN for cross-account access when using AWS MSK IAM. Used with Assume Role Session Name.")
-            .required(false)
+            .required(true)
             .dependsOn(
                     KafkaClientComponent.AWS_ROLE_SOURCE,
                     AwsRoleSource.SPECIFIED_ROLE
@@ -147,7 +147,7 @@ public interface KafkaClientComponent {
             .build();
 
     PropertyDescriptor AWS_ASSUME_ROLE_SESSION_NAME = new PropertyDescriptor.Builder()
-            .name("Assume Role Session Name")
+            .name("AWS Assume Role Session Name")
             .description("The AWS Role Session Name for cross-account access. Used in conjunction with Assume Role ARN.")
             .required(true)
             .dependsOn(

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
@@ -131,7 +131,7 @@ public interface KafkaClientComponent {
             )
             .required(true)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
             .build();
 
     PropertyDescriptor AWS_ASSUME_ROLE_ARN = new PropertyDescriptor.Builder()

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
@@ -120,6 +120,27 @@ public interface KafkaClientComponent {
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .build();
 
+    PropertyDescriptor AWS_ASSUME_ROLE_ARN = new PropertyDescriptor.Builder()
+            .name("Assume Role ARN")
+            .description("The AWS Role ARN for cross-account access when using AWS MSK IAM. Used with Assume Role Session Name.")
+            .required(false)
+            .dependsOn(
+                    SASL_MECHANISM,
+                    SaslMechanism.AWS_MSK_IAM
+            )
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .build();
+
+    PropertyDescriptor AWS_ASSUME_ROLE_SESSION_NAME = new PropertyDescriptor.Builder()
+            .name("Assume Role Session Name")
+            .description("The AWS Role Session Name for cross-account access. Used in conjunction with Assume Role ARN.")
+            .required(true)
+            .dependsOn(AWS_ASSUME_ROLE_ARN)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .build();
+
     PropertyDescriptor SSL_CONTEXT_SERVICE = new PropertyDescriptor.Builder()
             .name("SSL Context Service")
             .description("Service supporting SSL communication with Kafka brokers")

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProvider.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProvider.java
@@ -37,23 +37,21 @@ public class AwsMskIamLoginConfigProvider implements LoginConfigProvider {
     @Override
     public String getConfiguration(PropertyContext context) {
         final AwsRoleSource roleSource = context.getProperty(KafkaClientComponent.AWS_ROLE_SOURCE).asAllowableValue(AwsRoleSource.class);
-        final String awsProfileName = context.getProperty(KafkaClientComponent.AWS_PROFILE_NAME).evaluateAttributeExpressions().getValue();
-        final String assumeRoleArn = context.getProperty(KafkaClientComponent.AWS_ASSUME_ROLE_ARN).getValue();
-        final String assumeRoleSessionName = context.getProperty(KafkaClientComponent.AWS_ASSUME_ROLE_SESSION_NAME).getValue();
-
         final LoginConfigBuilder builder = new LoginConfigBuilder(MODULE_CLASS, REQUIRED);
 
-        if (roleSource == AwsRoleSource.SPECIFIED_PROFILE && StringUtils.isNotBlank(awsProfileName)) {
-            builder.append(AWS_PROFILE_NAME_KEY, awsProfileName);
+        if (roleSource == AwsRoleSource.SPECIFIED_PROFILE) {
+            final String awsProfileName = context.getProperty(KafkaClientComponent.AWS_PROFILE_NAME).evaluateAttributeExpressions().getValue();
+            if (!StringUtils.isBlank(awsProfileName)) {
+                builder.append(AWS_PROFILE_NAME_KEY, awsProfileName);
+            }
         }
 
         if (roleSource == AwsRoleSource.SPECIFIED_ROLE) {
-            if (StringUtils.isNotBlank(assumeRoleArn)) {
-                builder.append(ROLE_ARN_KEY, assumeRoleArn);
-            }
-            if (StringUtils.isNotBlank(assumeRoleSessionName)) {
-                builder.append(ROLE_SESSION_NAME_KEY, assumeRoleSessionName);
-            }
+            final String assumeRoleArn = context.getProperty(KafkaClientComponent.AWS_ASSUME_ROLE_ARN).getValue();
+            final String assumeRoleSessionName = context.getProperty(KafkaClientComponent.AWS_ASSUME_ROLE_SESSION_NAME).getValue();
+
+            builder.append(ROLE_ARN_KEY, assumeRoleArn);
+            builder.append(ROLE_SESSION_NAME_KEY, assumeRoleSessionName);
         }
 
         return builder.build();

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProvider.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProvider.java
@@ -30,15 +30,27 @@ public class AwsMskIamLoginConfigProvider implements LoginConfigProvider {
     private static final String MODULE_CLASS = "software.amazon.msk.auth.iam.IAMLoginModule";
 
     private static final String AWS_PROFILE_NAME_KEY = "awsProfileName";
+    private static final String ROLE_ARN_KEY = "awsRoleArn";
+    private static final String ROLE_SESSION_NAME_KEY = "awsRoleSessionName";
 
     @Override
     public String getConfiguration(PropertyContext context) {
         final String awsProfileName = context.getProperty(KafkaClientComponent.AWS_PROFILE_NAME).evaluateAttributeExpressions().getValue();
+        final String assumeRoleArn = context.getProperty(KafkaClientComponent.AWS_ASSUME_ROLE_ARN).getValue();
+        final String assumeRoleSessionName = context.getProperty(KafkaClientComponent.AWS_ASSUME_ROLE_SESSION_NAME).getValue();
 
         final LoginConfigBuilder builder = new LoginConfigBuilder(MODULE_CLASS, REQUIRED);
 
         if (StringUtils.isNotBlank(awsProfileName)) {
             builder.append(AWS_PROFILE_NAME_KEY, awsProfileName);
+        }
+
+        if (StringUtils.isNotBlank(assumeRoleArn)) {
+            builder.append(ROLE_ARN_KEY, assumeRoleArn);
+        }
+
+        if (StringUtils.isNotBlank(assumeRoleSessionName)) {
+            builder.append(ROLE_SESSION_NAME_KEY, assumeRoleSessionName);
         }
 
         return builder.build();

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProvider.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProvider.java
@@ -40,7 +40,7 @@ public class AwsMskIamLoginConfigProvider implements LoginConfigProvider {
         final LoginConfigBuilder builder = new LoginConfigBuilder(MODULE_CLASS, REQUIRED);
 
         if (roleSource == AwsRoleSource.SPECIFIED_PROFILE) {
-            final String awsProfileName = context.getProperty(KafkaClientComponent.AWS_PROFILE_NAME).evaluateAttributeExpressions().getValue();
+            final String awsProfileName = context.getProperty(KafkaClientComponent.AWS_PROFILE_NAME).getValue();
             if (!StringUtils.isBlank(awsProfileName)) {
                 builder.append(AWS_PROFILE_NAME_KEY, awsProfileName);
             }

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/AwsRoleSource.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/AwsRoleSource.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kafka.shared.property;
+
+import org.apache.nifi.components.DescribedValue;
+
+/**
+ * AWS Role Source strategy for AWS MSK IAM credentials selection
+ */
+public enum AwsRoleSource implements DescribedValue {
+    DEFAULT_PROFILE("DEFAULT_PROFILE", "Default Profile", "Use the default AWS credentials provider chain to locate credentials."),
+    SPECIFIED_PROFILE("SPECIFIED_PROFILE", "Specified Profile", "Use the configured AWS Profile Name from the default credentials file."),
+    SPECIFIED_ROLE("SPECIFIED_ROLE", "Specified Role", "Assume a specific AWS Role using the configured Role ARN and Session Name.");
+
+    private final String value;
+    private final String displayName;
+    private final String description;
+
+    AwsRoleSource(final String value, final String displayName, final String description) {
+        this.value = value;
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/AwsRoleSource.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/AwsRoleSource.java
@@ -22,23 +22,21 @@ import org.apache.nifi.components.DescribedValue;
  * AWS Role Source strategy for AWS MSK IAM credentials selection
  */
 public enum AwsRoleSource implements DescribedValue {
-    DEFAULT_PROFILE("DEFAULT_PROFILE", "Default Profile", "Use the default AWS credentials provider chain to locate credentials."),
-    SPECIFIED_PROFILE("SPECIFIED_PROFILE", "Specified Profile", "Use the configured AWS Profile Name from the default credentials file."),
-    SPECIFIED_ROLE("SPECIFIED_ROLE", "Specified Role", "Assume a specific AWS Role using the configured Role ARN and Session Name.");
+    DEFAULT_PROFILE("Default Profile", "Use the default AWS credentials provider chain to locate credentials."),
+    SPECIFIED_PROFILE("Specified Profile", "Use the configured AWS Profile Name from the default credentials file."),
+    SPECIFIED_ROLE("Specified Role", "Assume a specific AWS Role using the configured Role ARN and Session Name.");
 
-    private final String value;
     private final String displayName;
     private final String description;
 
-    AwsRoleSource(final String value, final String displayName, final String description) {
-        this.value = value;
+    AwsRoleSource(final String displayName, final String description) {
         this.displayName = displayName;
         this.description = description;
     }
 
     @Override
     public String getValue() {
-        return value;
+        return name();
     }
 
     @Override

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProviderTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProviderTest.java
@@ -38,7 +38,6 @@ class AwsMskIamLoginConfigProviderTest {
     @BeforeEach
     void setUp() {
         runner = TestRunners.newTestRunner(NoOpProcessor.class);
-        runner.setValidateExpressionUsage(false);
         provider = new AwsMskIamLoginConfigProvider();
     }
 

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProviderTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProviderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.kafka.shared.login;
+
+import org.apache.nifi.context.PropertyContext;
+import org.apache.nifi.kafka.shared.component.KafkaClientComponent;
+import org.apache.nifi.kafka.shared.property.SaslMechanism;
+import org.apache.nifi.util.NoOpProcessor;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AwsMskIamLoginConfigProviderTest {
+
+    private static final String IAM_LOGIN_MODULE = "software.amazon.msk.auth.iam.IAMLoginModule";
+
+    private TestRunner runner;
+    private AwsMskIamLoginConfigProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        runner = TestRunners.newTestRunner(NoOpProcessor.class);
+        runner.setValidateExpressionUsage(false);
+        provider = new AwsMskIamLoginConfigProvider();
+    }
+
+    @Test
+    void testConfigurationIncludesAssumeRoleProperties() {
+        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.AWS_MSK_IAM);
+        runner.setProperty(KafkaClientComponent.AWS_PROFILE_NAME, "myProfile");
+        runner.setProperty(KafkaClientComponent.AWS_ASSUME_ROLE_ARN, "arn:aws:iam::123456789012:role/MyRole");
+        runner.setProperty(KafkaClientComponent.AWS_ASSUME_ROLE_SESSION_NAME, "MySession");
+
+        final PropertyContext context = runner.getProcessContext();
+        final String configuration = provider.getConfiguration(context);
+
+        assertNotNull(configuration);
+        assertTrue(configuration.contains(IAM_LOGIN_MODULE), "IAM Login Module not present");
+        assertTrue(configuration.contains("awsProfileName=\"myProfile\""), "awsProfileName JAAS option not present");
+        assertTrue(configuration.contains("awsRoleArn=\"arn:aws:iam::123456789012:role/MyRole\""), "awsRoleArn JAAS option not present");
+        assertTrue(configuration.contains("awsRoleSessionName=\"MySession\""), "awsRoleSessionName JAAS option not present");
+    }
+}
+

--- a/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProviderTest.java
+++ b/nifi-extension-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/test/java/org/apache/nifi/kafka/shared/login/AwsMskIamLoginConfigProviderTest.java
@@ -43,9 +43,23 @@ class AwsMskIamLoginConfigProviderTest {
     }
 
     @Test
-    void testConfigurationIncludesAssumeRoleProperties() {
+    void testConfigurationWithSpecifiedProfile() {
         runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.AWS_MSK_IAM);
+        runner.setProperty(KafkaClientComponent.AWS_ROLE_SOURCE, "SPECIFIED_PROFILE");
         runner.setProperty(KafkaClientComponent.AWS_PROFILE_NAME, "myProfile");
+
+        final PropertyContext context = runner.getProcessContext();
+        final String configuration = provider.getConfiguration(context);
+
+        assertNotNull(configuration);
+        assertTrue(configuration.contains(IAM_LOGIN_MODULE), "IAM Login Module not present");
+        assertTrue(configuration.contains("awsProfileName=\"myProfile\""), "awsProfileName JAAS option not present");
+    }
+
+    @Test
+    void testConfigurationWithSpecifiedRole() {
+        runner.setProperty(KafkaClientComponent.SASL_MECHANISM, SaslMechanism.AWS_MSK_IAM);
+        runner.setProperty(KafkaClientComponent.AWS_ROLE_SOURCE, "SPECIFIED_ROLE");
         runner.setProperty(KafkaClientComponent.AWS_ASSUME_ROLE_ARN, "arn:aws:iam::123456789012:role/MyRole");
         runner.setProperty(KafkaClientComponent.AWS_ASSUME_ROLE_SESSION_NAME, "MySession");
 
@@ -54,9 +68,7 @@ class AwsMskIamLoginConfigProviderTest {
 
         assertNotNull(configuration);
         assertTrue(configuration.contains(IAM_LOGIN_MODULE), "IAM Login Module not present");
-        assertTrue(configuration.contains("awsProfileName=\"myProfile\""), "awsProfileName JAAS option not present");
         assertTrue(configuration.contains("awsRoleArn=\"arn:aws:iam::123456789012:role/MyRole\""), "awsRoleArn JAAS option not present");
         assertTrue(configuration.contains("awsRoleSessionName=\"MySession\""), "awsRoleSessionName JAAS option not present");
     }
 }
-


### PR DESCRIPTION
# Summary

NIFI-14927 - Expose Assume Role (ARN/Session Name) for AWS_MSK_IAM in AmazonMSKConnectionService

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
