### PR TITLE
NIFI-14896 Update ListenHTTP to record FFv3 package flowfile in the R…

### DIFF
--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/InvokeHTTP.java
@@ -185,7 +185,6 @@ public class InvokeHTTP extends AbstractProcessor {
             REMOTE_DN,
             EXCEPTION_CLASS,
             EXCEPTION_MESSAGE,
-            CoreAttributes.UUID.key(),
             CoreAttributes.PATH.key()
     );
 

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/ListenHTTP.java
@@ -88,15 +88,19 @@ import java.util.regex.Pattern;
 
 @InputRequirement(Requirement.INPUT_FORBIDDEN)
 @Tags({"ingest", "http", "https", "rest", "listen"})
-@CapabilityDescription("Starts an HTTP Server and listens on a given base path to transform incoming requests into FlowFiles. "
-        + "The default URI of the Service will be http://{hostname}:{port}/contentListener. Only HEAD and POST requests are "
-        + "supported. GET, PUT, DELETE, OPTIONS and TRACE will result in an error and the HTTP response status code 405; "
-        + "CONNECT will also result in an error and the HTTP response status code 400. "
-        + "GET is supported on <service_URI>/healthcheck. If the service is available, it returns \"200 OK\" with the content \"OK\". "
-        + "The health check functionality can be configured to be accessible via a different port. "
-        + "For details see the documentation of the \"Listening Port for health check requests\" property. "
-        + "A Record Reader and Record Writer property can be enabled on the processor to process incoming requests as records. "
-        + "Record processing is not allowed for multipart requests and request in FlowFileV3 format (minifi).")
+@CapabilityDescription("""
+        Starts an HTTP Server and listens on a given base path to transform incoming requests into FlowFiles.
+        The default URI of the Service will be http://{hostname}:{port}/contentListener. Only HEAD and POST requests are
+        supported. GET, PUT, DELETE, OPTIONS and TRACE will result in an error and the HTTP response status code 405;
+        CONNECT will also result in an error and the HTTP response status code 400.
+        GET is supported on <service_URI>/healthcheck. If the service is available, it returns \"200 OK\" with the content \"OK\".
+        The health check functionality can be configured to be accessible via a different port.
+        For details, see the documentation of the \"Listening Port for health check requests\" property.
+        A Record Reader and Record Writer property can be enabled on the processor to process incoming requests as records.
+        Record processing is not allowed for multipart requests and request in FlowFileV3 format (minifi).
+        If the incoming request contains a FlowFileV3 package format, the data will be unpacked automatically into individual
+        FlowFile(s) contained within the package; the original FlowFile names are restored.
+        """)
 @UseCase(
         description = "Unpack FlowFileV3 content received in a POST",
         keywords = {"flowfile", "flowfilev3", "unpack"},

--- a/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
+++ b/nifi-extension-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/servlets/ListenHTTPServlet.java
@@ -363,7 +363,8 @@ public class ListenHTTPServlet extends HttpServlet {
                 attributes.put(CoreAttributes.FILENAME.key(), nameVal);
             }
 
-            String sourceSystemFlowFileIdentifier = attributes.remove(CoreAttributes.UUID.key());
+            String sourceSystemFlowFileIdentifier = request.getHeader(CoreAttributes.UUID.key()) == null
+                    ? attributes.remove(CoreAttributes.UUID.key()) : request.getHeader(CoreAttributes.UUID.key());
             if (sourceSystemFlowFileIdentifier != null) {
                 sourceSystemFlowFileIdentifier = "urn:nifi:" + sourceSystemFlowFileIdentifier; //NOPMD
             }


### PR DESCRIPTION
…ECEIVE provenance event as Source FlowFile Id rather than the UUIDs of the internal flowfiles

<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

Updates details stored in a Provenance RECEIVE event recorded by ListenHTTP when receiving a FFv3 package. Previously, it would list the Source System FlowFile Id as the UUID of the packaged FlowFile. Doing so ignores the sent/received FlowFile - the FFv3 package itself. When unpacking the package within ListenHTTP, the original FFv3 package's UUID should be recorded as the Source System FlowFile Id for more accurate continuity. Recording the contained FlowFile UUID will ignore any changes that may have taken place on the package FlowFile on the source system when reconstructing complete history across multiple NiFi instances.

[NIFI-14896](https://issues.apache.org/jira/browse/NIFI-14896)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [X] Build completed using `./mvnw clean install -P contrib-check`
  - [X] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
