### PR TITLE
NIFI-14954 - Bump Netty to 4.2.6.Final, Kotlin to 2.2.20, Fabric8 k8s to 7.4.0, and others

### DIFF
--- a/nifi-code-coverage/pom.xml
+++ b/nifi-code-coverage/pom.xml
@@ -88,7 +88,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.2.9</version>
+                <version>1.2.10</version>
             </dependency>
             <!-- SSHD from Registry and other modules -->
             <dependency>

--- a/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/nifi-azure-processors/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.7.9</version>
+            <version>3.7.11</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.7.9</version>
+            <version>3.7.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-extension-bundles/nifi-azure-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-azure-bundle/pom.xml
@@ -80,7 +80,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.2.9</version>
+                <version>1.2.10</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <jline.version>3.30.5</jline.version>
+        <jline.version>3.30.6</jline.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -110,10 +110,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.791</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.33.4</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.33.5</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
-        <io.fabric8.kubernetes.client.version>7.3.1</io.fabric8.kubernetes.client.version>
-        <kotlin.version>2.2.10</kotlin.version>
+        <io.fabric8.kubernetes.client.version>7.4.0</io.fabric8.kubernetes.client.version>
+        <kotlin.version>2.2.20</kotlin.version>
         <okhttp.version>5.1.0</okhttp.version>
         <okio.version>3.16.0</okio.version>
         <org.apache.commons.cli.version>1.10.0</org.apache.commons.cli.version>
@@ -158,7 +158,7 @@
         <junit.version>5.13.4</junit.version>
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.5</snakeyaml.version>
-        <netty.4.version>4.2.5.Final</netty.4.version>
+        <netty.4.version>4.2.6.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <spring.version>6.2.10</spring.version>
         <spring.security.version>6.5.3</spring.security.version>


### PR DESCRIPTION
# Summary

NIFI-14954 - Bump Netty to 4.2.6.Final, Kotlin to 2.2.20, Fabric8 k8s to 7.4.0, and others

- reactor-netty-http from 1.2.9 to 1.2.10 - https://github.com/reactor/reactor-netty/releases/tag/v1.2.10
- reactor-core and reactor-test from 3.7.9 to 3.7.11 - https://github.com/reactor/reactor-core/releases/tag/v3.7.11
- jline from 3.30.5 to 3.30.6 - https://github.com/jline/jline3/releases/tag/jline-3.30.6
- AWS SDK v2 from 2.33.4 to 2.33.5 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Fabric8 k8s from 7.3.1 to 7.4.0 - https://github.com/fabric8io/kubernetes-client/releases/tag/v7.4.0
- Kotlin from 2.2.10 to 2.2.20 - https://github.com/JetBrains/kotlin/releases/tag/v2.2.20
- Netty from 4.2.5.Final to 4.2.6.Final - https://netty.io/news/2025/09/08/4-2-6.html

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
