### PR TITLE
NIFI-14947 Update StandardIssuerProvider to use InetAddress.getHostName

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProvider.java
@@ -50,7 +50,7 @@ public class StandardIssuerProvider implements IssuerProvider {
         return issuer;
     }
 
-    private String getResolvedHost(final String host) {
+    private static String getResolvedHost(final String host) {
         final String resolvedHost;
 
         if (host == null || host.isEmpty()) {
@@ -62,10 +62,10 @@ public class StandardIssuerProvider implements IssuerProvider {
         return resolvedHost;
     }
 
-    private String getLocalHost() {
+    private static String getLocalHost() {
         try {
             final InetAddress localHostAddress = InetAddress.getLocalHost();
-            return localHostAddress.getCanonicalHostName();
+            return localHostAddress.getHostName();
         } catch (final UnknownHostException e) {
             throw new IllegalStateException("Failed to resolve local host address", e);
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProviderTest.java
@@ -25,7 +25,6 @@ import java.net.UnknownHostException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class StandardIssuerProviderTest {
     private static final String HTTPS_SCHEME = "https";
@@ -51,9 +50,8 @@ class StandardIssuerProviderTest {
     }
 
     @Test
-    void testGetIssuerNullHostResolved() {
+    void testGetIssuerNullHostResolved() throws UnknownHostException {
         final String localHost = getLocalHost();
-        assumeFalse(localHost == null);
 
         final StandardIssuerProvider provider = new StandardIssuerProvider(null, PORT);
 
@@ -67,12 +65,8 @@ class StandardIssuerProviderTest {
         assertNull(issuer.getQuery());
     }
 
-    private String getLocalHost() {
-        try {
-            final InetAddress localHostAddress = InetAddress.getLocalHost();
-            return localHostAddress.getCanonicalHostName();
-        } catch (final UnknownHostException e) {
-            return null;
-        }
+    private String getLocalHost() throws UnknownHostException {
+        final InetAddress localHostAddress = InetAddress.getLocalHost();
+        return localHostAddress.getHostName();
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-14947](https://issues.apache.org/jira/browse/NIFI-14947) Updates the `StandardIssuerProvider` to use `getHostName()` instead of `getCanonicalHostName()` for the local host address when handling a `null` value for the HTTPS host property.

The `null` handling provides fallback behavior when the `nifi.web.https.host` property is not configured, which is not common. The `getCanonicalHostName()` method recently  returned unexpected values on macOS 14 GitHub Runners, resulting in unit test failures. Initial workflow evaluation resulted in a successful completion.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
