### PR TITLE
NIFI-14947 Add Host Validation to StandardIssuerProvider

### DIFF
--- a/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProviderTest.java
+++ b/nifi-framework-bundle/nifi-framework/nifi-web/nifi-web-security/src/test/java/org/apache/nifi/web/security/jwt/provider/StandardIssuerProviderTest.java
@@ -18,19 +18,20 @@ package org.apache.nifi.web.security.jwt.provider;
 
 import org.junit.jupiter.api.Test;
 
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class StandardIssuerProviderTest {
     private static final String HTTPS_SCHEME = "https";
 
     private static final String LOCALHOST = "localhost.localdomain";
+
+    private static final String HOST_INVALID = "local_host-1.local";
+
+    private static final String HOST_VALID = "local-host-1.local";
 
     private static final int PORT = 8443;
 
@@ -52,27 +53,31 @@ class StandardIssuerProviderTest {
 
     @Test
     void testGetIssuerNullHostResolved() {
-        final String localHost = getLocalHost();
-        assumeFalse(localHost == null);
-
         final StandardIssuerProvider provider = new StandardIssuerProvider(null, PORT);
 
         final URI issuer = provider.getIssuer();
 
         assertNotNull(issuer);
         assertEquals(HTTPS_SCHEME, issuer.getScheme());
-        assertEquals(localHost, issuer.getHost());
+        final String host = issuer.getHost();
+        assertNotNull(host, "Host not found in Issuer [%s]".formatted(issuer));
         assertEquals(PORT, issuer.getPort());
         assertEquals(EMPTY, issuer.getPath());
         assertNull(issuer.getQuery());
     }
 
-    private String getLocalHost() {
-        try {
-            final InetAddress localHostAddress = InetAddress.getLocalHost();
-            return localHostAddress.getCanonicalHostName();
-        } catch (final UnknownHostException e) {
-            return null;
-        }
+    @Test
+    void testGetIssuerInvalidHost() {
+        final StandardIssuerProvider provider = new StandardIssuerProvider(HOST_INVALID, PORT);
+
+        final URI issuer = provider.getIssuer();
+
+        assertNotNull(issuer);
+        assertEquals(HTTPS_SCHEME, issuer.getScheme());
+        final String host = issuer.getHost();
+        assertEquals(HOST_VALID, host);
+        assertEquals(PORT, issuer.getPort());
+        assertEquals(EMPTY, issuer.getPath());
+        assertNull(issuer.getQuery());
     }
 }


### PR DESCRIPTION
# Summary

[NIFI-14947](https://issues.apache.org/jira/browse/NIFI-14947) Adds host validation to the `StandardIssuerProvider` and replaces invalid characters with the hyphen character to support creation of a valid URI.

This change resolves test failures on GitHub macOS runners that can container the underscore character.

Changes include a new unit test for `StandardIssuerProvider` to evaluate expected replacement behavior.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
