### PR TITLE
NIFI-14948 - Adding null safe guarding when working on a set of flow differences

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/main/java/org/apache/nifi/util/FlowDifferenceFilters.java
@@ -321,6 +321,11 @@ public class FlowDifferenceFilters {
             return false;
         }
 
+        // If there is no local component, this is a change affecting only the proposed flow.
+        if (fd.getComponentA() == null) {
+            return false;
+        }
+
         if (fd.getComponentA().getComponentType() == ComponentType.CONTROLLER_SERVICE) {
             return true;
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-components/src/test/java/org/apache/nifi/util/TestFlowDifferenceFilters.java
@@ -23,8 +23,10 @@ import org.apache.nifi.flow.VersionedPort;
 import org.apache.nifi.flow.VersionedProcessor;
 import org.apache.nifi.flow.VersionedRemoteGroupPort;
 import org.apache.nifi.registry.flow.diff.DifferenceType;
+import org.apache.nifi.registry.flow.diff.FlowDifference;
 import org.apache.nifi.registry.flow.diff.StandardFlowDifference;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -140,5 +142,17 @@ public class TestFlowDifferenceFilters {
 
         assertTrue(FlowDifferenceFilters.isScheduledStateNew(flowDifference));
     }
-}
 
+    @Test
+    public void testIsLocalScheduleStateChangeWithNullComponentADoesNotNPE() {
+        // Simulate DEEP comparison producing a scheduled state change for a newly added component (no local A)
+        final FlowDifference flowDifference = Mockito.mock(FlowDifference.class);
+        Mockito.when(flowDifference.getDifferenceType()).thenReturn(DifferenceType.SCHEDULED_STATE_CHANGED);
+        Mockito.when(flowDifference.getComponentA()).thenReturn(null);
+        Mockito.when(flowDifference.getValueA()).thenReturn("RUNNING");
+        Mockito.when(flowDifference.getValueB()).thenReturn("RUNNING");
+
+        // Should not throw and should return false since no local component
+        assertFalse(FlowDifferenceFilters.isLocalScheduleStateChange(flowDifference));
+    }
+}

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/AffectedComponentSet.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/serialization/AffectedComponentSet.java
@@ -379,6 +379,12 @@ public class AffectedComponentSet {
             }
         }
 
+        // With DEEP comparison, configuration differences for newly added components may reference a null local component (Component A).
+        // These do not affect any existing local components, so ignore them.
+        if (difference.getComponentA() == null) {
+            return;
+        }
+
         if (differenceType == DifferenceType.COMPONENT_REMOVED && difference.getComponentA().getComponentType() == ComponentType.PROCESS_GROUP) {
             // If a Process Group is removed, we need to consider any component within the Process Group as affected also
             addAllComponentsWithinGroup(difference.getComponentA().getInstanceIdentifier());

--- a/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/serialization/TestAffectedComponentSet.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/test/java/org/apache/nifi/controller/serialization/TestAffectedComponentSet.java
@@ -20,6 +20,8 @@ package org.apache.nifi.controller.serialization;
 import org.apache.nifi.controller.FlowController;
 import org.apache.nifi.controller.ProcessorNode;
 import org.apache.nifi.controller.flow.FlowManager;
+import org.apache.nifi.registry.flow.diff.DifferenceType;
+import org.apache.nifi.registry.flow.diff.FlowDifference;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -82,5 +84,19 @@ public class TestAffectedComponentSet {
         final AffectedComponentSet removed = setA.removeComponents(componentSetFilter);
         assertEquals(2, setA.getComponentCount());
         assertEquals(8, removed.getComponentCount());
+    }
+
+    @Test
+    public void testAddAffectedComponentsWithNullComponentADoesNotNPE() {
+        final AffectedComponentSet set = new AffectedComponentSet(controller);
+
+        // Simulate a DEEP comparison config difference on an added Process Group
+        final FlowDifference difference = Mockito.mock(FlowDifference.class);
+        when(difference.getDifferenceType()).thenReturn(DifferenceType.EXECUTION_ENGINE_CHANGED);
+        when(difference.getComponentA()).thenReturn(null); // Newly added PG => local component is null
+
+        // Should not throw and should not add any local components
+        set.addAffectedComponents(difference);
+        assertEquals(0, set.getComponentCount());
     }
 }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-api/src/main/java/org/apache/nifi/web/StandardNiFiServiceFacade.java
@@ -5760,6 +5760,7 @@ public class StandardNiFiServiceFacade implements NiFiServiceFacade {
         final Set<AffectedComponentEntity> affectedComponents = comparison.getDifferences().stream()
                 .filter(difference -> difference.getDifferenceType() != DifferenceType.COMPONENT_ADDED) // components that are added are not components that will be affected in the local flow.
                 .filter(FlowDifferenceFilters.FILTER_ADDED_REMOVED_REMOTE_PORTS)
+                .filter(difference -> difference.getComponentA() != null) // a difference that would not affect a local component
                 .filter(diff -> !FlowDifferenceFilters.isNewPropertyWithDefaultValue(diff, flowManager))
                 .filter(diff -> !FlowDifferenceFilters.isNewRelationshipAutoTerminatedAndDefaulted(diff, proposedFlow.getContents(), flowManager))
                 .filter(diff -> !FlowDifferenceFilters.isScheduledStateNew(diff))


### PR DESCRIPTION
# Summary

NIFI-14948 - Adding null safe guarding when working on a set of flow differences

Following the change in [NIFI-14435](https://issues.apache.org/jira/browse/NIFI-14435), we may be facing a NPE in `getComponentsAffectedByFlowUpdate()` in `StandardNiFiServiceFacade` because the set of returned differences may have `componentA` set to `null` and we do not safe guard against it.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
