### PR TITLE
NIFI-14947 Simplified StandardIssuerProviderTest URI Host checking

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProvider.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/main/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProvider.java
@@ -53,7 +53,7 @@ public class StandardIssuerProvider implements IssuerProvider {
     private String getResolvedHost(final String host) {
         final String resolvedHost;
 
-        if (host == null || host.isEmpty()) {
+        if (host == null || host.isBlank()) {
             resolvedHost = getLocalHost();
         } else {
             resolvedHost = host;
@@ -65,7 +65,15 @@ public class StandardIssuerProvider implements IssuerProvider {
     private String getLocalHost() {
         try {
             final InetAddress localHostAddress = InetAddress.getLocalHost();
-            return localHostAddress.getCanonicalHostName();
+            final String canonicalHostName = localHostAddress.getCanonicalHostName();
+            final String localHost;
+            if (canonicalHostName.isBlank()) {
+                // Handle empty Canonical Host Name which can be returned on macOS
+                localHost = localHostAddress.getHostAddress();
+            } else {
+                localHost = canonicalHostName;
+            }
+            return localHost;
         } catch (final UnknownHostException e) {
             throw new IllegalStateException("Failed to resolve local host address", e);
         }

--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProviderTest.java
@@ -18,14 +18,12 @@ package org.apache.nifi.web.security.jwt.provider;
 
 import org.junit.jupiter.api.Test;
 
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class StandardIssuerProviderTest {
     private static final String HTTPS_SCHEME = "https";
@@ -52,27 +50,17 @@ class StandardIssuerProviderTest {
 
     @Test
     void testGetIssuerNullHostResolved() {
-        final String localHost = getLocalHost();
-        assumeFalse(localHost == null);
-
         final StandardIssuerProvider provider = new StandardIssuerProvider(null, PORT);
 
         final URI issuer = provider.getIssuer();
 
-        assertNotNull(issuer);
         assertEquals(HTTPS_SCHEME, issuer.getScheme());
-        assertEquals(localHost, issuer.getHost());
+
+        final String host = issuer.getHost();
+        assertNotNull(host, "Host not found in Issuer [%s]".formatted(issuer));
+        assertFalse(host.isEmpty(), "Host is empty in Issue [%s]".formatted(issuer));
         assertEquals(PORT, issuer.getPort());
         assertEquals(EMPTY, issuer.getPath());
         assertNull(issuer.getQuery());
-    }
-
-    private String getLocalHost() {
-        try {
-            final InetAddress localHostAddress = InetAddress.getLocalHost();
-            return localHostAddress.getCanonicalHostName();
-        } catch (final UnknownHostException e) {
-            return null;
-        }
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-14947](https://issues.apache.org/jira/browse/NIFI-14947) Simplifies the unit test method in `StandardIssuerProviderTest` that is responsible for evaluating the resolution when the input host property in `null`. The updated assertion expects a non-empty string as opposed to expecting a particular host value. This change avoids apparent inconsistent test behavior on macOS 14.7.6 with Java 21.0.8 when running on GitHub workflows.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
