### PR TITLE
NIFI-14960 - Bump Spring to 6.2.11, Jetty to 12.0.27, Protobuf to 4.32.1, and others

### DIFF
--- a/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-mongodb-bundle/pom.xml
@@ -34,6 +34,6 @@
     </modules>
 
     <properties>
-        <mongo.driver.version>5.5.1</mongo.driver.version>
+        <mongo.driver.version>5.6.0</mongo.driver.version>
     </properties>
 </project>

--- a/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-opentelemetry-bundle/pom.xml
@@ -32,7 +32,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
-                <version>4.32.0</version>
+                <version>4.32.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/nifi-extension-bundles/nifi-redis-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-redis-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring.data.redis.version>3.5.3</spring.data.redis.version>
+        <spring.data.redis.version>3.5.4</spring.data.redis.version>
         <jedis.version>6.2.0</jedis.version>
     </properties>
 

--- a/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-shared-bundle/nifi-standard-shared-bom/pom.xml
@@ -121,7 +121,7 @@
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
-                <version>3.50.0</version>
+                <version>3.51.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
+++ b/nifi-registry/nifi-registry-core/nifi-registry-test/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>3.5.5</version>
+            <version>3.5.6</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.791</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.33.5</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.33.8</software.amazon.awssdk.version>
         <gson.version>2.13.1</gson.version>
         <io.fabric8.kubernetes.client.version>7.4.0</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.20</kotlin.version>
@@ -136,7 +136,7 @@
         <org.slf4j.version>2.0.17</org.slf4j.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
         <derby.version>10.17.1.0</derby.version>
-        <jetty.version>12.0.26</jetty.version>
+        <jetty.version>12.0.27</jetty.version>
         <jackson.bom.version>2.20.0</jackson.bom.version>
         <jackson.annotations.version>2.20</jackson.annotations.version>
         <avro.version>1.12.0</avro.version>
@@ -145,7 +145,7 @@
         <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
         <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
         <json.smart.version>2.6.0</json.smart.version>
-        <groovy.version>5.0.0</groovy.version>
+        <groovy.version>5.0.1</groovy.version>
         <surefire.version>3.5.1</surefire.version>
         <hadoop.version>3.4.2</hadoop.version>
         <ozone.version>1.4.1</ozone.version>
@@ -160,7 +160,7 @@
         <snakeyaml.version>2.5</snakeyaml.version>
         <netty.4.version>4.2.6.Final</netty.4.version>
         <servlet-api.version>6.1.0</servlet-api.version>
-        <spring.version>6.2.10</spring.version>
+        <spring.version>6.2.11</spring.version>
         <spring.security.version>6.5.3</spring.security.version>
         <swagger.annotations.version>2.2.36</swagger.annotations.version>
         <caffeine.version>3.2.2</caffeine.version>


### PR DESCRIPTION
# Summary

NIFI-14960 - Bump Spring to 6.2.11, Jetty to 12.0.27, Protobuf to 4.32.1, and others

- MongoDB Driver from 5.5.1 to 5.6.0 - https://github.com/mongodb/mongo-java-driver/releases/tag/r5.6.0
- Protobuf from 4.32.0 to 4.32.1 - https://github.com/protocolbuffers/protobuf/releases/tag/v32.1
- Spring Data Redis from 3.5.3 to 3.5.4 - https://github.com/spring-projects/spring-data-redis/releases/tag/3.5.4
- Checker-qual from 3.50.0 to 3.51.0 - https://github.com/typetools/checker-framework/releases/tag/checker-framework-3.51.0
- MariaDB Java Client from 3.5.5 to 3.5.6 - https://github.com/mariadb-corporation/mariadb-connector-j/releases/tag/3.5.6
- AWS SDK v2 from 2.33.5 to 2.33.8 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- Jetty from 12.0.26 to 12.0.27 - https://github.com/jetty/jetty.project/releases/tag/jetty-12.0.27
- Groovy from 5.0.0 to 5.0.1 - https://groovy-lang.org/changelogs/changelog-5.0.1.html
- Spring from 6.2.10 to 6.2.11 - https://github.com/spring-projects/spring-framework/releases/tag/v6.2.11

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
