### PR TITLE
NIFI-14838 Adding a new processor and controller service to connect and listen to Ethereum Beacon Chain events.

### DIFF
--- a/nifi-assembly/LICENSE
+++ b/nifi-assembly/LICENSE
@@ -2685,6 +2685,28 @@ The binary distribution of this product bundles 'Py4J' under a BSD license.
      FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
      OTHER DEALINGS IN THE SOFTWARE.
 
+This product bundles 'eth-events-listener' which is available under an MIT license.
+
+    Copyright (c) 2025 Amilcar Gimenez
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
 For the binary distribution of nifi-ui see its 3rdpartylicenses.txt
 for additional license and notice information.
 

--- a/nifi-assembly/NOTICE
+++ b/nifi-assembly/NOTICE
@@ -2478,6 +2478,10 @@ The MIT License
       Checker Framework qualifiers
       Copyright 2004-present by the Checker Framework developers
 
+  (MIT) eth-events-listener
+    The following NOTICE information applies:
+      Copyright (c) 2025 Amilcar Gimenez
+
 *****************
 Mozilla Public License v2.0
 *****************

--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -879,6 +879,24 @@ language governing permissions and limitations under the License. -->
             <version>2.6.0-SNAPSHOT</version>
             <type>nar</type>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-eth-events-services-api-nar</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-eth-events-services-nar</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-eth-events-processors-nar</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
         <!-- AspectJ library needed by the Java Agent used for native library loading (see bootstrap.conf) -->
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors-nar/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-eth-events-bundle</artifactId>
+        <version>2.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-eth-events-processors-nar</artifactId>
+    <packaging>nar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-eth-events-processors</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-eth-events-services-api-nar</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-eth-events-bundle</artifactId>
+        <version>2.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-eth-events-processors</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-eth-events-services-api</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+
+        </dependency>
+        <!-- JSON parsing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors/src/main/java/org/apache/nifi/processors/ethereum/BeaconEventsProcessor.java
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors/src/main/java/org/apache/nifi/processors/ethereum/BeaconEventsProcessor.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.ethereum;
+
+
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+// Validator replaced by method reference
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.annotation.behavior.ReadsAttributes;
+import org.apache.nifi.annotation.behavior.WritesAttribute;
+import org.apache.nifi.annotation.behavior.WritesAttributes;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.annotation.lifecycle.OnStopped;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.SeeAlso;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.ProcessorInitializationContext;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.util.StringUtils;
+
+import org.apache.nifi.services.ethereum.BeaconEventsService;
+import org.apache.nifi.services.ethereum.EventType;
+import org.apache.nifi.services.ethereum.BeaconEvent;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Tags({ "ethereum", "eth2", "beacon", "blockchain", "web3j", "events" })
+@CapabilityDescription("Listens for Ethereum beacon chain events and generates FlowFiles when events are received. " +
+        "This processor connects to a controller service that provides access to Ethereum beacon chain events " +
+        "and creates a FlowFile for each event received.")
+@SeeAlso({})
+@ReadsAttributes({})
+@WritesAttributes({
+        @WritesAttribute(attribute = "eth.event.type", description = "The type of Ethereum beacon chain event"),
+        @WritesAttribute(attribute = "eth.event.timestamp", description = "The timestamp when the event was received"),
+        @WritesAttribute(attribute = "mime.type", description = "The MIME type of the event payload")
+})
+public class BeaconEventsProcessor extends AbstractProcessor {
+
+    public static final PropertyDescriptor ETH_EVENT_SERVICE = new PropertyDescriptor.Builder()
+            .name("Ethereum Events Service")
+            .displayName("Ethereum Events Service")
+            .description("The controller service that provides access to Ethereum beacon chain events")
+            .required(true)
+            .identifiesControllerService(BeaconEventsService.class)
+            .build();
+
+    public static final PropertyDescriptor EVENT_TYPES = new PropertyDescriptor.Builder()
+            .name("Event Types")
+            .displayName("Event Types")
+            .description("Comma-separated list of event types to subscribe to. Valid values are: " +
+                    java.util.Arrays.toString(EventType.values()).replace("[", "").replace("]", ""))
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .addValidator(BeaconEventsProcessor::validateEventTypes)
+            .build();
+
+
+
+    private static ValidationResult validateEventTypes(final String subject, final String input,
+            final ValidationContext context) {
+        if (StringUtils.isBlank(input)) {
+            return new ValidationResult.Builder()
+                    .subject(subject)
+                    .input(input)
+                    .valid(false)
+                    .explanation("Value is required and cannot be blank")
+                    .build();
+        }
+
+        final String[] tokens = input.split(",");
+        final StringBuilder invalids = new StringBuilder();
+        for (final String raw : tokens) {
+            final String token = raw.trim();
+            if (token.isEmpty()) {
+                continue;
+            }
+            try {
+                EventType.valueOf(token);
+            } catch (final IllegalArgumentException e) {
+                if (invalids.length() > 0)
+                    invalids.append(", ");
+                invalids.append(token);
+            }
+        }
+
+        if (invalids.length() > 0) {
+            return new ValidationResult.Builder()
+                    .subject(subject)
+                    .input(input)
+                    .valid(false)
+                    .explanation("Invalid event type(s): " + invalids + ". Allowed: " +
+                            java.util.Arrays.toString(EventType.values()))
+                    .build();
+        }
+
+        return new ValidationResult.Builder()
+                .subject(subject)
+                .input(input)
+                .valid(true)
+                .build();
+    }
+
+    public static final Relationship REL_SUCCESS = new Relationship.Builder()
+            .name("success")
+            .description("FlowFiles containing Ethereum beacon chain events")
+            .build();
+
+    private List<PropertyDescriptor> descriptors;
+    private Set<Relationship> relationships;
+
+    // Store received events
+    private final Map<String, BeaconEvent> receivedEvents = new ConcurrentHashMap<>();
+
+    // Track subscription ID
+    private final AtomicReference<String> subscriptionId = new AtomicReference<>();
+
+    // Track reconfiguration requests triggered by property changes
+    private final AtomicBoolean reconfigureRequested = new AtomicBoolean(false);
+
+    // Guard to ignore events from stale subscriptions
+    private final AtomicLong subscriptionGeneration = new AtomicLong(0);
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        descriptors = List.of(ETH_EVENT_SERVICE, EVENT_TYPES);
+        relationships = Set.of(REL_SUCCESS);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return this.relationships;
+    }
+
+    @Override
+    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return descriptors;
+    }
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+        // Initial subscription when scheduled
+        subscribeOrResubscribe(context);
+    }
+
+    @OnStopped
+    public void onStopped(final ProcessContext context) {
+        String subId = subscriptionId.getAndSet(null);
+        if (subId != null) {
+            final BeaconEventsService service = context.getProperty(ETH_EVENT_SERVICE)
+                    .asControllerService(BeaconEventsService.class);
+            boolean unsubscribed = service.unsubscribeFromEvents(subId);
+            if (unsubscribed) {
+                getLogger().info("Unsubscribed from Ethereum events with subscription ID: {}", subId);
+            } else {
+                getLogger().warn("Failed to unsubscribe from Ethereum events with subscription ID: {}", subId);
+            }
+        }
+
+        // Clear any pending events
+        receivedEvents.clear();
+    }
+
+    @Override
+    public void onPropertyModified(final PropertyDescriptor descriptor, final String oldValue, final String newValue) {
+        // If the controller service or the event types changed, request a
+        // resubscription.
+        if (ETH_EVENT_SERVICE.equals(descriptor) || EVENT_TYPES.equals(descriptor)) {
+            reconfigureRequested.set(true);
+            getLogger().debug("Property '{}' changed. Will reconfigure subscription on next trigger.",
+                    descriptor.getDisplayName());
+        }
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) {
+        // If a reconfiguration was requested while running, perform it now.
+        if (reconfigureRequested.compareAndSet(true, false)) {
+            // Best-effort resubscribe with current context
+            try {
+                unsubscribeCurrent(context);
+                subscribeOrResubscribe(context);
+            } catch (final Exception e) {
+                getLogger().warn("Failed to reconfigure subscription: {}", e.getMessage(), e);
+                // Avoid processing potentially mismatched events
+                context.yield();
+                return;
+            }
+        }
+
+        // Process any received events
+        if (receivedEvents.isEmpty()) {
+            context.yield(); // No events to process, yield to other processors
+            return;
+        }
+
+        // Get a copy of the events and clear the original map to avoid processing the
+        // same events multiple times
+        Map<String, BeaconEvent> eventsToProcess = new HashMap<>(receivedEvents);
+        receivedEvents.keySet().removeAll(eventsToProcess.keySet());
+
+        for (Map.Entry<String, BeaconEvent> entry : eventsToProcess.entrySet()) {
+            BeaconEvent event = entry.getValue();
+
+            // Create a FlowFile for the event
+            FlowFile flowFile = session.create();
+
+            try {
+                // Write the event data to the FlowFile
+                flowFile = session.write(flowFile, (out) -> {
+                    writeEventToOutputStream(event, out);
+                });
+
+                // Add attributes
+                Map<String, String> attributes = new HashMap<>();
+                attributes.put("eth.event.type", event.getEventType().name());
+                attributes.put("eth.event.timestamp", String.valueOf(System.currentTimeMillis()));
+                attributes.put("mime.type", "application/json");
+
+                flowFile = session.putAllAttributes(flowFile, attributes);
+
+                // Transfer the FlowFile to the success relationship
+                session.transfer(flowFile, REL_SUCCESS);
+                session.getProvenanceReporter().receive(flowFile, context.getProperty(ETH_EVENT_SERVICE)
+                        .asControllerService(BeaconEventsService.class).getBeaconNodeUrl());
+
+                getLogger().debug("Generated FlowFile for event: {}", event);
+            } catch (Exception e) {
+                getLogger().error("Failed to process event: {}", event, e);
+                session.remove(flowFile);
+            }
+        }
+    }
+
+    private void subscribeOrResubscribe(final ProcessContext context) {
+        final BeaconEventsService service = context.getProperty(ETH_EVENT_SERVICE)
+                .asControllerService(BeaconEventsService.class);
+        if (service == null) {
+            getLogger().warn("Ethereum Events Service is not configured or not enabled.");
+            return;
+        }
+
+        final String eventTypesStr = context.getProperty(EVENT_TYPES).getValue();
+
+        // Parse event types
+        EnumSet<EventType> eventTypes = EnumSet.noneOf(EventType.class);
+        if (!StringUtils.isBlank(eventTypesStr)) {
+            for (String eventType : eventTypesStr.split(",")) {
+                final String t = eventType.trim();
+                if (!t.isEmpty()) {
+                    try {
+                        eventTypes.add(EventType.valueOf(t));
+                    } catch (IllegalArgumentException e) {
+                        getLogger().warn("Invalid event type: {}", t);
+                    }
+                }
+            }
+        }
+
+        if (eventTypes.isEmpty()) {
+            getLogger().warn("No valid event types specified, processor will not receive any events");
+            return;
+        }
+
+        // New generation to invalidate any previous listeners that may still be
+        // attached in the service
+        final long generation = subscriptionGeneration.incrementAndGet();
+
+        // Subscribe to events
+        String subId = service.subscribeToEvents(eventTypes, event -> {
+            // Guard to ignore events from stale subscriptions
+            if (generation != subscriptionGeneration.get()) {
+                return;
+            }
+            // Store the event for processing in onTrigger
+            String eventId = UUID.randomUUID().toString();
+            receivedEvents.put(eventId, event);
+            getLogger().debug("Received event: {}", event);
+        });
+
+        subscriptionId.set(subId);
+        getLogger().info("Subscribed to Ethereum events with subscription ID: {}", subId);
+    }
+
+    private void unsubscribeCurrent(final ProcessContext context) {
+        final String subId = subscriptionId.getAndSet(null);
+        if (subId == null) {
+            return;
+        }
+        final BeaconEventsService service = context.getProperty(ETH_EVENT_SERVICE)
+                .asControllerService(BeaconEventsService.class);
+        if (service == null) {
+            return;
+        }
+        boolean ok = false;
+        try {
+            ok = service.unsubscribeFromEvents(subId);
+        } catch (final Exception e) {
+            getLogger().warn("Error unsubscribing from previous subscription {}: {}", subId, e.getMessage(), e);
+        }
+        if (ok) {
+            getLogger().info("Unsubscribed from previous subscription {}", subId);
+        } else {
+            getLogger().warn("Failed to unsubscribe from previous subscription {}", subId);
+        }
+        // Clear pending events to avoid mixing different configurations
+        receivedEvents.clear();
+    }
+
+    private void writeEventToOutputStream(final BeaconEvent event, final OutputStream out)
+            throws IOException {
+        // JSON serialization
+        final StringBuilder json = new StringBuilder();
+        json.append("{");
+        json.append("\"type\":\"").append(event.getEventType()).append("\",");
+        // event data is already JSON string; embed as raw JSON field named `data`
+        json.append("\"data\":").append(event.getJsonData());
+        json.append("}");
+        out.write(json.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+}

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.processors.ethereum.BeaconEventsProcessor

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors/src/main/resources/docs/org.apache.nifi.processors.ethereum.BeaconEventsProcessor/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors/src/main/resources/docs/org.apache.nifi.processors.ethereum.BeaconEventsProcessor/additionalDetails.md
@@ -1,0 +1,25 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Additional Details
+
+This processor subscribes to Ethereum Beacon Chain events using a configured Beacon Events Controller Service. Each received event is written as a single FlowFile with JSON content, and the following attributes are added:
+
+- eth.event.type
+- eth.event.timestamp
+
+Events are received asynchronously and emitted on trigger when available.

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors/src/test/java/org/apache/nifi/processors/ethereum/BeaconEventsProcessorTest.java
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-processors/src/test/java/org/apache/nifi/processors/ethereum/BeaconEventsProcessorTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.ethereum;
+
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.apache.nifi.services.ethereum.EventType;
+import org.apache.nifi.services.ethereum.BeaconEvent;
+import org.apache.nifi.services.ethereum.BeaconEventsService;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public class BeaconEventsProcessorTest {
+
+    private TestRunner testRunner;
+
+    @BeforeEach
+    public void init() throws InitializationException {
+        testRunner = TestRunners.newTestRunner(BeaconEventsProcessor.class);
+
+        // Set up the mock service
+        MockEthereumEventsService mockService = new MockEthereumEventsService();
+        testRunner.addControllerService("mockEthService", mockService);
+        testRunner.enableControllerService(mockService);
+
+        // Configure the processor
+        testRunner.setProperty(BeaconEventsProcessor.ETH_EVENT_SERVICE, "mockEthService");
+        testRunner.setProperty(BeaconEventsProcessor.EVENT_TYPES, "HEAD,BLOCK");
+    }
+
+    @Test
+    public void testJsonOutput() throws Exception {
+        // Grab the mock service to send an event
+        MockEthereumEventsService svc = (MockEthereumEventsService) testRunner.getControllerService("mockEthService");
+
+        // Run once to trigger onScheduled and register subscription, keep scheduled
+        testRunner.run(1, false, true);
+
+        // Ensure we have a subscription registered
+        Assertions.assertFalse(svc.subscriptions.isEmpty(), "No subscriptions registered");
+
+        // Simulate an incoming event via the registered consumer
+        String sampleJson = "{\"slot\":\"123\",\"body\":{\"foo\":\"bar\"}}";
+        BeaconEvent ev = new BeaconEvent(EventType.BLOCK, sampleJson);
+        svc.deliver(ev);
+
+        // Run again (without re-initializing) to process queued event
+        testRunner.run(1, false, false);
+
+        testRunner.assertTransferCount(BeaconEventsProcessor.REL_SUCCESS, 1);
+        java.util.List<org.apache.nifi.util.MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship(BeaconEventsProcessor.REL_SUCCESS);
+        String content = new String(flowFiles.get(0).toByteArray());
+
+        // Expect JSON output
+        Assertions.assertTrue(content.contains("\"type\":\"BLOCK\""));
+        Assertions.assertTrue(content.contains("\"data\":{\"slot\":\"123\",\"body\":{\"foo\":\"bar\"}}"));
+    }
+
+    @Test
+    public void testProcessorConfiguration() {
+        // Verify the processor is valid as configured
+        testRunner.assertValid();
+    }
+
+    @Test
+    public void testProcessorWithNoInput() {
+        // Run the processor once
+        testRunner.run(1);
+
+        // Verify no flowfiles were created since no events were triggered
+        testRunner.assertTransferCount(BeaconEventsProcessor.REL_SUCCESS, 0);
+    }
+
+    @Test
+    public void testInvalidEventType() {
+        // Set an invalid event type
+        testRunner.setProperty(BeaconEventsProcessor.EVENT_TYPES, "INVALID_TYPE");
+
+    // With the stricter validator the processor should be invalid at configuration time
+    testRunner.assertNotValid();
+    }
+
+    /**
+     * Mock implementation of the BeaconEventsService interface for testing
+     */
+    private static class MockEthereumEventsService extends AbstractControllerService implements BeaconEventsService {
+    final Map<String, Consumer<BeaconEvent>> subscriptions = new HashMap<>();
+        private final String beaconNodeUrl = "http://localhost:5051";
+
+        @Override
+        public String subscribeToEvents(EnumSet<EventType> eventTypes, Consumer<BeaconEvent> eventConsumer) {
+            String subscriptionId = UUID.randomUUID().toString();
+            subscriptions.put(subscriptionId, eventConsumer);
+            return subscriptionId;
+        }
+
+        @Override
+        public boolean unsubscribeFromEvents(String subscriptionId) {
+            return subscriptions.remove(subscriptionId) != null;
+        }
+
+        @Override
+        public String getBeaconNodeUrl() {
+            return beaconNodeUrl;
+        }
+
+        @Override
+        public void execute() {
+            // Legacy method, not used
+        }
+
+        void deliver(final BeaconEvent event) {
+            subscriptions.values().forEach(c -> c.accept(event));
+        }
+    }
+}

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-api-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-api-nar/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-eth-events-bundle</artifactId>
+        <version>2.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-eth-events-services-api-nar</artifactId>
+    <packaging>nar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-eth-events-services-api</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-shared-nar</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-api/pom.xml
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-api/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-eth-events-bundle</artifactId>
+        <version>2.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-eth-events-services-api</artifactId>
+
+</project>

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-api/src/main/java/org/apache/nifi/services/ethereum/BeaconEvent.java
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-api/src/main/java/org/apache/nifi/services/ethereum/BeaconEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.services.ethereum;
+
+import java.util.Objects;
+
+/**
+ * Minimal Beacon Event representation decoupled from any external library.
+ * Data is represented as a raw JSON string to avoid API dependencies.
+ */
+public final class BeaconEvent {
+    private final EventType eventType;
+    private final String jsonData;
+
+    public BeaconEvent(final EventType eventType, final String jsonData) {
+        this.eventType = Objects.requireNonNull(eventType, "eventType");
+        this.jsonData = Objects.requireNonNull(jsonData, "jsonData");
+    }
+
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    /**
+     * Returns the event payload as a JSON string.
+     */
+    public String getJsonData() {
+        return jsonData;
+    }
+
+    @Override
+    public String toString() {
+        return "BeaconEvent{" +
+                "eventType=" + eventType +
+                ", jsonData='" + jsonData + '\'' +
+                '}';
+    }
+}

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-api/src/main/java/org/apache/nifi/services/ethereum/BeaconEventsService.java
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-api/src/main/java/org/apache/nifi/services/ethereum/BeaconEventsService.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.services.ethereum;
+
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.controller.ControllerService;
+
+import java.util.EnumSet;
+import java.util.function.Consumer;
+
+@Tags({"ethereum", "eth2", "beacon", "blockchain", "events", "controller", "service"})
+@CapabilityDescription("Service for connecting to an Ethereum beacon chain node and listening for events. " +
+        "This service allows processors to subscribe to specific event types and receive notifications when those events occur. " +
+        "It uses the java-eth-events-listener library to connect to the beacon chain node and listen for events.")
+public interface BeaconEventsService extends ControllerService {
+
+    /**
+     * Subscribes to beacon chain events of the specified types.
+     * @param eventTypes The types of events to subscribe to
+     * @param eventConsumer The consumer that will process the events
+     * @return A subscription ID that can be used to unsubscribe
+     */
+    String subscribeToEvents(EnumSet<EventType> eventTypes, Consumer<BeaconEvent> eventConsumer);
+
+    /**
+     * Unsubscribes from events using the subscription ID.
+     * @param subscriptionId The subscription ID returned from subscribeToEvents
+     * @return true if the subscription was found and removed, false otherwise
+     */
+    boolean unsubscribeFromEvents(String subscriptionId);
+
+    /**
+     * Gets the URL of the beacon chain node.
+     * @return The URL of the beacon chain node
+     */
+    String getBeaconNodeUrl();
+
+    /**
+     * Legacy method for backward compatibility.
+     * @deprecated Use {@link #subscribeToEvents(EnumSet, Consumer)} instead.
+     */
+    @Deprecated
+    void execute();
+}

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-api/src/main/java/org/apache/nifi/services/ethereum/EventType.java
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-api/src/main/java/org/apache/nifi/services/ethereum/EventType.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.services.ethereum;
+
+/**
+ * Beacon chain event types supported by the Controller Service API.
+ * This enum intentionally mirrors the external listener library values
+ * without introducing a direct dependency in the API module.
+ */
+public enum EventType {
+    HEAD,
+    BLOCK,
+    BLOCK_GOSSIP,
+    ATTESTATION,
+    SINGLE_ATTESTATION,
+    VOLUNTARY_EXIT,
+    BLS_TO_EXECUTION_CHANGE,
+    PROPOSER_SLASHING,
+    ATTESTER_SLASHING,
+    FINALIZED_CHECKPOINT,
+    CHAIN_REORG,
+    CONTRIBUTION_AND_PROOF,
+    LIGHT_CLIENT_FINALITY_UPDATE,
+    LIGHT_CLIENT_OPTIMISTIC_UPDATE,
+    PAYLOAD_ATTRIBUTES,
+    BLOB_SIDECAR
+}

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-nar/pom.xml
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-nar/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-eth-events-bundle</artifactId>
+        <version>2.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-eth-events-services-nar</artifactId>
+    <packaging>nar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-eth-events-services-api-nar</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+            <type>nar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-eth-events-services</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-nar/src/main/resources/META-INF/LICENSE
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-nar/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,222 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright notice to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. You may not represent that You are providing,
+      or that You have the authority to represent that anyone else is providing,
+      warranty or support for the Work unless You have entered into a separate
+      legal agreement to provide such warranty or support.
+
+   10. Accepting Warranty or Support. You may not represent that You are providing,
+      or that You have the authority to represent that anyone else is providing,
+      warranty or support for the Work unless You have entered into a separate
+      legal agreement to provide such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same page as the copyright notice for easier identification within
+      third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+This product bundles 'eth-events-listener' which is available under an MIT license.
+
+    Copyright (c) 2025 Amilcar Gimenez
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-nar/src/main/resources/META-INF/NOTICE
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services-nar/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,15 @@
+Apache NiFi
+Copyright 2014-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+===========================================
+MIT License
+===========================================
+
+The following binary components are provided under the MIT License:
+
+  (MIT) eth-events-listener
+    The following NOTICE information applies:
+      Copyright (c) 2025 Amilcar Gimenez

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/pom.xml
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-eth-events-bundle</artifactId>
+        <version>2.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>nifi-eth-events-services</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-eth-events-services-api</artifactId>
+            <version>2.6.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.am-ilcar</groupId>
+            <artifactId>eth-events-listener</artifactId>
+            <version>1.0.2</version>
+            <exclusions>
+                <!-- Avoid bundling logging implementations in extensions -->
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/src/main/java/org/apache/nifi/services/ethereum/StandardBeaconEventsService.java
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/src/main/java/org/apache/nifi/services/ethereum/StandardBeaconEventsService.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.services.ethereum;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+import io.github.amilcar.eth.eventslistener.client.BeaconEventClient;
+import io.github.amilcar.eth.eventslistener.client.BeaconEventClientFactory;
+import io.github.amilcar.eth.eventslistener.listener.BeaconEventListener;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnDisabled;
+import org.apache.nifi.annotation.lifecycle.OnEnabled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.controller.AbstractControllerService;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.reporting.InitializationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@Tags({"ethereum", "eth2", "beacon", "blockchain", "events", "controller", "service"})
+@CapabilityDescription("ControllerService implementation for connecting to an Ethereum beacon chain node and listening for events. " +
+        "This service allows processors to subscribe to specific event types and receive notifications when those events occur. " +
+        "It uses the eth-events-listener library to connect to the beacon chain node and listen for events.")
+public class StandardBeaconEventsService extends AbstractControllerService implements BeaconEventsService {
+
+    private static final Logger logger = LoggerFactory.getLogger(StandardBeaconEventsService.class);
+
+    public static final PropertyDescriptor BEACON_NODE_URL = new PropertyDescriptor
+            .Builder()
+            .name("Beacon Node URL")
+            .displayName("Beacon Node URL")
+            .description("URL of the Ethereum beacon chain node to connect to. This should be the HTTP endpoint of a running " +
+                    "Ethereum beacon chain node that supports the standard beacon chain API. For example, " +
+                    "http://localhost:5051 for a local node, or the URL of a public beacon chain node.")
+            .required(true)
+            .defaultValue("http://localhost:5051")
+            .addValidator(StandardValidators.URL_VALIDATOR)
+            .build();
+
+    private static final List<PropertyDescriptor> properties = List.of(BEACON_NODE_URL);
+
+    private BeaconEventClient beaconEventClient;
+    private String beaconNodeUrl;
+
+    // Map to store subscriptions: subscription ID -> consumer
+    private final Map<String, Consumer<BeaconEvent>> subscriptions = new ConcurrentHashMap<>();
+
+    // Map to track which event types each subscription is interested in
+    private final Map<String, EnumSet<EventType>> subscriptionEventTypes = new ConcurrentHashMap<>();
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    /**
+     * Initialize the service and connect to the beacon chain node.
+     * This method is called when the service is enabled. It reads the configuration properties
+     * and connects to the beacon chain node.
+     * @param context the configuration context containing the service properties
+     * @throws InitializationException if unable to connect to the beacon chain node
+     */
+    @OnEnabled
+    public void onEnabled(final ConfigurationContext context) throws InitializationException {
+        beaconNodeUrl = context.getProperty(BEACON_NODE_URL).getValue();
+
+        try {
+            logger.info("Connecting to beacon node at {}", beaconNodeUrl);
+
+            // Create a client for all event types
+            beaconEventClient = BeaconEventClientFactory.createClientForAllEvents(beaconNodeUrl);
+
+            // We don't start the client here because we want to allow processors to subscribe
+            // to specific event types first. The subscribeToEvents method will start the client.
+
+            logger.info("Successfully created beacon event client");
+        } catch (Exception e) {
+            logger.error("Error creating beacon event client: {}", e.getMessage(), e);
+            throw new InitializationException("Failed to create beacon event client: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Clean up resources when the service is disabled.
+     * This method is called when the service is disabled. It clears all subscriptions
+     * and closes the connection to the beacon chain node if one exists.
+     */
+    @OnDisabled
+    public void shutdown() {
+        logger.info("Shutting down beacon event client");
+
+        // Clear all subscriptions
+        subscriptions.clear();
+        subscriptionEventTypes.clear();
+
+        // Close the beacon event client if it exists
+        if (beaconEventClient != null) {
+            try {
+                beaconEventClient.stop();
+                beaconEventClient.close();
+                logger.info("Beacon event client closed successfully");
+            } catch (Exception e) {
+                logger.error("Error closing beacon event client: {}", e.getMessage(), e);
+            } finally {
+                beaconEventClient = null;
+            }
+        }
+    }
+
+    /**
+     * Legacy method, kept for backward compatibility
+     */
+    @Override
+    public void execute() {
+        // This method is kept for backward compatibility
+        logger.debug("execute() method called, but it's deprecated. Use subscribeToEvents() instead.");
+    }
+
+    /**
+     * Subscribe to beacon chain events of the specified types
+     * @param eventTypes The types of events to subscribe to
+     * @param eventConsumer The consumer that will process the events
+     * @return A subscription ID that can be used to unsubscribe
+     */
+    @Override
+    public String subscribeToEvents(EnumSet<EventType> eventTypes, Consumer<BeaconEvent> eventConsumer) {
+        if (eventTypes == null || eventTypes.isEmpty()) {
+            throw new IllegalArgumentException("Event types cannot be null or empty");
+        }
+        if (eventConsumer == null) {
+            throw new IllegalArgumentException("Event consumer cannot be null");
+        }
+
+        String subscriptionId = UUID.randomUUID().toString();
+        subscriptions.put(subscriptionId, eventConsumer);
+        subscriptionEventTypes.put(subscriptionId, EnumSet.copyOf(eventTypes));
+
+        // If the beacon event client is null, log an error and throw an exception
+        if (beaconEventClient == null) {
+            logger.error("Cannot subscribe to events: beacon event client is null. Service may not be properly initialized.");
+            throw new IllegalStateException("Cannot subscribe to events: beacon event client is null");
+        }
+
+        try {
+            // For each event type, add a listener to the client
+            for (EventType eventType : eventTypes) {
+                // Map internal EventType to external library enum
+                final io.github.amilcar.eth.eventslistener.model.EventType externalType =
+                        io.github.amilcar.eth.eventslistener.model.EventType.valueOf(eventType.name());
+
+                // Create a listener that will dispatch converted events to the subscriber
+                BeaconEventListener<io.github.amilcar.eth.eventslistener.model.BeaconEvent> eventListener = externalEvent -> {
+                    logger.debug("Received external event: {}", externalEvent);
+                    try {
+                        // Convert external model to internal representation
+                        final EventType internalType = EventType.valueOf(externalEvent.getEventType().name());
+                        final String json = externalEvent.getData() != null ? externalEvent.getData().toString() : "{}";
+                        final BeaconEvent internalEvent = new BeaconEvent(internalType, json);
+                        eventConsumer.accept(internalEvent);
+                    } catch (Exception e) {
+                        logger.error("Error dispatching event to subscriber {}: {}", subscriptionId, e.getMessage(), e);
+                    }
+                };
+
+                // Add the listener to the client
+                beaconEventClient.addEventListener(externalType, eventListener);
+            }
+
+            // Start the client if it's not already started
+            if (!beaconEventClient.isConnected()) {
+                beaconEventClient.start();
+            }
+
+            logger.info("Created subscription {} for event types: {}", subscriptionId, eventTypes);
+        } catch (Exception e) {
+            logger.error("Error subscribing to events: {}", e.getMessage(), e);
+            subscriptions.remove(subscriptionId);
+            subscriptionEventTypes.remove(subscriptionId);
+            throw new RuntimeException("Failed to subscribe to events: " + e.getMessage(), e);
+        }
+
+        return subscriptionId;
+    }
+
+    /**
+     * Unsubscribe from events using the subscription ID
+     * @param subscriptionId The subscription ID returned from subscribeToEvents
+     * @return true if the subscription was found and removed, false otherwise
+     */
+    @Override
+    public boolean unsubscribeFromEvents(String subscriptionId) {
+        if (subscriptionId == null || subscriptionId.isEmpty()) {
+            return false;
+        }
+
+    Consumer<BeaconEvent> removed = subscriptions.remove(subscriptionId);
+    subscriptionEventTypes.remove(subscriptionId);
+
+        if (removed != null) {
+            // If we have a beacon event client and it's connected, remove the listeners
+            if (beaconEventClient != null && beaconEventClient.isConnected()) {
+                try {
+                    // We can't remove specific listeners since we don't store them,
+                    // but we can stop and restart the client if there are no more subscriptions
+                    if (subscriptions.isEmpty()) {
+                        beaconEventClient.stop();
+                    }
+                } catch (Exception e) {
+                    logger.error("Error removing event listeners: {}", e.getMessage(), e);
+                }
+            }
+
+            logger.info("Removed subscription {}", subscriptionId);
+            return true;
+        } else {
+            logger.warn("Subscription {} not found", subscriptionId);
+            return false;
+        }
+    }
+
+    /**
+     * Get the URL of the beacon chain node
+     * @return The URL of the beacon chain node
+     */
+    @Override
+    public String getBeaconNodeUrl() {
+        return beaconNodeUrl;
+    }
+}

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/src/main/resources/META-INF/services/org.apache.nifi.controller.ControllerService
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.nifi.services.ethereum.StandardBeaconEventsService

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/src/main/resources/docs/org.apache.nifi.services.ethereum.StandardBeaconEventsService/additionalDetails.md
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/src/main/resources/docs/org.apache.nifi.services.ethereum.StandardBeaconEventsService/additionalDetails.md
@@ -1,0 +1,27 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Additional Details
+
+StandardBeaconEventsService connects to a Beacon Node HTTP endpoint and manages subscriptions for Beacon Chain events.
+
+Required Properties:
+- Beacon Node URL: HTTP URL to the Beacon Node (e.g., http://localhost:5051).
+
+Security Considerations:
+- Do not include credentials in the URL.
+- Configure proxy/SSL using standard NiFi network configuration when applicable.

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/src/test/java/org/apache/nifi/services/ethereum/TestProcessor.java
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/src/test/java/org/apache/nifi/services/ethereum/TestProcessor.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.services.ethereum;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.processor.AbstractProcessor;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class TestProcessor extends AbstractProcessor {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestProcessor.class);
+
+    public static final PropertyDescriptor BEACON_EVENTS_SERVICE = new PropertyDescriptor.Builder()
+            .name("Ethereum Beacon Chain Event Service")
+            .description("Service for connecting to an Ethereum beacon chain node and listening for events")
+            .identifiesControllerService(BeaconEventsService.class)
+            .required(true)
+            .build();
+
+    private String subscriptionId;
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+        BeaconEventsService service = context.getProperty(BEACON_EVENTS_SERVICE).asControllerService(BeaconEventsService.class);
+
+        // If we don't have a subscription yet, create one
+        if (subscriptionId == null) {
+            // Subscribe to all event types
+            EnumSet<EventType> eventTypes = EnumSet.allOf(EventType.class);
+
+            // Create a consumer for beacon events
+            subscriptionId = service.subscribeToEvents(eventTypes, event -> {
+                logger.info("Received event: {}", event);
+                // Process the event here
+            });
+
+            logger.info("Subscribed to beacon events with ID: {}", subscriptionId);
+        } else {
+            // For testing purposes, unsubscribe after processing once
+            boolean unsubscribed = service.unsubscribeFromEvents(subscriptionId);
+            logger.info("Unsubscribed from beacon events with ID {}: {}", subscriptionId, unsubscribed);
+            subscriptionId = null;
+        }
+    }
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        List<PropertyDescriptor> propDescs = new ArrayList<>();
+        propDescs.add(BEACON_EVENTS_SERVICE);
+        return propDescs;
+    }
+}

--- a/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/src/test/java/org/apache/nifi/services/ethereum/TestStandardBeaconEventsService.java
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/nifi-eth-events-services/src/test/java/org/apache/nifi/services/ethereum/TestStandardBeaconEventsService.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.services.ethereum;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.amilcar.eth.eventslistener.client.BeaconEventClient;
+import io.github.amilcar.eth.eventslistener.listener.BeaconEventListener;
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.EnumSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+public class TestStandardBeaconEventsService {
+
+    private TestRunner runner;
+
+    @Spy
+    private StandardBeaconEventsService service;
+
+    @Mock
+    private BeaconEventClient mockBeaconEventClient;
+
+    private MockWebServer mockWebServer;
+    private String mockServerUrl;
+
+    @BeforeEach
+    public void init() throws InitializationException {
+        runner = TestRunners.newTestRunner(TestProcessor.class);
+
+        // Create a spy of StandardBeaconEventsService that overrides the onEnabled method
+        // to avoid connecting to a real beacon node
+        Mockito.doAnswer(invocation -> {
+            ConfigurationContext context = invocation.getArgument(0);
+            // Set the beacon node URL from the context
+            Field urlField = StandardBeaconEventsService.class.getDeclaredField("beaconNodeUrl");
+            urlField.setAccessible(true);
+            urlField.set(service, context.getProperty(StandardBeaconEventsService.BEACON_NODE_URL).getValue());
+
+            // Set the mock beacon event client
+            Field clientField = StandardBeaconEventsService.class.getDeclaredField("beaconEventClient");
+            clientField.setAccessible(true);
+            clientField.set(service, mockBeaconEventClient);
+
+            return null;
+        }).when(service).onEnabled(any(ConfigurationContext.class));
+
+        // Configure the mock beacon event client
+        Mockito.lenient().when(mockBeaconEventClient.isConnected()).thenReturn(true);
+
+        runner.addControllerService("test-good", service);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        if (mockWebServer != null) {
+            mockWebServer.shutdown();
+        }
+    }
+
+    @Test
+    public void testServiceConfiguration() throws InitializationException {
+        // Set the beacon node URL
+        runner.setProperty(service, StandardBeaconEventsService.BEACON_NODE_URL, "http://localhost:5051");
+
+        // Enable the service
+        runner.enableControllerService(service);
+
+        // Verify the service is valid
+        runner.assertValid(service);
+
+        // Verify the beacon node URL is set correctly
+        assertEquals("http://localhost:5051", service.getBeaconNodeUrl());
+    }
+
+    @Test
+    public void testSubscribeAndUnsubscribe() throws Exception {
+        // Set up the service with a mock beacon node service
+        runner.setProperty(service, StandardBeaconEventsService.BEACON_NODE_URL, "http://localhost:5051");
+
+        // Enable the service
+        runner.enableControllerService(service);
+
+        // Create a flag to track if our consumer was called
+        AtomicBoolean consumerCalled = new AtomicBoolean(false);
+
+        // Create a consumer for beacon events
+    Consumer<BeaconEvent> eventConsumer = event -> {
+            consumerCalled.set(true);
+        };
+
+        // Subscribe to events
+    EnumSet<EventType> eventTypes = EnumSet.allOf(EventType.class);
+        String subscriptionId = service.subscribeToEvents(eventTypes, eventConsumer);
+
+        // Verify the subscription ID is not null or empty
+        assertNotNull(subscriptionId);
+        assertFalse(subscriptionId.isEmpty());
+
+        // Unsubscribe from events
+        boolean unsubscribed = service.unsubscribeFromEvents(subscriptionId);
+
+        // Verify the unsubscribe was successful
+        assertTrue(unsubscribed);
+
+        // Try to unsubscribe again, which should fail
+        unsubscribed = service.unsubscribeFromEvents(subscriptionId);
+
+        // Verify the unsubscribe failed
+        assertFalse(unsubscribed);
+    }
+
+    @Test
+    public void testProcessorIntegration() throws Exception {
+        // Set up the service with mock BeaconEventClient
+        runner.setProperty(service, StandardBeaconEventsService.BEACON_NODE_URL, "http://localhost:5051");
+
+        // Enable the service
+        runner.enableControllerService(service);
+
+        // Set the service in the processor
+        runner.setProperty(TestProcessor.BEACON_EVENTS_SERVICE, "test-good");
+
+        // Run the processor once to subscribe to events
+        runner.run();
+
+        // Verify the processor ran without errors
+        runner.assertValid();
+
+        // Run the processor again to unsubscribe from events
+        runner.run();
+
+        // Verify the processor ran without errors
+        runner.assertValid();
+    }
+
+    @Test
+    public void testExecuteDeprecatedMethod() throws InitializationException {
+        // Set the beacon node URL
+        runner.setProperty(service, StandardBeaconEventsService.BEACON_NODE_URL, "http://localhost:5051");
+
+        // Enable the service
+        runner.enableControllerService(service);
+
+        // Call the deprecated execute method
+        service.execute();
+
+        // No assertion needed, we just want to make sure it doesn't throw an exception
+    }
+
+    @Test
+    public void testProcessorReceivesEventFromMockNode() throws Exception {
+        // Set up the MockWebServer
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        // Get the URL of the mock server
+        mockServerUrl = mockWebServer.url("/").toString();
+        // Remove trailing slash if present
+        mockServerUrl = mockServerUrl.substring(0, mockServerUrl.length() - (mockServerUrl.endsWith("/") ? 1 : 0));
+
+        // Create a sample event JSON
+        String eventJson = "{\"slot\":\"10\", \"block\":\"0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf\", " +
+                "\"state\":\"0x600e852a08c1200654ddf11025f1ceacb3c2e74bdd5c630cde0838b2591b69f9\", " +
+                "\"epoch_transition\":false, " +
+                "\"previous_duty_dependent_root\":\"0x5e0043f107cb57913498fbf2f99ff55e730bf1e151f02f221e977c91a90a0e91\", " +
+                "\"current_duty_dependent_root\":\"0x5e0043f107cb57913498fbf2f99ff55e730bf1e151f02f221e977c91a90a0e91\", " +
+                "\"execution_optimistic\": false}";
+
+        // Create a MockResponse that simulates an SSE event
+        MockResponse mockResponse = new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/event-stream")
+                .setHeader("Cache-Control", "no-cache")
+                .setHeader("Connection", "keep-alive")
+                .setBody("event: head\ndata: " + eventJson + "\n\n")
+                .setBodyDelay(100, TimeUnit.MILLISECONDS); // Small delay to simulate network
+
+        // Enqueue the response
+        mockWebServer.enqueue(mockResponse);
+
+        // Create a flag to track if our consumer was called
+        AtomicBoolean eventReceived = new AtomicBoolean(false);
+        CountDownLatch eventLatch = new CountDownLatch(1);
+    AtomicReference<BeaconEvent> receivedEvent = new AtomicReference<>();
+
+    // Internal representation used by the Controller Service consumer
+    BeaconEvent sampleInternalEvent = new BeaconEvent(EventType.HEAD, eventJson);
+
+        // Reset previous mocks
+        Mockito.reset(mockBeaconEventClient);
+
+        // Configure the mock beacon event client
+        Mockito.lenient().when(mockBeaconEventClient.isConnected()).thenReturn(true);
+        Mockito.lenient().when(mockBeaconEventClient.getNodeUrl()).thenReturn(mockServerUrl);
+
+        // Mock the addEventListener method to capture the listener and trigger it with our sample event
+    Mockito.doAnswer(invocation -> {
+            // Get the event type and listener from the invocation
+        io.github.amilcar.eth.eventslistener.model.EventType eventType = invocation.getArgument(0);
+            Object listenerObj = invocation.getArgument(1);
+
+            // If this is a HEAD event listener, simulate receiving an event
+        if (eventType == io.github.amilcar.eth.eventslistener.model.EventType.HEAD && listenerObj instanceof BeaconEventListener) {
+                // Schedule a task to call the listener after a short delay
+                new Thread(() -> {
+                    try {
+                        // Small delay to simulate network latency
+                        Thread.sleep(200);
+
+                        // Call the listener with our sample event
+                        @SuppressWarnings("unchecked")
+            BeaconEventListener<io.github.amilcar.eth.eventslistener.model.BeaconEvent> listener =
+                (BeaconEventListener<io.github.amilcar.eth.eventslistener.model.BeaconEvent>) listenerObj;
+            io.github.amilcar.eth.eventslistener.model.BeaconEvent externalEvent =
+                new io.github.amilcar.eth.eventslistener.model.BeaconEvent(
+                    io.github.amilcar.eth.eventslistener.model.EventType.HEAD,
+                    new ObjectMapper().readTree(eventJson)
+                );
+            listener.onEvent(externalEvent);
+
+                        // Mark that we received the event
+            receivedEvent.set(sampleInternalEvent);
+                        eventReceived.set(true);
+                        eventLatch.countDown();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }).start();
+            }
+
+            return mockBeaconEventClient;
+    }).when(mockBeaconEventClient).addEventListener(any(io.github.amilcar.eth.eventslistener.model.EventType.class), any());
+
+        // Set up the service with the mock server URL
+        runner.setProperty(service, StandardBeaconEventsService.BEACON_NODE_URL, mockServerUrl);
+
+        // Enable the service
+        runner.enableControllerService(service);
+
+        // Set the service in the processor
+        runner.setProperty(TestProcessor.BEACON_EVENTS_SERVICE, "test-good");
+
+        // Run the processor to subscribe to events
+        runner.run();
+
+        // Wait for the event to be received
+        boolean received = eventLatch.await(5, TimeUnit.SECONDS);
+
+        // Verify that the event was received
+        assertTrue(received, "Event should have been received");
+        assertTrue(eventReceived.get(), "Event should have been received");
+        assertNotNull(receivedEvent.get(), "Received event should not be null");
+    assertEquals(EventType.HEAD, receivedEvent.get().getEventType(), "Event type should be HEAD");
+    assertTrue(receivedEvent.get().getJsonData().contains("\"slot\":\"10\""), "Slot should match");
+
+        // Run the processor again to unsubscribe
+        runner.run();
+
+        // Verify the processor ran without errors
+        runner.assertValid();
+    }
+}

--- a/nifi-extension-bundles/nifi-eth-events-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-eth-events-bundle/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nifi</groupId>
+        <artifactId>nifi-standard-shared-bom</artifactId>
+        <version>2.6.0-SNAPSHOT</version>
+       <relativePath>../nifi-standard-shared-bundle/nifi-standard-shared-bom</relativePath>
+    </parent>
+
+    <artifactId>nifi-eth-events-bundle</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>nifi-eth-events-processors</module>
+        <module>nifi-eth-events-processors-nar</module>
+        <module>nifi-eth-events-services-api</module>
+        <module>nifi-eth-events-services-api-nar</module>
+        <module>nifi-eth-events-services</module>
+        <module>nifi-eth-events-services-nar</module>
+    </modules>
+
+</project>

--- a/nifi-extension-bundles/pom.xml
+++ b/nifi-extension-bundles/pom.xml
@@ -33,6 +33,7 @@
         <module>nifi-update-attribute-bundle</module>
         <module>nifi-kafka-bundle</module>
         <module>nifi-confluent-platform-bundle</module>
+        <module>nifi-eth-events-bundle</module>
         <module>nifi-aws-bundle</module>
         <module>nifi-social-media-bundle</module>
         <module>nifi-enrich-bundle</module>


### PR DESCRIPTION

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14838](https://issues.apache.org/jira/browse/NIFI-14838)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ x ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ x ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ x ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ x ] Pull Request based on current revision of the `main` branch
- [ x ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ x ] Build completed using `./mvnw clean install -P contrib-check`
  - [ x ] JDK 21

### Licensing

- [ x ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ x ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ x ] Documentation formatting appears as expected in rendered files
