### PR TITLE
NIFI-14975 fail Registry startup if nifi-registry-api handler is not available

### DIFF
--- a/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/main/java/org/apache/nifi/registry/jetty/handler/StandardHandlerProvider.java
+++ b/nifi-registry/nifi-registry-core/nifi-registry-jetty/src/main/java/org/apache/nifi/registry/jetty/handler/StandardHandlerProvider.java
@@ -110,6 +110,7 @@ public class StandardHandlerProvider implements HandlerProvider {
         final ClassLoader apiClassLoader = getApiClassLoader(properties.getDatabaseDriverDirectory());
         final WebAppContext apiContext = getWebAppContext(libDirectory, workDirectory, apiClassLoader, API_FILE_PATTERN, API_CONTEXT_PATH);
         apiContext.setAttribute(PROPERTIES_PARAMETER, properties);
+        apiContext.setThrowUnavailableOnStartupException(true);
         handlers.addHandler(apiContext);
 
         final WebAppContext docsContext = getWebAppContext(libDirectory, workDirectory, ClassLoader.getSystemClassLoader(), DOCS_FILE_PATTERN, DOCS_CONTEXT_PATH);


### PR DESCRIPTION
# Summary

[NIFI-14975](https://issues.apache.org/jira/browse/NIFI-14975)

On startup, bad configuration or startup errors can cause NiFi Registry to successfully start and the web UI works, but Jetty can return 503 UNAVAILABLE errors on nifi-registry-api.  One (of many) conditions this can happen is if the configuration is fine but an LdapUserGroupProvider or DatabaseUserGroupProvider cannot connect to external services.

This PR causes NiFi Registry to shutdown in these conditions.  This aligns with how NiFi behaves in similar scenarios.  It also works well in containerized environments, where an orchestrator can now notice Registry is not healthy and retry startup.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [x] Build completed using `./mvnw clean install -P contrib-check`
  - [x] JDK 21

### Licensing

- [n/a] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [n/a] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [n/a] Documentation formatting appears as expected in rendered files
