### PR TITLE
NIFI-14967 - Use ComponentLog in git registry clients

### DIFF
--- a/nifi-extension-bundles/nifi-atlassian-bundle/nifi-atlassian-extensions/src/main/java/org/apache/nifi/atlassian/bitbucket/BitbucketFlowRegistryClient.java
+++ b/nifi-extension-bundles/nifi-atlassian-bundle/nifi-atlassian-extensions/src/main/java/org/apache/nifi/atlassian/bitbucket/BitbucketFlowRegistryClient.java
@@ -138,6 +138,7 @@ public class BitbucketFlowRegistryClient extends AbstractGitFlowRegistryClient {
     protected GitRepositoryClient createRepositoryClient(final FlowRegistryClientConfigurationContext context) throws FlowRegistryException {
         return BitbucketRepositoryClient.builder()
                 .clientId(getIdentifier())
+                .logger(getLogger())
                 .apiUrl(context.getProperty(BITBUCKET_API_URL).getValue())
                 .apiVersion(context.getProperty(BITBUCKET_API_VERSION).getValue())
                 .workspace(context.getProperty(WORKSPACE_NAME).getValue())

--- a/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubFlowRegistryClient.java
+++ b/nifi-extension-bundles/nifi-github-bundle/nifi-github-extensions/src/main/java/org/apache/nifi/github/GitHubFlowRegistryClient.java
@@ -116,6 +116,7 @@ public class GitHubFlowRegistryClient extends AbstractGitFlowRegistryClient {
     @Override
     protected GitHubRepositoryClient createRepositoryClient(final FlowRegistryClientConfigurationContext context) throws IOException, FlowRegistryException {
         return GitHubRepositoryClient.builder()
+                .logger(getLogger())
                 .apiUrl(context.getProperty(GITHUB_API_URL).getValue())
                 .authenticationType(GitHubAuthenticationType.valueOf(context.getProperty(AUTHENTICATION_TYPE).getValue()))
                 .personalAccessToken(context.getProperty(PERSONAL_ACCESS_TOKEN).getValue())

--- a/nifi-extension-bundles/nifi-gitlab-bundle/nifi-gitlab-extensions/src/main/java/org/apache/nifi/gitlab/GitLabFlowRegistryClient.java
+++ b/nifi-extension-bundles/nifi-gitlab-bundle/nifi-gitlab-extensions/src/main/java/org/apache/nifi/gitlab/GitLabFlowRegistryClient.java
@@ -131,6 +131,7 @@ public class GitLabFlowRegistryClient extends AbstractGitFlowRegistryClient {
     protected GitRepositoryClient createRepositoryClient(final FlowRegistryClientConfigurationContext context) throws FlowRegistryException {
         return GitLabRepositoryClient.builder()
                 .clientId(getIdentifier())
+                .logger(getLogger())
                 .apiUrl(context.getProperty(GITLAB_API_URL).getValue())
                 .apiVersion(context.getProperty(GITLAB_API_VERSION).asAllowableValue(GitLabApi.ApiVersion.class))
                 .repoNamespace(context.getProperty(REPOSITORY_NAMESPACE).getValue())


### PR DESCRIPTION
# Summary

NIFI-14967 - Use ComponentLog in git registry clients

For some git-based registry client implementations, we're instantiating a dedicated logger using the SLF4J Logger Factory. We should instead leverage the existing component logger that comes from AbstractFlowRegistryClient. This is important to properly expose bulletins in case of warnings/errors.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `./mvnw clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
