### PR TITLE
NIFI-14984 - prevent ENTER from adding a new line in codemirror editors if the component is not dirty

### DIFF
--- a/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/property-table/editors/nf-editor/nf-editor.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/nifi/src/app/ui/common/property-table/editors/nf-editor/nf-editor.component.ts
@@ -167,9 +167,8 @@ export class NfEditor {
                         run: () => {
                             if (this.nfEditorForm.dirty && this.nfEditorForm.valid) {
                                 this.okClicked();
-                                return true;
                             }
-                            return false;
+                            return true;
                         }
                     },
                     ...defaultKeymap,

--- a/nifi-frontend/src/main/frontend/apps/update-attribute/src/app/pages/update-attribute/ui/ua-editor/ua-editor.component.ts
+++ b/nifi-frontend/src/main/frontend/apps/update-attribute/src/app/pages/update-attribute/ui/ua-editor/ua-editor.component.ts
@@ -148,9 +148,8 @@ export class UaEditor {
                         run: () => {
                             if (this.uaEditorForm.dirty && this.uaEditorForm.valid) {
                                 this.okClicked();
-                                return true;
                             }
-                            return false;
+                            return true;
                         }
                     },
                     ...defaultKeymap,

--- a/nifi-frontend/src/main/frontend/libs/shared/src/components/map-table/editors/text-editor/text-editor.component.ts
+++ b/nifi-frontend/src/main/frontend/libs/shared/src/components/map-table/editors/text-editor/text-editor.component.ts
@@ -182,9 +182,8 @@ export class TextEditor {
                     run: () => {
                         if (this.textEditorForm.dirty && this.textEditorForm.valid) {
                             this.okClicked();
-                            return true;
                         }
-                        return false;
+                        return true;
                     }
                 },
                 ...defaultKeymap,


### PR DESCRIPTION

[NIFI-14984](https://issues.apache.org/jira/browse/NIFI-14984)
