### PR TITLE
NIFI-14953 Validate inlined protobuf schemas

### DIFF
--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/main/java/org/apache/nifi/services/protobuf/ProtobufSchemaCompiler.java
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/main/java/org/apache/nifi/services/protobuf/ProtobufSchemaCompiler.java
@@ -130,7 +130,8 @@ final class ProtobufSchemaCompiler {
                 logger.debug("Successfully compiled schema for identifier: {}", schemaDefinition.getIdentifier());
                 return compiledSchema;
             } catch (final IllegalStateException e) {
-                throw new SchemaCompilationException(e); // Illegal state exception is thrown by the wire library for schema issues
+                // Illegal state exception is thrown by the wire library for schema issues
+                throw new SchemaCompilationException("Could not compile schema: %s".formatted(schemaDefinition.toString()), e);
             } catch (final Exception e) {
                 throw new RuntimeException("Failed to compile Protobuf schema for identifier: " + schemaDefinition.getIdentifier(), e);
             }

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/main/java/org/apache/nifi/services/protobuf/SchemaCompilationException.java
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/main/java/org/apache/nifi/services/protobuf/SchemaCompilationException.java
@@ -17,7 +17,7 @@
 package org.apache.nifi.services.protobuf;
 
 public class SchemaCompilationException extends RuntimeException {
-    public SchemaCompilationException(Throwable cause) {
-        super(cause);
+    public SchemaCompilationException(final String message, final Throwable cause) {
+        super(message, cause);
     }
 }

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/test/java/org/apache/nifi/services/protobuf/TestStandardProtobufReaderPropertyValidation.java
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/src/test/java/org/apache/nifi/services/protobuf/TestStandardProtobufReaderPropertyValidation.java
@@ -110,7 +110,7 @@ class TestStandardProtobufReaderPropertyValidation extends StandardProtobufReade
 
             final ValidationResult invalidResult = verifyExactlyOneValidationError();
 
-            assertTrue(invalidResult.getExplanation().contains("Message name 'test.NonExistentMessage' cannot be found"));
+            assertTrue(invalidResult.getExplanation().contains("test.NonExistentMessage"));
         }
 
         @Test


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-14953](https://issues.apache.org/jira/browse/NIFI-14953)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [x] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [x] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [x] Documentation formatting appears as expected in rendered files
