### PR TITLE
NIFI-14966 - Bump GCP SDK to 26.68.0, Lucene to 10.3.0, Saxon HE to 10.9, and others

### DIFF
--- a/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-gcp-bundle/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google.libraries.version>26.67.0</google.libraries.version>
+        <google.libraries.version>26.68.0</google.libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
+++ b/nifi-extension-bundles/nifi-registry-bundle/nifi-registry-service/pom.xml
@@ -56,7 +56,7 @@ language governing permissions and limitations under the License. -->
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>1.5.8</version>
+            <version>1.5.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -106,7 +106,7 @@
             <dependency>
                 <groupId>net.sf.saxon</groupId>
                 <artifactId>Saxon-HE</artifactId>
-                <version>12.8</version>
+                <version>12.9</version>
             </dependency>
             <dependency>
                 <groupId>javax.jms</groupId>
@@ -230,7 +230,7 @@
             <dependency>
                 <groupId>com.networknt</groupId>
                 <artifactId>json-schema-validator</artifactId>
-                <version>1.5.8</version>
+                <version>1.5.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-services/nifi-record-serialization-services-bundle/nifi-record-serialization-services/pom.xml
@@ -130,13 +130,13 @@
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-matchers</artifactId>
-            <version>2.10.3</version>
+            <version>2.10.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
-            <version>2.10.3</version>
+            <version>2.10.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/pom.xml
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-provenance-repository-bundle/pom.xml
@@ -27,7 +27,7 @@
         <module>nifi-provenance-repository-nar</module>
     </modules>
     <properties>
-        <lucene.version>10.2.2</lucene.version>
+        <lucene.version>10.3.0</lucene.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2014</inceptionYear>
         <com.amazonaws.version>1.12.791</com.amazonaws.version>
-        <software.amazon.awssdk.version>2.33.8</software.amazon.awssdk.version>
-        <gson.version>2.13.1</gson.version>
+        <software.amazon.awssdk.version>2.33.9</software.amazon.awssdk.version>
+        <gson.version>2.13.2</gson.version>
         <io.fabric8.kubernetes.client.version>7.4.0</io.fabric8.kubernetes.client.version>
         <kotlin.version>2.2.20</kotlin.version>
         <okhttp.version>5.1.0</okhttp.version>


### PR DESCRIPTION
# Summary

NIFI-14966 - Bump GCP SDK to 26.68.0, Lucene to 10.3.0, Saxon HE to 10.9, and others

- Google Cloud SDK from 26.67.0 to 26.68.0 - https://github.com/googleapis/java-cloud-bom/releases/tag/v26.68.0
- JSON Schema Validator from 1.5.8 to 1.5.9 - https://github.com/networknt/json-schema-validator/releases/tag/1.5.9
- Saxon HE from 12.8 to 12.9 - https://blog.saxonica.com/announcements/2025/09/saxon-12.9.html
- XML Unit from 2.10.3 to 2.10.4 - https://github.com/xmlunit/xmlunit/releases/tag/v2.10.4
- Apache Lucene from 10.2.2 to 10.3.0 - https://github.com/apache/lucene/releases/tag/releases%2Flucene%2F10.3.0
- AWS SDK v2 from 2.33.8 to 2.33.9 - https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md
- GSON from 2.13.1 to 2.13.2 - https://github.com/google/gson/releases/tag/gson-parent-2.13.2

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
